### PR TITLE
Silently detach kernel driver. This is needed in case

### DIFF
--- a/src/librtlsdr.c
+++ b/src/librtlsdr.c
@@ -1336,6 +1336,8 @@ int rtlsdr_open(rtlsdr_dev_t **out_dev, uint32_t index)
 
 	libusb_free_device_list(list, 1);
 
+    libusb_detach_kernel_driver(dev->devh, 0);
+
 	r = libusb_claim_interface(dev->devh, 0);
 	if (r < 0) {
 		fprintf(stderr, "usb_claim_interface error %d\n", r);


### PR DESCRIPTION
the device is detected as input device which blocks the
libusb_claim_interface call.

For example the Trekstor DVB-T Stick Terres 2.0 is
detected as a mouse.

Ref. https://www.linuxquestions.org/questions/programming-9/libusb-error-claim-device-6-a-887499/