### PR TITLE
new feature: allow multiple outputs (WIP)

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -316,7 +316,10 @@ void data_print(data_t* data, FILE *file, data_printer_t *printer, void *aux)
 		.aux     = aux
 	};
 	ctx.printer->print_data(&ctx, data, NULL, file);
-	fputc('\n', file);
+	if (file) {
+		fputc('\n', file);
+		fflush(file);
+	}
 }
 
 static void print_value(data_printer_context_t *printer_ctx, FILE *file, data_type_t type, void *value, char *format) {

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -193,13 +193,16 @@ static unsigned int signal_end = 0;
 static unsigned int signal_pulse_data[4000][3] = {
     {0}};
 static unsigned int signal_pulse_counter = 0;
-typedef enum  {
-    OUTPUT_KV,
-    OUTPUT_JSON,
-    OUTPUT_CSV
-} output_format_t;
-static output_format_t output_format;
-void *csv_aux_data;
+
+typedef struct output_handler {
+    /*data_printer_t*/ void *printer;
+    void (*aux_free)(void *aux);
+    FILE *file;
+    void *aux;
+    struct output_handler *next;
+} output_handler_t;
+static output_handler_t *output_handler = NULL;
+static output_handler_t **next_output_handler = &output_handler;
 
 /* handles incoming structured data by dumping it */
 void data_acquired_handler(data_t *data)
@@ -231,18 +234,9 @@ void data_acquired_handler(data_t *data)
         }
     }
 
-    switch (output_format) {
-    case OUTPUT_KV: {
-        data_print(data, stdout,  &data_kv_printer, NULL);
-    } break;
-    case OUTPUT_JSON: {
-        data_print(data, stdout,  &data_json_printer, NULL);
-    } break;
-    case OUTPUT_CSV: {
-        data_print(data, stdout,  &data_csv_printer, csv_aux_data);
-    } break;
+    for (output_handler_t *output = output_handler; output; output = output->next) {
+        data_print(data, output->file, output->printer, output->aux);
     }
-    fflush(stdout);
     data_free(data);
 }
 
@@ -748,6 +742,51 @@ void *determine_csv_fields(r_device* devices, int num_devices)
     return csv_aux;
 }
 
+void add_json_output()
+{
+    output_handler_t *output = calloc(1, sizeof(output_handler_t));
+    if (!output) {
+        fprintf(stderr, "rtl_433: failed to allocate memory for output handler\n");
+        exit(1);
+    }
+    output->printer = &data_json_printer;
+    output->file = stdout;
+    *next_output_handler = output;
+    next_output_handler = &output->next;
+}
+
+void add_csv_output(void *aux_data)
+{
+    if (!aux_data) {
+        fprintf(stderr, "rtl_433: failed to allocate memory for CSV auxiliary data\n");
+        exit(1);
+    }
+    output_handler_t *output = calloc(1, sizeof(output_handler_t));
+    if (!output) {
+        fprintf(stderr, "rtl_433: failed to allocate memory for output handler\n");
+        exit(1);
+    }
+    output->printer = &data_csv_printer;
+    output->aux_free = &data_csv_free;
+    output->file = stdout;
+    output->aux = aux_data;
+    *next_output_handler = output;
+    next_output_handler = &output->next;
+}
+
+void add_kv_output()
+{
+    output_handler_t *output = calloc(1, sizeof(output_handler_t));
+    if (!output) {
+        fprintf(stderr, "rtl_433: failed to allocate memory for output handler\n");
+        exit(1);
+    }
+    output->printer = &data_kv_printer;
+    output->file = stdout;
+    *next_output_handler = output;
+    next_output_handler = &output->next;
+}
+
 int main(int argc, char **argv) {
 #ifndef _WIN32
     struct sigaction sigact;
@@ -862,11 +901,11 @@ int main(int argc, char **argv) {
 		break;
 	    case 'F':
 		if (strcmp(optarg, "json") == 0) {
-		    output_format = OUTPUT_JSON;
+            add_json_output();
 		} else if (strcmp(optarg, "csv") == 0) {
-		    output_format = OUTPUT_CSV;
+            add_csv_output(determine_csv_fields(devices, num_r_devices));
 		} else if (strcmp(optarg, "kv") == 0) {
-		    output_format = OUTPUT_KV;
+            add_kv_output();
 		} else {
                     fprintf(stderr, "Invalid output format %s\n", optarg);
                     usage(devices);
@@ -900,12 +939,8 @@ int main(int argc, char **argv) {
         out_filename = argv[optind];
     }
 
-    if (output_format == OUTPUT_CSV) {
-        csv_aux_data = determine_csv_fields(devices, num_r_devices);
-        if (!csv_aux_data) {
-            fprintf(stderr, "rtl_433: failed to allocate memory for CSV auxiliary data\n");
-            exit(1);
-        }
+    if (!output_handler) {
+        add_kv_output();
     }
 
     for (i = 0; i < num_r_devices; i++) {
@@ -1152,8 +1187,10 @@ int main(int argc, char **argv) {
 
     rtlsdr_close(dev);
 out:
-    if (csv_aux_data) {
-        data_csv_free(csv_aux_data);
+    for (output_handler_t *output = output_handler; output; output = output->next) {
+        if (output->aux_free) {
+            output->aux_free(output->aux);
+        }
     }
     return r >= 0 ? r : -r;
 }


### PR DESCRIPTION
This is tested and works. *It's not intended/proposed for merge right now though.*

I'd like to allow multiple output handlers, i.e. allowing multiple `-F handler` arguments.
This code refactors the single `output_format` field to a chain of `output_handler`s, and allows the generalization of setup and tear down callbacks for each handler. It touches as few code as possible to do so.
It might not make immediate sense to introduce this but it clears the way to enhance the output printers:
The next step would be to add file arguments to the outputs. E.g. `-F kv:stderr -F json:/tmp/socket -F csv:log.txt` would be nice.

(TODO: aux_free() should be a general close() and there might need to be a sensible default if no `-F` is given.)

What are the thoughts on this? Is this appreciated? Is there a better way maybe?