### PR TITLE
The contact sensors required a larger pulse tolerance

### DIFF
--- a/src/devices/chuango.c
+++ b/src/devices/chuango.c
@@ -66,7 +66,7 @@ static int chuango_callback(bitbuffer_t *bitbuffer) {
 
 
 PWM_Precise_Parameters pwm_precise_parameters = {
-	.pulse_tolerance	= 20,
+	.pulse_tolerance	= 35,
 	.pulse_sync_width	= 0,	// No sync bit used
 };
 


### PR DESCRIPTION
The magnetic contact sensors from Chuango required a larger tolerance.