### PR TITLE
Acurite 606TX Sensor Support

### DIFF
--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -35,7 +35,7 @@
 #define DEFAULT_LEVEL_LIMIT     8000		// Theoretical high level at I/Q saturation is 128x128 = 16384 (above is ripple)
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           53
+#define MAX_PROTOCOLS           54
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -55,11 +55,8 @@
 		DECL(oregon_scientific_v1) \
 		DECL(proove) \
 		DECL(bresser_3ch) \
-<<<<<<< HEAD
 		DECL(springfield) \
 		DECL(oregon_scientific_sl109h) \
-=======
->>>>>>> a9058427b3e1545ee416f644f4c8365b9e9eeb35
 		DECL(acurite_606)
 
 typedef struct {

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -56,7 +56,8 @@
 		DECL(proove) \
 		DECL(bresser_3ch) \
 		DECL(springfield) \
-		DECL(oregon_scientific_sl109h)
+		DECL(oregon_scientific_sl109h) \
+		DECL(acurite_606)
 
 typedef struct {
 	char name[256];

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -816,11 +816,7 @@ r_device acurite_986 = {
  *
  */
 r_device acurite_606 = {
-<<<<<<< HEAD
     .name           = "Acurite 606TX Temperature Sensor",
-=======
-    .name           = "Acurite 606TX",
->>>>>>> a9058427b3e1545ee416f644f4c8365b9e9eeb35
     .modulation     = OOK_PULSE_PPM_RAW,
     .short_limit    = 3500,
     .long_limit     = 7000,

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -816,7 +816,7 @@ r_device acurite_986 = {
  *
  */
 r_device acurite_606 = {
-    .name           = "Acurite 606TX",
+    .name           = "Acurite 606TX Temperature Sensor",
     .modulation     = OOK_PULSE_PPM_RAW,
     .short_limit    = 3500,
     .long_limit     = 7000,


### PR DESCRIPTION
These changes are adding support for the Acurite 606TX temperature sensor. 

I've ported the old code that I had running about a year ago to the new demodulator architecture. The new code is using the checksum algorithm published in http://www.osengr.org/WxShield/Downloads/Weather-Sensor-RF-Protocols.pdf
