### PR TITLE
generic remote sc/pt226x ev1527: increase the tolerance to 50

### DIFF
--- a/src/devices/generic_remote.c
+++ b/src/devices/generic_remote.c
@@ -5,6 +5,7 @@
  * EV1527
  *
  * Copyright (C) 2015 Tommy Vestermark
+ * Copyright (C) 2015 nebman
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -66,7 +67,7 @@ static int generic_remote_callback(bitbuffer_t *bitbuffer) {
 
 
 PWM_Precise_Parameters pwm_precise_parameters_generic = {
-	.pulse_tolerance	= 20,
+	.pulse_tolerance	= 50,
 	.pulse_sync_width	= 0,	// No sync bit used
 };
 


### PR DESCRIPTION
very short follow-up to pull #156 three weeks ago: I increased the tolerance to 50, now it works with all the devices we can test so far (my SC2260 remote, merbanan's PT2262 sensor, plus I got a new EV1527 remote that also works fine with this setting).

sorry this is a bit late - but here it is anyway ;)

the code did not produce any false-positives with the samples repo.