### PR TITLE
used dup2(1, 2); to redirect all output to stdout

### DIFF
--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -790,7 +790,7 @@ int main(int argc, char **argv) {
 
     setbuf(stdout, NULL);
     setbuf(stderr, NULL);
-
+    dup2(1, 2);
     demod = malloc(sizeof (struct dm_state));
     memset(demod, 0, sizeof (struct dm_state));
 


### PR DESCRIPTION
If there is any reason to keep err messages please let me know. Propose to use stdout.
As rtl libs use err forcing err to std is needed imho