### PR TITLE
Decode device id from current_cost, and support more devices

### DIFF
--- a/src/devices/current_cost.c
+++ b/src/devices/current_cost.c
@@ -30,15 +30,19 @@ static int current_cost_callback(bitbuffer_t *bitbuffer) {
     bitbuffer_t packet_bits = {0};
 
     start_pos = bitbuffer_manchester_decode(bitbuffer, 0, start_pos, &packet_bits, 0);
+
     uint8_t *packet = packet_bits.bb[0];
     // Read data
-    if(packet_bits.bits_per_row[0] >= 56 && packet[0] == 0x0d){
+    if(packet_bits.bits_per_row[0] >= 56 && ((packet[0] & 0xf0) == 0) ){
+		    uint16_t device_id = (packet[0] & 0x0f) << 8 | packet[1];
+
         uint16_t watt0 = (packet[2] & 0x7F) << 8 | packet[3] ;
         uint16_t watt1 = (packet[4] & 0x7F) << 8 | packet[5] ;
         uint16_t watt2 = (packet[6] & 0x7F) << 8 | packet[7] ;
         data = data_make("time",          "",       DATA_STRING, time_str,
                 "model",         "",              DATA_STRING, "CurrentCost TX", //TODO: it may have different CC Model ? any ref ?
                 //"rc",            "Rolling Code",  DATA_INT, rc, //TODO: add rolling code b[1] ? test needed
+								"dev_id",       "Device Id",     DATA_FORMAT, "%d", DATA_INT, device_id,
                 "power0",       "Power 0",       DATA_FORMAT, "%d W", DATA_INT, watt0,
                 "power1",       "Power 1",       DATA_FORMAT, "%d W", DATA_INT, watt1,
                 "power2",       "Power 2",       DATA_FORMAT, "%d W", DATA_INT, watt2,


### PR DESCRIPTION
Decode the data from my currentcost device. Added the device id to the output.

The high bits of bytes 2,4 and 6 tell us if the data for channels 0,1 and 2 is valid. Is it possible to not include values in the data object based on the flags easily? Should we just always supply them?