### PR TITLE
fix Makefile.am and rename rfwireless  device and file name

### DIFF
--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -41,7 +41,7 @@
 		DECL(esperanza_ews) \
 		DECL(efergy_e2_classic) \
 		DECL(kw9015b) \
-		DECL(rfwireless)
+		DECL(generic_temperature_sensor)
 
 
 typedef struct {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,7 +57,7 @@ add_executable(rtl_433
 	devices/esperanza_ews.c
 	devices/efergy_e2_classic.c
 	devices/inovalley-kw9015b.c
-	devices/rfwireless.c
+	devices/generic_temperature_sensor.c
 )
 
 target_link_libraries(rtl_433

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,6 +41,8 @@ rtl_433_SOURCES      = baseband.c \
                        devices/waveman.c \
                        devices/wt450.c \
                        devices/x10_rf.c \
-                       devices/xc0348.c
+                       devices/xc0348.c \
+                       devices/inovalley-kw9015b.c \
+                       devices/rfwireless.c
 
 rtl_433_LDADD        = $(LIBRTLSDR) $(LIBM)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -43,6 +43,6 @@ rtl_433_SOURCES      = baseband.c \
                        devices/x10_rf.c \
                        devices/xc0348.c \
                        devices/inovalley-kw9015b.c \
-                       devices/rfwireless.c
+                       devices/generic_temperature_sensor.c
 
 rtl_433_LDADD        = $(LIBRTLSDR) $(LIBM)

--- a/src/devices/generic_temperature_sensor.c
+++ b/src/devices/generic_temperature_sensor.c
@@ -1,4 +1,4 @@
-/* Unknown Temperature weather station
+/* Generic temperature sensor 1
  *
  * Copyright (C) 2015 Alexandre Coffignal
  * This program is free software; you can redistribute it and/or modify
@@ -8,7 +8,7 @@
  */
 #include "rtl_433.h"
 
-static int rfwireless_callback(bitbuffer_t *bitbuffer) {
+static int generic_temperature_sensor_callback(bitbuffer_t *bitbuffer) {
 	bitrow_t *bb = bitbuffer->bb;
 
 	int i,device,battery;
@@ -42,14 +42,14 @@ static int rfwireless_callback(bitbuffer_t *bitbuffer) {
 	return 1;
 }
 
-r_device rfwireless = {
+r_device generic_temperature_sensor = {
 
   .name          = "RF Wireless Temp Transmitter",
   .modulation    = OOK_PWM_D,
   .short_limit   = 875,
   .long_limit    = 1200,
   .reset_limit   = 3000,
-  .json_callback = &rfwireless_callback,
+  .json_callback = &generic_temperature_sensor_callback,
   .disabled      = 0,
   .demod_arg     = 0,
 };

--- a/src/devices/generic_temperature_sensor.c
+++ b/src/devices/generic_temperature_sensor.c
@@ -34,7 +34,7 @@ static int generic_temperature_sensor_callback(bitbuffer_t *bitbuffer) {
 	fprintf(stdout, "Device        = %d\n", device);
 	fprintf(stdout, "Battery?      = %02X\n", battery);
 	fprintf(stdout, "Temp          = %f\n",fTemp);
-	fprintf(stdout, "Model         = RF Wireless Transmitter\n");
+	fprintf(stdout, "Model         = Generic temperature sensor 1\n");
 	fprintf(stdout, "Received Data = %02x %02x %02x\n", bb[1][0], bb[1][1], bb[1][2]);
 
 
@@ -44,7 +44,7 @@ static int generic_temperature_sensor_callback(bitbuffer_t *bitbuffer) {
 
 r_device generic_temperature_sensor = {
 
-  .name          = "RF Wireless Temp Transmitter",
+  .name          = "Generic temperature sensor 1",
   .modulation    = OOK_PWM_D,
   .short_limit   = 875,
   .long_limit    = 1200,

--- a/src/devices/inovalley-kw9015b.c
+++ b/src/devices/inovalley-kw9015b.c
@@ -62,7 +62,7 @@ static int kw9015b_callback(bitbuffer_t *bitbuffer) {
 }
 
 r_device kw9015b = {
-  .name          = "KW9015B Transmitter",
+  .name          = "Inovalley kw9015b rain and Temperature weather station",
   .modulation    = OOK_PWM_D,
   .short_limit   = 875,
   .long_limit    = 1200,


### PR DESCRIPTION
Hello,
those patch fix makefile.am and rename rfwireless into generic_temperature_sensor as rct advised

Thanks