### PR TITLE
Cleanup related to devices disabled by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,19 @@ Running:
 
 ```
 Usage:	= Tuner options =
-	[-d <device index>] (default: 0)
+	[-d <RTL-SDR USB device index>] (default: 0)
 	[-g <gain>] (default: 0 for auto)
 	[-f <frequency>] [-f...] Receive frequency(s) (default: 433920000 Hz)
 	[-p <ppm_error] Correct rtl-sdr tuner frequency offset error (default: 0)
 	[-s <sample rate>] Set sample rate (default: 250000 Hz)
 	[-S] Force sync output (default: async)
 	= Demodulator options =
-	[-R <device>] Listen only for the specified remote device (can be used multiple times)
+	[-R <device>] Enable only the specified device decoding protocol (can be used multiple times)
+	[-G] Enable all device protocols, included those disabled by default
 	[-l <level>] Change detection level used to determine pulses [0-32767] (0 = auto) (default: 8000)
 	[-z <value>] Override short value in data decoder
 	[-x <value>] Override long value in data decoder
+	[-n <value>] Specify number of samples to take (each sample is 2 bytes: 1 each of I & Q)
 	= Analyze/Debug options =
 	[-a] Analyze mode. Print a textual description of the signal. Disables decoding
 	[-A] Pulse Analyzer. Enable pulse analyzis and decode attempt
@@ -67,71 +69,81 @@ Usage:	= Tuner options =
 		 3 = Raw I/Q samples (cf32, 2 channel)
 		 Note: If output file is specified, input will always be I/Q
 	[-F] kv|json|csv Produce decoded output in given format. Not yet supported by all drivers.
+	[-C] native|si|customary Convert units in decoded output.
+	[-T] specify number of seconds to run
+	[-U] Print timestamps in UTC (this may also be accomplished by invocation with TZ environment variable set).
 	[<filename>] Save data stream to output file (a '-' dumps samples to stdout)
 
-Supported devices:
-	[01] Silvercrest Remote Control
-	[02] Rubicson Temperature Sensor
-	[03] Prologue Temperature Sensor
-	[04] Waveman Switch Transmitter
-	[05] Steffen Switch Transmitter
-	[06] ELV EM 1000
-	[07] ELV WS 2000
-	[08] LaCrosse TX Temperature / Humidity Sensor
-	[09] Acurite 5n1 Weather Station
-	[10] Acurite 896 Rain Gauge
-	[11] Acurite Temperature and Humidity Sensor
-	[12] Oregon Scientific Weather Sensor
-	[13] Mebus 433
-	[14] Intertechno 433
-	[15] KlikAanKlikUit Wireless Switch
-	[16] AlectoV1 Weather Sensor (Alecto WS3500 WS4500 Ventus W155/W044 Oregon)
-	[17] Cardin S466-TX2
-	[18] Fine Offset Electronics, WH-2 Sensor
-	[19] Nexus Temperature & Humidity Sensor
-	[20] Ambient Weather Temperature Sensor
-	[21] Calibeur RF-104 Sensor
-	[22] X10 RF
-	[23] DSC Security Contact
-	[24] Brennstuhl RCS 2044
-	[25] GT-WT-02 Sensor
-	[26] Danfoss CFR Thermostat
-	[27] Energy Count 3000 (868.3 MHz)
-	[28] Valeo Car Key
-	[29] Chuango Security Technology
-	[30] Generic Remote SC226x EV1527
-	[31] TFA-Twin-Plus-30.3049 and Ea2 BL999
-	[32] Fine Offset WH1080 Weather Station
-	[33] WT450
-	[34] LaCrosse WS-2310 Weather Station
-	[35] Esperanza EWS
-	[36] Efergy e2 classic
-	[37] Inovalley kw9015b rain and Temperature weather station
-	[38] Generic temperature sensor 1
-	[39] Acurite 592TXR Temperature/Humidity Sensor and 5n1 Weather Station
-	[40] Acurite 986 Refrigerator / Freezer Thermometer
-	[41] HIDEKI TS04 Temperature and Humidity Sensor
-	[42] Watchman Sonic / Apollo Ultrasonic / Beckett Rocket oil tank monitor
-	[43] CurrentCost Current Sensor
-	[44] OpenEnergyMonitor emonTx v3
-	[45] HT680 Remote control
-        [46] S3318P Temperature & Humidity Sensor
-        [47] Akhan 100F14 remote keyless entry
-        [48] Quhwa
-	[49] Oregon Scientific v1 Temperature Sensor
-        [50] Proove
-        [51] Bresser Thermo-/Hygro-Sensor 3CH
-	[52] Springfield PreciseTemp Temperature and Soil Moisture
-        [53] Oregon Scientific SL109H Temperature & Humidity Sensor
-	[54] Acurite 606TX Temperature Sensor 
-        [55] TFA pool temperature sensor
-        [56] Kedsum Temperature & Humidity Sensor
-        [57] blyss DC5-UK-WH (433.92 MHz)
-        [58] Steelmate TPMS
-        [59] Schraeder TPMS
-        [60] LightwaveRF
-        [61] Elro DB286A Doorbell
-        [62] Efergy Optical
+Supported device protocols:
+    [01]* Silvercrest Remote Control
+    [02]  Rubicson Temperature Sensor
+    [03]  Prologue Temperature Sensor
+    [04]  Waveman Switch Transmitter
+    [05]* Steffen Switch Transmitter
+    [06]* ELV EM 1000
+    [07]* ELV WS 2000
+    [08]  LaCrosse TX Temperature / Humidity Sensor
+    [09]* Acurite 5n1 Weather Station
+    [10]* Acurite 896 Rain Gauge
+    [11]* Acurite 609TXC Temperature and Humidity Sensor
+    [12]  Oregon Scientific Weather Sensor
+    [13]* Mebus 433
+    [14]* Intertechno 433
+    [15]  KlikAanKlikUit Wireless Switch
+    [16]  AlectoV1 Weather Sensor (Alecto WS3500 WS4500 Ventus W155/W044 Oregon)
+    [17]* Cardin S466-TX2
+    [18]  Fine Offset Electronics, WH-2 Sensor
+    [19]  Nexus Temperature & Humidity Sensor
+    [20]  Ambient Weather Temperature Sensor
+    [21]  Calibeur RF-104 Sensor
+    [22]* X10 RF
+    [23]* DSC Security Contact
+    [24]* Brennstuhl RCS 2044
+    [25]* GT-WT-02 Sensor
+    [26]* Danfoss CFR Thermostat
+    [27]* Energy Count 3000 (868.3 MHz)
+    [28]* Valeo Car Key
+    [29]  Chuango Security Technology
+    [30]  Generic Remote SC226x EV1527
+    [31]  TFA-Twin-Plus-30.3049 and Ea2 BL999
+    [32]  Fine Offset WH1080 Weather Station
+    [33]  WT450
+    [34]  LaCrosse WS-2310 Weather Station
+    [35]  Esperanza EWS
+    [36]* Efergy e2 classic
+    [37]* Inovalley kw9015b rain and Temperature weather station
+    [38]  Generic temperature sensor 1
+    [39]* Acurite 592TXR Temperature/Humidity Sensor and 5n1 Weather Station
+    [40]* Acurite 986 Refrigerator / Freezer Thermometer
+    [41]  HIDEKI TS04 Temperature and Humidity Sensor
+    [42]  Watchman Sonic / Apollo Ultrasonic / Beckett Rocket oil tank monitor
+    [43]  CurrentCost Current Sensor
+    [44]  emonTx OpenEnergyMonitor
+    [45]  HT680 Remote control
+    [46]  S3318P Temperature & Humidity Sensor
+    [47]  Akhan 100F14 remote keyless entry
+    [48]  Quhwa
+    [49]  OSv1 Temperature Sensor
+    [50]  Proove
+    [51]  Bresser Thermo-/Hygro-Sensor 3CH
+    [52]  Springfield Temperature and Soil Moisture
+    [53]  Oregon Scientific SL109H Remote Thermal Hygro Sensor
+    [54]  Acurite 606TX Temperature Sensor
+    [55]  TFA pool temperature sensor
+    [56]  Kedsum Temperature & Humidity Sensor
+    [57]  blyss DC5-UK-WH (433.92 MHz)
+    [58]  Steelmate TPMS
+    [59]  Schraeder TPMS
+    [60]* LightwaveRF
+    [61]  Elro DB286A Doorbell
+    [62]  Efergy Optical
+    [63]  Honda Car Key
+    [64]* Template decoder
+    [65]  Fine Offset Electronics, XC0400
+    [66]  Radiohead ASK
+    [67]  Kerui PIR Sensor
+
+* Disabled by default, use -R n or -G
 ```
 
 
