### PR TITLE
fix: missing NULL terminator

### DIFF
--- a/src/devices/emontx.c
+++ b/src/devices/emontx.c
@@ -132,7 +132,7 @@ static int emontx_callback(bitbuffer_t *bitbuffer) {
 static char *output_fields[] = {
 	"time", "model", "node", "ct1", "ct2", "ct3", "ct4", "Vrms/batt",
 	"temp1_C", "temp2_C", "temp3_C", "temp4_C", "temp5_C", "temp6_C",
-	"pulse"
+	"pulse", NULL
 };
 
 r_device emontx = {


### PR DESCRIPTION
The new Emontx is missing a NULL terminator in `output_fields`. Thus the CSV output is broken, i.e. `Segmentation fault`. Y U NO TERMINATE :p