### PR TITLE
Migrate "prologue" to new output handler

### DIFF
--- a/src/devices/prologue.c
+++ b/src/devices/prologue.c
@@ -6,7 +6,7 @@
  * the data is grouped in 9 nibles
  * [id0] [rid0] [rid1] [data0] [temp0] [temp1] [temp2] [humi0] [humi1]
  *
- * id0 is always 1001,9
+ * id0 is 1001,9 or 0110,5
  * rid is a random id that is generated when the sensor starts, could include battery status
  * the same batteries often generate the same id
  * data(3) is 0 the battery status, 1 ok, 0 low, first reading always say low
@@ -19,12 +19,24 @@
  * The sensor can be bought at Clas Ohlson
  */
 #include "rtl_433.h"
+#include "util.h"
+#include "data.h"
 
 static int prologue_callback(bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
-    int rid;
+    data_t *data;
 
+    time_t time_now;
+    char time_str[LOCAL_TIME_BUFLEN];
+
+    uint8_t rid;
+    uint8_t id;
+    uint8_t channel;
+    uint8_t button;
+    uint8_t battery;
     int16_t temp2;
+    float temp;
+    uint8_t humidity;
 
     /* FIXME validate the received message better */
     if (((bb[1][0]&0xF0) == 0x90 && (bb[2][0]&0xF0) == 0x90 && (bb[3][0]&0xF0) == 0x90 && (bb[4][0]&0xF0) == 0x90 &&
@@ -32,24 +44,50 @@ static int prologue_callback(bitbuffer_t *bitbuffer) {
         ((bb[1][0]&0xF0) == 0x50 && (bb[2][0]&0xF0) == 0x50 && (bb[3][0]&0xF0) == 0x50 && (bb[4][0]&0xF0) == 0x50 &&
         (bb[1][3] == bb[2][3]) && (bb[1][4] == bb[2][4]))) {
 
+        /* Get time now */
+        time(&time_now);
+        local_time_str(time_now, time_str);
+
         /* Prologue sensor */
+        id = (bb[1][0]&0xF0)>>4;
+        rid = ((bb[1][0]&0x0F)<<4) | ((bb[1][1]&0xF0)>>4);
+        battery = bb[1][1]&0x08;
+        channel = (bb[1][1]&0x03) + 1;
+        button = (bb[1][1]&0x04) >> 2;
         temp2 = (int16_t)((uint16_t)(bb[1][2] << 8) | (bb[1][3]&0xF0));
         temp2 = temp2 >> 4;
-        fprintf(stdout, "Sensor temperature event:\n");
-        fprintf(stdout, "protocol      = Prologue, %d bits\n",bitbuffer->bits_per_row[1]);
-        fprintf(stdout, "button        = %d\n",bb[1][1]&0x04?1:0);
-        fprintf(stdout, "battery       = %s\n",bb[1][1]&0x08?"Ok":"Low");
-        fprintf(stdout, "temp          = %s%d.%d\n",temp2<0?"-":"",abs((int16_t)temp2/10),abs((int16_t)temp2%10));
-        fprintf(stdout, "humidity      = %d\n", ((bb[1][3]&0x0F)<<4)|(bb[1][4]>>4));
-        fprintf(stdout, "channel       = %d\n",(bb[1][1]&0x03)+1);
-        fprintf(stdout, "id            = %d\n",(bb[1][0]&0xF0)>>4);
-        rid = ((bb[1][0]&0x0F)<<4)|(bb[1][1]&0xF0)>>4;
-        fprintf(stdout, "rid           = %d\n", rid);
-        fprintf(stdout, "hrid          = %02x\n", rid);
+        temp = temp2/10.;
+        humidity = ((bb[1][3]&0x0F)<<4) | (bb[1][4]>>4);
+
+        data = data_make("time",          "",            DATA_STRING, time_str,
+                         "model",         "",            DATA_STRING, "Prologue sensor",
+                         "id",            "",            DATA_INT, id,
+                         "rid",           "",            DATA_INT, rid,
+                         "channel",       "Channel",     DATA_INT, channel,
+                         "battery",       "Battery",     DATA_STRING, battery ? "OK" : "LOW",
+                         "button",        "Button",      DATA_INT, button,
+                         "temperature_C", "Temperature", DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp,
+                         "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, humidity,
+                          NULL);
+        data_acquired_handler(data);
+
         return 1;
     }
     return 0;
 }
+
+static char *output_fields[] = {
+    "time",
+    "model",
+    "id",
+    "rid",
+    "channel",
+    "battery",
+    "button",
+    "temperature_C",
+    "humidity",
+    NULL
+};
 
 r_device prologue = {
     .name           = "Prologue Temperature Sensor",
@@ -60,4 +98,5 @@ r_device prologue = {
     .json_callback  = &prologue_callback,
     .disabled       = 0,
     .demod_arg      = 0,
+    .fields         = output_fields
 };


### PR DESCRIPTION
Tested with data recently pushed to rtl_433_test (https://github.com/merbanan/rtl_433_tests/tree/master/tests/prologue/02)

Maybe an "unification" of id/rid naming over different sensors should be done ?

By the way, there is no checksum with this protocol. However one may test if the 6 transmitted packets are equals to better validate reception. Do you think it's a good idea ?