### PR TITLE
newkaku: support APA3-1500R

### DIFF
--- a/src/devices/newkaku.c
+++ b/src/devices/newkaku.c
@@ -18,7 +18,7 @@ static int newkaku_callback(bitbuffer_t *bitbuffer) {
     uint8_t bitcount = 0;
     uint32_t kakuid = 0;
 
-    if (bb[0][0] == 0xac) {//allways starts with ac
+    if (bb[0][0] == 0xac || bb[0][0] == 0xb2) {//allways starts with ac or b2
         // first bit is from startbit sequence, not part of payload!
         // check protocol if value is 10 or 01, else stop processing as it is no vallid KAKU packet!
         //get id=24bits, remember 1st 1 bit = startbit, no payload!


### PR DESCRIPTION
Just bought a KlikAanKlikUit APA3-1500R remote.  `rtl_433` did not seem to support it at first.  I reverse-engineered the protocol, just to find out that the existing `newkaku` code did exactly the same, except for accepting the starting byte.