### PR TITLE
Added missing wt450.c for autoconf compile

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,6 +37,7 @@ rtl_433_SOURCES      = baseband.c \
                        devices/tfa_twin_plus_30.3049.c \
                        devices/valeo.c \
                        devices/waveman.c \
+                       devices/wt450.c \
                        devices/x10_rf.c \
                        devices/esperanza_ews.c \
                        devices/xc0348.c


### PR DESCRIPTION
The recent addition of wt450 support was missing w450.c for autoconf based compile