### PR TITLE
fix: broken bit operation

### DIFF
--- a/src/devices/chuango.c
+++ b/src/devices/chuango.c
@@ -30,8 +30,8 @@ static int chuango_callback(bitbuffer_t *bitbuffer) {
 
 	// Validate package
 	if ((bits == 25)
-	 && (b[3] && 0x7F)	// Last bit is always 0
-	 && (b[0] != 0x00) && (b[1] != 0x00) && (b[2] != 0x00)	// Reduce false positives. ID 0x00000 not supported
+	 && (b[3] & 0x80)	// Last bit (MSB here) is always 1
+	 && (b[0] || b[1] || (b[2] & 0xF0))	// Reduce false positives. ID 0x00000 not supported
 	) {
 		uint32_t ID = (b[0] << 12) | (b[1] << 4) | (b[2] >> 4); // ID is 20 bits (Ad: "1 Million combinations" :-)
 		char *CMD;

--- a/src/devices/generic_remote.c
+++ b/src/devices/generic_remote.c
@@ -28,8 +28,9 @@ static int generic_remote_callback(bitbuffer_t *bitbuffer) {
 
 	// Validate package
 	if ((bits == 25)
-	 && (b[3] && 0x7F)	// Last bit is always 0
-	 && (b[0] != 0x00) && (b[1] != 0x00) && (b[2] != 0x00)	// Reduce false positives. ID 0x00000 not supported
+	 && (b[3] & 0x80)	// Last bit (MSB here) is always 1
+	 && (b[0] || b[1])	// Reduce false positives. ID 0x0000 not supported
+	 && (b[2])	// Reduce false positives. CMD 0x00 not supported
 	) {
 
 		uint32_t ID_16b = b[0] << 8 | b[1];


### PR DESCRIPTION
The intent `// Last bit is always 0` is not reflected int the code `b[3] && 0x7F` -- which translates to: `b[3] != 0 && 1`, i.e. `b[3] != 0`. Quite the opposite than intended!

The test files confirm that indeed the last bit is always `1`. This might be an artifact of the decoder, 24 bit length seem reasonable.

The bit count is 25 and `b[3]` will contain only a single bit (at MSB). Thus writing `b[3]` is sufficient. Or more verbose: `(b[3] && 0x80)` or even `((b[3] && 0x80) != 0)`.

The test for `ID 0x00000 not supported` is broken too. Actually here every ID with any single byte of all zeros will be dropped.


This patch keeps the original logic and changes the comment, as opposed to: https://github.com/zuckschwerdt/rtl_433/commit/484c87c986a9e6ad6d771cae54efabf3b147380a
But please note that
* more (valid) IDs will be accepted, e.g. 0xFF00 and 0x00FF
* the (valid) "test" command (0x00) will be accepted for Chuango
* the (maybe valid) command (0x00) will *still* be blocked for generic_remote