### PR TITLE
WT450: Add missing the supported device label in README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Supported devices:
 	[29] Chuango Security Technology
 	[30] Generic Remote SC226x EV1527
 	[31] TFA-Twin-Plus-30.3049
+	[32] WT450H/WT260H
 ```
 
 


### PR DESCRIPTION
I am sorry. Add new supported device label in README file.