### PR TITLE
adding a bitbuffer_find_repeated_row()

### DIFF
--- a/include/bitbuffer.h
+++ b/include/bitbuffer.h
@@ -64,4 +64,8 @@ unsigned bitbuffer_search(bitbuffer_t *bitbuffer, unsigned row, unsigned start,
 unsigned bitbuffer_manchester_decode(bitbuffer_t *inbuf, unsigned row, unsigned start,
 				     bitbuffer_t *outbuf, unsigned max);
 
+/// Find a repeated row that has a minimum count of bits.
+/// Return the row index or -1.
+int bitbuffer_find_repeated_row(bitbuffer_t *bits, int min_repeats, int min_bits);
+
 #endif /* INCLUDE_BITBUFFER_H_ */

--- a/src/bitbuffer.c
+++ b/src/bitbuffer.c
@@ -168,6 +168,33 @@ void bitbuffer_print(const bitbuffer_t *bits) {
 }
 
 
+static int compare_rows(bitbuffer_t *bits, unsigned row_a, unsigned row_b) {
+	return (bits->bits_per_row[row_a] == bits->bits_per_row[row_b] &&
+		!memcmp(bits->bb[row_a], bits->bb[row_b],
+				(bits->bits_per_row[row_a] + 7) / 8));
+}
+
+static unsigned count_repeats(bitbuffer_t *bits, unsigned row) {
+	unsigned cnt = 0;
+	for (int i = 0; i < bits->num_rows; ++i) {
+		if (compare_rows(bits, row, i)) {
+			++cnt;
+		}
+	}
+	return cnt;
+}
+
+int bitbuffer_find_repeated_row(bitbuffer_t *bits, int min_repeats, int min_bits) {
+	for (int i = 0; i < bits->num_rows; ++i) {
+		if (bits->bits_per_row[i] >= min_bits &&
+			count_repeats(bits, i) >= min_repeats) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+
 // Test code
 // gcc -I include/ -std=gnu11 -D _TEST src/bitbuffer.c
 #ifdef _TEST

--- a/src/devices/prologue.c
+++ b/src/devices/prologue.c
@@ -36,26 +36,25 @@ static int prologue_callback(bitbuffer_t *bitbuffer) {
     int16_t temp2;
     float temp;
     uint8_t humidity;
+    int r = bitbuffer_find_repeated_row(bitbuffer, 3, 36);
 
-    /* FIXME validate the received message better */
-    if (((bb[1][0]&0xF0) == 0x90 && (bb[2][0]&0xF0) == 0x90 && (bb[3][0]&0xF0) == 0x90 && (bb[4][0]&0xF0) == 0x90 &&
-        (bb[5][0]&0xF0) == 0x90 && (bb[6][0]&0xF0) == 0x90) ||
-        ((bb[1][0]&0xF0) == 0x50 && (bb[2][0]&0xF0) == 0x50 && (bb[3][0]&0xF0) == 0x50 && (bb[4][0]&0xF0) == 0x50 &&
-        (bb[1][3] == bb[2][3]) && (bb[1][4] == bb[2][4]))) {
+    if (r >= 0 &&
+        ((bb[r][0]&0xF0) == 0x90 ||
+         (bb[r][0]&0xF0) == 0x50)) {
 
         /* Get time now */
         local_time_str(0, time_str);
 
         /* Prologue sensor */
-        id = (bb[1][0]&0xF0)>>4;
-        rid = ((bb[1][0]&0x0F)<<4) | ((bb[1][1]&0xF0)>>4);
-        battery = bb[1][1]&0x08;
-        channel = (bb[1][1]&0x03) + 1;
-        button = (bb[1][1]&0x04) >> 2;
-        temp2 = (int16_t)((uint16_t)(bb[1][2] << 8) | (bb[1][3]&0xF0));
+        id = (bb[r][0]&0xF0)>>4;
+        rid = ((bb[r][0]&0x0F)<<4) | ((bb[r][1]&0xF0)>>4);
+        battery = bb[r][1]&0x08;
+        channel = (bb[r][1]&0x03) + 1;
+        button = (bb[r][1]&0x04) >> 2;
+        temp2 = (int16_t)((uint16_t)(bb[r][2] << 8) | (bb[r][3]&0xF0));
         temp2 = temp2 >> 4;
         temp = temp2/10.;
-        humidity = ((bb[1][3]&0x0F)<<4) | (bb[1][4]>>4);
+        humidity = ((bb[r][3]&0x0F)<<4) | (bb[r][4]>>4);
 
         data = data_make("time",          "",            DATA_STRING, time_str,
                          "model",         "",            DATA_STRING, "Prologue sensor",


### PR DESCRIPTION
this adds a function `bitbuffer_find_repeated_row()` with examples how it simplifies device code.
Just taking some 'middle' row and comparing all the fields to some other rows isn't good enough to reliably get 'good' data. Now you can explicitly get a 'strong' row that is repeated a given number of times.