### PR TITLE
Consistent ouput for reading sample files

### DIFF
--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -49,6 +49,7 @@
 #define	FSK_PULSE_PWM_RAW		17			// FSK, Pulse Width Modulation. Short pulses = 1, Long = 0
 
 extern int debug_output;
+extern float sample_file_pos;
 
 struct protocol_state {
     int (*callback)(bitbuffer_t *bitbuffer);

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -356,13 +356,11 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf) {
     float tempc, tempf, wind_dird, rainfall = 0.0, wind_speedmph;
     uint8_t humidity, sensor_status, repeat_no, message_type;
     char channel, *wind_dirstr = "";
-    time_t time_now;
     uint16_t sensor_id;
     int wind_speed, raincounter;
 
 
-    time(&time_now);
-    local_time_str(time_now, time_str);
+    local_time_str(0, time_str);
 
     if (debug_output > 1) {
         fprintf(stderr,"acurite_txr\n");
@@ -525,12 +523,10 @@ static int acurite_986_callback(bitbuffer_t *bitbuf) {
     uint8_t br[8];
     int8_t tempf; // Raw Temp is 8 bit signed Fahrenheit
     float tempc;
-    time_t time_now;
     uint16_t sensor_id, valid_cnt = 0;
     char sensor_type;
 
-    time(&time_now);
-    local_time_str(time_now, time_str);
+    local_time_str(0, time_str);
 
     if (debug_output > 1) {
         fprintf(stderr,"acurite_986\n");

--- a/src/devices/alecto.c
+++ b/src/devices/alecto.c
@@ -62,10 +62,8 @@ static int alectov1_callback(bitbuffer_t *bitbuffer) {
     int i;
 
 	data_t *data;
-	time_t time_now;
 	char time_str[LOCAL_TIME_BUFLEN];
-	time(&time_now);
-	local_time_str(time_now, time_str);
+	local_time_str(0, time_str);
 
     if (bb[1][0] == bb[5][0] && bb[2][0] == bb[6][0] && (bb[1][4] & 0xf) == 0 && (bb[5][4] & 0xf) == 0
             && (bb[5][0] != 0 && bb[5][1] != 0)) {

--- a/src/devices/ambient_weather.c
+++ b/src/devices/ambient_weather.c
@@ -103,11 +103,9 @@ ambient_weather_parser (bitbuffer_t *bitbuffer)
   uint16_t channel;
   uint16_t deviceID;
 
-  time_t time_now;
   char time_str[LOCAL_TIME_BUFLEN];
   data_t *data;
-  time(&time_now);
-  local_time_str(time_now, time_str);
+  local_time_str(0, time_str);
 
   if(bitbuffer->bits_per_row[0] != 195)	// There seems to be 195 bits in a correct message
     return 0;

--- a/src/devices/brennstuhl_rcs_2044.c
+++ b/src/devices/brennstuhl_rcs_2044.c
@@ -30,10 +30,8 @@ static int brennstuhl_rcs_2044_process_row(int row, const bitbuffer_t *bitbuffer
 #if 0
   {
     // print raw bit sequence for debug purposes (before exclusion of invalid sequenced is executed)
-    time_t time_now;
     char time_str[LOCAL_TIME_BUFLEN];
-    time(&time_now);
-    local_time_str(time_now, time_str);
+    local_time_str(0, time_str);
     fprintf(stdout, "%s Brennstuhl RCS 2044: received RAW bit sequence (%d bits): ", time_str, length);
     for(int i=0; i<4; i++)
     {
@@ -69,10 +67,8 @@ static int brennstuhl_rcs_2044_process_row(int row, const bitbuffer_t *bitbuffer
 #if 0 && !defined(NDEBUG)
   {
     // print raw bit sequence for debug purposes (before exclusion of invalid sequenced is executed)
-    time_t time_now;
     char time_str[LOCAL_TIME_BUFLEN];
-    time(&time_now);
-    local_time_str(time_now, time_str);
+    local_time_str(0, time_str);
     fprintf(stdout, "%s Brennstuhl RCS 2044: received bit sequence: ", time_str);
     for(int i=0; i<4; i++)
     {
@@ -152,10 +148,8 @@ static int brennstuhl_rcs_2044_process_row(int row, const bitbuffer_t *bitbuffer
 
   {
     /* @todo: remove timestamp printing as soon as the controller takes this task */
-    time_t time_now;
     char time_str[LOCAL_TIME_BUFLEN];
-    time(&time_now);
-    local_time_str(time_now, time_str);
+    local_time_str(0, time_str);
     fprintf(stdout, "%s Brennstuhl RCS 2044: system code: %d%d%d%d%d. key: %c, state: %s\n",
       time_str,
       system_code[0], system_code[1], system_code[2], system_code[3], system_code[4],

--- a/src/devices/current_cost.c
+++ b/src/devices/current_cost.c
@@ -7,11 +7,9 @@ static int current_cost_callback(bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
     uint8_t *b = bb[0];
 
-    time_t time_now;
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
-    time(&time_now);
-    local_time_str(time_now, time_str);
+    local_time_str(0, time_str);
 
     uint8_t init_pattern[] = {
       0b11001100, //8

--- a/src/devices/gt_wt_02.c
+++ b/src/devices/gt_wt_02.c
@@ -104,10 +104,8 @@ static int gt_wt_02_process_row(int row, const bitbuffer_t *bitbuffer)
   float tempC = (negative_sign ? ( temp - (1<<12) ) : temp ) * 0.1F;
   {
     /* @todo: remove timestamp printing as soon as the controller takes this task */
-    time_t time_now;
     char time_str[LOCAL_TIME_BUFLEN];
-    time(&time_now);
-    local_time_str(time_now, time_str);
+    local_time_str(0, time_str);
 
     /* @todo make temperature unit configurable, not printing both */
     fprintf(stdout, "%s GT-WT-02 Sensor %02x: battery %s, channel %d, button %d, temperature %3.1f C / %3.1f F, humidity %s%%\n"

--- a/src/devices/hideki.c
+++ b/src/devices/hideki.c
@@ -15,11 +15,9 @@ static int hideki_ts04_callback(bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
     uint8_t *b = bb[0];//TODO: handle the 3 row, need change in PULSE_CLOCK decoding
 
-    time_t time_now;
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
-    time(&time_now);
-    local_time_str(time_now, time_str);
+    local_time_str(0, time_str);
 
     uint8_t packet[HIDEKI_BYTES_PER_ROW];
 

--- a/src/devices/lacrosse.c
+++ b/src/devices/lacrosse.c
@@ -62,7 +62,6 @@ static int lacrossetx_detect(uint8_t *pRow, uint8_t *msg_nybbles, int16_t rowlen
 	int i;
 	uint8_t rbyte_no, rbit_no, mnybble_no, mbit_no;
 	uint8_t bit, checksum, parity_bit, parity = 0;
-	time_t time_now;
 	char time_str[LOCAL_TIME_BUFLEN];
 
 
@@ -110,8 +109,7 @@ static int lacrossetx_detect(uint8_t *pRow, uint8_t *msg_nybbles, int16_t rowlen
 		if (checksum == msg_nybbles[10] && (parity % 2 == 0)) {
 			return 1;
 		} else {
-			time(&time_now);
-			local_time_str(time_now, time_str);
+			local_time_str(0, time_str);
 			fprintf(stdout,
 				"%s LaCrosse Checksum/Parity error: Comp. %d != Recv. %d, Parity %d\n",
 				time_str, checksum, msg_nybbles[10], parity);
@@ -175,7 +173,7 @@ static int lacrossetx_callback(bitbuffer_t *bitbuffer) {
 			    continue;
 			}
 
-			local_time_str(time_now, time_str);
+			local_time_str(0, time_str);
 
 			// Check Repeated data values as another way of verifying
 			// message integrity.

--- a/src/devices/lacrossews.c
+++ b/src/devices/lacrossews.c
@@ -26,7 +26,6 @@ static int lacrossews_detect(uint8_t *pRow, uint8_t *msg_nybbles, int16_t rowlen
 	int i;
 	uint8_t rbyte_no, rbit_no, mnybble_no, mbit_no;
 	uint8_t bit, checksum = 0, parity = 0;
-	time_t time_now;
 	char time_str[LOCAL_TIME_BUFLEN];
 
 	// Weather Station 2310 Packets
@@ -61,8 +60,7 @@ static int lacrossews_detect(uint8_t *pRow, uint8_t *msg_nybbles, int16_t rowlen
 			checksum == msg_nybbles[12])
 			return 1;
 		else {
-			time(&time_now);
-			local_time_str(time_now, time_str);
+			local_time_str(0, time_str);
 			fprintf(stdout,
 				"%s LaCrosse Packet Validation Failed error: Checksum Comp. %d != Recv. %d, Parity %d\n",
 				time_str, checksum, msg_nybbles[12], parity);
@@ -86,7 +84,6 @@ static int lacrossews_callback(bitbuffer_t *bitbuffer) {
 	uint8_t ws_id, msg_type, sensor_id, msg_data, msg_unknown, msg_checksum;
 	int msg_value_bcd, msg_value_bcd2, msg_value_bin;
 	float temp_c, temp_f, wind_dir, wind_spd, rain_mm, rain_in;
-	time_t time_now;
 	char time_str[LOCAL_TIME_BUFLEN];
 
 	for (m = 0; m < BITBUF_ROWS; m++) {
@@ -103,9 +100,7 @@ static int lacrossews_callback(bitbuffer_t *bitbuffer) {
 			msg_value_bin = (msg_nybbles[7] * 256 + msg_nybbles[8] * 16 + msg_nybbles[9]);
 			msg_checksum = msg_nybbles[12];
 
-			time(&time_now);
-
-			local_time_str(time_now, time_str);
+			local_time_str(0, time_str);
 
 			if (debug_output) 
 				fprintf(stderr, "%1X%1X%1X%1X%1X%1X%1X%1X%1X%1X%1X%1X%1X   ",

--- a/src/devices/oil_watchman.c
+++ b/src/devices/oil_watchman.c
@@ -28,14 +28,12 @@ static int oil_watchman_callback(bitbuffer_t *bitbuffer) {
 	uint16_t binding_countdown = 0;
 	uint8_t flags;
 	uint8_t maybetemp;
-	time_t time_now;
 	char time_str[LOCAL_TIME_BUFLEN];
 	data_t *data;
 	unsigned bitpos = 0;
 	bitbuffer_t databits = {0};
 
-	time(&time_now);
-	local_time_str(time_now, time_str);
+	local_time_str(0, time_str);
 
 	// Find a preamble with enough bits after it that it could be a complete packet
 	while ((bitpos = bitbuffer_search(bitbuffer, 0, bitpos, &preamble_pattern, 6)) + 136 <=

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -189,10 +189,8 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
     } // for (pattern...
 
     data_t *data;
-    time_t time_now;
     char time_str[LOCAL_TIME_BUFLEN];
-    time(&time_now);
-    local_time_str(time_now, time_str);
+    local_time_str(0, time_str);
 
     int sensor_id = (msg[0] << 8) | msg[1];
     if ((sensor_id == ID_THGR122N) || (sensor_id == ID_THGR968)){

--- a/src/devices/prologue.c
+++ b/src/devices/prologue.c
@@ -26,7 +26,6 @@ static int prologue_callback(bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
     data_t *data;
 
-    time_t time_now;
     char time_str[LOCAL_TIME_BUFLEN];
 
     uint8_t rid;
@@ -45,8 +44,7 @@ static int prologue_callback(bitbuffer_t *bitbuffer) {
         (bb[1][3] == bb[2][3]) && (bb[1][4] == bb[2][4]))) {
 
         /* Get time now */
-        time(&time_now);
-        local_time_str(time_now, time_str);
+        local_time_str(0, time_str);
 
         /* Prologue sensor */
         id = (bb[1][0]&0xF0)>>4;

--- a/src/devices/tfa_twin_plus_30.3049.c
+++ b/src/devices/tfa_twin_plus_30.3049.c
@@ -88,10 +88,8 @@ static int tfa_twin_plus_303049_process_row(int row, const bitbuffer_t *bitbuffe
   float tempC = (negative_sign ? -( (1<<9) - temp ) : temp ) * 0.1F;
   {
     /* @todo: remove timestamp printing as soon as the controller takes this task */
-    time_t time_now;
     char time_str[LOCAL_TIME_BUFLEN];
-    time(&time_now);
-    local_time_str(time_now, time_str);
+    local_time_str(0, time_str);
 
     /* @todo make temperature unit configurable, not printing both */
     fprintf(stdout, "%s TFA-Twin-Plus-30.3049 Sensor %02x: battery %s, channel %d, temperature %3.1f C / %3.1f F, humidity %2d%%\n"

--- a/src/devices/wt450.c
+++ b/src/devices/wt450.c
@@ -73,11 +73,9 @@ static int wt450_callback(bitbuffer_t *bitbuffer) {
    uint8_t bit;
    uint8_t parity = 0;
 
-   time_t time_now;
    char time_str[LOCAL_TIME_BUFLEN];
    data_t *data;
-   time(&time_now);
-   local_time_str(time_now, time_str);
+   local_time_str(0, time_str);
 
 //bitbuffer_print(bitbuffer);
 

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -36,6 +36,7 @@ uint32_t frequency[MAX_PROTOCOLS];
 time_t rawtime_old;
 int flag;
 uint32_t samp_rate = DEFAULT_SAMPLE_RATE;
+float sample_file_pos = -1;
 static uint32_t bytes_to_read = 0;
 static rtlsdr_dev_t *dev = NULL;
 static int override_short = 0;
@@ -1058,9 +1059,11 @@ int main(int argc, char **argv) {
 	if (!quiet_mode) {
 	    fprintf(stderr, "Test mode active. Reading samples from file: %s\n", in_filename);
 	}
+	sample_file_pos = 0.0;
         while (fread(test_mode_buf, 131072, 1, in_file) != 0) {
             rtlsdr_callback(test_mode_buf, 131072, demod);
             i++;
+	    sample_file_pos = (float)i * 131072 / samp_rate;
         }
 
         // Call a last time with cleared samples to ensure EOP detection

--- a/src/util.c
+++ b/src/util.c
@@ -74,6 +74,11 @@ void local_time_str(time_t time_secs, char *buf) {
 	struct tm *tm_info;
 
 	if (time_secs == 0) {
+		extern float sample_file_pos;
+		if (sample_file_pos != -1.0) {
+			snprintf(buf, LOCAL_TIME_BUFLEN, "@%fs", sample_file_pos);
+			return;
+		}
 		time(&etime);
 	} else {
 		etime = time_secs;


### PR DESCRIPTION
When comparing results on the test packet corpus I was offended by the number of false mismatches I got on the current time. This makes it print the offset within the packet when reading from the file, rather than the time of day.

It's not perfect, because in most cases there's only one block of data within the file, so we always print @0.00000s. Perhaps we could actually report the offset within that block at which the pulse stream was found. But this achieves my real objective (consistent output when reading sample files) well enough for now.