### PR TITLE
Add initial Elro DB286A support

### DIFF
--- a/include/bitbuffer.h
+++ b/include/bitbuffer.h
@@ -72,6 +72,7 @@ unsigned count_repeats(bitbuffer_t *bits, unsigned row);
 /// Return the row index or -1.
 int bitbuffer_find_repeated_row(bitbuffer_t *bits, unsigned min_repeats, unsigned min_bits);
 
+
 /// Return a single bit from a bitrow at bit_idx position
 static inline uint8_t bitrow_get_bit(const bitrow_t bitrow, unsigned bit_idx)
 {

--- a/include/bitbuffer.h
+++ b/include/bitbuffer.h
@@ -64,10 +64,13 @@ unsigned bitbuffer_search(bitbuffer_t *bitbuffer, unsigned row, unsigned start,
 unsigned bitbuffer_manchester_decode(bitbuffer_t *inbuf, unsigned row, unsigned start,
 				     bitbuffer_t *outbuf, unsigned max);
 
+// Function to compare bitbuffer rows and count repetitions
+int compare_rows(bitbuffer_t *bits, unsigned row_a, unsigned row_b);
+unsigned count_repeats(bitbuffer_t *bits, unsigned row);
+
 /// Find a repeated row that has a minimum count of bits.
 /// Return the row index or -1.
 int bitbuffer_find_repeated_row(bitbuffer_t *bits, unsigned min_repeats, unsigned min_bits);
-
 
 /// Return a single bit from a bitrow at bit_idx position
 static inline uint8_t bitrow_get_bit(const bitrow_t bitrow, unsigned bit_idx)

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -35,7 +35,7 @@
 #define DEFAULT_LEVEL_LIMIT     8000		// Theoretical high level at I/Q saturation is 128x128 = 16384 (above is ripple)
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           59
+#define MAX_PROTOCOLS           60
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -67,6 +67,7 @@
 		DECL(elro_db286a) \
 		DECL(template)
 
+
 typedef struct {
 	char name[256];
 	unsigned int modulation;

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -64,8 +64,8 @@
 		DECL(steelmate) \
 		DECL(schraeder) \
 		DECL(lightwave_rf) \
+		DECL(elro_db286a) \
 		DECL(template)
-
 
 typedef struct {
 	char name[256];

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,7 @@ add_executable(rtl_433
 	devices/oregon_scientific_sl109h.c
 	devices/steelmate.c
 	devices/schraeder.c
+	devices/elro_db286a.c
 	devices/new_template.c
 
 )

--- a/src/bitbuffer.c
+++ b/src/bitbuffer.c
@@ -168,13 +168,13 @@ void bitbuffer_print(const bitbuffer_t *bits) {
 }
 
 
-static int compare_rows(bitbuffer_t *bits, unsigned row_a, unsigned row_b) {
+int compare_rows(bitbuffer_t *bits, unsigned row_a, unsigned row_b) {
 	return (bits->bits_per_row[row_a] == bits->bits_per_row[row_b] &&
 		!memcmp(bits->bb[row_a], bits->bb[row_b],
 				(bits->bits_per_row[row_a] + 7) / 8));
 }
 
-static unsigned count_repeats(bitbuffer_t *bits, unsigned row) {
+unsigned count_repeats(bitbuffer_t *bits, unsigned row) {
 	unsigned cnt = 0;
 	for (int i = 0; i < bits->num_rows; ++i) {
 		if (compare_rows(bits, row, i)) {

--- a/src/devices/elro_db286a.c
+++ b/src/devices/elro_db286a.c
@@ -1,4 +1,4 @@
-/* Initial doorbell implementation for Elro DB286A devices
+/* Doorbell implementation for Elro DB286A devices
  * 
  * Note that each device seems to have two codes, which alternate
  * for every other button press.
@@ -44,15 +44,15 @@ static int doorbell_db286a_callback(bitbuffer_t *bitbuffer) {
 		return 0;
 	}
 	
+	if (count_repeats(bitbuffer, 1) < DB286A_MINPATTERN) {
+		return 0;
+	}
+	
 	//Get hex string representation of code pattern
 	for (i = 0; i <= DB286A_CODEBYTES; i++) {
 	    idsp += sprintf(idsp, "%02x", b[i]);	
 	}
 	id_string[DB286A_CODECHARS] = '\0';
-
-	if (count_repeats(bitbuffer, 1) < DB286A_MINPATTERN) {
-		return 0;
-	}
 	
 	local_time_str(0, time_str);
 	

--- a/src/devices/elro_db286a.c
+++ b/src/devices/elro_db286a.c
@@ -37,8 +37,11 @@ static int doorbell_db286a_callback(bitbuffer_t *bitbuffer) {
 	char bitrow_string[totalpulses + 1];
 	char *brp = bitrow_string;
 	
-	unsigned i;
+	const char *brpcount = bitrow_string;
 	
+	unsigned i;
+	unsigned count = 0;
+
 	//Get binary string representation of bitrow
 	for (i = 0; i < bits; i++) {
 	    brp += sprintf(brp, "%d", bitrow_get_bit(bb[0], i));	
@@ -51,12 +54,9 @@ static int doorbell_db286a_callback(bitbuffer_t *bitbuffer) {
 	
 	//Check if pattern is received at least x times
 	
-	unsigned count = 0;
-	const char *tmp = bitrow_string;
-	
-	while((tmp = strstr(tmp, id_string))) {
+	while((brpcount = strstr(brpcount, id_string))) {
 	   count++;
-	   tmp++;
+	   brpcount++;
 	}
 	
 	if (count < minpattern) {

--- a/src/devices/elro_db286a.c
+++ b/src/devices/elro_db286a.c
@@ -68,7 +68,7 @@ static int doorbell_db286a_callback(bitbuffer_t *bitbuffer) {
 	data = data_make(
 				"time",			"",		DATA_STRING, time_str,
 				"model",		"",		DATA_STRING, "Elro DB286A",
-				"id",			"Code",	DATA_STRING, id_string,
+				"code",			"Code",	DATA_STRING, id_string,
 				NULL);
 	
 	data_acquired_handler(data);
@@ -80,7 +80,7 @@ static int doorbell_db286a_callback(bitbuffer_t *bitbuffer) {
 static char *output_fields[] = {
     "time",
     "model",
-    "id",
+    "code",
     NULL
 };
 

--- a/src/devices/elro_db286a.c
+++ b/src/devices/elro_db286a.c
@@ -1,9 +1,15 @@
 /* Initial doorbell implementation for Elro DB286A devices
  * 
- * Note that each device seems to have two id patterns, which alternate
+ * Note that each device seems to have two codes, which alternate
  * for every other button press.
  * 
- * Example pattern: 001101111111011000101010011011001
+ * Example code: 37f62a6c80
+ * 
+ * Copyright (C) 2016 Fabian Zaremba <fabian@youremail.eu>
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
  */
  
 #include "rtl_433.h"

--- a/src/devices/elro_db286a.c
+++ b/src/devices/elro_db286a.c
@@ -2,6 +2,8 @@
  * 
  * Note that each device seems to have two id patterns, which alternate
  * for every other button press.
+ * 
+ * Example pattern: 001101111111011000101010011011001
  */
  
 #include "rtl_433.h"
@@ -24,13 +26,6 @@ static int doorbell_db286a_callback(bitbuffer_t *bitbuffer) {
 	uint8_t *b = bb[0];
 	unsigned bits = bitbuffer->bits_per_row[0];
 
-	if (bits != DB286A_TOTALPULSES) {
-		return 0;
-	}
-	
-	//33 pulses + trailing null byte for C string
-	//Example pattern: 001101111111011000101010011011001
-	
 	char id_string[DB286A_PULSECOUNT + 1];
 	char *idsp = id_string;
 	
@@ -41,7 +36,11 @@ static int doorbell_db286a_callback(bitbuffer_t *bitbuffer) {
 	
 	unsigned i;
 	unsigned count = 0;
-
+	
+	if (bits != DB286A_TOTALPULSES) {
+		return 0;
+	}
+	
 	//Get binary string representation of bitrow
 	for (i = 0; i < bits; i++) {
 	    brp += sprintf(brp, "%d", bitrow_get_bit(bb[0], i));	


### PR DESCRIPTION
Some aspects of my implementation:

* ID is only given as a binary string representation, I currently doubt something more sensible can be extracted from the pattern
* ID string alternates between two values for each sending unit
* Looking at the signal, there are both long/short pulses and long/short pauses afterwards. I chose OOK_PULSE_PWM_PRECISE here.
* The current values for short_limit / long_limit / reset_limit are taken from measuring short pulse length, long pulse length and the length of the pause between data patterns in Audacity. These values allow to receive all 15 repetitions of the data pattern.

Tracking issue: #397 (also referencing signal captures in [merbanan/rtl_433_tests](https://github.com/merbanan/rtl_433_tests))

Looking forward to your feedback.