### PR TITLE
Fix handling of SIGPIPE

### DIFF
--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -758,7 +758,11 @@ sighandler(int signum)
 #else
 static void sighandler(int signum)
 {
-    fprintf(stderr, "Signal caught, exiting!\n");
+    if (signum == SIGPIPE) {
+	signal(SIGPIPE,SIG_IGN);
+    } else {
+	fprintf(stderr, "Signal caught, exiting!\n");
+    }
     do_exit = 1;
     rtlsdr_cancel_async(dev);
 }


### PR DESCRIPTION
Fixes #41 - "SIGPIPE handling"
fixes sigpipe handling to not cause an infinite loop when a SIGPIPE occurs trying to write to stderr.