### PR TITLE
Disable FM demodulation when no FSK devices are enables

### DIFF
--- a/include/baseband.h
+++ b/include/baseband.h
@@ -36,6 +36,7 @@ typedef struct {
 /// FM_Demod state buffer
 typedef struct {
 	int16_t	br, bi;		// Last I/Q sample
+	int16_t xlp, ylp;	// Low-pass filter state
 } DemodFM_State;
 
 /// Lowpass filter

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -41,7 +41,9 @@
 #define	OOK_PULSE_PPM_RAW		5			// Pulse Position Modulation. No startbit removal. Short gap = 0, Long = 1
 #define	OOK_PULSE_PWM_RAW		6			// Pulse Width Modulation. Short pulses = 1, Long = 0
 #define	OOK_PULSE_PWM_TERNARY	7			// Pulse Width Modulation with three widths: Sync, 0, 1. Sync determined by argument
-#define	FSK_PULSE_PCM			8			// FSK, Pulse Code Modulation
+
+#define	FSK_DEMOD_MIN_VAL		16			// Dummy. FSK demodulation must start at this value
+#define	FSK_PULSE_PCM			16			// FSK, Pulse Code Modulation
 
 extern int debug_output;
 

--- a/src/baseband.c
+++ b/src/baseband.c
@@ -92,6 +92,7 @@ void baseband_demod_FM(const uint8_t *x_buf, int16_t *y_buf, unsigned num_sample
 
 	// Pre-feed old sample
 	ar = state->br; ai = state->bi;
+	xlp_old = state->xlp; ylp_old = state->ylp;
 
 	for (unsigned n = 0; n < num_samples; n++) {
 		// delay old sample 
@@ -113,6 +114,7 @@ void baseband_demod_FM(const uint8_t *x_buf, int16_t *y_buf, unsigned num_sample
 
 	// Store newest sample for next run
 	state->br = ar; state->bi = ai;
+	state->xlp = xlp_old; state->ylp = ylp_old;
 }
 
 


### PR DESCRIPTION
CPU usage on a Raspberry Pi 1 B (800 MHz):
- rtl_433 -R 18 (Fine Offset) : ~10% CPU
- rtl_433 -R 26 (Danfoss) : ~15% CPU

(Plus a bugfix...)