### PR TITLE
Adjust low pass filtering and add hysteresis to pulse detection.

### DIFF
--- a/include/baseband.h
+++ b/include/baseband.h
@@ -1,0 +1,39 @@
+/**
+ * Baseband
+ * 
+ * Various functions for baseband sample processing
+ *
+ * Copyright (C) 2012 by Benjamin Larsson <benjamin@southpole.se>
+ * Copyright (C) 2015 Tommy Vestermark
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef INCLUDE_BASEBAND_H_
+#define INCLUDE_BASEBAND_H_
+
+#include <stdint.h>
+
+/** This will give a noisy envelope of OOK/ASK signals
+ *  Subtract the bias (-128) and get an envelope estimation
+ *  The output will be written in the input buffer
+ *  @returns   pointer to the input buffer
+ */
+void envelope_detect(unsigned char *buf, uint32_t len, int decimate);
+
+#define FILTER_ORDER 1
+
+/// Lowpass filter
+void low_pass_filter(uint16_t *x_buf, int16_t *y_buf, uint32_t len);
+
+/// Initialize tables and constants
+/// Should be called once at startup
+void baseband_init(void);
+
+/// Dump binary data (for debug purposes)
+void baseband_dumpfile(uint8_t *buf, uint32_t len);
+
+#endif /* INCLUDE_BASEBAND_H_ */

--- a/include/pulse_detect.h
+++ b/include/pulse_detect.h
@@ -24,6 +24,15 @@ typedef struct {
 	unsigned int num_pulses;
 	unsigned int pulse[PD_MAX_PULSES];	// Contains width of a pulse	(high)
 	unsigned int gap[PD_MAX_PULSES];	// Width of gaps between pulses (low)
+	// Statistics for levels
+	int16_t		pulse_max;	// Maximum level detected
+	int16_t		pulse_min;	// Minimum level detected
+	int64_t		pulse_sum;	// Sum of levels (for averaging)
+	uint32_t	pulse_num;	// Number of samples (for averaging)
+	int16_t		gap_max;	// Maximum level detected
+	int16_t		gap_min;	// Minimum level detected
+	int64_t		gap_sum;	// Sum of levels (for averaging)
+	uint32_t	gap_num;	// Number of samples (for averaging)
 } pulse_data_t;
 
 

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -31,7 +31,6 @@
 #define DEFAULT_DECIMATION_LEVEL 0
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define FILTER_ORDER            1
 #define MAX_PROTOCOLS           25
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -27,7 +27,7 @@
 #define DEFAULT_HOP_EVENTS      2
 #define DEFAULT_ASYNC_BUF_NUMBER    32
 #define DEFAULT_BUF_LENGTH      (16 * 16384)
