### PR TITLE
FSK demodulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ Installation using cmake:
     cd build
     cmake ../
     make
-	make install
+    make install
 
 Installation using autoconf:
 
     cd rtl_433/
     autoreconf --install
-	./configure
-	make
-	make install
+    ./configure
+    make
+    make install
 
 
 Running:
@@ -31,24 +31,28 @@ Running:
 
     rtl_433 -h
 
-    Usage: [-d device index (default: 0)]
-           [-g gain (default: 0 for auto)]
-           [-a analyze mode, print a textual description of the signal]
-           [-t signal auto save, use it together with analyze mode (-a -t)
-           [-l change the detection level used to determine pulses (0-3200) default: 10000]
-           [-f [-f...] receive frequency[s], default: 433920000 Hz]
-           [-s sample rate (default: 250000 Hz)]
-           [-S force sync output (default: async)]
-           [-r read data from file instead of from a receiver]
-           [-p ppm_error (default: 0)]
-           [-r test file name (indata)]
-           [-m test file mode (0 rtl_sdr data, 1 rtl_433 data)]
-           [-D print debug info on event]
-           [-z override short value]
-           [-x override long value]
-           [-R listen only for the specified remote device (can be used multiple times)]
-           filename (a '-' dumps samples to stdout)
-           
+    Usage: [-d <device index>] (default: 0)
+           [-g <gain>] (default: 0 for auto)
+           [-f <frequency>] [-f...] Receive frequency(s) (default: 433920000 Hz)
+           [-p <ppm_error>] (default: 0)
+           [-s <sample rate>] Set sample rate (default: 250000 Hz)
+           [-S] Force sync output (default: async)
+           [-R <device>] Listen only for the specified remote device (can be used multiple times)
+           [-l <level>] Change detection level used to determine pulses [0-32767] (default: 8000)
+           [-z <value>] Override short value in data decoder
+           [-x <value>] Override long value in data decoder
+           [-D] Print debug info on event (repeat for more info)
+           [-a] Analyze mode. Print a textual description of the signal
+           [-t] Test signal auto save. Use it together with analyze mode (-a -t). Creates one file per signal
+                Note: Saves raw I/Q samples (uint8, 2 channel). Preferred mode for generating test files
+           [-r <filename>] Read data from input file instead of a receiver
+           [-m <mode>] Data file mode for input / output file (default: 0)
+                0 = Raw I/Q samples (uint8, 2 channel)
+                1 = AM demodulated samples (int16)
+                2 = FM demodulated samples (int16) (experimental)
+                Note: If output file is specified, input will always be I/Q
+           [<filename>] Save data stream to output file (a '-' dumps samples to stdout)
+
      Supported devices:
            [01] Silvercrest Remote Control
            [02] Rubicson Temperature Sensor
@@ -80,14 +84,21 @@ Examples:
 
 | Command | Description
 |---------|------------
-| `rtl_433 -a` | will run in analyze mode and you will get a text log of the received signal.
-| `rtl_433 -a file_name` | will save the demodulated signal in a file. The format of the file is 48kHz 16 bit samples.
-| `rtl_433` | will run the software in receive mode. Some sensor data can be receviced.
+| `rtl_433` | Will run the software in receive mode. Some sensor data can be received and decoded.
+| `rtl_433 -a` | Will run in analyze mode and you will get a text description of the received signal.
+| `rtl_433 -a -t` | Will run in analyze mode and save a test file per detected signal (gfile###.data). Format is uint8, 2 channels.
+| `rtl_433 -r file_name` | Will run with a saved test file as input data.
+| `rtl_433 file_name` | Will save the received signal data stream in a file (file may become large).
 
 This software is mostly useable for developers right now.
+
+Test Data
+------------
+
+Test data files for supported devices can be found here: https://github.com/merbanan/rtl_433_tests
+Please add test data for all devices added to the code to facilitate regression testing.
 
 Google Group
 ------------
 
 https://groups.google.com/forum/#!forum/rtl_433
-

--- a/include/baseband.h
+++ b/include/baseband.h
@@ -26,8 +26,20 @@ void envelope_detect(unsigned char *buf, uint32_t len, int decimate);
 
 #define FILTER_ORDER 1
 
+/// Filter state buffer
+typedef struct {
+	int16_t	y[FILTER_ORDER];
+	int16_t	x[FILTER_ORDER];
+} FilterState;
+
 /// Lowpass filter
-void low_pass_filter(uint16_t *x_buf, int16_t *y_buf, uint32_t len);
+///
+/// Function is stateful
+/// @param *x_buf: input samples to be filtered
+/// @param *y_buf: output from filter
+/// @param len: number of samples to process
+/// @param FilterState: State to store between chunk processing
+void baseband_low_pass_filter(const uint16_t *x_buf, int16_t *y_buf, uint32_t len, FilterState *state);
 
 /// Initialize tables and constants
 /// Should be called once at startup

--- a/include/baseband.h
+++ b/include/baseband.h
@@ -17,12 +17,13 @@
 
 #include <stdint.h>
 
-/** This will give a noisy envelope of OOK/ASK signals
- *  Subtract the bias (-128) and get an envelope estimation
- *  The output will be written in the input buffer
- *  @returns   pointer to the input buffer
- */
-void envelope_detect(unsigned char *buf, uint32_t len, int decimate);
+/// This will give a noisy envelope of OOK/ASK signals
+
+/// Subtract the bias (-128) and get an envelope estimation (absolute squared)
+/// @param *iq_buf: input samples (I/Q samples in interleaved uint8)
+/// @param *y_buf: output 
+/// @param len: number of samples to process
+void envelope_detect(const uint8_t *iq_buf, uint16_t *y_buf, uint32_t len, int decimate);
 
 #define FILTER_ORDER 1
 

--- a/include/baseband.h
+++ b/include/baseband.h
@@ -32,6 +32,11 @@ typedef struct {
 	int16_t	x[FILTER_ORDER];
 } FilterState;
 
+/// FM_Demod state buffer
+typedef struct {
+	int16_t	br, bi;		// Last I/Q sample
+} DemodFM_State;
+
 /// Lowpass filter
 ///
 /// Function is stateful
@@ -41,11 +46,20 @@ typedef struct {
 /// @param FilterState: State to store between chunk processing
 void baseband_low_pass_filter(const uint16_t *x_buf, int16_t *y_buf, uint32_t len, FilterState *state);
 
+/// FM demodulator
+///
+/// Function is stateful
+/// @param *x_buf: input samples (I/Q samples in interleaved uint8)
+/// @param *y_buf: output from FM demodulator
+/// @param len: number of samples to process
+/// @param DemodFM_State: State to store between chunk processing
+void baseband_demod_FM(const uint8_t *x_buf, int16_t *y_buf, unsigned num_samples, DemodFM_State *state);
+
 /// Initialize tables and constants
 /// Should be called once at startup
 void baseband_init(void);
 
 /// Dump binary data (for debug purposes)
-void baseband_dumpfile(uint8_t *buf, uint32_t len);
+void baseband_dumpfile(const uint8_t *buf, uint32_t len);
 
 #endif /* INCLUDE_BASEBAND_H_ */

--- a/include/baseband.h
+++ b/include/baseband.h
@@ -23,7 +23,7 @@
 /// @param *iq_buf: input samples (I/Q samples in interleaved uint8)
 /// @param *y_buf: output 
 /// @param len: number of samples to process
-void envelope_detect(const uint8_t *iq_buf, uint16_t *y_buf, uint32_t len, int decimate);
+void envelope_detect(const uint8_t *iq_buf, uint16_t *y_buf, uint32_t len);
 
 #define FILTER_ORDER 1
 

--- a/include/bitbuffer.h
+++ b/include/bitbuffer.h
@@ -15,8 +15,8 @@
 
 #include <stdint.h>
 
-#define BITBUF_COLS		34		// Number of bytes in a column
-#define BITBUF_ROWS		50
+#define BITBUF_COLS		80		// Number of bytes in a column
+#define BITBUF_ROWS		25
 #define BITBUF_MAX_PRINT_BITS	50	// Maximum number of bits to print (in addition to hex values)
 
 typedef uint8_t bitrow_t[BITBUF_COLS];

--- a/include/pulse_demod.h
+++ b/include/pulse_demod.h
@@ -20,8 +20,10 @@
 
 /// Demodulate a Pulse Code Modulation signal
 ///
-/// Demodulate a Pulse Code Modulation (PPM) signal with Return-to-Zero encoding.
-/// Binary width is fixed and each bit starts with a pulse or not
+/// Demodulate a Pulse Code Modulation (PPM) signal where bit width 
+/// is fixed and each bit starts with a pulse or not. It may be either 
+/// Return-to-Zero (RZ) encoding, where pulses are shorter than bit width
+/// or Non-Return-to-Zero (NRZ) encoding, where pulses are equal to bit width
 /// The presence of a pulse is:
 /// - Presence of a pulse equals 1
 /// - Absence of a pulse equals 0
@@ -29,7 +31,7 @@
 /// @param device->long_limit:  Nominal width of bit period [samples]
 /// @param device->reset_limit: Maximum gap size before End Of Message [samples].
 /// @return number of events processed
-int pulse_demod_pcm_rz(const pulse_data_t *pulses, struct protocol_state *device);
+int pulse_demod_pcm(const pulse_data_t *pulses, struct protocol_state *device);
 
 
 /// Demodulate a Pulse Position Modulation signal

--- a/include/pulse_detect.h
+++ b/include/pulse_detect.h
@@ -26,15 +26,6 @@ typedef struct {
 	unsigned int num_pulses;
 	unsigned int pulse[PD_MAX_PULSES];	// Contains width of a pulse	(high)
 	unsigned int gap[PD_MAX_PULSES];	// Width of gaps between pulses (low)
-	// Statistics for levels
-	int16_t		pulse_max;	// Maximum level detected
-	int16_t		pulse_min;	// Minimum level detected
-	int64_t		pulse_sum;	// Sum of levels (for averaging)
-	uint32_t	pulse_num;	// Number of samples (for averaging)
-	int16_t		gap_max;	// Maximum level detected
-	int16_t		gap_min;	// Minimum level detected
-	int64_t		gap_sum;	// Sum of levels (for averaging)
-	uint32_t	gap_num;	// Number of samples (for averaging)
 } pulse_data_t;
 
 

--- a/include/pulse_detect.h
+++ b/include/pulse_detect.h
@@ -14,7 +14,7 @@
 #include <stdint.h>
 
 #define PD_MAX_PULSES 1000			// Maximum number of pulses before forcing End Of Package
-#define PD_MIN_PULSES 4				// Minimum number of pulses before declaring a proper package
+#define PD_MIN_PULSES 16			// Minimum number of pulses before declaring a proper package
 #define PD_MIN_PULSE_SAMPLES 10		// Minimum number of samples in a pulse for proper detection
 #define PD_MIN_GAP_MS 10			// Minimum gap size in milliseconds to exceed to declare End Of Package
 #define PD_MAX_GAP_MS 100			// Maximum gap size in milliseconds to exceed to declare End Of Package

--- a/include/pulse_detect.h
+++ b/include/pulse_detect.h
@@ -14,6 +14,8 @@
 #include <stdint.h>
 
 #define PD_MAX_PULSES 1000			// Maximum number of pulses before forcing End Of Package
+#define PD_MIN_PULSES 4				// Minimum number of pulses before declaring a proper package
+#define PD_MIN_PULSE_SAMPLES 10		// Minimum number of samples in a pulse for proper detection
 #define PD_MIN_GAP_MS 10			// Minimum gap size in milliseconds to exceed to declare End Of Package
 #define PD_MAX_GAP_MS 100			// Maximum gap size in milliseconds to exceed to declare End Of Package
 #define PD_MAX_GAP_RATIO 10			// Ratio gap/pulse width to exceed to declare End Of Package (heuristic)
@@ -43,14 +45,19 @@ void pulse_data_clear(pulse_data_t *data);		// Clear the struct
 void pulse_data_print(const pulse_data_t *data);
 
 
-/// Demodulate On/Off Keying from an envelope signal
+/// Demodulate On/Off Keying (OOK) and Frequency Shift Keying (FSK) from an envelope signal
 ///
 /// Function is stateful and can be called with chunks of input data
+/// @param envelope_data: Samples with amplitude envelope of carrier 
+/// @param fm_data: Samples with frequency offset from center frequency
+/// @param len: Number of samples in input buffers
 /// @param samp_rate: Sample rate in samples per second
 /// @param *pulses: Will return a pulse_data_t structure
-/// @return 0 if all input data is processed
-/// @return 1 if package is detected (but data is still not completely processed)
-int detect_pulse_package(const int16_t *envelope_data, uint32_t len, int16_t level_limit, uint32_t samp_rate, pulse_data_t *pulses);
+/// @param *fsk_pulses: Will return a pulse_data_t structure for FSK demodulated data
+/// @return 0 if all input sample data is processed
+/// @return 1 if OOK package is detected (but all sample data is still not completely processed)
+/// @return 2 if FSK package is detected (but all sample data is still not completely processed)
+int detect_pulse_package(const int16_t *envelope_data, const int16_t *fm_data, uint32_t len, int16_t level_limit, uint32_t samp_rate, pulse_data_t *pulses, pulse_data_t *fsk_pulses);
 
 
 /// Analyze and print result

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -28,7 +28,6 @@
 #define DEFAULT_ASYNC_BUF_NUMBER    32
 #define DEFAULT_BUF_LENGTH      (16 * 16384)
 #define DEFAULT_LEVEL_LIMIT     8000		// Theoretical high level at I/Q saturation is 128x128 = 16384 (above is ripple)
-#define DEFAULT_DECIMATION_LEVEL 0
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
 #define MAX_PROTOCOLS           25

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -30,7 +30,7 @@
 #define DEFAULT_LEVEL_LIMIT     8000		// Theoretical high level at I/Q saturation is 128x128 = 16384 (above is ripple)
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           25
+#define MAX_PROTOCOLS           30
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */
@@ -41,6 +41,7 @@
 #define	OOK_PULSE_PPM_RAW		5			// Pulse Position Modulation. No startbit removal. Short gap = 0, Long = 1
 #define	OOK_PULSE_PWM_RAW		6			// Pulse Width Modulation. Short pulses = 1, Long = 0
 #define	OOK_PULSE_PWM_TERNARY	7			// Pulse Width Modulation with three widths: Sync, 0, 1. Sync determined by argument
+#define	FSK_PULSE_PCM			8			// FSK, Pulse Code Modulation
 
 extern int debug_output;
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -28,7 +28,9 @@
 		DECL(X10_RF) \
 		DECL(DSC) \
 		DECL(brennstuhl_rcs_2044) \
-		DECL(gt_wt_02)
+		DECL(gt_wt_02) \
+		DECL(danfoss_CFR) \
+		DECL(ec3k) 
 
 
 typedef struct {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,8 @@ add_executable(rtl_433
 	devices/dsc.c
 	devices/brennstuhl_rcs_2044.c
 	devices/gt_wt_02.c
+	devices/danfoss.c
+	devices/ec3k.c
 )
 
 target_link_libraries(rtl_433

--- a/src/baseband.c
+++ b/src/baseband.c
@@ -85,7 +85,6 @@ void baseband_demod_FM(const uint8_t *x_buf, int16_t *y_buf, unsigned num_sample
 	int16_t br, bi;		// Old IQ sample: x[n-1]
 	int32_t pr, pi;		// Phase difference vector
 	int16_t angle;		// Phase difference angle
-	int16_t xdc, ydc, xdc_old, ydc_old;	// DC blocker variables
 	int16_t xlp, ylp, xlp_old, ylp_old;	// Low Pass filter variables
 
 	// Pre-feed old sample
@@ -102,15 +101,10 @@ void baseband_demod_FM(const uint8_t *x_buf, int16_t *y_buf, unsigned num_sample
 		//pr = ar*br+ai*bi;	// May exactly overflow an int16_t (-128*-128 + -128*-128)
 		pi = ai*br-ar*bi; 
 		//angle = (int16_t)((atan2f(pi, pr) / M_PI) * INT16_MAX);	// Inefficient floating point for now...
-		// DC blocker filter
-		xdc = pi;	// We cheat for now and only use imaginary part (works well for small angles)
-		ydc = xdc - xdc_old + ydc_old - ydc_old/256;
-		ydc_old = ydc; xdc_old = xdc;
+		xlp = pi;	// We cheat for now and only use imaginary part (works OK for small angles)
 		// Low pass filter
-		xlp = ydc;
 		ylp = ((alp[1] * ylp_old >> 1) + (blp[0] * xlp >> 1) + (blp[1] * xlp_old >> 1)) >> (F_SCALE - 1);
 		ylp_old = ylp; xlp_old = xlp;
-		
 		y_buf[n] = ylp;
 	}
 

--- a/src/baseband.c
+++ b/src/baseband.c
@@ -32,13 +32,10 @@ static void calc_squares() {
  *  The output will be written in the input buffer
  *  @returns   pointer to the input buffer
  */
-void envelope_detect(const uint8_t *iq_buf, uint16_t *y_buf, uint32_t len, int decimate) {
+void envelope_detect(const uint8_t *iq_buf, uint16_t *y_buf, uint32_t len) {
     unsigned int i;
-    unsigned op = 0;
-    unsigned int stride = 1 << decimate;
-
-    for (i = 0; i < len; i += stride) {
-        y_buf[op++] = scaled_squares[iq_buf[2 * i ]] + scaled_squares[iq_buf[2 * i + 1]];
+    for (i = 0; i < len; i++) {
+        y_buf[i] = scaled_squares[iq_buf[2 * i ]] + scaled_squares[iq_buf[2 * i + 1]];
     }
 }
 

--- a/src/baseband.c
+++ b/src/baseband.c
@@ -32,14 +32,13 @@ static void calc_squares() {
  *  The output will be written in the input buffer
  *  @returns   pointer to the input buffer
  */
-void envelope_detect(unsigned char *buf, uint32_t len, int decimate) {
-    uint16_t* sample_buffer = (uint16_t*) buf;
+void envelope_detect(const uint8_t *iq_buf, uint16_t *y_buf, uint32_t len, int decimate) {
     unsigned int i;
     unsigned op = 0;
     unsigned int stride = 1 << decimate;
 
-    for (i = 0; i < len / 2; i += stride) {
-        sample_buffer[op++] = scaled_squares[buf[2 * i ]] + scaled_squares[buf[2 * i + 1]];
+    for (i = 0; i < len; i += stride) {
+        y_buf[op++] = scaled_squares[iq_buf[2 * i ]] + scaled_squares[iq_buf[2 * i + 1]];
     }
 }
 

--- a/src/baseband.c
+++ b/src/baseband.c
@@ -77,8 +77,11 @@ void baseband_low_pass_filter(const uint16_t *x_buf, int16_t *y_buf, uint32_t le
 }
 
 ///  [b,a] = butter(1, 0.1) -> 3x tau (95%) ~10 samples
-static int alp[2] = {FIX(1.00000), FIX(0.72654)};
-static int blp[2] = {FIX(0.13673), FIX(0.13673)};
+//static int alp[2] = {FIX(1.00000), FIX(0.72654)};
+//static int blp[2] = {FIX(0.13673), FIX(0.13673)};
+///  [b,a] = butter(1, 0.2) -> 3x tau (95%) ~5 samples
+static int alp[2] = {FIX(1.00000), FIX(0.50953)};
+static int blp[2] = {FIX(0.24524), FIX(0.24524)};
 
 void baseband_demod_FM(const uint8_t *x_buf, int16_t *y_buf, unsigned num_samples, DemodFM_State *state) {
 	int16_t ar, ai;		// New IQ sample: x[n]

--- a/src/devices/alecto.c
+++ b/src/devices/alecto.c
@@ -89,9 +89,11 @@ static int alectov1_callback(bitbuffer_t *bitbuffer) {
             //fprintf(stdout, "\nAlectoV1 CRC error");
             time(&time_now);
             local_time_str(time_now, time_str);
-            fprintf(stdout,
-            "%s AlectoV1 Checksum/Parity error\n",
-            time_str);
+            if(debug_output) {
+                fprintf(stderr,
+                "%s AlectoV1 Checksum/Parity error\n",
+                time_str);
+            }
             return 0;
         } //Invalid checksum
 

--- a/src/devices/danfoss.c
+++ b/src/devices/danfoss.c
@@ -1,0 +1,33 @@
+/* Danfoss thermostat sensor protocol
+ *
+ * Stub driver
+ * 
+ * Copyright (C) 2015 Tommy Vestermark
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+#include "rtl_433.h"
+#include "util.h"
+
+static int danfoss_CFR_callback(bitbuffer_t *bitbuffer) {
+    bitrow_t *bb = bitbuffer->bb;
+    return 0;
+}
+
+
+r_device danfoss_CFR = {
+    .name           = "Danfoss CFR Thermostat",
+    .modulation     = FSK_PULSE_PCM,
+    .short_limit    = 25,	// NRZ decoding
+    .long_limit     = 25,	// Bit width
+    .reset_limit    = 250,	// 10 zeros...
+    .json_callback  = NULL,
+//    .json_callback  = &danfoss_CFR_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
+};
+
+
+

--- a/src/devices/danfoss.c
+++ b/src/devices/danfoss.c
@@ -12,22 +12,26 @@
 #include "util.h"
 
 static int danfoss_CFR_callback(bitbuffer_t *bitbuffer) {
-    bitrow_t *bb = bitbuffer->bb;
-    return 0;
+	bitrow_t *bb = bitbuffer->bb;
+
+	// Validate package
+	unsigned bits = bitbuffer->bits_per_row[0];
+	if (bits >= 246 && bits <= 262) {	// Package is likely 254 always
+		fprintf(stdout, "Danfoss CFR Thermostat:\n");
+		bitbuffer_print(bitbuffer);
+		return 1;
+	}
+	return 0;
 }
 
 
 r_device danfoss_CFR = {
-    .name           = "Danfoss CFR Thermostat",
-    .modulation     = FSK_PULSE_PCM,
-    .short_limit    = 25,	// NRZ decoding
-    .long_limit     = 25,	// Bit width
-    .reset_limit    = 250,	// 10 zeros...
-    .json_callback  = NULL,
-//    .json_callback  = &danfoss_CFR_callback,
-    .disabled       = 0,
-    .demod_arg      = 0,
+	.name           = "Danfoss CFR Thermostat",
+	.modulation     = FSK_PULSE_PCM,
+	.short_limit    = 25,	// NRZ decoding
+	.long_limit     = 25,	// Bit width
+	.reset_limit    = 250,	// 10 zeros...
+	.json_callback  = &danfoss_CFR_callback,
+	.disabled       = 0,
+	.demod_arg      = 0,
 };
-
-
-

--- a/src/devices/dsc.c
+++ b/src/devices/dsc.c
@@ -73,7 +73,7 @@ static int DSC_callback(bitbuffer_t *bitbuffer) {
     }
 
     for (int row = 0; row < bitbuffer->num_rows; row++) {
-	if (debug_output && bitbuffer->bits_per_row[row] > 0 ) {
+	if (debug_output > 1 && bitbuffer->bits_per_row[row] > 0 ) {
 	    fprintf(stderr,"row %d bit count %d\n", row, 
 		    bitbuffer->bits_per_row[row]);
 	}
@@ -87,7 +87,7 @@ static int DSC_callback(bitbuffer_t *bitbuffer) {
 	// will need to be changed as there may be more zero bit padding
 	if (bitbuffer->bits_per_row[row] < 48 || 
 	    bitbuffer->bits_per_row[row] > 70) {  // should be 48 at most
-	    if (debug_output && bitbuffer->bits_per_row[row] > 0) {
+	    if (debug_output > 1 && bitbuffer->bits_per_row[row] > 0) {
 		fprintf(stderr,"DSC row %d invalid bit count %d\n",
 			row, bitbuffer->bits_per_row[row]);
 	    }
@@ -100,7 +100,7 @@ static int DSC_callback(bitbuffer_t *bitbuffer) {
 	      (bb[row][2] & 0x04) &&	// every 8 data bits
 	      (bb[row][3] & 0x02) &&
 	      (bb[row][4] & 0x01))) {
-	    if (debug_output) {
+	    if (debug_output > 1) {
 		fprintf(stderr,
 			"DSC Invalid start/sync bits %02x %02x %02x %02x %02x\n",
 			bb[row][0] & 0xF0,

--- a/src/devices/ec3k.c
+++ b/src/devices/ec3k.c
@@ -1,0 +1,38 @@
+/* EC3k Energy Count Control
+ * 
+ * "Voltcraft Energy Count 3000" sensor sold by Conrad
+ * aka “Velleman NETBSEM4” 
+ * aka “La Crosse Techology Remote Cost Control Monitor – RS3620”.
+ * aka "ELV Cost Control"
+ *
+ * Stub driver
+ * 
+ * Copyright (C) 2015 Tommy Vestermark
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+#include "rtl_433.h"
+#include "util.h"
+
+static int ec3k_callback(bitbuffer_t *bitbuffer) {
+    bitrow_t *bb = bitbuffer->bb;
+    return 0;
+}
+
+
+r_device ec3k = {
+    .name           = "Energy Count 3000 (868.3 MHz)",
+    .modulation     = FSK_PULSE_PCM,
+    .short_limit    = 12,	// NRZ decoding
+    .long_limit     = 12,	// Bit width
+    .reset_limit    = 120,	// 10 zeros...
+    .json_callback  = NULL,
+//    .json_callback  = &ec3k_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
+};
+
+
+

--- a/src/devices/ec3k.c
+++ b/src/devices/ec3k.c
@@ -17,21 +17,28 @@
 #include "util.h"
 
 static int ec3k_callback(bitbuffer_t *bitbuffer) {
-    bitrow_t *bb = bitbuffer->bb;
-    return 0;
+	bitrow_t *bb = bitbuffer->bb;
+
+	// Validate package
+	unsigned bits = bitbuffer->bits_per_row[0];
+	if (bits >= 550 && bits <= 590) {	// Package should be around 578?!
+		fprintf(stdout, "Energy Count 3000:\n");
+		bitbuffer_print(bitbuffer);
+		return 1;
+	}
+	return 0;
 }
 
 
 r_device ec3k = {
-    .name           = "Energy Count 3000 (868.3 MHz)",
-    .modulation     = FSK_PULSE_PCM,
-    .short_limit    = 12,	// NRZ decoding
-    .long_limit     = 12,	// Bit width
-    .reset_limit    = 120,	// 10 zeros...
-    .json_callback  = NULL,
-//    .json_callback  = &ec3k_callback,
-    .disabled       = 0,
-    .demod_arg      = 0,
+	.name           = "Energy Count 3000 (868.3 MHz)",
+	.modulation     = FSK_PULSE_PCM,
+	.short_limit    = 12,	// NRZ decoding
+	.long_limit     = 12,	// Bit width
+	.reset_limit    = 120,	// 10 zeros...
+	.json_callback  = &ec3k_callback,
+	.disabled       = 0,
+	.demod_arg      = 0,
 };
 
 

--- a/src/devices/ec3k.c
+++ b/src/devices/ec3k.c
@@ -33,9 +33,9 @@ static int ec3k_callback(bitbuffer_t *bitbuffer) {
 r_device ec3k = {
 	.name           = "Energy Count 3000 (868.3 MHz)",
 	.modulation     = FSK_PULSE_PCM,
-	.short_limit    = 12,	// NRZ decoding
+	.short_limit    = 12,	// NRZ decoding (it apparently 12.5 which is a problem!!)
 	.long_limit     = 12,	// Bit width
-	.reset_limit    = 120,	// 10 zeros...
+	.reset_limit    = 192,	// 16 zeros (up to 12 seen)...
 	.json_callback  = &ec3k_callback,
 	.disabled       = 0,
 	.demod_arg      = 0,

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -72,27 +72,28 @@ void usage(r_device *devices) {
 
 	fprintf(stderr,
             "rtl_433, an ISM band generic data receiver for RTL2832 based DVB-T receivers\n\n"
-            "Usage:\t[-d device index (default: 0)]\n"
-            "\t[-g gain (default: 0 for auto)]\n"
-            "\t[-a analyze mode, print a textual description of the signal]\n"
-            "\t[-t signal auto save, use it together with analyze mode (-a -t)\n"
-            "\t[-l change the detection level used to determine pulses (0-32767) default: %i]\n"
-            "\t[-f [-f...] receive frequency[s], default: %i Hz]\n"
-            "\t[-s sample rate (default: %i Hz)]\n"
-            "\t[-S force sync output (default: async)]\n"
-            "\t[-r read data from file instead of from a receiver]\n"
-            "\t[-p ppm_error (default: 0)]\n"
-            "\t[-r test file name (indata)]\n"
-            "\t[-m test file mode (default: 0)\n"
+            "Usage:\t[-d <device index>] (default: 0)\n"
+            "\t[-g <gain>] (default: 0 for auto)\n"
+            "\t[-f <frequency>] [-f...] Receive frequency(s) (default: %i Hz)\n"
+            "\t[-p <ppm_error>] (default: 0)\n"
+            "\t[-s <sample rate>] Set sample rate (default: %i Hz)\n"
+            "\t[-S] Force sync output (default: async)\n"
+            "\t[-R <device>] Listen only for the specified remote device (can be used multiple times)\n"
+            "\t[-l <level>] Change detection level used to determine pulses [0-32767] (default: %i)\n"
+            "\t[-z <value>] Override short value in data decoder\n"
+            "\t[-x <value>] Override long value in data decoder\n"
+            "\t[-D] Print debug info on event (repeat for more info)\n"
+            "\t[-a] Analyze mode. Print a textual description of the signal\n"
+            "\t[-t] Test signal auto save. Use it together with analyze mode (-a -t). Creates one file per signal\n"
+            "\t\t Note: Saves raw I/Q samples (uint8, 2 channel). Preferred mode for generating test files\n"
+            "\t[-r <filename>] Read data from input file instead of a receiver\n"
+            "\t[-m <mode>] Data file mode for input / output file (default: 0)\n"
             "\t\t 0 = Raw I/Q samples (uint8, 2 channel)\n"
-            "\t\t 1 = AM demodulated samples (uint16)\n"
-            "\t\t 2 = FM demodulated samples (uint16) (experimental)\n"
+            "\t\t 1 = AM demodulated samples (int16)\n"
+            "\t\t 2 = FM demodulated samples (int16) (experimental)\n"
             "\t\t Note: If output file is specified, input will always be I/Q\n"
-            "\t[-D print debug info on event\n"
-            "\t[-z override short value]\n"
-            "\t[-x override long value]\n"
-            "\t[-R listen only for the specified remote device (can be used multiple times)]\n"
-            "\tout_filename (a '-' dumps samples to stdout)\n\n", DEFAULT_LEVEL_LIMIT, DEFAULT_FREQUENCY, DEFAULT_SAMPLE_RATE);
+            "\t[<filename>] Save data stream to output file (a '-' dumps samples to stdout)\n\n", 
+            DEFAULT_FREQUENCY, DEFAULT_SAMPLE_RATE, DEFAULT_LEVEL_LIMIT);
 
     fprintf(stderr, "Supported devices:\n");
     for (i = 0; i < num_r_devices; i++) {

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -87,6 +87,7 @@ void usage(r_device *devices) {
             "\t\t 0 = Raw I/Q samples (uint8, 2 channel)\n"
             "\t\t 1 = AM demodulated samples (uint16)\n"
             "\t\t 2 = FM demodulated samples (uint16) (experimental)\n"
+            "\t\t Note: If output file is specified, input will always be I/Q\n"
             "\t[-D print debug info on event\n"
             "\t[-z override short value]\n"
             "\t[-x override long value]\n"
@@ -634,7 +635,7 @@ static void rtlsdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
 	baseband_low_pass_filter(demod->temp_buf, demod->am_buf, len >> (demod->decimation_level + 1), &demod->lowpass_filter_state);
 
 	// Handle special input formats
-	if(!demod->out_file) {
+	if(!demod->out_file) {				// If output file is specified we always assume I/Q input
 		if (demod->debug_mode == 1) {	// The IQ buffer is really AM demodulated data
 			memcpy(demod->am_buf, iq_buf, len);
 		} else if (demod->debug_mode == 2) {	// The IQ buffer is really FM demodulated data

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -704,8 +704,6 @@ static void rtlsdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
 				} // for demodulators
 				if(debug_output > 1) pulse_data_print(&demod->pulse_data);
 				if(debug_output) pulse_analyzer(&demod->pulse_data);
-				pulse_data_clear(&demod->pulse_data);
-				pulse_data_clear(&demod->fsk_pulse_data);
 			} else if (package_type == 2) {
 				if(debug_output) fprintf(stderr, "Detected FSK package\n");
 				for (i = 0; i < demod->r_dev_num; i++) {
@@ -728,8 +726,6 @@ static void rtlsdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
 				} // for demodulators
 				if(debug_output > 1) pulse_data_print(&demod->fsk_pulse_data);
 				if(debug_output) pulse_analyzer(&demod->fsk_pulse_data);
-				pulse_data_clear(&demod->pulse_data);
-				pulse_data_clear(&demod->fsk_pulse_data);
 			}
 		}
 	}
@@ -801,8 +797,6 @@ int main(int argc, char **argv) {
     num_r_devices = sizeof(devices)/sizeof(*devices);
 
     demod->level_limit = DEFAULT_LEVEL_LIMIT;
-    pulse_data_clear(&demod->pulse_data);
-    pulse_data_clear(&demod->fsk_pulse_data);
 
     while ((opt = getopt(argc, argv, "x:z:p:Dtam:r:c:l:d:f:g:s:b:n:SR:")) != -1) {
         switch (opt) {

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -42,12 +42,11 @@ int debug_output = 0;
 int num_r_devices = 0;
 
 struct dm_state {
-    FILE *file;
-    int save_data;
+    FILE *out_file;
     int32_t level_limit;
     int32_t decimation_level;
-    int16_t f_buf[MAXIMAL_BUF_LENGTH];
-    int16_t fm_buf[MAXIMAL_BUF_LENGTH];
+    int16_t am_buf[MAXIMAL_BUF_LENGTH];	// AM demodulated signal (for OOK decoding)
+    int16_t fm_buf[MAXIMAL_BUF_LENGTH];	// FM demodulated signal (for FSK decoding)
     FilterState lowpass_filter_state;
     DemodFM_State demod_FM_state;
     int analyze;
@@ -88,7 +87,7 @@ void usage(r_device *devices) {
             "\t[-z override short value]\n"
             "\t[-x override long value]\n"
             "\t[-R listen only for the specified remote device (can be used multiple times)]\n"
-            "\tfilename (a '-' dumps samples to stdout)\n\n", DEFAULT_LEVEL_LIMIT, DEFAULT_FREQUENCY, DEFAULT_SAMPLE_RATE);
+            "\tout_filename (a '-' dumps samples to stdout)\n\n", DEFAULT_LEVEL_LIMIT, DEFAULT_FREQUENCY, DEFAULT_SAMPLE_RATE);
 
     fprintf(stderr, "Supported devices:\n");
     for (i = 0; i < num_r_devices; i++) {
@@ -606,122 +605,121 @@ static void rtlsdr_callback(unsigned char *buf, uint32_t len, void *ctx) {
     struct dm_state *demod = ctx;
     uint16_t* sbuf = (uint16_t*) buf;
     int i;
-    if (demod->file || !demod->save_data) {
-        if (do_exit || do_exit_async)
-            return;
 
-        if ((bytes_to_read > 0) && (bytes_to_read < len)) {
-            len = bytes_to_read;
-            do_exit = 1;
-            rtlsdr_cancel_async(dev);
-        }
+	if (do_exit || do_exit_async)
+		return;
 
-        if (demod->signal_grabber) {
-            //fprintf(stderr, "[%d] sg_index - len %d\n", demod->sg_index, len );
-            memcpy(&demod->sg_buf[demod->sg_index], buf, len);
-            demod->sg_len = len;
-            demod->sg_index += len;
-            if (demod->sg_index + len > SIGNAL_GRABBER_BUFFER)
-                demod->sg_index = 0;
-        }
+	if ((bytes_to_read > 0) && (bytes_to_read < len)) {
+		len = bytes_to_read;
+		do_exit = 1;
+		rtlsdr_cancel_async(dev);
+	}
+
+	if (demod->signal_grabber) {
+		//fprintf(stderr, "[%d] sg_index - len %d\n", demod->sg_index, len );
+		memcpy(&demod->sg_buf[demod->sg_index], buf, len);
+		demod->sg_len = len;
+		demod->sg_index += len;
+		if (demod->sg_index + len > SIGNAL_GRABBER_BUFFER)
+			demod->sg_index = 0;
+	}
 
 
-        if (demod->debug_mode == 0) {
-            baseband_demod_FM(buf, demod->fm_buf, len/2, &demod->demod_FM_state);
-            //baseband_dumpfile((uint8_t*)demod->fm_buf, len);				// Debug
-            envelope_detect(buf, len, demod->decimation_level);
-            // baseband_dumpfile(buf, len);				// Debug
-            baseband_low_pass_filter(sbuf, demod->f_buf, len >> (demod->decimation_level + 1), &demod->lowpass_filter_state);
-            // baseband_dumpfile((uint8_t*)demod->f_buf, len);	// Debug
-        } else if (demod->debug_mode == 1) {
-            memcpy(demod->f_buf, buf, len);
-        }
-        if (demod->analyze) {
-            pwm_analyze(demod, demod->f_buf, len / 2);
-        } else {
-            // Loop through all demodulators for all samples (CPU intensive!)
-            for (i = 0; i < demod->r_dev_num; i++) {
-                switch (demod->r_devs[i]->modulation) {
-                    case OOK_PWM_D:
-                        pwm_d_decode(demod, demod->r_devs[i], demod->f_buf, len / 2);
-                        break;
-                    case OOK_PWM_P:
-                        pwm_p_decode(demod, demod->r_devs[i], demod->f_buf, len / 2);
-                        break;
-                    // Add pulse demodulators here
-                    case OOK_PULSE_PCM_RZ:
-                    case OOK_PULSE_PPM_RAW:
-                    case OOK_PULSE_PWM_RAW:
-                    case OOK_PULSE_PWM_TERNARY:
-                    case OOK_PULSE_MANCHESTER_ZEROBIT:
-                        break;
-                    default:
-                        fprintf(stderr, "Unknown modulation %d in protocol!\n", demod->r_devs[i]->modulation);
-                }
-            }
-            // Detect a package and loop through demodulators with pulse data
-            while(detect_pulse_package(demod->f_buf, len/2, demod->level_limit, samp_rate, &demod->pulse_data)) {
-                for (i = 0; i < demod->r_dev_num; i++) {
-                    switch (demod->r_devs[i]->modulation) {
-                        // Old style decoders
-                        case OOK_PWM_D:
-                        case OOK_PWM_P:
-                            break;
-                        case OOK_PULSE_PCM_RZ:
-                            pulse_demod_pcm_rz(&demod->pulse_data, demod->r_devs[i]);
-                            break;
-                        case OOK_PULSE_PPM_RAW:
-                            pulse_demod_ppm(&demod->pulse_data, demod->r_devs[i]);
-                            break;
-                        case OOK_PULSE_PWM_RAW:
-                            pulse_demod_pwm(&demod->pulse_data, demod->r_devs[i]);
-                            break;
-                        case OOK_PULSE_PWM_TERNARY:
-                            pulse_demod_pwm_ternary(&demod->pulse_data, demod->r_devs[i]);
-                            break;
-                        case OOK_PULSE_MANCHESTER_ZEROBIT:
-                            pulse_demod_manchester_zerobit(&demod->pulse_data, demod->r_devs[i]);
-                            break;
-                        default:
-                            fprintf(stderr, "Unknown modulation %d in protocol!\n", demod->r_devs[i]->modulation);
-                    }
-                } // for demodulators
-                if(debug_output > 1) pulse_data_print(&demod->pulse_data);
-                if(debug_output) pulse_analyzer(&demod->pulse_data);
-                pulse_data_clear(&demod->pulse_data);
-            }
-        }
+	if (demod->debug_mode == 0) {
+		baseband_demod_FM(buf, demod->fm_buf, len/2, &demod->demod_FM_state);
+		//baseband_dumpfile((uint8_t*)demod->fm_buf, len);				// Debug
+		envelope_detect(buf, len, demod->decimation_level);
+		// baseband_dumpfile(buf, len);				// Debug
+		baseband_low_pass_filter(sbuf, demod->am_buf, len >> (demod->decimation_level + 1), &demod->lowpass_filter_state);
+		// baseband_dumpfile((uint8_t*)demod->am_buf, len);	// Debug
+	} else if (demod->debug_mode == 1) {
+		memcpy(demod->am_buf, buf, len);
+	}
+	if (demod->analyze) {
+		pwm_analyze(demod, demod->am_buf, len / 2);
+	} else {
+		// Loop through all demodulators for all samples (CPU intensive!)
+		for (i = 0; i < demod->r_dev_num; i++) {
+			switch (demod->r_devs[i]->modulation) {
+				case OOK_PWM_D:
+					pwm_d_decode(demod, demod->r_devs[i], demod->am_buf, len / 2);
+					break;
+				case OOK_PWM_P:
+					pwm_p_decode(demod, demod->r_devs[i], demod->am_buf, len / 2);
+					break;
+				// Add pulse demodulators here
+				case OOK_PULSE_PCM_RZ:
+				case OOK_PULSE_PPM_RAW:
+				case OOK_PULSE_PWM_RAW:
+				case OOK_PULSE_PWM_TERNARY:
+				case OOK_PULSE_MANCHESTER_ZEROBIT:
+					break;
+				default:
+					fprintf(stderr, "Unknown modulation %d in protocol!\n", demod->r_devs[i]->modulation);
+			}
+		}
+		// Detect a package and loop through demodulators with pulse data
+		while(detect_pulse_package(demod->am_buf, len/2, demod->level_limit, samp_rate, &demod->pulse_data)) {
+			for (i = 0; i < demod->r_dev_num; i++) {
+				switch (demod->r_devs[i]->modulation) {
+					// Old style decoders
+					case OOK_PWM_D:
+					case OOK_PWM_P:
+						break;
+					case OOK_PULSE_PCM_RZ:
+						pulse_demod_pcm_rz(&demod->pulse_data, demod->r_devs[i]);
+						break;
+					case OOK_PULSE_PPM_RAW:
+						pulse_demod_ppm(&demod->pulse_data, demod->r_devs[i]);
+						break;
+					case OOK_PULSE_PWM_RAW:
+						pulse_demod_pwm(&demod->pulse_data, demod->r_devs[i]);
+						break;
+					case OOK_PULSE_PWM_TERNARY:
+						pulse_demod_pwm_ternary(&demod->pulse_data, demod->r_devs[i]);
+						break;
+					case OOK_PULSE_MANCHESTER_ZEROBIT:
+						pulse_demod_manchester_zerobit(&demod->pulse_data, demod->r_devs[i]);
+						break;
+					default:
+						fprintf(stderr, "Unknown modulation %d in protocol!\n", demod->r_devs[i]->modulation);
+				}
+			} // for demodulators
+			if(debug_output > 1) pulse_data_print(&demod->pulse_data);
+			if(debug_output) pulse_analyzer(&demod->pulse_data);
+			pulse_data_clear(&demod->pulse_data);
+		}
+	}
 
-        if (demod->save_data) {
-            if (fwrite(demod->f_buf, 1, len >> demod->decimation_level, demod->file) != len >> demod->decimation_level) {
-                fprintf(stderr, "Short write, samples lost, exiting!\n");
-                rtlsdr_cancel_async(dev);
-            }
-        }
+	if (demod->out_file) {
+		if (fwrite(demod->am_buf, 1, len >> demod->decimation_level, demod->out_file) != len >> demod->decimation_level) {
+			fprintf(stderr, "Short write, samples lost, exiting!\n");
+			rtlsdr_cancel_async(dev);
+		}
+	}
 
-        if (bytes_to_read > 0)
-            bytes_to_read -= len;
+	if (bytes_to_read > 0)
+		bytes_to_read -= len;
 
-        if (frequencies > 1) {
-            time_t rawtime;
-            time(&rawtime);
-            if (difftime(rawtime, rawtime_old) > DEFAULT_HOP_TIME || events >= DEFAULT_HOP_EVENTS) {
-                rawtime_old = rawtime;
-                events = 0;
-                do_exit_async = 1;
-                rtlsdr_cancel_async(dev);
-            }
-        }
-    }
+	if (frequencies > 1) {
+		time_t rawtime;
+		time(&rawtime);
+		if (difftime(rawtime, rawtime_old) > DEFAULT_HOP_TIME || events >= DEFAULT_HOP_EVENTS) {
+			rawtime_old = rawtime;
+			events = 0;
+			do_exit_async = 1;
+			rtlsdr_cancel_async(dev);
+		}
+	}
 }
 
 int main(int argc, char **argv) {
 #ifndef _WIN32
     struct sigaction sigact;
 #endif
-    char *filename = NULL;
-    char *test_mode_file = NULL;
-    FILE *test_mode;
+    char *out_filename = NULL;
+    char *in_filename = NULL;
+    FILE *in_file;
     int n_read;
     int r, opt;
     int i, gain = 0;
@@ -791,7 +789,7 @@ int main(int argc, char **argv) {
                 demod->analyze = 1;
                 break;
             case 'r':
-                test_mode_file = optarg;
+                in_filename = optarg;
                 break;
             case 't':
                 demod->signal_grabber = 1;
@@ -836,7 +834,7 @@ int main(int argc, char **argv) {
     if (argc <= optind - 1) {
         usage(devices);
     } else {
-        filename = argv[optind];
+        out_filename = argv[optind];
     }
 
     for (i = 0; i < num_r_devices; i++) {
@@ -858,11 +856,11 @@ int main(int argc, char **argv) {
 
     buffer = malloc(out_block_size * sizeof (uint8_t));
 
-    if (!test_mode_file) {
+    if (!in_filename) {
 	device_count = rtlsdr_get_device_count();
 	if (!device_count) {
 	    fprintf(stderr, "No supported devices found.\n");
-	    if (!test_mode_file)
+	    if (!in_filename)
 		exit(1);
 	}
 
@@ -927,35 +925,34 @@ int main(int argc, char **argv) {
 
     }
 
-    demod->save_data = 1;
-    if (!filename) {
-        demod->save_data = 0;
-    } else if (strcmp(filename, "-") == 0) { /* Write samples to stdout */
-        demod->file = stdout;
+	if (out_filename) {
+		if (strcmp(out_filename, "-") == 0) { /* Write samples to stdout */
+			demod->out_file = stdout;
 #ifdef _WIN32
-        _setmode(_fileno(stdin), _O_BINARY);
+			_setmode(_fileno(stdin), _O_BINARY);
 #endif
-    } else {
-        demod->file = fopen(filename, "wb");
-        if (!demod->file) {
-            fprintf(stderr, "Failed to open %s\n", filename);
-            goto out;
-        }
-    }
+		} else {
+			demod->out_file = fopen(out_filename, "wb");
+			if (!demod->out_file) {
+				fprintf(stderr, "Failed to open %s\n", out_filename);
+				goto out;
+			}
+		}
+	}
 
     if (demod->signal_grabber)
         demod->sg_buf = malloc(SIGNAL_GRABBER_BUFFER);
 
-    if (test_mode_file) {
+    if (in_filename) {
         int i = 0;
         unsigned char test_mode_buf[DEFAULT_BUF_LENGTH];
-        fprintf(stderr, "Test mode active. Reading samples from file: %s\n", test_mode_file);
-        test_mode = fopen(test_mode_file, "r");
-        if (!test_mode) {
-            fprintf(stderr, "Opening file: %s failed!\n", test_mode_file);
+        fprintf(stderr, "Test mode active. Reading samples from file: %s\n", in_filename);
+        in_file = fopen(in_filename, "r");
+        if (!in_file) {
+            fprintf(stderr, "Opening file: %s failed!\n", in_filename);
             goto out;
         }
-        while (fread(test_mode_buf, 131072, 1, test_mode) != 0) {
+        while (fread(test_mode_buf, 131072, 1, in_file) != 0) {
             rtlsdr_callback(test_mode_buf, 131072, demod);
             i++;
         }
@@ -989,7 +986,7 @@ int main(int argc, char **argv) {
                 do_exit = 1;
             }
 
-            if (fwrite(buffer, 1, n_read, demod->file) != (size_t) n_read) {
+            if (fwrite(buffer, 1, n_read, demod->out_file) != (size_t) n_read) {
                 fprintf(stderr, "Short write, samples lost, exiting!\n");
                 break;
             }
@@ -1030,8 +1027,8 @@ int main(int argc, char **argv) {
     else
         fprintf(stderr, "\nLibrary error %d, exiting...\n", r);
 
-    if (demod->file && (demod->file != stdout))
-        fclose(demod->file);
+    if (demod->out_file && (demod->out_file != stdout))
+        fclose(demod->out_file);
 
     for (i = 0; i < demod->r_dev_num; i++)
         free(demod->r_devs[i]);

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -47,7 +47,9 @@ struct dm_state {
     int32_t level_limit;
     int32_t decimation_level;
     int16_t f_buf[MAXIMAL_BUF_LENGTH];
+    int16_t fm_buf[MAXIMAL_BUF_LENGTH];
     FilterState lowpass_filter_state;
+    DemodFM_State demod_FM_state;
     int analyze;
     int debug_mode;
 
@@ -625,6 +627,8 @@ static void rtlsdr_callback(unsigned char *buf, uint32_t len, void *ctx) {
 
 
         if (demod->debug_mode == 0) {
+            baseband_demod_FM(buf, demod->fm_buf, len/2, &demod->demod_FM_state);
+            //baseband_dumpfile((uint8_t*)demod->fm_buf, len);				// Debug
             envelope_detect(buf, len, demod->decimation_level);
             // baseband_dumpfile(buf, len);				// Debug
             baseband_low_pass_filter(sbuf, demod->f_buf, len >> (demod->decimation_level + 1), &demod->lowpass_filter_state);


### PR DESCRIPTION
OK, this is a big one :-)
It adds support for FSK demodulation and adds a couple of stub device drivers (these FSK devices have long bit sequences and might take some time to decipher).
The FM demodulated data can be output to a test file by using -m 2.
It has been successfully regression tested against the existing test corpus and should not make changes for the OOK devices.