@@ -139,7 +151,7 @@ Examples:
 
 | Command | Description
 |---------|------------
-| `rtl_433` | Default receive mode, attempt to decode all known devices
+| `rtl_433 -G` | Default receive mode, attempt to decode all known devices
 | `rtl_433 -p NN -R 1 -R 9 -R 36 -R 40` | Typical usage: Enable device decoders for desired devices. Correct rtl-sdr tuning error (ppm offset).
 | `rtl_433 -a` | Will run in analyze mode and you will get a text description of the received signal.
 | `rtl_433 -A` | Enable pulse analyzer. Summarizes the timings of pulses, gaps, and periods. Can be used in either the normal decode mode, or analyze mode.
@@ -152,6 +164,9 @@ This software is mostly useable for developers right now.
 
 Supporting Additional Devices and Test Data
 -------------------------------------------
+
+Note: Not all device protocol decoders are enabled by default. When testing to see if your device
+is decoded by rtl_433, use `-G` to enable all device protocols.
 
 The first step in decoding new devices is to record the signals using `-a -t`. The signals will be
 stored individually in files named gfileNNN.data that can be played back with `rtl_433 -r gfileNNN.data`.

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -35,7 +35,7 @@
 #define DEFAULT_LEVEL_LIMIT     8000		// Theoretical high level at I/Q saturation is 128x128 = 16384 (above is ripple)
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           65
+#define MAX_PROTOCOLS           67
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */


### PR DESCRIPTION
* MAX_PROTOCOLS bumped to 67 (didn't get increased when last two devices where added.)
* MAX_PROTOCOLS too small is now a fatal error, instead of segfault'ing later.
* Usage message: show which devices are disabled by default.
* Usage message: be more clear/consistent referring to device protocols vs RTL-SDR USB device numbers
* Update README.md to match current usage (help) message.