### PR TITLE
Remove unused command line argument 'c' (used to be decimation level)

### DIFF
--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -830,7 +830,7 @@ int main(int argc, char **argv) {
 
     demod->level_limit = DEFAULT_LEVEL_LIMIT;
 
-    while ((opt = getopt(argc, argv, "x:z:p:DtaAqm:r:c:l:d:f:g:s:b:n:SR:")) != -1) {
+    while ((opt = getopt(argc, argv, "x:z:p:DtaAqm:r:l:d:f:g:s:b:n:SR:")) != -1) {
         switch (opt) {
             case 'd':
                 dev_index = atoi(optarg);


### PR DESCRIPTION
Decimation support was almost removed in db9b44ab31be2090123d839d0d76c4736d1a6d5c