### PR TITLE
Pulse detect: Suppress spurious short gaps

### DIFF
--- a/include/pulse_detect.h
+++ b/include/pulse_detect.h
@@ -50,7 +50,7 @@ void pulse_data_print(const pulse_data_t *data);
 /// @return 0 if all input sample data is processed
 /// @return 1 if OOK package is detected (but all sample data is still not completely processed)
 /// @return 2 if FSK package is detected (but all sample data is still not completely processed)
-int detect_pulse_package(const int16_t *envelope_data, const int16_t *fm_data, int len, int16_t level_limit, uint32_t samp_rate, pulse_data_t *pulses, pulse_data_t *fsk_pulses);
+int pulse_detect_package(const int16_t *envelope_data, const int16_t *fm_data, int len, int16_t level_limit, uint32_t samp_rate, pulse_data_t *pulses, pulse_data_t *fsk_pulses);
 
 
 /// Analyze and print result

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -623,7 +623,7 @@ static void rtlsdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
 		// Detect a package and loop through demodulators with pulse data
 		int package_type = 1;	// Just to get us started
 		while(package_type) {
-			package_type = detect_pulse_package(demod->am_buf, demod->fm_buf, len/2, demod->level_limit, samp_rate, &demod->pulse_data, &demod->fsk_pulse_data);
+			package_type = pulse_detect_package(demod->am_buf, demod->fm_buf, len/2, demod->level_limit, samp_rate, &demod->pulse_data, &demod->fsk_pulse_data);
 			if (package_type == 1) {
 				if(demod->analyze_pulses) fprintf(stderr, "Detected OOK package\n");
 				for (i = 0; i < demod->r_dev_num; i++) {


### PR DESCRIPTION
Now decodes all the tricky oil_watchman files besides the following two, which are malformed:
rtl_433_tests/tests/oil_watchman/02/gfile001.data 
rtl_433_tests/tests/oil_watchman/05/gfile455.data
Extra files decoded:
rtl_433_tests/tests/oil_watchman/05/gfile023.data
rtl_433_tests/tests/oil_watchman/05/gfile239.data
rtl_433_tests/tests/xc0348/01/gfile003.data
