### PR TITLE
Add support for RFMxx/Si4320 FSK encoding and Watchman Sonic oil tank monitor

### DIFF
--- a/include/pulse_demod.h
+++ b/include/pulse_demod.h
@@ -115,6 +115,32 @@ int pulse_demod_pwm_ternary(const pulse_data_t *pulses, struct protocol_state *d
 /// @return number of events processed
 int pulse_demod_manchester_zerobit(const pulse_data_t *pulses, struct protocol_state *device);
 
+/// Demodulate a Manchester encoded signal with preamble and postamble as used by HopeRF RFMxx modules
+///
+/// Each frame has a preamble of three high-level periods, followed by three low-level
+/// periods (which we presume might be four, if the first data bit is a 1. Although
+/// we actually have yet to see a transmission where the first data bit is a 1).
+/// The end of frame is marked by staying at the same level (high or low
+/// depending on the value of the last data bit) for two further periods.
+///
+/// +-----------+           +---+       +-----------+  high frequency
+/// |           |           |   |       |
+/// |           |           |   |       |
+/// +           +-----------+   +-------+              low frequency
+///
+/// ^   ^   ^   ^   ^   ^   ^   ^   ^   ^   ^   ^   ^
+/// |  preamble | preamble  |   0   |   1   |  end      translates as
+///
+/// Clock is recovered from the data based on pulse width. When time since last bit is more
+/// than 1.5 times the clock half period (short_width) it is declared a data edge where:
+/// - Rising edge means bit = 1
+/// - Falling edge means bit = 0
+/// @param device->short_limit: Nominal width of clock half period [samples]
+/// @param device->long_limit:  Not used
+/// @param device->reset_limit: Not used
+/// @return number of events processed
+int pulse_demod_manchester_framed(const pulse_data_t *pulses, struct protocol_state *device);
+
 
 /// No level shift within the clock cycle translates to a logic 0
 /// One level shift within the clock cycle translates to a logic 1

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -31,7 +31,7 @@
 #define DEFAULT_LEVEL_LIMIT     8000		// Theoretical high level at I/Q saturation is 128x128 = 16384 (above is ripple)
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           41
+#define MAX_PROTOCOLS           42
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -43,10 +43,10 @@
 #define	OOK_PULSE_PWM_RAW		7			// Pulse Width Modulation. Short pulses = 1, Long = 0
 #define	OOK_PULSE_PWM_TERNARY	8			// Pulse Width Modulation with three widths: Sync, 0, 1. Sync determined by argument
 #define	OOK_PULSE_CLOCK_BITS		9			// Level shift within the clock cycle.
-
 #define	FSK_DEMOD_MIN_VAL		16			// Dummy. FSK demodulation must start at this value
 #define	FSK_PULSE_PCM			16			// FSK, Pulse Code Modulation
 #define	FSK_PULSE_PWM_RAW		17			// FSK, Pulse Width Modulation. Short pulses = 1, Long = 0
+#define	FSK_PULSE_MANCHESTER_FRAMED 18		// FSK, Framed Manchester encoding as used by HopeRF RFMxx modules.
 
 extern int debug_output;
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -44,7 +44,8 @@
 		DECL(generic_temperature_sensor) \
 		DECL(acurite_txr) \
 		DECL(acurite_986) \
-		DECL(hideki_ts04)
+		DECL(hideki_ts04) \
+		DECL(oil_watchman)
 
 typedef struct {
 	char name[256];

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,7 @@ add_executable(rtl_433
 	devices/inovalley-kw9015b.c
 	devices/generic_temperature_sensor.c
 	devices/hideki.c
+	devices/oil_watchman.c
 )
 
 add_library(data data.c)

--- a/src/devices/oil_watchman.c
+++ b/src/devices/oil_watchman.c
@@ -1,0 +1,91 @@
+/* Oil tank monitor using Si4320 framed FSK protocol
+ *
+ * Tested devices:
+ * Sensor Systems Watchman Sonic
+ *
+ * Copyright © 2015 David Woodhouse
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+#include "rtl_433.h"
+#include "pulse_demod.h"
+#include "util.h"
+
+static int oil_watchman_callback(bitbuffer_t *bitbuffer) {
+	bitrow_t *bb = bitbuffer->bb;
+	uint8_t *b = bb[0];
+	uint32_t unit_id;
+	uint16_t depth = 0;
+	uint16_t binding_countdown = 0;
+	uint8_t flags;
+	uint8_t maybetemp;
+	time_t time_now;
+	char time_str[LOCAL_TIME_BUFLEN];
+	data_t *data;
+
+	if (bitbuffer->bits_per_row[0] != 64 ||
+		b[0] != 0x28 || b[7] != crc8le(b, 7, 0x31, 0))
+			return 0;
+
+	time(&time_now);
+	local_time_str(time_now, time_str);
+
+	// The unit ID changes when you rebind by holding a magnet to the
+	// sensor for long enough; it seems to be time-based.
+	unit_id = (b[1] << 16) | (b[2] << 8) | b[3];
+
+	// 0x01: Rebinding (magnet held to sensor)
+	// 0x08: Leak/theft alarm
+	flags = b[4];
+
+	// Not entirely sure what this is but it might be inversely
+	// proportional to temperature.
+	maybetemp = b[5] >> 2;
+
+	if (flags & 1)
+			// When binding, the countdown counts up from 0x51 to 0x5a
+			// (as long as you hold the magnet to it for long enough)
+			// before the device ID changes. The receiver unit needs
+			// to receive this *strongly* in order to change its
+			// allegiance.
+			binding_countdown = b[6];
+	else
+			// A depth reading of zero indicates no reading. Even with
+			// the sensor flat down on a table, it still reads about 13.
+			depth = b[6] | ((((uint16_t)b[5]) & 3) << 8);
+
+	data = data_make("time", "", DATA_STRING, time_str,
+			 "model", "", DATA_STRING, "Oil Watchman",
+			 "id", "", DATA_FORMAT, "%06x", DATA_INT, unit_id,
+			 "flags", "", DATA_FORMAT, "%02x", DATA_INT, flags,
+			 "maybetemp", "", DATA_INT, maybetemp,
+		     "binding_countdown", "", DATA_INT, binding_countdown,
+		     "depth", "", DATA_INT, depth,
+		     NULL);
+    data_acquired_handler(data);
+
+	return 0;
+};
+
+static char *output_fields[] = {
+	"time",
+	"model",
+	"id",
+	"flags",
+	"maybetemp",
+	"binding_countdown",
+	"depth",
+	NULL
+};
+
+r_device oil_watchman = {
+	.name			= "Ultrasonic oil monitor",
+	.modulation		= FSK_PULSE_MANCHESTER_FRAMED,
+	.short_limit	= 250,
+	.json_callback	= &oil_watchman_callback,
+	.disabled		= 0,
+	.fields			= output_fields,
+};

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -435,6 +435,9 @@ void pulse_analyzer(pulse_data_t *data)
 			case OOK_PULSE_MANCHESTER_ZEROBIT:
 				pulse_demod_manchester_zerobit(data, &device);
 				break;
+			case FSK_PULSE_MANCHESTER_FRAMED:
+				pulse_demod_manchester_framed(data, &device);
+				break;
 			default:
 				fprintf(stderr, "Unsupported\n");
 		}

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -335,6 +335,40 @@ void histogram_print(const histogram_t *hist) {
 
 #define TOLERANCE (0.2)		// 20% tolerance should still discern between the pulse widths: 0.33, 0.66, 1.0
 
+// Detecting the RFM01/Si4320 framed FSK is non-trivial so do it in a separate function
+static int detect_framed_fsk(histogram_t *hist_pulses, histogram_t *hist_gaps, pulse_data_t *data)
+{
+	unsigned halfbit;
+
+	// It is theoretically possible for a valid data packet to contain
+	// no double-halfbit pulses, or no single-halfbit pulses, if the
+	// packet is either *all* zeroes or repeated 010101, respectively.
+	// As long the actual devices decoders *will* work for this unlikely
+	// case, it's probably OK for the heuristic not to guess it. This
+	// function is fun enough already without coping with that...
+	if (hist_pulses->bins_count < 3 || hist_gaps->bins_count < 3)
+		return 0;
+
+	// We use the gaps not the pulses because we *consistently* see
+	// a misdetected pulse of a few (5 or 6) samples, after a frame
+	// ends with a low frequency (i.e. last data bit is a 0). See
+	// discussion in Issue #218.
+	halfbit = min(hist_gaps->bins[0].mean, hist_gaps->bins[1].mean);
+
+	// Start of frame must be 3 halfbits high, followed by 3 or 4 low.
+	if (data->pulse[0] < halfbit * 5/2 || data->pulse[0] > halfbit * 7/2 ||
+	    data->gap[0] < halfbit * 5/2 || data->gap[0] > halfbit * 9/2)
+		return 0;
+
+	// We could do a lot here, to the extent of a full decoding to check
+	// the framing. That doesn't seem necessary, as long as we don't have
+	// too many false positives. This is just a heuristic, after all.
+	if (hist_gaps->bins[2].mean < halfbit * 5/2)
+		return 0;
+
+	return 1;
+}
+
 /// Analyze the statistics of a pulse data structure and print result
 void pulse_analyzer(pulse_data_t *data)
 {
@@ -400,6 +434,12 @@ void pulse_analyzer(pulse_data_t *data)
 		device.short_limit	= min(hist_pulses.bins[0].mean, hist_pulses.bins[1].mean);		// Assume shortest pulse is half period
 		device.long_limit	= 0; // Not used
 		device.reset_limit	= hist_gaps.bins[hist_gaps.bins_count-1].max + 1;				// Set limit above biggest gap
+	} else if(detect_framed_fsk(&hist_pulses, &hist_gaps, data)) {
+		fprintf(stderr, "RFM Framed Manchester coding\n");
+		device.modulation	= FSK_PULSE_MANCHESTER_FRAMED;
+		device.short_limit	= min(hist_gaps.bins[0].mean, hist_gaps.bins[1].mean);		// Assume shortest pulse is half period
+		device.long_limit	= 0; // Not used
+		device.reset_limit	= 0; // Not used
 	} else if(hist_pulses.bins_count == 3) {
 		fprintf(stderr, "Pulse Width Modulation with startbit/delimiter\n");
 		device.modulation	= OOK_PULSE_PWM_TERNARY;

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -636,6 +636,7 @@ static void rtlsdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
 				case OOK_PULSE_CLOCK_BITS:
 				case FSK_PULSE_PCM:
 				case FSK_PULSE_PWM_RAW:
+				case FSK_PULSE_MANCHESTER_FRAMED:
 					break;
 				default:
 					fprintf(stderr, "Unknown modulation %d in protocol!\n", demod->r_devs[i]->modulation);
@@ -676,6 +677,7 @@ static void rtlsdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
 						// FSK decoders
 						case FSK_PULSE_PCM:
 						case FSK_PULSE_PWM_RAW:
+						case FSK_PULSE_MANCHESTER_FRAMED:
 							break;
 						default:
 							fprintf(stderr, "Unknown modulation %d in protocol!\n", demod->r_devs[i]->modulation);
@@ -702,6 +704,9 @@ static void rtlsdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
 							break;
 						case FSK_PULSE_PWM_RAW:
 							pulse_demod_pwm(&demod->fsk_pulse_data, demod->r_devs[i]);
+							break;
+						case FSK_PULSE_MANCHESTER_FRAMED:
+							pulse_demod_manchester_framed(&demod->fsk_pulse_data, demod->r_devs[i]);
 							break;
 						default:
 							fprintf(stderr, "Unknown modulation %d in protocol!\n", demod->r_devs[i]->modulation);


### PR DESCRIPTION
Fixes Issue #218

The encoding (and the RFMxx/SI chip) is also used by a number of other devices, such as the WH1080 weather system.