### PR TITLE
support for acurite5n1

### DIFF
--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -533,7 +533,7 @@ static int acurite5n1_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS]) {
 
             fprintf(stderr, "wind speed: %d kph, ", 
                 acurite_getWindSpeed(buf[3], buf[4]));
-            fprintf(stderr, "wind direction: %0.1f deg., ",
+            fprintf(stderr, "wind direction: %0.1f°, ",
                 acurite_getWindDirection(buf[4]));
             fprintf(stderr, "rain gauge: %0.2f in.\n", rainfall);
 
@@ -541,7 +541,7 @@ static int acurite5n1_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS]) {
             // wind speed, temp, RH
             fprintf(stderr, "wind speed: %d kph, ", 
                 acurite_getWindSpeed(buf[3], buf[4]));          
-            fprintf(stderr, "temp: %2.1f F, ", 
+            fprintf(stderr, "temp: %2.1f° F, ", 
                 acurite_getTemp(buf[4], buf[5]));
             fprintf(stderr, "humidity: %d% RH\n", 
                 acurite_getHumidity(buf[6]));


### PR DESCRIPTION
as discussed in #42 here is a basic, working merge worthy PR for support of Acurite 5n1 sensor. 
I'll look at implementing some other refactorings in another PR.

output looks like:

```
Detected Acurite 5n1 sensor
wind speed: 5 kph, wind direction: 90.0°, rain gauge: 0.00 in.
Detected Acurite 5n1 sensor
wind speed: 6 kph, temp: 81.3° F, humidity: 76% RH
```
