### PR TITLE
 rewrite LaCrosse TX output to data fields

### DIFF
--- a/src/devices/lacrosse.c
+++ b/src/devices/lacrosse.c
@@ -190,20 +190,22 @@ static int lacrossetx_callback(bitbuffer_t *bitbuffer) {
 			switch (msg_type) {
 			case 0x00:
 				temp_c = msg_value - 50.0;
-				events++;
-
 				data = data_make("time",          "",            DATA_STRING, time_str,
 								 "model",         "",            DATA_STRING, "LaCrosse TX Sensor",
 								 "id",            "",            DATA_INT, sensor_id,
 								 "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
 								 NULL);
 				data_acquired_handler(data);
-
+				events++;
 				break;
 
 			case 0x0E:
-				printf("%s LaCrosse TX Sensor %02x: Humidity %3.1f %%\n",
-					time_str, sensor_id, msg_value);
+				data = data_make("time",          "",            DATA_STRING, time_str,
+								 "model",         "",            DATA_STRING, "LaCrosse TX Sensor",
+								 "id",            "",            DATA_INT, sensor_id,
+								 "humidity",      "Humidity", DATA_FORMAT, "%.1f C", DATA_DOUBLE, msg_value,
+								 NULL);
+				data_acquired_handler(data);
 				events++;
 				break;
 
@@ -230,6 +232,7 @@ static char *output_fields[] = {
     "model",
     "id",
     "temperature_C",
+    "humidity",
     NULL
 };
 

--- a/src/devices/lacrosse.c
+++ b/src/devices/lacrosse.c
@@ -203,7 +203,7 @@ static int lacrossetx_callback(bitbuffer_t *bitbuffer) {
 				data = data_make("time",          "",            DATA_STRING, time_str,
 								 "model",         "",            DATA_STRING, "LaCrosse TX Sensor",
 								 "id",            "",            DATA_INT, sensor_id,
-								 "humidity",      "Humidity", DATA_FORMAT, "%.1f C", DATA_DOUBLE, msg_value,
+								 "humidity",      "Humidity", DATA_FORMAT, "%.1f %%", DATA_DOUBLE, msg_value,
 								 NULL);
 				data_acquired_handler(data);
 				events++;


### PR DESCRIPTION
modified from https://github.com/zuckschwerdt/rtl_433/commit/1a7a7545f85168c3c3aa8d6ad62b595a6a1bc8f8

Please note that this removes the output of a secondary Fahrenheit value. (s.a. https://github.com/merbanan/rtl_433/issues/260)