### PR TITLE
Prevent crash when no output file is given with `-S`

### DIFF
--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1128,6 +1128,11 @@ int main(int argc, char **argv) {
         fprintf(stderr, "WARNING: Failed to reset buffers.\n");
 
     if (sync_mode) {
+        if (!demod->out_file) {
+            fprintf(stderr, "Specify an output file for sync mode.\n");
+            exit(0);
+        }
+
 	fprintf(stderr, "Reading samples in sync mode...\n");
 	uint8_t *buffer = malloc(out_block_size * sizeof (uint8_t));
 


### PR DESCRIPTION
This prevents `fwrite()` on unintialized `demod->out_file` and gives an informative error message.