### PR TITLE
Chuango WI-200 comment

### DIFF
--- a/src/devices/chuango.c
+++ b/src/devices/chuango.c
@@ -8,6 +8,7 @@
  * PIR-900 PIR sensor (Default: Home Mode Zone)
  * RC-80 Remote Control (Arm, Disarm, Home Mode, Alarm!)
  * SMK-500 Smoke sensor (Default: 24H Zone)
+ * WI-200 Water sensor (Default: 24H Zone)
  *
  * Copyright (C) 2015 Tommy Vestermark
  * This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Chuango WI-200 (water sensor) is also supported, see rtl_433_tests/tests/chuango/02/gfile020.data. Update comment.