### PR TITLE
Implement a PWM decoder with precise timing for increased selectivity

### DIFF
--- a/include/pulse_demod.h
+++ b/include/pulse_demod.h
@@ -63,6 +63,28 @@ int pulse_demod_ppm(const pulse_data_t *pulses, struct protocol_state *device);
 int pulse_demod_pwm(const pulse_data_t *pulses, struct protocol_state *device);
 
 
+/// Parameters for pulse_demod_pwm_precise
+typedef struct {
+	int	pulse_sync_width;		// Width of a sync pulse [samples] (optional, ignored if 0)
+	int	pulse_tolerance;		// Tolerance of pulse widths [samples]
+} PWM_Precise_Parameters;
+
+
+/// Demodulate a Pulse Width Modulation signal with precise timing
+///
+/// Demodulate a Pulse Width Modulation (PWM) signal consisting of short and long high pulses.
+/// Gap between pulses may be of fixed size or variable (e.g. fixed period)
+/// - Short pulse will add a 1 bit
+/// - Long  pulse will add a 0 bit
+/// - Sync  pulse will add a new row to bitbuffer
+/// @param device->short_limit: Width in samples of '1' [samples]
+/// @param device->long_limit:  Width in samples of '0' [samples]
+/// @param device->reset_limit: Maximum gap size before End Of Message [samples].
+/// @param device->demod_arg: pointer to PWM_Precise_Parameters
+/// @return number of events processed
+int pulse_demod_pwm_precise(const pulse_data_t *pulses, struct protocol_state *device);
+
+
 /// Demodulate a Pulse Width Modulation signal with three pulse widths
 ///
 /// Demodulate a Pulse Width Modulation (PWM) signal consisting of short, middle and long high pulses.

