### PR TITLE
Add support for Efergy e2 classic

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,11 @@ Supported devices:
 	[29] Chuango Security Technology
 	[30] Generic Remote SC226x EV1527
 	[31] TFA-Twin-Plus-30.3049
-	[32] WT450H/WT260H
-	[33] LaCrosse Weather Station WS-2310TWC
+	[32] Digitech XC0348 Weather Station
+	[33] WT450
+	[34] LaCrosse WS-2310 Weather Station
+	[35] Esperanza EWS
+	[36] Efergy e2 classic
 ```
 
 

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -30,7 +30,7 @@
 #define DEFAULT_LEVEL_LIMIT     8000		// Theoretical high level at I/Q saturation is 128x128 = 16384 (above is ripple)
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           35
+#define MAX_PROTOCOLS           36
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */
@@ -46,6 +46,7 @@
 
 #define	FSK_DEMOD_MIN_VAL		16			// Dummy. FSK demodulation must start at this value
 #define	FSK_PULSE_PCM			16			// FSK, Pulse Code Modulation
+#define	FSK_PULSE_PWM_RAW		17			// FSK, Pulse Width Modulation. Short pulses = 1, Long = 0
 
 extern int debug_output;
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -38,7 +38,8 @@
 		DECL(digitech_ws) \
 		DECL(wt450) \
 		DECL(lacrossews) \
-		DECL(esperanza_ews)
+		DECL(esperanza_ews) \
+		DECL(efergy_e2_classic)
 
 
 typedef struct {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@
 ########################################################################
 add_executable(rtl_433 
 	rtl_433.c
-    baseband.c
+	baseband.c
 	bitbuffer.c
 	pulse_demod.c
 	pulse_detect.c
@@ -55,6 +55,7 @@ add_executable(rtl_433
 	devices/wt450.c
 	devices/lacrossews.c
 	devices/esperanza_ews.c
+	devices/efergy_e2_classic.c
 )
 
 target_link_libraries(rtl_433

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,7 +19,9 @@ rtl_433_SOURCES      = baseband.c \
                        devices/danfoss.c \
                        devices/dsc.c \
                        devices/ec3k.c \
+                       devices/efergy_e2_classic.c \
                        devices/elv.c \
+                       devices/esperanza_ews.c \
                        devices/fineoffset.c \
                        devices/generic_remote.c \
                        devices/gt_wt_02.c \
@@ -39,7 +41,6 @@ rtl_433_SOURCES      = baseband.c \
                        devices/waveman.c \
                        devices/wt450.c \
                        devices/x10_rf.c \
-                       devices/esperanza_ews.c \
                        devices/xc0348.c
 
 rtl_433_LDADD        = $(LIBRTLSDR) $(LIBM)

--- a/src/devices/efergy_e2_classic.c
+++ b/src/devices/efergy_e2_classic.c
@@ -1,0 +1,84 @@
+/* Efergy e2 classic (electricity meter)
+ *
+ * This electricity meter periodically reports current power consumption
+ * on frequency ~433.55 MHz. The data that is transmitted consists of 8
+ * bytes:
+ *
+ * Byte 1-4: Start bits (0000), then static data (probably device id)
+ * Byte 5-7: Current power consumption
+ * Byte 8: Checksum
+ *
+ * Power calculations come from Nathaniel Elijah's program EfergyRPI_001.
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "rtl_433.h"
+
+static int efergy_e2_classic_callback(bitbuffer_t *bitbuffer) {
+	unsigned num_bits = bitbuffer->bits_per_row[0];
+	uint8_t *bytes = bitbuffer->bb[0];
+
+	if (num_bits < 64 || num_bits > 80) {
+		return 0;
+	}
+
+	// The bit buffer isn't always aligned to the transmitted data, so
+	// search for data start and shift out the bits which aren't part
+	// of the data. The data always starts with 0000 (or 1111 if
+	// gaps/pulses are mixed up).
+	while ((bytes[0] & 0xf0) != 0xf0 && (bytes[0] & 0xf0) != 0x00) {
+		num_bits -= 1;
+		if (num_bits < 64) {
+			return 0;
+		}
+
+		for (unsigned i = 0; i < (num_bits + 7) / 8; ++i) {
+			bytes[i] <<= 1;
+			bytes[i] |= (bytes[i + 1] & 0x80) >> 7;
+		}
+	}
+
+	// Sometimes pulses and gaps are mixed up. If this happens, invert
+	// all bytes to get correct interpretation.
+	if (bytes[0] & 0xf0) {
+		for (unsigned i = 0; i < 8; ++i) {
+			bytes[i] = ~bytes[i];
+		}
+	}
+
+	unsigned checksum = 0;
+	for (unsigned i = 0; i < 7; ++i) {
+		checksum += bytes[i];
+	}
+	checksum &= 0xff;
+	if (checksum != bytes[7]) {
+		return 0;
+	}
+
+	const unsigned VOLTAGES[] = {110, 115, 120, 220, 230, 240, 0};
+
+	double current_adc = 256 * bytes[4] + bytes[5];
+	for (unsigned i = 0; VOLTAGES[i] != 0; ++i) {
+		double power  = (VOLTAGES[i] * current_adc * (1 << bytes[6])) / 32768;
+		fprintf(stderr, "Power consumption at %u volts: %.2f watts\n", VOLTAGES[i], power);
+	}
+
+	return 1;
+}
+
+
+r_device efergy_e2_classic = {
+	.name           = "Efergy e2 classic",
+	.modulation     = FSK_PULSE_PWM_RAW,
+	.short_limit    = 23,
+	.long_limit     = 100,
+	.reset_limit    = 100,
+	.json_callback  = &efergy_e2_classic_callback,
+	.disabled       = 0,
+	.demod_arg      = 0,
+};

--- a/src/pulse_demod.c
+++ b/src/pulse_demod.c
@@ -77,7 +77,7 @@ int pulse_demod_pcm(const pulse_data_t *pulses, struct protocol_state *device)
 int pulse_demod_ppm(const pulse_data_t *pulses, struct protocol_state *device) {
 	int events = 0;
 	bitbuffer_t bits = {0};
-	
+
 	for(unsigned n = 0; n < pulses->num_pulses; ++n) {
 		// Short gap
 		if(pulses->gap[n] < (unsigned)device->short_limit) {
@@ -124,13 +124,14 @@ int pulse_demod_pwm(const pulse_data_t *pulses, struct protocol_state *device) {
 			}
 		}
 		// End of Message?
-		if(pulses->gap[n] > (unsigned)device->reset_limit) {
+                if (n == pulses->num_pulses - 1                           // No more pulses (FSK)
+		    || pulses->gap[n] > (unsigned)device->reset_limit) {  // Long silence (OOK)
 			if (device->callback) {
 				events += device->callback(&bits);
 			}
 			// Debug printout
 			if(!device->callback || (debug_output && events > 0)) {
-				fprintf(stderr, "pulse_demod_pwm(): %s \n", device->name);
+				fprintf(stderr, "pulse_demod_pwm(): %s\n", device->name);
 				bitbuffer_print(&bits);
 			}
 			bitbuffer_clear(&bits);
@@ -150,7 +151,7 @@ int pulse_demod_pwm_precise(const pulse_data_t *pulses, struct protocol_state *d
 	int events = 0;
 	bitbuffer_t bits = {0};
 	PWM_Precise_Parameters *p = (PWM_Precise_Parameters *)device->demod_arg;
-	
+
 	for(unsigned n = 0; n < pulses->num_pulses; ++n) {
 		// 'Short' 1 pulse
 		if (abs(pulses->pulse[n] - device->short_limit) < p->pulse_tolerance) {
@@ -187,7 +188,7 @@ int pulse_demod_pwm_ternary(const pulse_data_t *pulses, struct protocol_state *d
 	int events = 0;
 	bitbuffer_t bits = {0};
 	unsigned sync_bit = device->demod_arg;
-	
+
 	for(unsigned n = 0; n < pulses->num_pulses; ++n) {
 		// Short pulse
 		if (pulses->pulse[n] < (unsigned)device->short_limit) {
@@ -235,7 +236,7 @@ int pulse_demod_manchester_zerobit(const pulse_data_t *pulses, struct protocol_s
 	int events = 0;
 	unsigned time_since_last = 0;
 	bitbuffer_t bits = {0};
-	
+
 	// First rising edge is allways counted as a zero (Seems to be hardcoded policy for the Oregon Scientific sensors...)
 	bitbuffer_add_bit(&bits, 0);
 
@@ -249,7 +250,7 @@ int pulse_demod_manchester_zerobit(const pulse_data_t *pulses, struct protocol_s
 		} else {
 			time_since_last += pulses->pulse[n];
 		}
-		
+
 		// End of Message?
 		if(pulses->gap[n] > (unsigned)device->reset_limit) {
 			int newevents = 0;
@@ -317,4 +318,3 @@ int pulse_demod_clock_bits(const pulse_data_t *pulses, struct protocol_state *de
 
    return events;
 }
-

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -678,6 +678,7 @@ static void rtlsdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
 				case OOK_PULSE_MANCHESTER_ZEROBIT:
 				case OOK_PULSE_CLOCK_BITS:
 				case FSK_PULSE_PCM:
+				case FSK_PULSE_PWM_RAW:
 					break;
 				default:
 					fprintf(stderr, "Unknown modulation %d in protocol!\n", demod->r_devs[i]->modulation);
@@ -718,6 +719,7 @@ static void rtlsdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
 							break;
 						// FSK decoders
 						case FSK_PULSE_PCM:
+						case FSK_PULSE_PWM_RAW:
 							break;
 						default:
 							fprintf(stderr, "Unknown modulation %d in protocol!\n", demod->r_devs[i]->modulation);
@@ -742,6 +744,9 @@ static void rtlsdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
 							break;
 						case FSK_PULSE_PCM:
 							pulse_demod_pcm(&demod->fsk_pulse_data, demod->r_devs[i]);
+							break;
+						case FSK_PULSE_PWM_RAW:
+							pulse_demod_pwm(&demod->fsk_pulse_data, demod->r_devs[i]);
 							break;
 						default:
 							fprintf(stderr, "Unknown modulation %d in protocol!\n", demod->r_devs[i]->modulation);


### PR DESCRIPTION
Decoding is pretty stable, but sometimes the data start isn't properly detected (some problematic samples are gfile435.data, gfile546.data and gfile734.data in the tests repo).

This fixes #14.