### PR TITLE
Added decode/parsing for Oregon Scientific v2.1 and v3 sensors and rough...

### DIFF
--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -104,8 +104,9 @@ static int override_short = 0;
 static int override_long = 0;
 
 /* Supported modulation types */
-#define     OOK_PWM_D   1   /* Pulses are of the same length, the distance varies */
-#define     OOK_PWM_P   2   /* The length of the pulses varies */
+#define     OOK_PWM_D   	1   /* Pulses are of the same length, the distance varies */
+#define     OOK_PWM_P   	2   /* The length of the pulses varies */
+#define     OOK_MANCHESTER	3	/* Manchester code */
 
 
 typedef struct {
@@ -424,6 +425,264 @@ static int ws2000_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS]) {
     return 1;
 }
 
+static int acurite_rain_gauge_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS]) {
+    // This needs more validation to positively identify correct sensor type, but it basically works if message is really from acurite raingauge and it doesn't have any errors
+    if ((bb[0][0] != 0) && (bb[0][1] != 0) && (bb[0][2]!=0) && (bb[0][3] == 0) && (bb[0][4] == 0)) {
+	    float total_rain = ((bb[0][1]&0xf)<<8)+ bb[0][2];
+		total_rain /= 2; // Sensor reports number of bucket tips.  Each bucket tip is .5mm
+        fprintf(stderr, "AcuRite Rain Gauge Total Rain is %2.1fmm\n", total_rain);
+		fprintf(stderr, "Raw Message: %02x %02x %02x %02x %02x\n",bb[0][0],bb[0][1],bb[0][2],bb[0][3],bb[0][4]);
+        return 1;
+    }
+    return 0;
+}
+
+float get_os_temperature(unsigned char *message, unsigned int sensor_id) {
+  // sensor ID included  to support sensors with temp in different position
+  float temp_c = 0;
+  temp_c = (((message[5]>>4)*100)+((message[4]&0x0f)*10) + ((message[4]>>4)&0x0f)) /10.0F;
+  if (message[5] & 0x0f)
+       temp_c = -temp_c;
+  return temp_c;
+}
+unsigned int get_os_humidity(unsigned char *message, unsigned int sensor_id) {
+ // sensor ID included to support sensors with temp in different position
+ int humidity = 0;
+    humidity = ((message[6]&0x0f)*10)+(message[6]>>4);
+ return humidity;
+}
+
+static int validate_os_checksum(unsigned char *msg, int checksum_nibble_idx) {
+  // Oregon Scientific v2.1 and v3 checksum is a  1 byte  'sum of nibbles' checksum.  
+  // with the 2 nibbles of the checksum byte  swapped.
+  int i;
+  unsigned int checksum, sum_of_nibbles=0;
+  for (i=0; i<(checksum_nibble_idx-1);i+=2) {
+    unsigned char val=msg[i>>1];
+	sum_of_nibbles += ((val>>4) + (val &0x0f));
+  }
+  if (checksum_nibble_idx & 1) {
+     sum_of_nibbles += (msg[checksum_nibble_idx>>1]>>4);
+     checksum = (msg[checksum_nibble_idx>>1] & 0x0f) | (msg[(checksum_nibble_idx+1)>>1]&0xf0);
+  } else
+     checksum = (msg[checksum_nibble_idx>>1]>>4) | ((msg[checksum_nibble_idx>>1]&0x0f)<<4);
+  sum_of_nibbles &= 0xff;
+  
+  if (sum_of_nibbles == checksum)
+    return 0;
+  else {
+    fprintf(stderr, "Checksum error in Oregon Scientific message.  Expected: %02x  Calculated: %02x\n", checksum, sum_of_nibbles);	
+	fprintf(stderr, "Message: "); int i; for (i=0 ;i<((checksum_nibble_idx+4)>>1) ; i++) fprintf(stderr, "%02x ", msg[i]); fprintf(stderr, "\n\n");
+	return 1;
+  }
+}
+
+static int validate_os_v2_message(unsigned char * msg, int bits_expected, int valid_v2_bits_received, 
+                                int nibbles_in_checksum) {
+  // Oregon scientific v2.1 protocol sends each bit using the complement of the bit, then the bit  for better error checking.  Compare number of valid bits processed vs number expected
+  if (bits_expected == valid_v2_bits_received) {
+    return (validate_os_checksum(msg, nibbles_in_checksum));	
+  } else {
+    fprintf(stderr, "Bit validation error on Oregon Scientific message.  Expected %d bits, received error after bit %d \n",        bits_expected, valid_v2_bits_received);	
+    fprintf(stderr, "Message: "); int i; for (i=0 ;i<(bits_expected+7)/8 ; i++) fprintf(stderr, "%02x ", msg[i]); fprintf(stderr, "\n\n");
+  }
+  return 1;
+}
+
+static int oregon_scientific_v2_1_parser(uint8_t bb[BITBUF_ROWS][BITBUF_COLS]) {
+   // Check 2nd and 3rd bytes of stream for possible Oregon Scientific v2.1 sensor data (skip first byte to get past sync/startup bit errors)
+   if ( ((bb[0][1] == 0x55) && (bb[0][2] == 0x55)) ||
+	    ((bb[0][1] == 0xAA) && (bb[0][2] == 0xAA))) {
+	  int i,j;
+	  unsigned char msg[BITBUF_COLS] = {0};
+	   
+	  // Possible  v2.1 Protocol message
+	  int num_valid_v2_bits = 0;
+	  
+	  unsigned int sync_test_val = (bb[0][3]<<24) | (bb[0][4]<<16) | (bb[0][5]<<8) | (bb[0][6]);
+	  int dest_bit = 0;
+	  int pattern_index;
+	  // Could be extra/dropped bits in stream.  Look for sync byte at expected position +/- some bits in either direction
+      for(pattern_index=0; pattern_index<8; pattern_index++) {
+        unsigned int mask     = (unsigned int) (0xffff0000>>pattern_index);
+		unsigned int pattern  = (unsigned int)(0x55990000>>pattern_index);
+        unsigned int pattern2 = (unsigned int)(0xaa990000>>pattern_index);
+
+	//fprintf(stderr, "OS v2.1 sync byte search - test_val=%08x pattern=%08x  mask=%08x\n", sync_test_val, pattern, mask);
+
+	    if (((sync_test_val & mask) == pattern) || 
+		    ((sync_test_val & mask) == pattern2)) {
+		  //  Found sync byte - start working on decoding the stream data.
+		  // pattern_index indicates  where sync nibble starts, so now we can find the start of the payload
+	      int start_byte = 5 + (pattern_index>>3);
+	      int start_bit = pattern_index & 0x07;
+	//fprintf(stderr, "OS v2.1 Sync test val %08x found, starting decode at byte index %d bit %d\n", sync_test_val, start_byte, start_bit);
+	      int bits_processed = 0;
+		  unsigned char last_bit_val = 0;
+		  j=start_bit;
+	      for (i=start_byte;i<BITBUF_COLS;i++) {
+	        while (j<8) {
+			   if (bits_processed & 0x01) {
+			     unsigned char bit_val = ((bb[0][i] & (0x80 >> j)) >> (7-j));
+				 
+				 // check if last bit received was the complement of the current bit
+				 if ((num_valid_v2_bits == 0) && (last_bit_val == bit_val))
+				   num_valid_v2_bits = bits_processed; // record position of first bit in stream that doesn't verify correctly
+				 last_bit_val = bit_val;
+				   
+			     // copy every other bit from source stream to dest packet
+				 msg[dest_bit>>3] |= (((bb[0][i] & (0x80 >> j)) >> (7-j)) << (7-(dest_bit & 0x07)));
+				 
+	//fprintf(stderr,"i=%d j=%d dest_bit=%02x bb=%02x msg=%02x\n",i, j, dest_bit, bb[0][i], msg[dest_bit>>3]); 
+				 if ((dest_bit & 0x07) == 0x07) {
+				    // after assembling each dest byte, flip bits in each nibble to convert from lsb to msb bit ordering
+				    int k = (dest_bit>>3);
+                    unsigned char indata = msg[k];
+	                // flip the 4 bits in the upper and lower nibbles
+	                msg[k] = ((indata & 0x11) << 3) | ((indata & 0x22) << 1) |
+	   	                     ((indata & 0x44) >> 1) | ((indata & 0x88) >> 3);
+		            }
+				 dest_bit++;
+			     }
+				 else 
+				   last_bit_val = ((bb[0][i] & (0x80 >> j)) >> (7-j)); // used for v2.1 bit error detection
+			   bits_processed++;
+			   j++;
+	        }
+		    j=0;
+		  }
+		  break;
+	    } //if (sync_test_val...
+      } // for (pattern...
+	  
+
+    int sensor_id = (msg[0] << 8) | msg[1];
+	if ((sensor_id == 0x1d20) || (sensor_id == 0x1d30))	{
+	   if (validate_os_v2_message(msg, 153, num_valid_v2_bits, 15) == 0) {
+         int  channel = ((msg[2] >> 4)&0x0f);
+	     if (channel == 4)
+	       channel = 3; // sensor 3 channel number is 0x04
+         float temp_c = get_os_temperature(msg, sensor_id);
+		 if (sensor_id == 0x1d20) fprintf(stderr, "Weather Sensor THGR122N Channel %d ", channel);
+		 else fprintf(stderr, "Weather Sensor THGR968  Outdoor   ");
+		 fprintf(stderr, "Temp: %3.1f°C  %3.1f°F   Humidity: %d%%\n", temp_c, ((temp_c*9)/5)+32,get_os_humidity(msg, sensor_id));
+	   }
+	   return 1;  
+    } else if (sensor_id == 0x5d60) {
+	   if (validate_os_v2_message(msg, 185, num_valid_v2_bits, 19) == 0) {
+	     unsigned int comfort = msg[7] >>4;
+	     char *comfort_str="Normal";
+	     if      (comfort == 4)   comfort_str = "Comfortable";
+	     else if (comfort == 8)   comfort_str = "Dry";
+	     else if (comfort == 0xc) comfort_str = "Humid";
+	     unsigned int forecast = msg[9]>>4;
+	     char *forecast_str="Cloudy";
+	     if      (forecast == 3)   forecast_str = "Rainy";
+	     else if (forecast == 6)   forecast_str = "Partly Cloudy";
+	     else if (forecast == 0xc) forecast_str = "Sunny";
+         float temp_c = get_os_temperature(msg, 0x5d60);
+	     fprintf(stderr,"Weather Sensor BHTR968  Indoor    Temp: %3.1f°C  %3.1f°F   Humidity: %d%%", temp_c, ((temp_c*9)/5)+32, get_os_humidity(msg, 0x5d60));  
+	     fprintf(stderr, " (%s) Pressure: %dmbar (%s)\n", comfort_str, ((msg[7] & 0x0f) | (msg[8] & 0xf0))+856, forecast_str);  
+	   }
+	   return 1;
+	} else if (sensor_id == 0x2d10) {
+	   if (validate_os_v2_message(msg, 161, num_valid_v2_bits, 16) == 0) {
+	   float rain_rate = (((msg[4] &0x0f)*100)+((msg[4]>>4)*10) + ((msg[5]>>4)&0x0f)) /10.0F;
+       float total_rain = (((msg[7]&0xf)*10000)+((msg[7]>>4)*1000) + ((msg[6]&0xf)*100)+((msg[6]>>4)*10) + (msg[5]&0xf))/10.0F;
+	   fprintf(stderr, "Weather Sensor RGR968   Rain Gauge  Rain Rate: %2.0fmm/hr Total Rain %3.0fmm\n", rain_rate, total_rain);
+	   }
+	   return 1;
+	} else if (num_valid_v2_bits > 16) {
+fprintf(stderr, "%d bit message received from unrecognized Oregon Scientific v2.1 sensor.\n", num_valid_v2_bits);
+fprintf(stderr, "Message: "); for (i=0 ; i<20 ; i++) fprintf(stderr, "%02x ", msg[i]); fprintf(stderr,"\n\n");
+    } else {
+//fprintf(stderr, "\nPossible Oregon Scientific v2.1 message, but sync nibble wasn't found\n"); fprintf(stderr, "Raw Data: "); for (i=0 ; i<BITBUF_COLS ; i++) fprintf(stderr, "%02x ", bb[0][i]); fprintf(stderr,"\n\n");    
+    } 
+   } else {
+//if (bb[0][3] != 0) int i; fprintf(stderr, "\nBadly formatted OS v2.1 message encountered."); for (i=0 ; i<BITBUF_COLS ; i++) fprintf(stderr, "%02x ", bb[0][i]); fprintf(stderr,"\n\n");}
+   }
+   return 0;
+}
+
+static int oregon_scientific_v3_parser(uint8_t bb[BITBUF_ROWS][BITBUF_COLS]) {
+ 
+   // Check stream for possible Oregon Scientific v3 protocol data (skip part of first and last bytes to get past sync/startup bit errors)
+   if ((((bb[0][0]&0xf) == 0x0f) && (bb[0][1] == 0xff) && ((bb[0][2]&0xc0) == 0xc0)) || 
+       (((bb[0][0]&0xf) == 0x00) && (bb[0][1] == 0x00) && ((bb[0][2]&0xc0) == 0x00))) {
+	  int i,j;
+	  unsigned char msg[BITBUF_COLS] = {0};	  
+	  unsigned int sync_test_val = (bb[0][2]<<24) | (bb[0][3]<<16) | (bb[0][4]<<8);
+	  int dest_bit = 0;
+	  int pattern_index;
+	  // Could be extra/dropped bits in stream.  Look for sync byte at expected position +/- some bits in either direction
+      for(pattern_index=0; pattern_index<16; pattern_index++) {
+        unsigned int     mask = (unsigned int)(0xfff00000>>pattern_index);
+        unsigned int  pattern = (unsigned int)(0xffa00000>>pattern_index);
+        unsigned int pattern2 = (unsigned int)(0xff500000>>pattern_index);
+		unsigned int pattern3 = (unsigned int)(0x00500000>>pattern_index);
+//fprintf(stderr, "OS v3 Sync nibble search - test_val=%08x pattern=%08x  mask=%08x\n", sync_test_val, pattern, mask);
+	    if (((sync_test_val & mask) == pattern)  ||
+            ((sync_test_val & mask) == pattern2) ||		
+            ((sync_test_val & mask) == pattern3)) {
+		  //  Found sync byte - start working on decoding the stream data.
+		  // pattern_index indicates  where sync nibble starts, so now we can find the start of the payload
+	      int start_byte = 3 + (pattern_index>>3);
+	      int start_bit = (pattern_index+4) & 0x07;
+//fprintf(stderr, "Oregon Scientific v3 Sync test val %08x ok, starting decode at byte index %d bit %d\n", sync_test_val, start_byte, start_bit);
+          j = start_bit;
+	      for (i=start_byte;i<BITBUF_COLS;i++) {
+	        while (j<8) {
+			   unsigned char bit_val = ((bb[0][i] & (0x80 >> j)) >> (7-j));
+				   
+			   // copy every  bit from source stream to dest packet
+			   msg[dest_bit>>3] |= (((bb[0][i] & (0x80 >> j)) >> (7-j)) << (7-(dest_bit & 0x07)));
+				 
+//fprintf(stderr,"i=%d j=%d dest_bit=%02x bb=%02x msg=%02x\n",i, j, dest_bit, bb[0][i], msg[dest_bit>>3]); 
+			   if ((dest_bit & 0x07) == 0x07) {
+				  // after assembling each dest byte, flip bits in each nibble to convert from lsb to msb bit ordering
+				  int k = (dest_bit>>3);
+                  unsigned char indata = msg[k];
+	              // flip the 4 bits in the upper and lower nibbles
+	              msg[k] = ((indata & 0x11) << 3) | ((indata & 0x22) << 1) |
+	   	                   ((indata & 0x44) >> 1) | ((indata & 0x88) >> 3);
+		         }
+			   dest_bit++;
+			   j++;
+			}
+			j=0;
+	       }
+		  break;
+		  }
+	    }
+		
+	if ((msg[0] == 0xf8) && (msg[1] == 0x24))	{
+	   if (validate_os_checksum(msg, 15) == 0) {
+	     int  channel = ((msg[2] >> 4)&0x0f);
+	     float temp_c = get_os_temperature(msg, 0xf824);
+		 int humidity = get_os_humidity(msg, 0xf824);
+		 fprintf(stderr,"Weather Sensor THGR810  Channel %d Temp: %3.1f°C  %3.1f°F   Humidity: %d%%\n", channel, temp_c, ((temp_c*9)/5)+32, humidity);
+	   }
+	   return 1;
+    } else if ((msg[0] != 0) && (msg[1]!= 0)) { //  sync nibble was found  and some data is present...
+fprintf(stderr, "Message received from unrecognized Oregon Scientific v3 sensor.\n");	
+fprintf(stderr, "Message: "); for (i=0 ; i<BITBUF_COLS ; i++) fprintf(stderr, "%02x ", msg[i]); fprintf(stderr, "\n");
+fprintf(stderr, "    Raw: "); for (i=0 ; i<BITBUF_COLS ; i++) fprintf(stderr, "%02x ", bb[0][i]); fprintf(stderr,"\n\n");       
+    } else if (bb[0][3] != 0) {
+//fprintf(stderr, "\nPossible Oregon Scientific v3 message, but sync nibble wasn't found\n"); fprintf(stderr, "Raw Data: "); for (i=0 ; i<BITBUF_COLS ; i++) fprintf(stderr, "%02x ", bb[0][i]); fprintf(stderr,"\n\n");   	
+    }
+   }	
+   else { // Based on first couple of bytes, either corrupt message or something other than an Oregon Scientific v3 message
+//if (bb[0][3] != 0) { fprintf(stderr, "\nUnrecognized Msg in v3: "); int i; for (i=0 ; i<BITBUF_COLS ; i++) fprintf(stderr, "%02x ", bb[0][i]); fprintf(stderr,"\n\n"); }
+   } 
+   return 0;
+}
+
+static int oregon_scientific_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS]) {
+ int ret = oregon_scientific_v2_1_parser(bb);
+ if (ret == 0)
+   ret = oregon_scientific_v3_parser(bb);
+ return ret;
+}
 
 // timings based on samp_rate=1024000
 r_device rubicson = {
@@ -527,6 +786,25 @@ r_device steffen = {
     /* .json_callback  = */ &steffen_callback,
 };
 
+r_device acurite_rain_gauge = {
+    /* .id             = */ 10,
+    /* .name           = */ "Acurite 896 Rain Gauge",
+    /* .modulation     = */ OOK_PWM_D,
+    /* .short_limit    = */ 1744/4,
+    /* .long_limit     = */ 3500/4,
+    /* .reset_limit    = */ 5000/4,
+    /* .json_callback  = */ &acurite_rain_gauge_callback,
+};
+
+r_device oregon_scientific = {
+    /* .id             = */ 11,
+    /* .name           = */ "Oregon Scientific Weather Sensor",
+    /* .modulation     = */ OOK_MANCHESTER,
+    /* .short_limit    = */ 125, 
+    /* .long_limit     = */ 0, // not used
+    /* .reset_limit    = */ 600,
+    /* .json_callback  = */ &oregon_scientific_callback,
+};
 
 struct protocol_state {
     int (*callback)(uint8_t bits_buffer[BITBUF_ROWS][BITBUF_COLS]);
@@ -1180,7 +1458,56 @@ static void pwm_p_decode(struct dm_state *demod, struct protocol_state* p, int16
     }
 }
 
+/*  Machester Decode for Oregon Scientific Weather Sensors
+   Decode data streams sent by Oregon Scientific v2.1, and v3 weather sensors.  
+   With manchester encoding, both the pulse width and pulse distance vary.  Clock sync
+   is recovered from the data stream based on pulse widths and distances exceeding a 
+   minimum threashold (short limit* 1.5). 
+ */
+static void manchester_decode(struct dm_state *demod, struct protocol_state* p, int16_t *buf, uint32_t len) {
+    unsigned int i;
 
+	if (p->sample_counter == 0)
+	    p->sample_counter = p->short_limit*2;
+		
+    for (i=0 ; i<len ; i++) {
+	
+	    if (p->start_c) 
+		    p->sample_counter++; /* For this decode type, sample counter is count since last data bit recorded */			
+
+        if (!p->pulse_count && (buf[i] > demod->level_limit)) { /* Pulse start (rising edge) */
+            p->pulse_count = 1;
+			if (p->sample_counter  > (p->short_limit + (p->short_limit>>1))) {
+			   /* Last bit was recorded more than short_limit*1.5 samples ago */
+			   /* so this pulse start must be a data edge (rising data edge means bit = 0) */
+               demod_add_bit(p, 0);			   
+			   p->sample_counter=1;
+			   p->start_c++; // start_c counts number of bits received
+			}
+        }
+        if (p->pulse_count && (buf[i] <= demod->level_limit)) { /* Pulse end (falling edge) */
+		    if (p->sample_counter > (p->short_limit + (p->short_limit>>1))) {
+		       /* Last bit was recorded more than "short_limit*1.5" samples ago */
+			   /* so this pulse end is a data edge (falling data edge means bit = 1) */
+               demod_add_bit(p, 1);				   
+			   p->sample_counter=1;
+			   p->start_c++;
+			}
+            p->pulse_count = 0;
+        }
+
+        if (p->sample_counter > p->reset_limit) {
+	//fprintf(stderr, "manchester_decode number of bits received=%d\n",p->start_c); 
+		   if (p->callback)
+              events+=p->callback(p->bits_buffer);
+           else
+              demod_print_bits_packet(p);
+			demod_reset_bits_packet(p);
+	        p->sample_counter = p->short_limit*2;
+			p->start_c = 0;
+        }
+    }
+}
 
 /** Something that might look like a IIR lowpass filter
  *
@@ -1259,6 +1586,9 @@ static void rtlsdr_callback(unsigned char *buf, uint32_t len, void *ctx)
                         break;
                     case OOK_PWM_P:
                         pwm_p_decode(demod, demod->r_devs[i], demod->f_buf, len/2);
+                        break;
+                    case OOK_MANCHESTER:
+                        manchester_decode(demod, demod->r_devs[i], demod->f_buf, len/2);
                         break;
                     default:
                         fprintf(stderr, "Unknown modulation %d in protocol!\n", demod->r_devs[i]->modulation);
@@ -1391,6 +1721,8 @@ int main(int argc, char **argv)
     register_protocol(demod, &elv_ws2000);
     register_protocol(demod, &waveman);
     register_protocol(demod, &steffen);
+//    register_protocol(demod, &acurite_rain_gauge);
+   register_protocol(demod, &oregon_scientific);
 
     if (argc <= optind-1) {
         usage();


### PR DESCRIPTION
Adds support for a handful of Oregon Scientific v2.1 and v3 sensors plus very rough support for the AcuRite 0896 Rain Gauge.

OS v2.1 sensors tested include: BTHR968, RGR968, THGR968, THGR268
OS v3 sensors tested: THGR810

AcuRite (Chaney) Rain Gauge: 0896  (very rough with no error checking)