### PR TITLE
Better message validation in prologue_callback()

### DIFF
--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -206,7 +206,8 @@ static int prologue_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS]) {
     /* FIXME validate the received message better */
     if (((bb[1][0]&0xF0) == 0x90 && (bb[2][0]&0xF0) == 0x90 && (bb[3][0]&0xF0) == 0x90 && (bb[4][0]&0xF0) == 0x90 &&
         (bb[5][0]&0xF0) == 0x90 && (bb[6][0]&0xF0) == 0x90) ||
-        ((bb[1][0]&0xF0) == 0x50 && (bb[2][0]&0xF0) == 0x50 && (bb[3][0]&0xF0) == 0x50 && (bb[4][0]&0xF0) == 0x50)) {
+        ((bb[1][0]&0xF0) == 0x50 && (bb[2][0]&0xF0) == 0x50 && (bb[3][0]&0xF0) == 0x50 && (bb[4][0]&0xF0) == 0x50) &&
+        (bb[1][3] == bb[2][3]) && (bb[1][4] == bb[2][4])) {
 
         /* Prologue sensor */
         temp2 = (int16_t)((uint16_t)(bb[1][2] << 8) | (bb[1][3]&0xF0));


### PR DESCRIPTION
Validate the last two bytes of the the first and second received message to confirm message integrity. (Dataset is usually send in 4 - 8 identical messages).