### PR TITLE
Cardin improved

### DIFF
--- a/src/devices/cardin.c
+++ b/src/devices/cardin.c
@@ -15,102 +15,107 @@ static int cardin_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_pe
 	int i, j, k;
 	unsigned char dip[10] = {'-','-','-','-','-','-','-','-','-', '\0'};
 
-	fprintf(stderr, "------------------------------\n");
-	fprintf(stderr, "protocol       = Cardin S466\n");
-	fprintf(stderr, "message        = ");
-	for (i=0 ; i<3 ; i++) {
-		for (k = 7; k >= 0; k--) {
-			if (bb[0][i] & 1 << k)
-				fprintf(stderr, "1");
-			else
-				fprintf(stderr, "0");
+	// validate message as we can
+	if((bb[0][2] & 48) == 0 && (
+				(bb[0][2] & 3) == 3 ||
+				(bb[0][2] & 9) == 9 ||
+				(bb[0][2] & 12) == 12 ||
+				(bb[0][2] & 6) == 6) ) {
+
+		fprintf(stderr, "------------------------------\n");
+		fprintf(stderr, "protocol       = Cardin S466\n");
+		fprintf(stderr, "message        = ");
+		for (i=0 ; i<3 ; i++) {
+			for (k = 7; k >= 0; k--) {
+				if (bb[0][i] & 1 << k)
+					fprintf(stderr, "1");
+				else
+					fprintf(stderr, "0");
+			}
+			fprintf(stderr, " ");
 		}
-		fprintf(stderr, " ");
-	}
-	if(bb[0][2] == 0) {
-		fprintf(stderr, "\npartial message - abording\n");
-		return 0;
-	}
-	fprintf(stderr, "\n\n");
+		fprintf(stderr, "\n\n");
 
-	// Dip 1
-	if(bb[0][0] & 8) {
-		dip[0]='o';
-		if(bb[0][1] & 8)
-			dip[0]='+';
-	}
-	// Dip 2
-	if(bb[0][0] & 16) {
-		dip[1]='o';
-		if(bb[0][1] & 16)
-			dip[1]='+';
-	}
-	// Dip 3
-	if(bb[0][0] & 32) {
-		dip[2]='o';
-		if(bb[0][1] & 32)
-			dip[2]='+';
-	}
-	// Dip 4
-	if(bb[0][0] & 64) {
-		dip[3]='o';
-		if(bb[0][1] & 64)
-			dip[3]='+';
-	}
-	// Dip 5
-	if(bb[0][0] & 128) {
-		dip[4]='o';
-		if(bb[0][1] & 128)
-			dip[4]='+';
-	}
-	// Dip 6
-	if(bb[0][2] & 128) {
-		dip[5]='o';
-		if(bb[0][2] & 64)
-			dip[5]='+';
-	}
-	// Dip 7
-	if(bb[0][0] & 1) {
-		dip[6]='o';
-		if(bb[0][1] & 1)
-			dip[6]='+';
-	}
-	// Dip 8
-	if(bb[0][0] & 2) {
-		dip[7]='o';
-		if(bb[0][1] & 2)
-			dip[7]='+';
-	}
-	// Dip 9
-	if(bb[0][0] & 4) {
-		dip[8]='o';
-		if(bb[0][1] & 4)
-			dip[8]='+';
-	}
+		// Dip 1
+		if(bb[0][0] & 8) {
+			dip[0]='o';
+			if(bb[0][1] & 8)
+				dip[0]='+';
+		}
+		// Dip 2
+		if(bb[0][0] & 16) {
+			dip[1]='o';
+			if(bb[0][1] & 16)
+				dip[1]='+';
+		}
+		// Dip 3
+		if(bb[0][0] & 32) {
+			dip[2]='o';
+			if(bb[0][1] & 32)
+				dip[2]='+';
+		}
+		// Dip 4
+		if(bb[0][0] & 64) {
+			dip[3]='o';
+			if(bb[0][1] & 64)
+				dip[3]='+';
+		}
+		// Dip 5
+		if(bb[0][0] & 128) {
+			dip[4]='o';
+			if(bb[0][1] & 128)
+				dip[4]='+';
+		}
+		// Dip 6
+		if(bb[0][2] & 128) {
+			dip[5]='o';
+			if(bb[0][2] & 64)
+				dip[5]='+';
+		}
+		// Dip 7
+		if(bb[0][0] & 1) {
+			dip[6]='o';
+			if(bb[0][1] & 1)
+				dip[6]='+';
+		}
+		// Dip 8
+		if(bb[0][0] & 2) {
+			dip[7]='o';
+			if(bb[0][1] & 2)
+				dip[7]='+';
+		}
+		// Dip 9
+		if(bb[0][0] & 4) {
+			dip[8]='o';
+			if(bb[0][1] & 4)
+				dip[8]='+';
+		}
 
-	fprintf(stderr, "                 123456789\n");
-	fprintf(stderr, "dipswitch      = %s\n\n",dip);
+		fprintf(stderr, "                 123456789\n");
+		fprintf(stderr, "dipswitch      = %s\n\n",dip);
 
-        fprintf(stderr, "                 -->ON\n");
-	fprintf(stderr, "right button   = ");
-	if((bb[0][2] & 3) == 3) {
-		fprintf(stderr,                  "2 --o (this is right button)\n");
-		fprintf(stderr, "                 1 --o\n");
-	}
-	if((bb[0][2] & 9) == 9) {
-		fprintf(stderr,                  "2 --o (this is right button)\n");
-		fprintf(stderr, "                 1 o--\n");
-	}
-	if((bb[0][2] & 12) == 12) {
-		fprintf(stderr,                  "2 o-- (this is left button or two buttons on same channel)\n");
-		fprintf(stderr, "                 1 o--\n");
-	}
-	if((bb[0][2] & 6) == 6) {
-		fprintf(stderr,                  "2 o-- (this is right button)\n");
-		fprintf(stderr, "                 1 --o\n");
-	}
+		fprintf(stderr, "                 -->ON\n");
+		fprintf(stderr, "right button   = ");
+		if((bb[0][2] & 3) == 3) {
+			fprintf(stderr,                  "2 --o (this is right button)\n");
+			fprintf(stderr, "                 1 --o\n");
+		}
+		if((bb[0][2] & 9) == 9) {
+			fprintf(stderr,                  "2 --o (this is right button)\n");
+			fprintf(stderr, "                 1 o--\n");
+		}
+		if((bb[0][2] & 12) == 12) {
+			fprintf(stderr,                  "2 o-- (this is left button or two buttons on same channel)\n");
+			fprintf(stderr, "                 1 o--\n");
+		}
+		if((bb[0][2] & 6) == 6) {
+			fprintf(stderr,                  "2 o-- (this is right button)\n");
+			fprintf(stderr, "                 1 --o\n");
+		}
 
-	return 1;
+		return 1;
+	}
+	return 0;
 }
 
 r_device cardin = {

--- a/src/devices/cardin.c
+++ b/src/devices/cardin.c
@@ -16,7 +16,7 @@ static int cardin_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_pe
 	unsigned char dip[10] = {'-','-','-','-','-','-','-','-','-', '\0'};
 
 	// validate message as we can
-	if((bb[0][2] & 48) == 0 && (
+	if((bb[0][2] & 48) == 0 && bits_per_row[0] == 24 && (
 				(bb[0][2] & 3) == 3 ||
 				(bb[0][2] & 9) == 9 ||
 				(bb[0][2] & 12) == 12 ||


### PR DESCRIPTION
Hi,

Getting false positive with Oregon Scientific and/or Lacrosse Sensors, i've added some tests in Cardin remote control decoding.

Bits 4&5 of byte 2 must allways be 0 and 4 and bits 0-3 can only be 3, 9, 12 or 6. 24 bits Cardin remote messages are so simples that's there is nothing else to test for. The rest of the message (18 bits on 24) is the encoded dipswitchs positions.

Regards