### PR TITLE
Change bit limits in r_device structure to float too

### DIFF
--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -52,9 +52,9 @@
 typedef struct {
 	char name[256];
 	unsigned int modulation;
-	unsigned int short_limit;
-	unsigned int long_limit;
-	unsigned int reset_limit;
+	float short_limit;
+	float long_limit;
+	float reset_limit;
 	int (*json_callback)(bitbuffer_t *bitbuffer);
 	unsigned int disabled;
 	unsigned long demod_arg;	// Decoder specific optional argument (may be pointer to struct)


### PR DESCRIPTION
Oops, missed this. In order to decode tests/emontx/01/gfile001.data we do
*really* need emonTx to be able to give the 20.3µs bit period precisely.