### PR TITLE
Overall cleanup - fix most compile warnings

### DIFF
--- a/include/bitbuffer.h
+++ b/include/bitbuffer.h
@@ -17,14 +17,16 @@
 
 #define BITBUF_COLS		34		// Number of bytes in a column
 #define BITBUF_ROWS		50
+#define BITBUF_MAX_PRINT_BITS	50	// Maximum number of bits to print (in addition to hex values)
 
+typedef uint8_t bitrow_t[BITBUF_COLS];
+typedef bitrow_t bitarray_t[BITBUF_ROWS];
 
 /// Bit buffer
 typedef struct {
-	int		row_index;		// Number of active rows - 1
-	int		bit_col_index;	// Bit index into byte (0 is MSB, 7 is LSB)
-	int16_t bits_per_row[BITBUF_ROWS];
-	uint8_t bits_buffer[BITBUF_ROWS][BITBUF_COLS];
+	uint16_t	num_rows;	// Number of active rows
+	uint16_t	bits_per_row[BITBUF_ROWS];	// Number of active bits per row
+	bitarray_t	bb;			// The actual bits buffer
 } bitbuffer_t;
 
 

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -45,11 +45,9 @@
 #define	OOK_PULSE_PWM_TERNARY	7			// Pulse Width Modulation with three widths: Sync, 0, 1. Sync determined by argument
 
 extern int debug_output;
