### PR TITLE
Change pulse data from unsigned to int to avoid undefined behaviour

### DIFF
--- a/include/pulse_detect.h
+++ b/include/pulse_detect.h
@@ -24,8 +24,8 @@
 /// Data for a compact representation of generic pulse train
 typedef struct {
 	unsigned int num_pulses;
-	unsigned int pulse[PD_MAX_PULSES];	// Contains width of a pulse	(high)
-	unsigned int gap[PD_MAX_PULSES];	// Width of gaps between pulses (low)
+	int pulse[PD_MAX_PULSES];	// Contains width of a pulse	(high)
+	int gap[PD_MAX_PULSES];		// Width of gaps between pulses (low)
 	int ook_low_estimate;				// Estimate for the OOK low level (base noise level) at beginning of package
 	int ook_high_estimate;				// Estimate for the OOK high level at end of package
 } pulse_data_t;
@@ -50,7 +50,7 @@ void pulse_data_print(const pulse_data_t *data);
 /// @return 0 if all input sample data is processed
 /// @return 1 if OOK package is detected (but all sample data is still not completely processed)
 /// @return 2 if FSK package is detected (but all sample data is still not completely processed)
-int detect_pulse_package(const int16_t *envelope_data, const int16_t *fm_data, uint32_t len, int16_t level_limit, uint32_t samp_rate, pulse_data_t *pulses, pulse_data_t *fsk_pulses);
+int detect_pulse_package(const int16_t *envelope_data, const int16_t *fm_data, int len, int16_t level_limit, uint32_t samp_rate, pulse_data_t *pulses, pulse_data_t *fsk_pulses);
 
 
 /// Analyze and print result

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -63,9 +63,9 @@ struct protocol_state {
     unsigned int modulation;
 
     /* pwm limits */
-    unsigned int short_limit;
-    unsigned int long_limit;
-    unsigned int reset_limit;
+    int short_limit;
+    int long_limit;
+    int reset_limit;
     char *name;
     unsigned long demod_arg;
 };

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -134,11 +134,11 @@ typedef struct {
 		PD_STATE_PULSE		= 1,
 		PD_STATE_GAP		= 2
 	} state;
-	unsigned int pulse_length;		// Counter for internal pulse detection
-	unsigned int max_pulse;			// Size of biggest pulse detected
+	int pulse_length;		// Counter for internal pulse detection
+	int max_pulse;			// Size of biggest pulse detected
 
-	unsigned int data_counter;		// Counter for how much of data chunck is processed
-	unsigned int lead_in_counter;	// Counter for allowing initial noise estimate to settle
+	int data_counter;		// Counter for how much of data chunck is processed
+	int lead_in_counter;	// Counter for allowing initial noise estimate to settle
 
 	int ook_low_estimate;		// Estimate for the OOK low level (base noise level) in the envelope data
 	int ook_high_estimate;		// Estimate for the OOK high level
@@ -149,8 +149,8 @@ typedef struct {
 static pulse_state_t pulse_state;
 
 
-int detect_pulse_package(const int16_t *envelope_data, const int16_t *fm_data, uint32_t len, int16_t level_limit, uint32_t samp_rate, pulse_data_t *pulses, pulse_data_t *fsk_pulses) {
-	const unsigned int samples_per_ms = samp_rate / 1000;
+int detect_pulse_package(const int16_t *envelope_data, const int16_t *fm_data, int len, int16_t level_limit, uint32_t samp_rate, pulse_data_t *pulses, pulse_data_t *fsk_pulses) {
+	const int samples_per_ms = samp_rate / 1000;
 	pulse_state_t *s = &pulse_state;
 	s->ook_high_estimate = max(s->ook_high_estimate, OOK_MIN_HIGH_LEVEL);	// Be sure to set initial minimum level
 
@@ -286,10 +286,10 @@ int detect_pulse_package(const int16_t *envelope_data, const int16_t *fm_data, u
 /// Histogram data for single bin
 typedef struct {
 	unsigned count;
-	unsigned sum;
-	unsigned mean;
-	unsigned min;
-	unsigned max;
+	int sum;
+	int mean;
+	int min;
+	int max;
 } hist_bin_t;
 
 /// Histogram data for all bins
@@ -300,7 +300,7 @@ typedef struct {
 
 
 /// Generate a histogram (unsorted)
-void histogram_sum(histogram_t *hist, const unsigned *data, unsigned len, float tolerance) {
+void histogram_sum(histogram_t *hist, const int *data, unsigned len, float tolerance) {
 	unsigned bin;	// Iterator will be used outside for!
 
 	for(unsigned n = 0; n < len; ++n) {


### PR DESCRIPTION
Thanks to zuckschwerdt for noticing this!
Tested with test corpus with no differences.