### PR TITLE
waveman: added missing comma to fix CSV output

### DIFF
--- a/src/devices/waveman.c
+++ b/src/devices/waveman.c
@@ -53,7 +53,7 @@ static int waveman_callback(bitbuffer_t *bitbuffer) {
 static char *output_fields[] = {
 	"model",
 	"id",
-	"channel"
+	"channel",
 	"button",
 	"state",
 	NULL


### PR DESCRIPTION
The missing comma at the end of the line concatenates these two strings.