### PR TITLE
FSK demodulator rewritten

### DIFF
--- a/include/bitbuffer.h
+++ b/include/bitbuffer.h
@@ -40,7 +40,7 @@ void bitbuffer_add_bit(bitbuffer_t *bits, int bit);
 void bitbuffer_add_row(bitbuffer_t *bits);
 
 /// Invert all bits in the bitbuffer (do not invert the empty bits)
-//void bitbuffer_invert(bitbuffer_t *bits);
+void bitbuffer_invert(bitbuffer_t *bits);
 
 /// Print the content of the bitbuffer
 void bitbuffer_print(const bitbuffer_t *bits);

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -35,7 +35,7 @@
 #define DEFAULT_LEVEL_LIMIT     8000		// Theoretical high level at I/Q saturation is 128x128 = 16384 (above is ripple)
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           43
+#define MAX_PROTOCOLS           44
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -46,7 +46,8 @@
 		DECL(acurite_986) \
 		DECL(hideki_ts04) \
 		DECL(oil_watchman) \
-		DECL(current_cost)
+		DECL(current_cost) \
+		DECL(emontx)
 
 typedef struct {
 	char name[256];

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(rtl_433
 	devices/ec3k.c
 	devices/efergy_e2_classic.c
 	devices/elv.c
+	devices/emontx.c
 	devices/esperanza_ews.c
 	devices/fineoffset.c
 	devices/generic_remote.c

--- a/src/bitbuffer.c
+++ b/src/bitbuffer.c
@@ -48,6 +48,21 @@ void bitbuffer_add_row(bitbuffer_t *bits) {
 	}
 }
 
+
+void bitbuffer_invert(bitbuffer_t *bits) {
+	for (unsigned row = 0; row < bits->num_rows; ++row) {
+		if (bits->bits_per_row[row] > 0) {
+			const unsigned last_col  = (bits->bits_per_row[row]-1) / 8;
+			const unsigned last_bits = ((bits->bits_per_row[row]-1) % 8) +1;
+			for (unsigned col = 0; col <= last_col; ++col) {
+				bits->bb[row][col] = ~bits->bb[row][col];	// Invert
+			}
+			bits->bb[row][last_col] ^= 0xFF >> last_bits;	// Re-invert unused bits in last byte
+		}
+	}
+}
+
+
 // If we make this an inline function instead of a macro, it means we don't
 // have to worry about using bit numbers with side-effects (bit++).
 static inline int bit(const uint8_t *bytes, unsigned bit)
@@ -159,6 +174,10 @@ int main(int argc, char **argv) {
 	for (int i=0; i <= BITBUF_COLS*8; ++i) {
 		bitbuffer_add_bit(&bits, i%2);
 	}
+	bitbuffer_print(&bits);
+
+	fprintf(stderr, "TEST: bitbuffer:: invert\n");
+	bitbuffer_invert(&bits);
 	bitbuffer_print(&bits);
 
 	fprintf(stderr, "TEST: bitbuffer:: Clear\n");

--- a/src/devices/current_cost.c
+++ b/src/devices/current_cost.c
@@ -4,6 +4,7 @@
 #include "data.h"
 
 static int current_cost_callback(bitbuffer_t *bitbuffer) {
+    bitbuffer_invert(bitbuffer);
     bitrow_t *bb = bitbuffer->bb;
     uint8_t *b = bb[0];
 

--- a/src/devices/emontx.c
+++ b/src/devices/emontx.c
@@ -1,0 +1,37 @@
+/* OpenEnergyMonitor.org emonTx sensor protocol
+ *
+ * Stub driver - to be refined
+ *
+ * Copyright (C) 2016 Tommy Vestermark
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+#include "rtl_433.h"
+#include "util.h"
+
+static int emontx_callback(bitbuffer_t *bitbuffer) {
+	bitrow_t *bb = bitbuffer->bb;
+
+	// Validate package
+	unsigned bits = bitbuffer->bits_per_row[0];
+	if (bits >= 290 && bits <= 300) {
+		fprintf(stdout, "emonTx stub driver:\n");
+		bitbuffer_print(bitbuffer);
+		return 1;
+	}
+	return 0;
+}
+
+
+r_device emontx = {
+	.name           = "emonTx OpenEnergyMonitor (stub driver)",
+	.modulation     = FSK_PULSE_PCM,
+	.short_limit    = 50,	// NRZ decoding
+	.long_limit     = 50,	// Bit width
+	.reset_limit    = 3000, // 600 zeros...
+	.json_callback  = &emontx_callback,
+	.disabled       = 0,
+	.demod_arg      = 0,
+};

--- a/src/devices/emontx.c
+++ b/src/devices/emontx.c
@@ -28,9 +28,9 @@ static int emontx_callback(bitbuffer_t *bitbuffer) {
 r_device emontx = {
 	.name           = "emonTx OpenEnergyMonitor (stub driver)",
 	.modulation     = FSK_PULSE_PCM,
-	.short_limit    = 50,	// NRZ decoding
-	.long_limit     = 50,	// Bit width
-	.reset_limit    = 3000, // 600 zeros...
+	.short_limit    = 5,	// NRZ decoding - Needs a sample frequency of 2500000!
+	.long_limit     = 5,	// Bit width
+	.reset_limit    = 300,	// 600 zeros...
 	.json_callback  = &emontx_callback,
 	.disabled       = 0,
 	.demod_arg      = 0,

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -100,6 +100,9 @@ void pulse_FSK_detect(int16_t fm_n, pulse_data_t *fsk_pulses, pulse_FSK_state_t 
 					fsk_pulses->pulse[0] = s->fsk_pulse_length;	// Store pulse width
 					s->fsk_pulse_length = 0;
 				}
+			// Still below threshold
+			} else {
+				s->fm_f1_est += fm_n/FSK_EST_RATIO - s->fm_f1_est/FSK_EST_RATIO;	// Slow estimator
 			}
 			break;
 		case PD_STATE_FSK_F1:		// Pulse high at F1 frequency
@@ -116,6 +119,7 @@ void pulse_FSK_detect(int16_t fm_n, pulse_data_t *fsk_pulses, pulse_FSK_state_t 
 					fsk_pulses->num_pulses--;		// Rewind one pulse
 					// Are we back to initial frequency? (Was initial frequency a gap?)
 					if ((fsk_pulses->num_pulses == 0) && (fsk_pulses->pulse[0] == 0)) {
+						s->fm_f1_est = s->fm_f2_est;	// Switch back estimates
 						s->state_fsk = PD_STATE_FSK_INIT;
 					}
 				}
@@ -146,7 +150,7 @@ void pulse_FSK_detect(int16_t fm_n, pulse_data_t *fsk_pulses, pulse_FSK_state_t 
 						s->state_fsk = PD_STATE_FSK_INIT;
 					}
 				}
-			// Still above threshold
+			// Still below threshold
 			} else {
 				s->fm_f2_est += fm_n/FSK_EST_RATIO - s->fm_f2_est/FSK_EST_RATIO;	// Slow estimator
 			}

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -220,6 +220,7 @@ int detect_pulse_package(const int16_t *envelope_data, const int16_t *fm_data, u
 						// Store estimates
 						fsk_pulses->ook_low_estimate = s->ook_low_estimate;
 						fsk_pulses->ook_high_estimate = s->ook_high_estimate;
+						s->state = PD_STATE_IDLE;	// Ensure everything is reset
 						return 2;	// FSK package detected!!!
 					}
 				} else {

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -39,7 +39,7 @@ void pulse_data_print(const pulse_data_t *data) {
 #define OOK_EST_RATIO		64			// Constant for slowness of OOK estimators
 
 // FSK adaptive frequency estimator constants
-#define FSK_DEFAULT_FM_DELTA	4000	// Default estimate for frequency delta
+#define FSK_DEFAULT_FM_DELTA	6000	// Default estimate for frequency delta
 #define FSK_EST_RATIO		32			// Constant for slowness of FSK estimators
 
 

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -62,11 +62,13 @@ typedef struct {
 /// Demodulate Frequency Shift Keying (FSK) sample by sample
 ///
 /// Function is stateful between calls
-/// Builds estimate for initial frequency F1 (fm_f1_est). When frequency deviates more than a
-/// threshold value it will transition to other state (F2 or gap) and build an estimate of
-/// the F2 frequency (fm_f2_est). It will then transition back and forth when current
+/// Builds estimate for initial frequency. When frequency deviates more than a
+/// threshold value it will determine whether the deviation is positive or negative
+/// to classify it as a pulse or gap. It will then transition to other state (F1 or F2)
+/// and build an estimate of the other frequency. It will then transition back and forth when current
 /// frequency is closer to other frequency estimate.
-/// Includes spurious suppression by coalescing pulses when pulse widths are too short.
+/// Includes spurious suppression by coalescing pulses when pulse/gap widths are too short.
+/// Pulses equal higher frequency (F1) and Gaps equal lower frequency (F2)
 /// @param fm_n: One single sample of FM data
 /// @param *fsk_pulses: Will return a pulse_data_t structure for FSK demodulated data
 /// @param *s: Internal state

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -987,8 +987,8 @@ int main(int argc, char **argv) {
 		goto out;
 	    }
 	}
+	fprintf(stderr, "Test mode active. Reading samples from file: %s\n", in_filename);	// Essential information (not quiet)
 	if (!quiet_mode) {
-	    fprintf(stderr, "Test mode active. Reading samples from file: %s\n", in_filename);
 	    fprintf(stderr, "Input format: %s\n", (demod->debug_mode == 3) ? "cf32" : "uint8");
 	}
 	sample_file_pos = 0.0;


### PR DESCRIPTION
FSK demodulator will now estimate the absolute frequency levels instead of using relative frequency deviation increasing robustness against signals with an initial intermediate frequency level (emonTx).
Furthermore the polarity of the pulse sequence will now be absolute with regard to high/low frequency avoiding "random" polarity due to unstable initial signals.
The emonTx device is just a stub driver that will be superseded by dwmw2.
Tested against the test corpus of FSK files.