-int debug_callback(uint8_t buffer[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_row[BITBUF_ROWS]);
-
 
 struct protocol_state {
-    int (*callback)(uint8_t bits_buffer[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_row[BITBUF_ROWS]);
+    int (*callback)(bitbuffer_t *bitbuffer);
 
    // Bits state (for old sample based decoders)
     bitbuffer_t bits;

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -1,6 +1,8 @@
 #ifndef INCLUDE_RTL_433_DEVICES_H_
 #define INCLUDE_RTL_433_DEVICES_H_
 
+#include "bitbuffer.h"
+
 #define DEVICES \
 		DECL(silvercrest) \
 		DECL(rubicson) \
@@ -27,17 +29,13 @@
 		DECL(DSC)
 
 
-#define BITBUF_COLS             34
-#define BITBUF_ROWS             50
-
 typedef struct {
 	char name[256];
 	unsigned int modulation;
 	unsigned int short_limit;
 	unsigned int long_limit;
 	unsigned int reset_limit;
-	int (*json_callback)(uint8_t bits_buffer[BITBUF_ROWS][BITBUF_COLS],
-			int16_t bits_per_row[BITBUF_ROWS]);
+	int (*json_callback)(bitbuffer_t *bitbuffer);
 	unsigned int disabled;
 	unsigned long demod_arg;	// Decoder specific optional argument (may be pointer to struct)
 } r_device;

--- a/src/bitbuffer.c
+++ b/src/bitbuffer.c
@@ -16,22 +16,21 @@
 
 
 void bitbuffer_clear(bitbuffer_t *bits) {
-	bits->row_index = 0;
-	bits->bit_col_index = 0;
+	bits->num_rows = 0;
 	memset(bits->bits_per_row, 0, BITBUF_ROWS*2);
-	memset(bits->bits_buffer, 0, BITBUF_ROWS * BITBUF_COLS);
+	memset(bits->bb, 0, BITBUF_ROWS * BITBUF_COLS);
 }
 
 
 void bitbuffer_add_bit(bitbuffer_t *bits, int bit) {
-	uint16_t col_index = bits->bits_per_row[bits->row_index]/8;
+	if(bits->num_rows == 0) bits->num_rows++;	// Add first row automatically
+	uint16_t col_index = bits->bits_per_row[bits->num_rows-1] / 8;
+	uint16_t bit_index = bits->bits_per_row[bits->num_rows-1] % 8;
 	if((col_index < BITBUF_COLS)
-	&& (bits->row_index < BITBUF_ROWS)
+	&& (bits->num_rows <= BITBUF_ROWS)
 	) {
-		bits->bits_buffer[bits->row_index][col_index] |= bit << (7-bits->bit_col_index);
-		bits->bit_col_index++;
-		bits->bit_col_index %= 8;		// Wrap around
-		bits->bits_per_row[bits->row_index]++;
+		bits->bb[bits->num_rows-1][col_index] |= (bit << (7-bit_index));
+		bits->bits_per_row[bits->num_rows-1]++;
 	}
 	else {
 //		fprintf(stderr, "ERROR: bitbuffer:: Could not add more columns\n");	// Some decoders may add many columns...
@@ -40,10 +39,10 @@ void bitbuffer_add_bit(bitbuffer_t *bits, int bit) {
 
 
 void bitbuffer_add_row(bitbuffer_t *bits) {
-	if(bits->row_index < BITBUF_ROWS) {
-		bits->row_index++;
-		bits->bit_col_index = 0;
-	} 
+	if(bits->num_rows == 0) bits->num_rows++;	// Add first row automatically
+	if(bits->num_rows < BITBUF_ROWS) {
+		bits->num_rows++;
+	}
 	else {
 //		fprintf(stderr, "ERROR: bitbuffer:: Could not add more rows\n");	// Some decoders may add many rows...
 	}
@@ -51,11 +50,23 @@ void bitbuffer_add_row(bitbuffer_t *bits) {
 
 
 void bitbuffer_print(const bitbuffer_t *bits) {
-	fprintf(stderr, "bitbuffer:: row_index: %d, bit_col_index: %d\n", bits->row_index, bits->bit_col_index);
-	for (int row = 0; row <= bits->row_index; ++row) {
+	fprintf(stderr, "bitbuffer:: Number of rows: %d \n", bits->num_rows);
+	for (uint16_t row = 0; row < bits->num_rows; ++row) {
 		fprintf(stderr, "[%02d] {%d} ", row, bits->bits_per_row[row]);
-		for (int col = 0; col < (bits->bits_per_row[row]+7)/8; ++col) {
-			fprintf(stderr, "%02x ", bits->bits_buffer[row][col]);
+		for (uint16_t col = 0; col < (bits->bits_per_row[row]+7)/8; ++col) {
+			fprintf(stderr, "%02x ", bits->bb[row][col]);
+		}
+		// Print binary values also?
+		if (bits->bits_per_row[row] <= BITBUF_MAX_PRINT_BITS) {
+			fprintf(stderr, ": ");
+			for (uint16_t bit = 0; bit < bits->bits_per_row[row]; ++bit) {
+				if (bits->bb[row][bit/8] & (0x80 >> (bit % 8))) {
+					fprintf(stderr, "1");
+				} else {
+					fprintf(stderr, "0");
+				}
+				if ((bit % 8) == 7) { fprintf(stderr, " "); }	// Add byte separators
+			}
 		}
 		fprintf(stderr, "\n");
 	}

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -72,9 +72,10 @@ static int acurite_getRainfallCounter (uint8_t hibyte, uint8_t lobyte) {
     return raincounter;
 }
 
-static int acurite5n1_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_per_row[BITBUF_ROWS]) {
+int acurite5n1_callback(bitbuffer_t *bitbuffer) {
     // acurite 5n1 weather sensor decoding for rtl_433
     // Jens Jensen 2014
+	bitrow_t *bb = bitbuffer->bb;
     int i;
     uint8_t *buf = NULL;
     // run through rows til we find one with good crc (brute force)
@@ -87,7 +88,7 @@ static int acurite5n1_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits
 
     if (buf) {
         // decode packet here
-        fprintf(stdout, "Detected Acurite 5n1 sensor, %d bits\n",bits_per_row[1]);
+        fprintf(stdout, "Detected Acurite 5n1 sensor, %d bits\n",bitbuffer->bits_per_row[1]);
         if (debug_output) {
             for (i=0; i < 8; i++)
                 fprintf(stdout, "%02X ", buf[i]);
@@ -126,14 +127,12 @@ static int acurite5n1_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits
     	return 0;
     }
 
-    if (debug_output)
-    	debug_callback(bb, bits_per_row);
-
     return 1;
 }
 
-static int acurite_rain_gauge_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_row[BITBUF_ROWS]) {
-    // This needs more validation to positively identify correct sensor type, but it basically works if message is really from acurite raingauge and it doesn't have any errors
+static int acurite_rain_gauge_callback(bitbuffer_t *bitbuffer) {
+ 	bitrow_t *bb = bitbuffer->bb;
+   // This needs more validation to positively identify correct sensor type, but it basically works if message is really from acurite raingauge and it doesn't have any errors
     if ((bb[0][0] != 0) && (bb[0][1] != 0) && (bb[0][2]!=0) && (bb[0][3] == 0) && (bb[0][4] == 0)) {
 	    float total_rain = ((bb[0][1]&0xf)<<8)+ bb[0][2];
 		total_rain /= 2; // Sensor reports number of bucket tips.  Each bucket tip is .5mm
@@ -154,7 +153,8 @@ static float acurite_th_temperature(uint8_t *s){
     uint16_t shifted = (((s[1] & 0x0f) << 8) | s[2]) << 4; // Logical left shift
     return (((int16_t)shifted) >> 4) / 10.0; // Arithmetic right shift
 }
-static int acurite_th_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_row[BITBUF_ROWS]) {
+static int acurite_th_callback(bitbuffer_t *bitbuffer) {
+	bitrow_t *bb = bitbuffer->bb;
     uint8_t *buf = NULL;
     int i;
     for(i = 0; i < BITBUF_ROWS; i++){
@@ -175,28 +175,34 @@ static int acurite_th_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bit
 }
 
 r_device acurite5n1 = {
-    /* .name           = */ "Acurite 5n1 Weather Station",
-    /* .modulation     = */ OOK_PWM_P,
-    /* .short_limit    = */ 70,
-    /* .long_limit     = */ 240,
-    /* .reset_limit    = */ 21000,
-    /* .json_callback  = */ &acurite5n1_callback,
+    .name           = "Acurite 5n1 Weather Station",
+    .modulation     = OOK_PWM_P,
+    .short_limit    = 70,
+    .long_limit     = 240,
+    .reset_limit    = 21000,
+    .json_callback  = &acurite5n1_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
 };
 
 r_device acurite_rain_gauge = {
-    /* .name           = */ "Acurite 896 Rain Gauge",
-    /* .modulation     = */ OOK_PWM_D,
-    /* .short_limit    = */ 1744/4,
-    /* .long_limit     = */ 3500/4,
-    /* .reset_limit    = */ 5000/4,
-    /* .json_callback  = */ &acurite_rain_gauge_callback,
+    .name           = "Acurite 896 Rain Gauge",
+    .modulation     = OOK_PWM_D,
+    .short_limit    = 1744/4,
+    .long_limit     = 3500/4,
+    .reset_limit    = 5000/4,
+    .json_callback  = &acurite_rain_gauge_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
 };
 
 r_device acurite_th = {
-    /* .name           = */ "Acurite Temperature and Humidity Sensor",
-    /* .modulation     = */ OOK_PWM_D,
-    /* .short_limit    = */ 300,
-    /* .long_limit     = */ 550,
-    /* .reset_limit    = */ 2500,
-    /* .json_callback  = */ &acurite_th_callback,
+    .name           = "Acurite Temperature and Humidity Sensor",
+    .modulation     = OOK_PWM_D,
+    .short_limit    = 300,
+    .long_limit     = 550,
+    .reset_limit    = 2500,
+    .json_callback  = &acurite_th_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
 };

--- a/src/devices/alecto.c
+++ b/src/devices/alecto.c
@@ -59,7 +59,8 @@ uint8_t bcd_decode8(uint8_t x) {
     return ((x & 0xF0) >> 4) * 10 + (x & 0x0F);
 }
 
-static int alectov1_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_row[BITBUF_ROWS]) {
+static int alectov1_callback(bitbuffer_t *bitbuffer) {
+    bitrow_t *bb = bitbuffer->bb;
     int temperature_before_dec;
     int temperature_after_dec;
     int16_t temp;
@@ -168,7 +169,6 @@ static int alectov1_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_
          /*
          * fprintf(stdout, "L2M: %02x %02x %02x %02x %02x\n",reverse8(bb[1][0]),reverse8(bb[1][1]),reverse8(bb[1][2]),reverse8(bb[1][3]),reverse8(bb[1][4]));
          */
-            debug_callback(bb, bits_per_row);
         }
         return 1;
     }
@@ -177,12 +177,12 @@ static int alectov1_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_
 
 //Timing based on 250000
 r_device alectov1 = {
-    /* .name           = */ "AlectoV1 Weather Sensor (Alecto WS3500 WS4500 Ventus W155/W044 Oregon)",
-    /* .modulation     = */ OOK_PWM_D,
-    /* .short_limit    = */ 3500 / 4, //875
-    /* .long_limit     = */ 7000 / 4, //1750
-    /* .reset_limit    = */ 15000 / 4, //3750
-    /* .json_callback  = */ &alectov1_callback,
-    /* .Disable        = */ 0,
-    /* .demod_arg      = */ 0,
+    .name           = "AlectoV1 Weather Sensor (Alecto WS3500 WS4500 Ventus W155/W044 Oregon)",
+    .modulation     = OOK_PWM_D,
+    .short_limit    = 3500 / 4, //875
+    .long_limit     = 7000 / 4, //1750
+    .reset_limit    = 15000 / 4, //3750
+    .json_callback  = &alectov1_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
 };

--- a/src/devices/ambient_weather.c
+++ b/src/devices/ambient_weather.c
@@ -93,8 +93,9 @@ get_channel (uint8_t * msg)
 }
 
 static int
-ambient_weather_parser (uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_row[BITBUF_ROWS])
+ambient_weather_parser (bitbuffer_t *bitbuffer)
 {
+  bitrow_t *bb = bitbuffer->bb;
   /* shift all the bits left 1 to align the fields */
   int i;
   for (i = 0; i < BITBUF_COLS-1; i++) {
@@ -132,23 +133,25 @@ ambient_weather_parser (uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_r
 
     uint16_t deviceID = get_device_id (bb[0]);
     fprintf (stderr, "id            = %d\n", deviceID);
-
-  } 
+    return 1;
+  }
 
   return 0;
 }
 
 static int
-ambient_weather_callback (uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_row[BITBUF_ROWS])
+ambient_weather_callback (bitbuffer_t *bitbuffer)
 {
-  return ambient_weather_parser (bb, bits_per_row);
+  return ambient_weather_parser (bitbuffer);
 }
 
 r_device ambient_weather = {
-    /* .name           = */ "Ambient Weather Temperature Sensor",
-    /* .modulation     = */ OOK_PULSE_MANCHESTER_ZEROBIT,
-    /* .short_limit    = */ 125,
-    /* .long_limit     = */ 0, // not used
-    /* .reset_limit    = */ 600,
-    /* .json_callback  = */ &ambient_weather_callback,
+    .name           = "Ambient Weather Temperature Sensor",
+    .modulation     = OOK_PULSE_MANCHESTER_ZEROBIT,
+    .short_limit    = 125,
+    .long_limit     = 0, // not used
+    .reset_limit    = 600,
+    .json_callback  = &ambient_weather_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
 };

--- a/src/devices/calibeur.c
+++ b/src/devices/calibeur.c
@@ -33,13 +33,16 @@
 #include "rtl_433.h"
 #include "util.h"
 
-static int calibeur_rf104_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_row[BITBUF_ROWS]) {
+//static int calibeur_rf104_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_row[BITBUF_ROWS]) {
+static int calibeur_rf104_callback(bitbuffer_t *bitbuffer) {
+
 	uint8_t ID;
 	float temperature;
 	float humidity;
+	bitrow_t *bb = bitbuffer->bb;
 
 	// Validate package (row [0] is empty due to sync bit)
-	if ((bits_per_row[1] == 21)			// Dont waste time on a long/short package
+	if ((bitbuffer->bits_per_row[1] == 21)			// Dont waste time on a long/short package
 	 && (crc8(bb[1], 3, 0x80) != 0)		// It should be odd parity
 	 && (memcmp(bb[1], bb[2], 3) == 0)	// We want at least two messages in a row
 	)
@@ -77,9 +80,6 @@ static int calibeur_rf104_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t
 		fprintf(stdout, "ID          = 0x%02X\n", ID);
 		fprintf(stdout, "temperature = %.1f C\n", temperature);
 		fprintf(stdout, "humidity    = %2.0f %%\n", humidity);
-
-		if (debug_output)
-			debug_callback(bb, bits_per_row);
 
 		return 1;
 	}

--- a/src/devices/cardin.c
+++ b/src/devices/cardin.c
@@ -11,12 +11,13 @@
  * published by the Free Software Foundation.
  */
 
-static int cardin_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_row[BITBUF_ROWS]) {
+static int cardin_callback(bitbuffer_t *bitbuffer) {
+	bitrow_t *bb = bitbuffer->bb;
 	int i, j, k;
 	unsigned char dip[10] = {'-','-','-','-','-','-','-','-','-', '\0'};
 
 	// validate message as we can
-	if((bb[0][2] & 48) == 0 && bits_per_row[0] == 24 && (
+	if((bb[0][2] & 48) == 0 && bitbuffer->bits_per_row[0] == 24 && (
 				(bb[0][2] & 3) == 3 ||
 				(bb[0][2] & 9) == 9 ||
 				(bb[0][2] & 12) == 12 ||
@@ -119,12 +120,12 @@ static int cardin_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_pe
 }
 
 r_device cardin = {
-    /* .name           = */ "Cardin S466-TX2",
-    /* .modulation     = */ OOK_PULSE_PPM_RAW,
-    /* .short_limit    = */ 303,
-    /* .long_limit     = */ 400,
-    /* .reset_limit    = */ 8000,
-    /* .json_callback  = */ &cardin_callback,
-    /* .disabled       = */ 0,
-    /* .json_callback  = */ //&debug_callback,
+    .name           = "Cardin S466-TX2",
+    .modulation     = OOK_PULSE_PPM_RAW,
+    .short_limit    = 303,
+    .long_limit     = 400,
+    .reset_limit    = 8000,
+    .json_callback  = &cardin_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
 };

--- a/src/devices/dsc.c
+++ b/src/devices/dsc.c
@@ -11,9 +11,10 @@
  */
 #include "rtl_433.h"
 
-static int DSC_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_row[BITBUF_ROWS]) {
+static int DSC_callback(bitbuffer_t *bitbuffer) {
+	bitrow_t *bb = bitbuffer->bb;
 	// Validate package
-	if ((bits_per_row[0] >= 48)			// Dont waste time on a short package
+	if ((bitbuffer->bits_per_row[0] >= 48)	// Dont waste time on a short package
 	 && (bb[0][0] & 0xF0)				// First 4 bits are sync bits
 	 && (bb[0][1] & 0x08)				// Start bit
 	 && (bb[0][2] & 0x04)				// Start bit
@@ -29,9 +30,6 @@ static int DSC_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_r
 
 		fprintf(stdout, "DSC (Digital Security Controls):\n");
 		fprintf(stdout, "data    = %02X %02X %02X %02X %02X\n", bytes[0], bytes[1], bytes[2], bytes[3], bytes[4]);
-
-		if (debug_output)
-			debug_callback(bb, bits_per_row);
 
 		return 1;
 	}

--- a/src/devices/elv.c
+++ b/src/devices/elv.c
@@ -11,8 +11,9 @@ uint16_t AD_POP(uint8_t bb[BITBUF_COLS], uint8_t bits, uint8_t bit) {
     return val;
 }
 
-static int em1000_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_per_row[BITBUF_ROWS]) {
+static int em1000_callback(bitbuffer_t *bitbuffer) {
     // based on fs20.c
+    bitrow_t *bb = bitbuffer->bb;
     uint8_t dec[10];
     uint8_t bytes=0;
     uint8_t bit=18; // preamble
@@ -53,7 +54,7 @@ static int em1000_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_per
 
     // based on 15_CUL_EM.pm
     fprintf(stdout, "Energy sensor event:\n");
-    fprintf(stdout, "protocol      = ELV EM 1000, %d bits\n",bits_per_row[1]);
+    fprintf(stdout, "protocol      = ELV EM 1000, %d bits\n",bitbuffer->bits_per_row[1]);
     fprintf(stdout, "type          = EM 1000-%s\n",dec[0]>=1&&dec[0]<=3?types[dec[0]-1]:"?");
     fprintf(stdout, "code          = %d\n",dec[1]);
     fprintf(stdout, "seqno         = %d\n",dec[2]);
@@ -64,8 +65,9 @@ static int em1000_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_per
     return 1;
 }
 
-static int ws2000_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_per_row[BITBUF_ROWS]) {
+static int ws2000_callback(bitbuffer_t *bitbuffer) {
     // based on http://www.dc3yc.privat.t-online.de/protocol.htm
+    bitrow_t *bb = bitbuffer->bb;
     uint8_t dec[13];
     uint8_t nibbles=0;
     uint8_t bit=11; // preamble
@@ -114,7 +116,7 @@ static int ws2000_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_per
 //for (i = 0; i < nibbles; i++) fprintf(stdout, "%02X ", dec[i]); fprintf(stdout, "\n");
 
     fprintf(stdout, "Weather station sensor event:\n");
-    fprintf(stdout, "protocol      = ELV WS 2000, %d bits\n",bits_per_row[1]);
+    fprintf(stdout, "protocol      = ELV WS 2000, %d bits\n",bitbuffer->bits_per_row[1]);
     fprintf(stdout, "type (!=ToDo) = %s\n", dec[0]<=7?types[dec[0]]:"?");
     fprintf(stdout, "code          = %d\n", dec[1]&7);
     fprintf(stdout, "temp          = %s%d.%d\n", dec[1]&8?"-":"", dec[4]*10+dec[3], dec[2]);
@@ -127,19 +129,23 @@ static int ws2000_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_per
 }
 
 r_device elv_em1000 = {
-    /* .name           = */ "ELV EM 1000",
-    /* .modulation     = */ OOK_PWM_D,
-    /* .short_limit    = */ 750/4,
-    /* .long_limit     = */ 7250/4,
-    /* .reset_limit    = */ 30000/4,
-    /* .json_callback  = */ &em1000_callback,
+    .name           = "ELV EM 1000",
+    .modulation     = OOK_PWM_D,
+    .short_limit    = 750/4,
+    .long_limit     = 7250/4,
+    .reset_limit    = 30000/4,
+    .json_callback  = &em1000_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
 };
 
 r_device elv_ws2000 = {
-    /* .name           = */ "ELV WS 2000",
-    /* .modulation     = */ OOK_PWM_D,
-    /* .short_limit    = */ (602+(1155-602)/2)/4,
-    /* .long_limit     = */ ((1755635-1655517)/2)/4, // no repetitions
-    /* .reset_limit    = */ ((1755635-1655517)*2)/4,
-    /* .json_callback  = */ &ws2000_callback,
+    .name           = "ELV WS 2000",
+    .modulation     = OOK_PWM_D,
+    .short_limit    = (602+(1155-602)/2)/4,
+    .long_limit     = ((1755635-1655517)/2)/4, // no repetitions
+    .reset_limit    = ((1755635-1655517)*2)/4,
+    .json_callback  = &ws2000_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
 };

--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -29,7 +29,8 @@
 #include "rtl_433.h"
 #include "util.h"
 
-static int fineoffset_WH2_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_row[BITBUF_ROWS]) {
+static int fineoffset_WH2_callback(bitbuffer_t *bitbuffer) {
+    bitrow_t *bb = bitbuffer->bb;
     uint8_t ID;
     float temperature;
     float humidity;
@@ -37,7 +38,7 @@ static int fineoffset_WH2_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t
     const uint8_t polynomial = 0x31;    // x8 + x5 + x4 + 1 (x8 is implicit)
 
     // Validate package
-    if (bits_per_row[0] >= 48 &&        // Dont waste time on a short package
+    if (bitbuffer->bits_per_row[0] >= 48 &&         // Dont waste time on a short package
         bb[0][0] == 0xFF &&             // Preamble
         bb[0][5] == crc8(&bb[0][1], 4, polynomial)	// CRC (excluding preamble)
     ) 
@@ -63,10 +64,6 @@ static int fineoffset_WH2_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t
         fprintf(stdout, "ID          = 0x%2X\n", ID);
         fprintf(stdout, "temperature = %.1f C\n", temperature);
         fprintf(stdout, "humidity    = %2.0f %%\n", humidity);
-        // fprintf(stdout, "raw         = %02x %02x %02x %02x %02x %02x\n",bb[0][0],bb[0][1],bb[0][2],bb[0][3],bb[0][4],bb[0][5]);
-
-        if (debug_output)
-            debug_callback(bb, bits_per_row);
 
         return 1;
     }
@@ -75,12 +72,14 @@ static int fineoffset_WH2_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t
 
 
 r_device fineoffset_WH2 = {
-    /* .name           = */ "Fine Offset Electronics, WH-2 Sensor",
-    /* .modulation     = */ OOK_PULSE_PWM_RAW,
-    /* .short_limit    = */ 200,	// Short pulse 136, long pulse 381, fixed gap 259
-    /* .long_limit     = */ 700,	// Maximum pulse period (long pulse + fixed gap)
-    /* .reset_limit    = */ 700,	// We just want 1 package
-    /* .json_callback  = */ &fineoffset_WH2_callback,
+    .name           = "Fine Offset Electronics, WH-2 Sensor",
+    .modulation     = OOK_PULSE_PWM_RAW,
+    .short_limit    = 200,	// Short pulse 136, long pulse 381, fixed gap 259
+    .long_limit     = 700,	// Maximum pulse period (long pulse + fixed gap)
+    .reset_limit    = 700,	// We just want 1 package
+    .json_callback  = &fineoffset_WH2_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
 };
 
 

--- a/src/devices/intertechno.c
+++ b/src/devices/intertechno.c
@@ -1,6 +1,7 @@
 #include "rtl_433.h"
 
-static int intertechno_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_row[BITBUF_ROWS]) {
+static int intertechno_callback(bitbuffer_t *bitbuffer) {
+    bitrow_t *bb = bitbuffer->bb;
 
       //if (bb[1][1] == 0 && bb[1][0] != 0 && bb[1][3]==bb[2][3]){
       if(bb[0][0]==0 && bb[0][0] == 0 && bb[1][0] == 0x56){
@@ -16,11 +17,8 @@ static int intertechno_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bi
         fprintf(stdout, "rid            = %x\n",bb[1][7]);
         fprintf(stdout, "ADDR Slave     = %i\n",bb[1][7] & 0b00001111);
         fprintf(stdout, "ADDR Master    = %i\n",(bb[1][7] & 0b11110000) >> 4);
-	fprintf(stdout, "command        = %i\n",(bb[1][6] & 0b00000111));
+        fprintf(stdout, "command        = %i\n",(bb[1][6] & 0b00000111));
         fprintf(stdout, "%02x %02x %02x %02x %02x\n",bb[1][0],bb[1][1],bb[1][2],bb[1][3],bb[1][4]);
-
-        if (debug_output)
-            debug_callback(bb, bits_per_row);
 
         return 1;
     }
@@ -28,11 +26,12 @@ static int intertechno_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bi
 }
 
 r_device intertechno = {
-    /* .name           = */ "Intertechno 433",
-    /* .modulation     = */ OOK_PWM_D,
-    /* .short_limit    = */ 100,
-    /* .long_limit     = */ 350,
-    /* .reset_limit    = */ 3000,
-    /* .json_callback  = */ &intertechno_callback,
-    /* .json_callback  = */ //&debug_callback,
+    .name           = "Intertechno 433",
+    .modulation     = OOK_PWM_D,
+    .short_limit    = 100,
+    .long_limit     = 350,
+    .reset_limit    = 3000,
+    .json_callback  = &intertechno_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
 };

--- a/src/devices/lacrosse.c
+++ b/src/devices/lacrosse.c
@@ -119,8 +119,9 @@ static int lacrossetx_detect(uint8_t *pRow, uint8_t *msg_nybbles, int16_t rowlen
 		}
 	} else {
 	    if (debug_output) {
-		fprintf(stderr,"LaCrosse TX Invalid packet: Start %02x, bit count %d\n",
-			pRow[0], rowlen);
+		// Debug: This is very noisy
+		//fprintf(stderr,"LaCrosse TX Invalid packet: Start %02x, bit count %d\n",
+		//	pRow[0], rowlen);
 	    }
 	}
 

--- a/src/devices/mebus.c
+++ b/src/devices/mebus.c
@@ -1,6 +1,7 @@
 #include "rtl_433.h"
 
-static int mebus433_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_row[BITBUF_ROWS]) {
+static int mebus433_callback(bitbuffer_t *bitbuffer) {
+    bitrow_t *bb = bitbuffer->bb;
     int temperature_before_dec;
     int temperature_after_dec;
     int16_t temp;
@@ -29,20 +30,18 @@ static int mebus433_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_
         fprintf(stdout, "humidity       = %i%%\n", hum);
         fprintf(stdout, "%02x %02x %02x %02x %02x\n",bb[1][0],bb[1][1],bb[1][2],bb[1][3],bb[1][4]);
 
-        if (debug_output)
-            debug_callback(bb, bits_per_row);
-
         return 1;
     }
     return 0;
 }
 
 r_device mebus433 = {
-    /* .name           = */ "Mebus 433",
-    /* .modulation     = */ OOK_PWM_D,
-    /* .short_limit    = */ 300,
-    /* .long_limit     = */ 600,
-    /* .reset_limit    = */ 1500,
-    /* .json_callback  = */ &mebus433_callback,
-    /* .json_callback  = */ //&debug_callback,
+    .name           = "Mebus 433",
+    .modulation     = OOK_PWM_D,
+    .short_limit    = 300,
+    .long_limit     = 600,
+    .reset_limit    = 1500,
+    .json_callback  = &mebus433_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
 };

--- a/src/devices/newkaku.c
+++ b/src/devices/newkaku.c
@@ -1,6 +1,6 @@
 #include "rtl_433.h"
 
-static int newkaku_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_row[BITBUF_ROWS]) {
+static int newkaku_callback(bitbuffer_t *bitbuffer) {
     /* Two bits map to 2 states, 0 1 -> 0 and 1 1 -> 1 */
     /* Status bit can be 1 1 -> 1 which indicates DIM value. 4 extra bits are present with value */
     /*start pulse: 1T high, 10.44T low */
@@ -10,6 +10,7 @@ static int newkaku_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_p
     /*- 4  bit:  unit*/
     /*- [4 bit:  dim level. Present if [dim] is used, but might be present anyway...]*/
     /*- stop pulse: 1T high, 40T low */
+    bitrow_t *bb = bitbuffer->bb;
     int i;
     uint8_t tmp = 0;
     uint8_t unit = 0;
@@ -109,18 +110,18 @@ static int newkaku_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_p
         }
         fprintf(stdout, "%02x %02x %02x %02x %02x %02x %02x %02x %02x\n",
                 bb[0][0], bb[0][1], bb[0][2], bb[0][3], bb[0][4], bb[0][5], bb[0][6], bb[0][7], bb[0][8]);
-        if (debug_output)
-            debug_callback(bb, bits_per_row);
         return 1;
     }
     return 0;
 }
 
 r_device newkaku = {
-    /* .name           = */ "KlikAanKlikUit Wireless Switch",
-    /* .modulation     = */ OOK_PWM_D,
-    /* .short_limit    = */ 200,
-    /* .long_limit     = */ 800,
-    /* .reset_limit    = */ 4000,
-    /* .json_callback  = */ &newkaku_callback,
+    .name           = "KlikAanKlikUit Wireless Switch",
+    .modulation     = OOK_PWM_D,
+    .short_limit    = 200,
+    .long_limit     = 800,
+    .reset_limit    = 4000,
+    .json_callback  = &newkaku_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
 };

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -14,7 +14,8 @@
  * The sensor can be bought at Clas Ohlsen
  */
 
-static int nexus_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_per_row[BITBUF_ROWS]) {
+static int nexus_callback(bitbuffer_t *bitbuffer) {
+    bitrow_t *bb = bitbuffer->bb;
     int temperature_before_dec;
     int temperature_after_dec;
     int16_t temp;
@@ -40,9 +41,6 @@ static int nexus_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_per_
         fprintf(stdout, "Temp: %s%d.%d\n",temp<0?"-":"",temperature_before_dec,temperature_after_dec);
         fprintf(stdout, "Humidity: %d\n", humidity);
 
-        if (debug_output)
-            debug_callback(bb, bits_per_row);
-
         return 1;
     }
     return 0;
@@ -50,11 +48,13 @@ static int nexus_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_per_
 
 // timings based on samp_rate=1024000
 r_device nexus = {
-    /* .name           = */ "Nexus Temperature & Humidity Sensor",
-    /* .modulation     = */ OOK_PWM_D,
-    /* .short_limit    = */ 1744/4,
-    /* .long_limit     = */ 3500/4,
-    /* .reset_limit    = */ 5000/4,
-    /* .json_callback  = */ &nexus_callback,
+    .name           = "Nexus Temperature & Humidity Sensor",
+    .modulation     = OOK_PWM_D,
+    .short_limit    = 1744/4,
+    .long_limit     = 3500/4,
+    .reset_limit    = 5000/4,
+    .json_callback  = &nexus_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
 };
 

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -86,7 +86,8 @@ static int validate_os_v2_message(unsigned char * msg, int bits_expected, int va
   return 1;
 }
 
-static int oregon_scientific_v2_1_parser(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_row[BITBUF_ROWS]) {
+static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
+    bitrow_t *bb = bitbuffer->bb;
    // Check 2nd and 3rd bytes of stream for possible Oregon Scientific v2.1 sensor data (skip first byte to get past sync/startup bit errors)
    if ( ((bb[0][1] == 0x55) && (bb[0][2] == 0x55)) ||
 	    ((bb[0][1] == 0xAA) && (bb[0][2] == 0xAA))) {
@@ -227,7 +228,8 @@ fprintf(stdout, "Message: "); for (i=0 ; i<20 ; i++) fprintf(stdout, "%02x ", ms
    return 0;
 }
 
-static int oregon_scientific_v3_parser(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_row[BITBUF_ROWS]) {
+static int oregon_scientific_v3_parser(bitbuffer_t *bitbuffer) {
+    bitrow_t *bb = bitbuffer->bb;
 
    // Check stream for possible Oregon Scientific v3 protocol data (skip part of first and last bytes to get past sync/startup bit errors)
     if ((((bb[0][0]&0xf) == 0x0f) && (bb[0][1] == 0xff) && ((bb[0][2]&0xc0) == 0xc0)) ||
@@ -333,18 +335,20 @@ static int oregon_scientific_v3_parser(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int
    return 0;
 }
 
-static int oregon_scientific_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_row[BITBUF_ROWS]) {
- int ret = oregon_scientific_v2_1_parser(bb, bits_per_row);
+static int oregon_scientific_callback(bitbuffer_t *bitbuffer) {
+ int ret = oregon_scientific_v2_1_parser(bitbuffer);
  if (ret == 0)
-   ret = oregon_scientific_v3_parser(bb, bits_per_row);
+   ret = oregon_scientific_v3_parser(bitbuffer);
  return ret;
 }
 
 r_device oregon_scientific = {
-    /* .name           = */ "Oregon Scientific Weather Sensor",
-    /* .modulation     = */ OOK_PULSE_MANCHESTER_ZEROBIT,
-    /* .short_limit    = */ 125,
-    /* .long_limit     = */ 0, // not used
-    /* .reset_limit    = */ 600,
-    /* .json_callback  = */ &oregon_scientific_callback,
+    .name           = "Oregon Scientific Weather Sensor",
+    .modulation     = OOK_PULSE_MANCHESTER_ZEROBIT,
+    .short_limit    = 125,
+    .long_limit     = 0, // not used
+    .reset_limit    = 600,
+    .json_callback  = &oregon_scientific_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
 };

--- a/src/devices/prologue.c
+++ b/src/devices/prologue.c
@@ -20,7 +20,8 @@
  */
 #include "rtl_433.h"
 
-static int prologue_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_per_row[BITBUF_ROWS]) {
+static int prologue_callback(bitbuffer_t *bitbuffer) {
+    bitrow_t *bb = bitbuffer->bb;
     int rid;
 
     int16_t temp2;
@@ -28,14 +29,14 @@ static int prologue_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_p
     /* FIXME validate the received message better */
     if (((bb[1][0]&0xF0) == 0x90 && (bb[2][0]&0xF0) == 0x90 && (bb[3][0]&0xF0) == 0x90 && (bb[4][0]&0xF0) == 0x90 &&
         (bb[5][0]&0xF0) == 0x90 && (bb[6][0]&0xF0) == 0x90) ||
-        ((bb[1][0]&0xF0) == 0x50 && (bb[2][0]&0xF0) == 0x50 && (bb[3][0]&0xF0) == 0x50 && (bb[4][0]&0xF0) == 0x50) &&
-        (bb[1][3] == bb[2][3]) && (bb[1][4] == bb[2][4])) {
+        ((bb[1][0]&0xF0) == 0x50 && (bb[2][0]&0xF0) == 0x50 && (bb[3][0]&0xF0) == 0x50 && (bb[4][0]&0xF0) == 0x50 &&
+        (bb[1][3] == bb[2][3]) && (bb[1][4] == bb[2][4]))) {
 
         /* Prologue sensor */
         temp2 = (int16_t)((uint16_t)(bb[1][2] << 8) | (bb[1][3]&0xF0));
         temp2 = temp2 >> 4;
         fprintf(stdout, "Sensor temperature event:\n");
-        fprintf(stdout, "protocol      = Prologue, %d bits\n",bits_per_row[1]);
+        fprintf(stdout, "protocol      = Prologue, %d bits\n",bitbuffer->bits_per_row[1]);
         fprintf(stdout, "button        = %d\n",bb[1][1]&0x04?1:0);
         fprintf(stdout, "battery       = %s\n",bb[1][1]&0x08?"Ok":"Low");
         fprintf(stdout, "temp          = %s%d.%d\n",temp2<0?"-":"",abs((int16_t)temp2/10),abs((int16_t)temp2%10));
@@ -45,22 +46,18 @@ static int prologue_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_p
         rid = ((bb[1][0]&0x0F)<<4)|(bb[1][1]&0xF0)>>4;
         fprintf(stdout, "rid           = %d\n", rid);
         fprintf(stdout, "hrid          = %02x\n", rid);
-
-        fprintf(stdout, "%02x %02x %02x %02x %02x\n",bb[1][0],bb[1][1],bb[1][2],bb[1][3],bb[1][4]);
-
-        if (debug_output)
-            debug_callback(bb, bits_per_row);
-
         return 1;
     }
     return 0;
 }
 
 r_device prologue = {
-    /* .name           = */ "Prologue Temperature Sensor",
-    /* .modulation     = */ OOK_PULSE_PPM_RAW,
-    /* .short_limit    = */ 3500/4,
-    /* .long_limit     = */ 7000/4,
-    /* .reset_limit    = */ 2500,
-    /* .json_callback  = */ &prologue_callback,
+    .name           = "Prologue Temperature Sensor",
+    .modulation     = OOK_PULSE_PPM_RAW,
+    .short_limit    = 3500/4,
+    .long_limit     = 7000/4,
+    .reset_limit    = 2500,
+    .json_callback  = &prologue_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
 };

--- a/src/devices/rubicson.c
+++ b/src/devices/rubicson.c
@@ -14,7 +14,8 @@
  * The sensor can be bought at Kjell&Co
  */
 
-static int rubicson_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_per_row[BITBUF_ROWS]) {
+static int rubicson_callback(bitbuffer_t *bitbuffer) {
+    bitrow_t *bb = bitbuffer->bb;
     int temperature_before_dec;
     int temperature_after_dec;
     int16_t temp;
@@ -33,13 +34,10 @@ static int rubicson_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_p
         temperature_after_dec = abs(temp % 10);
 
         fprintf(stdout, "Sensor temperature event:\n");
-        fprintf(stdout, "protocol       = Rubicson/Auriol, %d bits\n",bits_per_row[1]);
+        fprintf(stdout, "protocol       = Rubicson/Auriol, %d bits\n",bitbuffer->bits_per_row[1]);
         fprintf(stdout, "rid            = %x\n",bb[0][0]);
         fprintf(stdout, "temp           = %s%d.%d\n",temp<0?"-":"",temperature_before_dec, temperature_after_dec);
         fprintf(stdout, "%02x %02x %02x %02x %02x\n",bb[1][0],bb[0][1],bb[0][2],bb[0][3],bb[0][4]);
-
-        if (debug_output)
-            debug_callback(bb, bits_per_row);
 
         return 1;
     }
@@ -48,11 +46,13 @@ static int rubicson_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_p
 
 // timings based on samp_rate=1024000
 r_device rubicson = {
-    /* .name           = */ "Rubicson Temperature Sensor",
-    /* .modulation     = */ OOK_PWM_D,
-    /* .short_limit    = */ 1744/4,
-    /* .long_limit     = */ 3500/4,
-    /* .reset_limit    = */ 5000/4,
-    /* .json_callback  = */ &rubicson_callback,
+    .name           = "Rubicson Temperature Sensor",
+    .modulation     = OOK_PWM_D,
+    .short_limit    = 1744/4,
+    .long_limit     = 3500/4,
+    .reset_limit    = 5000/4,
+    .json_callback  = &rubicson_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
 };
 

--- a/src/devices/silvercrest.c
+++ b/src/devices/silvercrest.c
@@ -1,6 +1,7 @@
 #include "rtl_433.h"
 
-static int silvercrest_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_per_row[BITBUF_ROWS]) {
+static int silvercrest_callback(bitbuffer_t *bitbuffer) {
+    bitrow_t *bb = bitbuffer->bb;
     /* FIXME validate the received message better */
     if (bb[1][0] == 0xF8 &&
         bb[2][0] == 0xF8 &&
@@ -12,11 +13,8 @@ static int silvercrest_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bit
         bb[4][1] == 0x4d) {
         /* Pretty sure this is a Silvercrest remote */
         fprintf(stdout, "Remote button event:\n");
-        fprintf(stdout, "model = Silvercrest, %d bits\n",bits_per_row[1]);
+        fprintf(stdout, "model = Silvercrest, %d bits\n",bitbuffer->bits_per_row[1]);
         fprintf(stdout, "%02x %02x %02x %02x %02x\n",bb[1][0],bb[0][1],bb[0][2],bb[0][3],bb[0][4]);
-
-        if (debug_output)
-            debug_callback(bb, bits_per_row);
 
         return 1;
     }
@@ -24,10 +22,12 @@ static int silvercrest_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bit
 }
 
 r_device silvercrest = {
-    /* .name           = */ "Silvercrest Remote Control",
-    /* .modulation     = */ OOK_PWM_P,
-    /* .short_limit    = */ 600/4,
-    /* .long_limit     = */ 5000/4,
-    /* .reset_limit    = */ 15000/4,
-    /* .json_callback  = */ &silvercrest_callback,
+    .name           = "Silvercrest Remote Control",
+    .modulation     = OOK_PWM_P,
+    .short_limit    = 600/4,
+    .long_limit     = 5000/4,
+    .reset_limit    = 15000/4,
+    .json_callback  = &silvercrest_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
 };

--- a/src/devices/steffen.c
+++ b/src/devices/steffen.c
@@ -1,11 +1,12 @@
 #include "rtl_433.h"
 
-static int steffen_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_per_row[BITBUF_ROWS]) {
+static int steffen_callback(bitbuffer_t *bitbuffer) {
+    bitrow_t *bb = bitbuffer->bb;
 
     if (bb[0][0]==0x00 && ((bb[1][0]&0x07)==0x07) && bb[1][0]==bb[2][0] && bb[2][0]==bb[3][0]) {
 
         fprintf(stdout, "Remote button event:\n");
-        fprintf(stdout, "model   = Steffan Switch Transmitter, %d bits\n",bits_per_row[1]);
+        fprintf(stdout, "model   = Steffan Switch Transmitter, %d bits\n",bitbuffer->bits_per_row[1]);
 	fprintf(stdout, "code    = %d%d%d%d%d\n", (bb[1][0]&0x80)>>7, (bb[1][0]&0x40)>>6, (bb[1][0]&0x20)>>5, (bb[1][0]&0x10)>>4, (bb[1][0]&0x08)>>3);
 
 	if ((bb[1][2]&0x0f)==0x0e)
@@ -27,19 +28,18 @@ static int steffen_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_pe
             fprintf(stdout, "state   = ON\n");
         }
 
-        if (debug_output)
-            debug_callback(bb, bits_per_row);
-
         return 1;
     }
     return 0;
 }
 
 r_device steffen = {
-    /* .name           = */ "Steffen Switch Transmitter",
-    /* .modulation     = */ OOK_PWM_D,
-    /* .short_limit    = */ 140,
-    /* .long_limit     = */ 270,
-    /* .reset_limit    = */ 1500,
-    /* .json_callback  = */ &steffen_callback,
+    .name           = "Steffen Switch Transmitter",
+    .modulation     = OOK_PWM_D,
+    .short_limit    = 140,
+    .long_limit     = 270,
+    .reset_limit    = 1500,
+    .json_callback  = &steffen_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
 };

--- a/src/devices/waveman.c
+++ b/src/devices/waveman.c
@@ -1,6 +1,7 @@
 #include "rtl_433.h"
 
-static int waveman_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_per_row[BITBUF_ROWS]) {
+static int waveman_callback(bitbuffer_t *bitbuffer) {
+    bitrow_t *bb = bitbuffer->bb;
     /* Two bits map to 2 states, 0 1 -> 0 and 1 1 -> 1 */
     int i;
     uint8_t nb[3] = {0};
@@ -14,15 +15,12 @@ static int waveman_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_pe
         }
 
         fprintf(stdout, "Remote button event:\n");
-        fprintf(stdout, "model   = Waveman Switch Transmitter, %d bits\n",bits_per_row[1]);
+        fprintf(stdout, "model   = Waveman Switch Transmitter, %d bits\n",bitbuffer->bits_per_row[1]);
         fprintf(stdout, "id      = %c\n", 'A'+nb[0]);
         fprintf(stdout, "channel = %d\n", (nb[1]>>2)+1);
         fprintf(stdout, "button  = %d\n", (nb[1]&3)+1);
         fprintf(stdout, "state   = %s\n", (nb[2]==0xe) ? "on" : "off");
         fprintf(stdout, "%02x %02x %02x\n",nb[0],nb[1],nb[2]);
-
-        if (debug_output)
-            debug_callback(bb, bits_per_row);
 
         return 1;
     }
@@ -30,10 +28,12 @@ static int waveman_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS],int16_t bits_pe
 }
 
 r_device waveman = {
-    /* .name           = */ "Waveman Switch Transmitter",
-    /* .modulation     = */ OOK_PWM_P,
-    /* .short_limit    = */ 1000/4,
-    /* .long_limit     = */ 8000/4,
-    /* .reset_limit    = */ 30000/4,
-    /* .json_callback  = */ &waveman_callback,
+    .name           = "Waveman Switch Transmitter",
+    .modulation     = OOK_PWM_P,
+    .short_limit    = 1000/4,
+    .long_limit     = 8000/4,
+    .reset_limit    = 30000/4,
+    .json_callback  = &waveman_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
 };

--- a/src/devices/x10_rf.c
+++ b/src/devices/x10_rf.c
@@ -11,10 +11,11 @@
  */
 #include "rtl_433.h"
 
-static int X10_RF_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_per_row[BITBUF_ROWS]) {
+static int X10_RF_callback(bitbuffer_t *bitbuffer) {
+    bitrow_t *bb = bitbuffer->bb;
 	// Row [0] is sync pulse
 	// Validate package
-	if ((bits_per_row[1] == 32)		// Dont waste time on a short package
+	if ((bitbuffer->bits_per_row[1] == 32)		// Dont waste time on a short package
 	// && (bb[1][0] == (uint8_t)(~bb[1][1]))		// Check integrity - apparently some chips may use both bytes..
 	 && (bb[1][2] == (uint8_t)(~bb[1][3]))		// Check integrity
 	)
@@ -22,11 +23,8 @@ static int X10_RF_callback(uint8_t bb[BITBUF_ROWS][BITBUF_COLS], int16_t bits_pe
 		fprintf(stdout, "X10 RF:\n");
 		fprintf(stdout, "data    = %02X %02X %02X %02X\n", bb[1][0], bb[1][1], bb[1][2], bb[1][3]);
 
-		if (debug_output)
-			debug_callback(bb, bits_per_row);
-
 		return 1;
-    }
+	}
 	return 0;
 }
 

--- a/src/pulse_demod.c
+++ b/src/pulse_demod.c
@@ -55,7 +55,7 @@ int pulse_demod_pcm_rz(const pulse_data_t *pulses, struct protocol_state *device
 			}
 			// Debug printout
 			if(!device->callback || (debug_output && events > 0)) {
-				fprintf(stderr, "pulse_demod_pcm(): %s \n", device->name);
+				fprintf(stderr, "\npulse_demod_pcm(): %s \n", device->name);
 				bitbuffer_print(&bits);
 			}
 			bitbuffer_clear(&bits);
@@ -86,7 +86,7 @@ int pulse_demod_ppm(const pulse_data_t *pulses, struct protocol_state *device) {
 			}
 			// Debug printout
 			if(!device->callback || (debug_output && events > 0)) {
-				fprintf(stderr, "pulse_demod_ppm(): %s \n", device->name);
+				fprintf(stderr, "\npulse_demod_ppm(): %s \n", device->name);
 				bitbuffer_print(&bits);
 			}
 			bitbuffer_clear(&bits);
@@ -121,7 +121,7 @@ int pulse_demod_pwm(const pulse_data_t *pulses, struct protocol_state *device) {
 			}
 			// Debug printout
 			if(!device->callback || (debug_output && events > 0)) {
-				fprintf(stderr, "pulse_demod_pwm(): %s \n", device->name);
+				fprintf(stderr, "\npulse_demod_pwm(): %s \n", device->name);
 				bitbuffer_print(&bits);
 			}
 			bitbuffer_clear(&bits);
@@ -175,7 +175,7 @@ int pulse_demod_pwm_ternary(const pulse_data_t *pulses, struct protocol_state *d
 			}
 			// Debug printout
 			if(!device->callback || (debug_output && events > 0)) {
-				fprintf(stderr, "pulse_demod_pwm_ternary(): %s \n", device->name);
+				fprintf(stderr, "\npulse_demod_pwm_ternary(): %s \n", device->name);
 				bitbuffer_print(&bits);
 			}
 			bitbuffer_clear(&bits);
@@ -212,7 +212,7 @@ int pulse_demod_manchester_zerobit(const pulse_data_t *pulses, struct protocol_s
 			}
 			// Debug printout
 			if(!device->callback || (debug_output && events > 0)) {
-				fprintf(stderr, "pulse_demod_manchester_zerobit(): %s \n", device->name);
+				fprintf(stderr, "\npulse_demod_manchester_zerobit(): %s \n", device->name);
 				bitbuffer_print(&bits);
 			}
 			bitbuffer_clear(&bits);


### PR DESCRIPTION
- Removed debug_callback() from drivers and added consistent bitbuffer_print() in decoders
- Cleaned up drivers struct initialization
- Converted all drivers to bitbuffer for more future flexibility
