### PR TITLE
fixed automake build system

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,6 +16,7 @@ rtl_433_SOURCES      = rtl_433.c \
                        devices/elv.c \
                        devices/mebus.c \
                        devices/prologue.c \
-                       devices/steffen.c
+                       devices/steffen.c \
+                       devices/fineoffset.c
 
 rtl_433_LDADD        = $(LIBRTLSDR) $(LIBM)


### PR DESCRIPTION
In the long-run, it might be best to settle on a single build system instead of the two inherited from librtlsdr