--- a/include/pulse_detect.h
+++ b/include/pulse_detect.h
@@ -52,7 +52,7 @@ int detect_pulse_package(const int16_t *envelope_data, const int16_t *fm_data, u
 
 
 /// Analyze and print result
-void pulse_analyzer(const pulse_data_t *data);
+void pulse_analyzer(pulse_data_t *data);
 
 
 #endif /* INCLUDE_PULSE_DETECT_H_ */

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -39,8 +39,9 @@
 #define	OOK_PULSE_MANCHESTER_ZEROBIT	3	// Manchester encoding. Hardcoded zerobit. Rising Edge = 0, Falling edge = 1
 #define	OOK_PULSE_PCM_RZ		4			// Pulse Code Modulation with Return-to-Zero encoding, Pulse = 0, No pulse = 1
 #define	OOK_PULSE_PPM_RAW		5			// Pulse Position Modulation. No startbit removal. Short gap = 0, Long = 1
-#define	OOK_PULSE_PWM_RAW		6			// Pulse Width Modulation. Short pulses = 1, Long = 0
-#define	OOK_PULSE_PWM_TERNARY	7			// Pulse Width Modulation with three widths: Sync, 0, 1. Sync determined by argument
+#define	OOK_PULSE_PWM_PRECISE	6			// Pulse Width Modulation with precise timing parameters
+#define	OOK_PULSE_PWM_RAW		7			// Pulse Width Modulation. Short pulses = 1, Long = 0
+#define	OOK_PULSE_PWM_TERNARY	8			// Pulse Width Modulation with three widths: Sync, 0, 1. Sync determined by argument
 
 #define	FSK_DEMOD_MIN_VAL		16			// Dummy. FSK demodulation must start at this value
 #define	FSK_PULSE_PCM			16			// FSK, Pulse Code Modulation

--- a/src/devices/ambient_weather.c
+++ b/src/devices/ambient_weather.c
@@ -96,6 +96,10 @@ static int
 ambient_weather_parser (bitbuffer_t *bitbuffer)
 {
   bitrow_t *bb = bitbuffer->bb;
+
+  if(bitbuffer->bits_per_row[0] != 195)	// There seems to be 195 bits in a correct message
+    return 0;
+
   /* shift all the bits left 1 to align the fields */
   int i;
   for (i = 0; i < BITBUF_COLS-1; i++) {

--- a/src/devices/chuango.c
+++ b/src/devices/chuango.c
@@ -16,6 +16,7 @@
  * (at your option) any later version.
  */
 #include "rtl_433.h"
+#include "pulse_demod.h"
 
 
 static int chuango_callback(bitbuffer_t *bitbuffer) {
@@ -60,13 +61,18 @@ static int chuango_callback(bitbuffer_t *bitbuffer) {
 }
 
 
+PWM_Precise_Parameters pwm_precise_parameters = {
+	.pulse_tolerance	= 20,
+	.pulse_sync_width	= 0,	// No sync bit used
+};
+
 r_device chuango = {
 	.name			= "Chuango Security Technology",
-	.modulation		= OOK_PULSE_PWM_RAW,
-	.short_limit	= 284,	// Pulse: Short 142, Long 426 
-	.long_limit		= 450,	// Gaps:  Short 142, Long 424
+	.modulation		= OOK_PULSE_PWM_PRECISE,
+	.short_limit	= 142,	// Pulse: Short 142, Long 426 
+	.long_limit		= 426,	// Gaps:  Short 142, Long 424
 	.reset_limit	= 450,	// Intermessage Gap 4300 (individually for now)
 	.json_callback	= &chuango_callback,
 	.disabled		= 0,
-	.demod_arg		= 0,	// Do not remove startbit
+	.demod_arg		= (unsigned long)&pwm_precise_parameters,
 };

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -336,7 +336,7 @@ void histogram_print(const histogram_t *hist) {
 #define TOLERANCE (0.2)		// 20% tolerance should still discern between the pulse widths: 0.33, 0.66, 1.0
 
 /// Analyze the statistics of a pulse data structure and print result
-void pulse_analyzer(const pulse_data_t *data)
+void pulse_analyzer(pulse_data_t *data)
 {
 	// Generate pulse period data
 	pulse_data_t pulse_periods = {0};
@@ -418,6 +418,7 @@ void pulse_analyzer(const pulse_data_t *data)
 	if(device.modulation) {
 		fprintf(stderr, "Attempting demodulation... short_limit: %u, long_limit: %u, reset_limit: %u, demod_arg: %lu\n", 
 			device.short_limit, device.long_limit, device.reset_limit, device.demod_arg);
+		data->gap[data->num_pulses-1] = device.reset_limit + 1;	// Be sure to terminate package
 		switch(device.modulation) {
 //			case OOK_PULSE_PCM_RZ:
 //				pulse_demod_pcm(data, &device);

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -668,6 +668,7 @@ static void rtlsdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
 				// Add pulse demodulators here
 				case OOK_PULSE_PCM_RZ:
 				case OOK_PULSE_PPM_RAW:
+				case OOK_PULSE_PWM_PRECISE:
 				case OOK_PULSE_PWM_RAW:
 				case OOK_PULSE_PWM_TERNARY:
 				case OOK_PULSE_MANCHESTER_ZEROBIT:
@@ -694,6 +695,9 @@ static void rtlsdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
 							break;
 						case OOK_PULSE_PPM_RAW:
 							pulse_demod_ppm(&demod->pulse_data, demod->r_devs[i]);
+							break;
+						case OOK_PULSE_PWM_PRECISE:
+							pulse_demod_pwm_precise(&demod->pulse_data, demod->r_devs[i]);
 							break;
 						case OOK_PULSE_PWM_RAW:
 							pulse_demod_pwm(&demod->pulse_data, demod->r_devs[i]);
@@ -722,6 +726,7 @@ static void rtlsdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
 						case OOK_PWM_P:
 						case OOK_PULSE_PCM_RZ:
 						case OOK_PULSE_PPM_RAW:
+						case OOK_PULSE_PWM_PRECISE:
 						case OOK_PULSE_PWM_RAW:
 						case OOK_PULSE_PWM_TERNARY:
 						case OOK_PULSE_MANCHESTER_ZEROBIT:


### PR DESCRIPTION
Makes Chuango less noisy
Has provision for replacing ternary encoder (implements sync)
Can be expanded to include more selectivity (e.g. gap timing)
Can be expanded to include start bit removal (for replacing RAW)