### PR TITLE
use binary mode to open file - fixes decoding on windows

### DIFF
--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1096,7 +1096,7 @@ int main(int argc, char **argv) {
 	    in_file = stdin;
 	    in_filename = "<stdin>";
 	} else {
-	    in_file = fopen(in_filename, "r");
+	    in_file = fopen(in_filename, "rb");
 	    if (!in_file) {
 		fprintf(stderr, "Opening file: %s failed!\n", in_filename);
 		goto out;


### PR DESCRIPTION
Another little windows fix (sorry) - file input was failing silently due to file opened in text mode