### PR TITLE
revert additional chuango output, add new device "generic_remote" to deal with SC226x and EV1527 coding

### DIFF
--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -32,7 +32,8 @@
 		DECL(danfoss_CFR) \
 		DECL(ec3k) \
 		DECL(valeo) \
-		DECL(chuango) 
+		DECL(chuango) \
+		DECL(generic_remote) 
 
 
 typedef struct {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(rtl_433
 	devices/ec3k.c
 	devices/valeo.c
 	devices/chuango.c
+	devices/generic_remote.c
 )
 
 target_link_libraries(rtl_433

--- a/src/devices/chuango.c
+++ b/src/devices/chuango.c
@@ -37,53 +37,27 @@ static int chuango_callback(bitbuffer_t *bitbuffer) {
 		char *CMD;
 		switch(b[2] & 0x0F) {
 			case 0xF:	CMD = "0xF (?)";	break;
-			case 0xE:	CMD = "0xE (?)";	break; //tristate 1110 = 1? invalid code!
+			case 0xE:	CMD = "0xE (?)";	break;
 			case 0xD:	CMD = "0xD (Low Battery)";	break;
 			case 0xC:	CMD = "0xC (?)";	break;
 			case 0xB:	CMD = "0xB (24H Zone)";	break;
 			case 0xA:	CMD = "0xA (Single Delay Zone)";	break;
 			case 0x9:	CMD = "0x9 (?)";	break;
 			case 0x8:	CMD = "0x8 (Arm)";	break;
-			case 0x7:	CMD = "0x7 (Normal Zone)";	break; //tristate 0111 = F1, all floating tristate should be impossible in data part, only valid in address!
-			case 0x6:	CMD = "0x6 (Home Mode Zone)";	break; //tristate 0110 = F?, invalid code!
-			case 0x5:	CMD = "0x5 (?)";	break; //tristate 0101 = FF
-			case 0x4:	CMD = "0x4 (Home Mode)";	break; //tristate 0100 = F0
+			case 0x7:	CMD = "0x7 (Normal Zone)";	break;
+			case 0x6:	CMD = "0x6 (Home Mode Zone)";	break; 
+			case 0x5:	CMD = "0x5 (?)";	break; 
+			case 0x4:	CMD = "0x4 (Home Mode)";	break; 
 			case 0x3:	CMD = "0x3 (Tamper)";	break;
 			case 0x2:	CMD = "0x2 (Alarm!)";	break;
-			case 0x1:	CMD = "0x1 (Disarm)";	break; //tristate 0001 = 0F 
+			case 0x1:	CMD = "0x1 (Disarm)";	break; 
 			case 0x0:	CMD = "0x0 (Test)";	break;
 			default:	CMD = ""; break;
 		}
 
-		uint32_t ID_16b = b[0] << 8 | b[1];
-		unsigned char CMD_8b = b[2];
-
 		fprintf(stdout, "Chuango Security Technology\n");
 		fprintf(stdout, "ID 20bit = 0x%05X\n", ID);
 		fprintf(stdout, "CMD 4bit = %s\n", CMD);
-		fprintf(stdout, "ID 16bit = 0x%04X\n", ID_16b);
-		fprintf(stdout, "CMD 8bit = 0x%02X\n", CMD_8b);
-
-
-		// output tristate coding
-
-		uint32_t FULL = b[0] << 16 | b[1] << 8 | b[2];
-		char c;
-
-		fprintf(stdout, "TRISTATE = ");
-		for (signed char i=22; i>=0; i-=2) {
-
-			switch ((FULL>>i) & 0x03) {
-				case 0x00:	c = '0'; break;
-				case 0x01:	c = 'F'; break;
-				case 0x02:	c = '!'; break; // tristate 10 is invalid code!
-				case 0x03:	c = '1'; break;
-				default:	c = '?'; break; // not possible anyway
-			}
-
-			fputc(c, stdout);
-		}
-		fprintf(stdout, "\n");
 
 		return 1;
 	}

--- a/src/devices/generic_remote.c
+++ b/src/devices/generic_remote.c
@@ -1,0 +1,82 @@
+/* Generic remotes and sensors using PT2260/PT2262 SC2260/SC2262 EV1527 protocol
+ *
+ * Tested devices:
+ * SC2260
+ * EV1527
+ *
+ * Copyright (C) 2015 Tommy Vestermark
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+#include "rtl_433.h"
+#include "pulse_demod.h"
+
+
+static int generic_remote_callback(bitbuffer_t *bitbuffer) {
+	bitrow_t *bb = bitbuffer->bb;
+	uint8_t *b = bb[0];
+	
+	//invert bits, short pulse is 0, long pulse is 1
+	b[0] = ~b[0];
+	b[1] = ~b[1];
+	b[2] = ~b[2];
+
+	unsigned bits = bitbuffer->bits_per_row[0];
+
+	// Validate package
+	if ((bits == 25)
+	 && (b[3] && 0x7F)	// Last bit is always 0
+	 && (b[0] != 0x00) && (b[1] != 0x00) && (b[2] != 0x00)	// Reduce false positives. ID 0x00000 not supported
+	) {
+
+		uint32_t ID_16b = b[0] << 8 | b[1];
+		unsigned char CMD_8b = b[2];
+
+		fprintf(stdout, "Generic remote keypress / sensor\n");
+		fprintf(stdout, "ID 16bit = 0x%04X\n", ID_16b);
+		fprintf(stdout, "CMD 8bit = 0x%02X\n", CMD_8b);
+
+
+		// output tristate coding
+
+		uint32_t FULL = b[0] << 16 | b[1] << 8 | b[2];
+		char c;
+
+		fprintf(stdout, "TRISTATE = ");
+		for (signed char i=22; i>=0; i-=2) {
+
+			switch ((FULL>>i) & 0x03) {
+				case 0x00:	c = '0'; break;
+				case 0x01:	c = 'F'; break;
+				case 0x02:	c = '!'; break; // tristate 10 is invalid code for SC226x but valid in EV1527
+				case 0x03:	c = '1'; break;
+				default:	c = '?'; break; // not possible anyway
+			}
+
+			fputc(c, stdout);
+		}
+		fprintf(stdout, "\n");
+
+		return 1;
+	}
+	return 0;
+}
+
+
+PWM_Precise_Parameters pwm_precise_parameters_generic = {
+	.pulse_tolerance	= 20,
+	.pulse_sync_width	= 0,	// No sync bit used
+};
+
+r_device generic_remote = {
+	.name			= "Generic Remote SC226x EV1527",
+	.modulation		= OOK_PULSE_PWM_PRECISE,
+	.short_limit	= 116,
+	.long_limit		= 351,
+	.reset_limit	= 450,
+	.json_callback	= &generic_remote_callback,
+	.disabled		= 0,
+	.demod_arg		= (unsigned long)&pwm_precise_parameters_generic,
+};


### PR DESCRIPTION
So after the discussion in pull request #156 I reverted the additional output in chuango device, thus the device stays very vendor specific.  
I created a new device to deal with other devices using the SC/PT226x and EV1527 chips. For now the timing is tight and fits the remote I submitted in the test samples. Running all other tests resulted in no single false positive.