### PR TITLE
Fix typo in installation instructions

### DIFF
--- a/README
+++ b/README
@@ -3,7 +3,7 @@ rtl_433, turns your Realtek RTL2832 based DVB dongle into a 433.92MHz generic da
 
 Installation instructions:
 
-cd rtl-433/
+cd rtl_433/
 mkdir build
 cd build
 cmake ../


### PR DESCRIPTION
Correcting a small typo, repo name is "rtl_433"
