### PR TITLE
clean up casts regarding C Integer Promotions

### DIFF
--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -63,8 +63,7 @@ static int fineoffset_WH2_callback(bitbuffer_t *bitbuffer) {
 
         // Nibble 5,6,7 contains 12 bits of temperature
         // The temperature is signed magnitude and scaled by 10
-        temp = bb[0][3];
-        temp |= (int16_t)(bb[0][2] & 0x0F) << 8;
+        temp = ((bb[0][2] & 0x0F) << 8) | bb[0][3];
         if(temp & 0x800) {
             temp &= 0x7FF;	// remove sign bit
             temp = -temp;	// reverse magnitude

--- a/src/devices/oil_watchman.c
+++ b/src/devices/oil_watchman.c
@@ -80,7 +80,7 @@ static int oil_watchman_callback(bitbuffer_t *bitbuffer) {
 		else
 			// A depth reading of zero indicates no reading. Even with
 			// the sensor flat down on a table, it still reads about 13.
-			depth = b[6] | ((((uint16_t)b[5]) & 3) << 8);
+			depth = ((b[5] & 3) << 8) | b[6];
 
 		data = data_make("time", "", DATA_STRING, time_str,
 				 "model", "", DATA_STRING, "Oil Watchman",

--- a/src/devices/s3318p.c
+++ b/src/devices/s3318p.c
@@ -86,8 +86,8 @@ static int s3318p_callback(bitbuffer_t *bitbuffer) {
     channel = (uint8_t)(((bb[1][1] & 0x30) >> 4) + 1);
     sensor_id = (uint8_t)(bb[1][0]);
 
-    temperature_with_offset = (uint16_t)(((bb[1][2] & 0x0F) << 8) | (bb[1][2] & 0xF0) | (bb[1][1] & 0x0F));
-    temperature_f = (float)((temperature_with_offset - 900) / 10.0);
+    temperature_with_offset = ((bb[1][2] & 0x0F) << 8) | (bb[1][2] & 0xF0) | (bb[1][1] & 0x0F);
+    temperature_f = (temperature_with_offset - 900) / 10.0;
 
     if (debug_output) {
       bitbuffer_print(bitbuffer);


### PR DESCRIPTION
C's Integer Promotion will promote arguments in arithmetic operations to int (very generally speaking). Don't put explicit cast in those operations, it won't do what you think it does.
(for a quick refresh maybe look at https://www.securecoding.cert.org/confluence/display/c/INT02-C.+Understand+integer+conversion+rules )
This change is purely for style, to give readers a cleaner picture and new authors a better template.