-#define DEFAULT_LEVEL_LIMIT     10000
+#define DEFAULT_LEVEL_LIMIT     8000		// Theoretical high level at I/Q saturation is 128x128 = 16384 (above is ripple)
 #define DEFAULT_DECIMATION_LEVEL 0
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@
 ########################################################################
 add_executable(rtl_433 
 	rtl_433.c
+    baseband.c
 	bitbuffer.c
 	pulse_demod.c
 	pulse_detect.c

--- a/src/baseband.c
+++ b/src/baseband.c
@@ -23,7 +23,7 @@ static uint16_t scaled_squares[256];
 static void calc_squares() {
     int i;
     for (i = 0; i < 256; i++)
-        scaled_squares[i] = (128 - i) * (128 - i);
+        scaled_squares[i] = (127 - i) * (127 - i);
 }
 
 /** This will give a noisy envelope of OOK/ASK signals

--- a/src/baseband.c
+++ b/src/baseband.c
@@ -45,22 +45,25 @@ void envelope_detect(unsigned char *buf, uint32_t len, int decimate) {
 
 /** Something that might look like a IIR lowpass filter
  *
- *  [b,a] = butter(1, 0.01) ->  quantizes nicely thus suitable for fixed point
+ *  [b,a] = butter(1, Wc) # low pass filter with cutoff pi*Wc radians
  *  Q1.15*Q15.0 = Q16.15
  *  Q16.15>>1 = Q15.14
  *  Q15.14 + Q15.14 + Q15.14 could possibly overflow to 17.14
  *  but the b coeffs are small so it wont happen
  *  Q15.14>>14 = Q15.0 \o/
  */
-
 #define F_SCALE 15
 #define S_CONST (1<<F_SCALE)
 #define FIX(x) ((int)(x*S_CONST))
 
 static uint16_t lp_xmem[FILTER_ORDER] = {0};
 
-static int a[FILTER_ORDER + 1] = {FIX(1.00000), FIX(0.96907)};
-static int b[FILTER_ORDER + 1] = {FIX(0.015466), FIX(0.015466)};
+///  [b,a] = butter(1, 0.01) -> 3x tau (95%) ~100 samples
+//static int a[FILTER_ORDER + 1] = {FIX(1.00000), FIX(0.96907)};
+//static int b[FILTER_ORDER + 1] = {FIX(0.015466), FIX(0.015466)};
+///  [b,a] = butter(1, 0.1) -> 3x tau (95%) ~10 samples
+static int a[FILTER_ORDER + 1] = {FIX(1.00000), FIX(0.72654)};
+static int b[FILTER_ORDER + 1] = {FIX(0.13673), FIX(0.13673)};
 
 void low_pass_filter(uint16_t *x_buf, int16_t *y_buf, uint32_t len) {
     unsigned int i;

--- a/src/baseband.c
+++ b/src/baseband.c
@@ -61,9 +61,9 @@ static uint16_t lp_xmem[FILTER_ORDER] = {0};
 ///  [b,a] = butter(1, 0.01) -> 3x tau (95%) ~100 samples
 //static int a[FILTER_ORDER + 1] = {FIX(1.00000), FIX(0.96907)};
 //static int b[FILTER_ORDER + 1] = {FIX(0.015466), FIX(0.015466)};
-///  [b,a] = butter(1, 0.1) -> 3x tau (95%) ~10 samples
-static int a[FILTER_ORDER + 1] = {FIX(1.00000), FIX(0.72654)};
-static int b[FILTER_ORDER + 1] = {FIX(0.13673), FIX(0.13673)};
+///  [b,a] = butter(1, 0.05) -> 3x tau (95%) ~20 samples
+static int a[FILTER_ORDER + 1] = {FIX(1.00000), FIX(0.85408)};
+static int b[FILTER_ORDER + 1] = {FIX(0.07296), FIX(0.07296)};
 
 void low_pass_filter(uint16_t *x_buf, int16_t *y_buf, uint32_t len) {
     unsigned int i;

--- a/src/baseband.c
+++ b/src/baseband.c
@@ -1,0 +1,99 @@
+/**
+ * Baseband
+ * 
+ * Various functions for baseband sample processing
+ *
+ * Copyright (C) 2012 by Benjamin Larsson <benjamin@southpole.se>
+ * Copyright (C) 2015 Tommy Vestermark
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "baseband.h"
+#include <stdio.h>
+#include <string.h>
+
+
+static uint16_t scaled_squares[256];
+
+/* precalculate lookup table for envelope detection */
+static void calc_squares() {
+    int i;
+    for (i = 0; i < 256; i++)
+        scaled_squares[i] = (128 - i) * (128 - i);
+}
+
+/** This will give a noisy envelope of OOK/ASK signals
+ *  Subtract the bias (-128) and get an envelope estimation
+ *  The output will be written in the input buffer
+ *  @returns   pointer to the input buffer
+ */
+void envelope_detect(unsigned char *buf, uint32_t len, int decimate) {
+    uint16_t* sample_buffer = (uint16_t*) buf;
+    unsigned int i;
+    unsigned op = 0;
+    unsigned int stride = 1 << decimate;
+
+    for (i = 0; i < len / 2; i += stride) {
+        sample_buffer[op++] = scaled_squares[buf[2 * i ]] + scaled_squares[buf[2 * i + 1]];
+    }
+}
+
+
+/** Something that might look like a IIR lowpass filter
+ *
+ *  [b,a] = butter(1, 0.01) ->  quantizes nicely thus suitable for fixed point
+ *  Q1.15*Q15.0 = Q16.15
+ *  Q16.15>>1 = Q15.14
+ *  Q15.14 + Q15.14 + Q15.14 could possibly overflow to 17.14
+ *  but the b coeffs are small so it wont happen
+ *  Q15.14>>14 = Q15.0 \o/
+ */
+
+#define F_SCALE 15
+#define S_CONST (1<<F_SCALE)
+#define FIX(x) ((int)(x*S_CONST))
+
+static uint16_t lp_xmem[FILTER_ORDER] = {0};
+
+static int a[FILTER_ORDER + 1] = {FIX(1.00000), FIX(0.96907)};
+static int b[FILTER_ORDER + 1] = {FIX(0.015466), FIX(0.015466)};
+
+void low_pass_filter(uint16_t *x_buf, int16_t *y_buf, uint32_t len) {
+    unsigned int i;
+
+    /* Calculate first sample */
+    y_buf[0] = ((a[1] * y_buf[-1] >> 1) + (b[0] * x_buf[0] >> 1) + (b[1] * lp_xmem[0] >> 1)) >> (F_SCALE - 1);
+    for (i = 1; i < len; i++) {
+        y_buf[i] = ((a[1] * y_buf[i - 1] >> 1) + (b[0] * x_buf[i] >> 1) + (b[1] * x_buf[i - 1] >> 1)) >> (F_SCALE - 1);
+    }
+
+    /* Save last sample */
+    memcpy(lp_xmem, &x_buf[len - 1 - FILTER_ORDER], FILTER_ORDER * sizeof (int16_t));
+    memcpy(&y_buf[-FILTER_ORDER], &y_buf[len - 1 - FILTER_ORDER], FILTER_ORDER * sizeof (int16_t));
+    //fprintf(stderr, "%d\n", y_buf[0]);
+}
+
+
+void baseband_init(void) {
+	calc_squares();
+}
+
+
+static FILE *dumpfile = NULL;
+
+void baseband_dumpfile(uint8_t *buf, uint32_t len) {
+	if (dumpfile == NULL) {
+		dumpfile = fopen("dumpfile.dat", "wb");
+	}
+	
+	if (dumpfile == NULL) {
+		fprintf(stderr, "Error: could not open dumpfile.dat\n");
+	} else {
+		fwrite(buf, 1, len, dumpfile);
+		fflush(dumpfile);		// Flush as file is not closed cleanly...
+	}
+}

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -345,7 +345,7 @@ static int oregon_scientific_callback(bitbuffer_t *bitbuffer) {
 r_device oregon_scientific = {
     .name           = "Oregon Scientific Weather Sensor",
     .modulation     = OOK_PULSE_MANCHESTER_ZEROBIT,
-    .short_limit    = 125,
+    .short_limit    = 110, // Nominal 1024Hz (122), but pulses are shorter than pauses 
     .long_limit     = 0, // not used
     .reset_limit    = 600,
     .json_callback  = &oregon_scientific_callback,

--- a/src/pulse_demod.c
+++ b/src/pulse_demod.c
@@ -22,10 +22,11 @@ int pulse_demod_pcm_rz(const pulse_data_t *pulses, struct protocol_state *device
 	int events = 0;
 	bitbuffer_t bits = {0};
 	const int MAX_ZEROS = device->reset_limit / device->long_limit;
-	const int TOLERANCE = device->long_limit / 10;		// Tolerance is 10% of a bit period
-	
+	const int TOLERANCE = device->long_limit / 4;		// Tolerance is ±25% of a bit period
+
 	for(unsigned n = 0; n < pulses->num_pulses; ++n) {
-		int periods = (pulses->pulse[n] + pulses->gap[n] + device->long_limit/2) / device->long_limit;	// Number of bits
+		// Determine number of bit periods in current pulse/gap length (rounded)
+		int periods = (pulses->pulse[n] + pulses->gap[n] + device->long_limit/2) / device->long_limit;
 
 		// Validate data
 		if ((abs(pulses->pulse[n] - device->short_limit) < TOLERANCE)					// Pulse must be within tolerance

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -752,7 +752,7 @@ int main(int argc, char **argv) {
     demod->f_buf = &demod->filter_buffer[FILTER_ORDER];
     demod->decimation_level = DEFAULT_DECIMATION_LEVEL;
     demod->level_limit = DEFAULT_LEVEL_LIMIT;
-
+    pulse_data_clear(&demod->pulse_data);
 
     while ((opt = getopt(argc, argv, "x:z:p:Dtam:r:c:l:d:f:g:s:b:n:SR:")) != -1) {
         switch (opt) {

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -628,7 +628,7 @@ static void rtlsdr_callback(unsigned char *buf, uint32_t len, void *ctx) {
             envelope_detect(buf, len, demod->decimation_level);
             // baseband_dumpfile(buf, len);				// Debug
             low_pass_filter(sbuf, demod->f_buf, len >> (demod->decimation_level + 1));
-            // baseband_dumpfile(demod->f_buf, len);	// Debug
+            // baseband_dumpfile((uint8_t*)demod->f_buf, len);	// Debug
         } else if (demod->debug_mode == 1) {
             memcpy(demod->f_buf, buf, len);
         }

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -22,6 +22,7 @@
 
 #include "rtl-sdr.h"
 #include "rtl_433.h"
+#include "baseband.h"
 #include "pulse_detect.h"
 #include "pulse_demod.h"
 
@@ -34,7 +35,6 @@ int flag;
 uint32_t samp_rate = DEFAULT_SAMPLE_RATE;
 static uint32_t bytes_to_read = 0;
 static rtlsdr_dev_t *dev = NULL;
-static uint16_t scaled_squares[256];
 static int override_short = 0;
 static int override_long = 0;
 int debug_output = 0;
@@ -119,30 +119,6 @@ static void sighandler(int signum) {
     rtlsdr_cancel_async(dev);
 }
 #endif
-
-/* precalculate lookup table for envelope detection */
-static void calc_squares() {
-    int i;
-    for (i = 0; i < 256; i++)
-        scaled_squares[i] = (128 - i) * (128 - i);
-}
-
-/** This will give a noisy envelope of OOK/ASK signals
- *  Subtract the bias (-128) and get an envelope estimation
- *  The output will be written in the input buffer
- *  @returns   pointer to the input buffer
- */
-
-static void envelope_detect(unsigned char *buf, uint32_t len, int decimate) {
-    uint16_t* sample_buffer = (uint16_t*) buf;
-    unsigned int i;
-    unsigned op = 0;
-    unsigned int stride = 1 << decimate;
-
-    for (i = 0; i < len / 2; i += stride) {
-        sample_buffer[op++] = scaled_squares[buf[2 * i ]] + scaled_squares[buf[2 * i + 1]];
-    }
-}
 
 
 static void register_protocol(struct dm_state *demod, r_device *t_dev) {
@@ -624,40 +600,6 @@ static void pwm_p_decode(struct dm_state *demod, struct protocol_state* p, int16
 }
 
 
-/** Something that might look like a IIR lowpass filter
- *
- *  [b,a] = butter(1, 0.01) ->  quantizes nicely thus suitable for fixed point
- *  Q1.15*Q15.0 = Q16.15
- *  Q16.15>>1 = Q15.14
- *  Q15.14 + Q15.14 + Q15.14 could possibly overflow to 17.14
- *  but the b coeffs are small so it wont happen
- *  Q15.14>>14 = Q15.0 \o/
- */
-
-static uint16_t lp_xmem[FILTER_ORDER] = {0};
-
-#define F_SCALE 15
-#define S_CONST (1<<F_SCALE)
-#define FIX(x) ((int)(x*S_CONST))
-
-int a[FILTER_ORDER + 1] = {FIX(1.00000), FIX(0.96907)};
-int b[FILTER_ORDER + 1] = {FIX(0.015466), FIX(0.015466)};
-
-static void low_pass_filter(uint16_t *x_buf, int16_t *y_buf, uint32_t len) {
-    unsigned int i;
-
-    /* Calculate first sample */
-    y_buf[0] = ((a[1] * y_buf[-1] >> 1) + (b[0] * x_buf[0] >> 1) + (b[1] * lp_xmem[0] >> 1)) >> (F_SCALE - 1);
-    for (i = 1; i < len; i++) {
-        y_buf[i] = ((a[1] * y_buf[i - 1] >> 1) + (b[0] * x_buf[i] >> 1) + (b[1] * x_buf[i - 1] >> 1)) >> (F_SCALE - 1);
-    }
-
-    /* Save last sample */
-    memcpy(lp_xmem, &x_buf[len - 1 - FILTER_ORDER], FILTER_ORDER * sizeof (int16_t));
-    memcpy(&y_buf[-FILTER_ORDER], &y_buf[len - 1 - FILTER_ORDER], FILTER_ORDER * sizeof (int16_t));
-    //fprintf(stderr, "%d\n", y_buf[0]);
-}
-
 static void rtlsdr_callback(unsigned char *buf, uint32_t len, void *ctx) {
     struct dm_state *demod = ctx;
     uint16_t* sbuf = (uint16_t*) buf;
@@ -684,7 +626,9 @@ static void rtlsdr_callback(unsigned char *buf, uint32_t len, void *ctx) {
 
         if (demod->debug_mode == 0) {
             envelope_detect(buf, len, demod->decimation_level);
+            // baseband_dumpfile(buf, len);				// Debug
             low_pass_filter(sbuf, demod->f_buf, len >> (demod->decimation_level + 1));
+            // baseband_dumpfile(demod->f_buf, len);	// Debug
         } else if (demod->debug_mode == 1) {
             memcpy(demod->f_buf, buf, len);
         }
@@ -795,7 +739,7 @@ int main(int argc, char **argv) {
     memset(demod, 0, sizeof (struct dm_state));
 
     /* initialize tables */
-    calc_squares();
+    baseband_init();
 
 	r_device devices[] = {
 #define DECL(name) name,
@@ -1020,9 +964,6 @@ int main(int argc, char **argv) {
         //Always classify a signal at the end of the file
         classify_signal();
         fprintf(stderr, "Test mode file issued %d packets\n", i);
-        fprintf(stderr, "Filter coeffs used:\n");
-        fprintf(stderr, "a: %d %d\n", a[0], a[1]);
-        fprintf(stderr, "b: %d %d\n", b[0], b[1]);
         exit(0);
     }
 

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -74,7 +74,7 @@ void usage(r_device *devices) {
             "\t[-g gain (default: 0 for auto)]\n"
             "\t[-a analyze mode, print a textual description of the signal]\n"
             "\t[-t signal auto save, use it together with analyze mode (-a -t)\n"
-            "\t[-l change the detection level used to determine pulses (0-3200) default: %i]\n"
+            "\t[-l change the detection level used to determine pulses (0-32767) default: %i]\n"
             "\t[-f [-f...] receive frequency[s], default: %i Hz]\n"
             "\t[-s sample rate (default: %i Hz)]\n"
             "\t[-S force sync output (default: async)]\n"


### PR DESCRIPTION
Low pass filter was very aggressive to avoid glitches in pulse detection. That would make pulse edges soft and pulse widths dependent on detection limit/signal level.
Now decodes Acurite test files correctly and all DSC test files. No regression found for other test files (including the new Brennstuhl)

...and a bit of clean up and FSK decoding preparation.