### PR TITLE
Acurite tower json

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -394,12 +394,28 @@ static void print_json_string(data_printer_context_t *printer_ctx, const char *s
 
 static void print_json_double(data_printer_context_t *printer_ctx, double data, char *format, FILE *file)
 {
-	fprintf(file, "%.3f", data);
+    if(format == NULL) {
+	    fprintf(file, "%.3f", data);
+    } else {
+        int length = snprintf(NULL, 0, format, data) + 1; //add space for null byte
+        char *formatted_str = malloc(sizeof(char) * length);
+        sprintf(formatted_str, format, data);
+        print_json_string(printer_ctx, formatted_str, "", file);
+        free(formatted_str);
+    }
 }
 
 static void print_json_int(data_printer_context_t *printer_ctx, int data, char *format, FILE *file)
 {
-	fprintf(file, "%d", data);
+    if(format == NULL) {
+	    fprintf(file, "%d", data);
+    } else {
+        int length = snprintf(NULL, 0, format, data) + 1; //add space for null byte
+        char *formatted_str = malloc(sizeof(char) * length);
+        sprintf(formatted_str, format, data);
+        print_json_string(printer_ctx, formatted_str, "", file);
+        free(formatted_str);
+    }
 }
 
 /* Key-Value printer */

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -417,15 +417,24 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf) {
 	    tempc = acurite_txr_getTemp(bb[4], bb[5]);
 	    tempf = celsius2fahrenheit(tempc);
 
-	    printf("%s Acurite tower sensor 0x%04X Ch %c: %3.1F C %3.1F F %d %% RH\n",
-		   time_str, sensor_id, channel, tempc, tempf, humidity);
+        data_acquired_handler(data_make("time","",DATA_STRING, time_str,
+                                        "model", "",DATA_STRING,"Acurite Tower Sensor",
+                                        "id", "Sensor ID", DATA_FORMAT, "%#X", DATA_INT, sensor_id,
+                                        "channel", "Channel", DATA_FORMAT, "%c", DATA_INT, channel,
+                                        "temperature_C", "Temp ℃", DATA_DOUBLE, tempc,
+                                        "temperature_F", "Temp ℉", DATA_DOUBLE, tempf,
+                                        "relative_humidity", "Relative Humidity (%)", DATA_INT, humidity, NULL));
+
 
 	    // currently 0x44 seens to be a normal status and/or type
 	    // for tower sensors.  Battery OK/Normal == 0x40
-	    if (sensor_status != 0x44)
-		printf("%s Acurite tower sensor 0x%04X Ch %c, Status %02X\n",
-		       time_str, sensor_id, channel, sensor_status);
-
+        if (sensor_status != 0x44) {
+            data_acquired_handler(data_make("time","",DATA_STRING, time_str,
+                                            "model", "",DATA_STRING,"Acurite Tower Sensor",
+                                            "id", "Sensor ID", DATA_FORMAT, "%#X", DATA_INT, sensor_id,
+                                            "channel", "Channel", DATA_FORMAT, "%c", DATA_INT, channel,
+                                            "sensor_status", "Sensor Status", DATA_INT, sensor_status, NULL));
+        }
 	}
 
 	// The 5-n-1 weather sensor messages are 8 bytes.


### PR DESCRIPTION
the acurite device is missing json functionality, so I've implemented it for the acurite device I happen to have.  I could add code for other acurite devices, but I'm unable to test those, so I refrained at present.
 
Additionally, the json printer for ints & floats had a hard-coded format string, which means e.g. a single char can't be printed as an int, nor an integer as a hexadecimal string. I'm somewhat dissatisfied with this code, but it's not immediately clear to me how to DRY it up: suggestions welcome.  Alternatively I could refactor it so that I pass a pre-computed DATA_STRING, instead of a DATA_INT with a DATA_FORMAT parameter, to get the desired char & hex strings.