### PR TITLE
Minor fixes for auto level as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Usage:	= Tuner options =
 	= Demodulator options =
 	[-R <device>] Enable only the specified device decoding protocol (can be used multiple times)
 	[-G] Enable all device protocols, included those disabled by default
-	[-l <level>] Change detection level used to determine pulses [0-32767] (0 = auto) (default: 8000)
+	[-l <level>] Change detection level used to determine pulses [0-16384] (0 = auto) (default: 0)
 	[-z <value>] Override short value in data decoder
 	[-x <value>] Override long value in data decoder
 	[-n <value>] Specify number of samples to take (each sample is 2 bytes: 1 each of I & Q)

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -105,7 +105,7 @@ void usage(r_device *devices) {
             "\t= Demodulator options =\n"
             "\t[-R <device>] Enable only the specified device decoding protocol (can be used multiple times)\n"
             "\t[-G] Enable all device protocols, included those disabled by default\n"
-            "\t[-l <level>] Change detection level used to determine pulses [0-32767] (0 = auto) (default: %i)\n"
+            "\t[-l <level>] Change detection level used to determine pulses [0-16384] (0 = auto) (default: %i)\n"
             "\t[-z <value>] Override short value in data decoder\n"
             "\t[-x <value>] Override long value in data decoder\n"
             "\t[-n <value>] Specify number of samples to take (each sample is 2 bytes: 1 each of I & Q)\n"
@@ -1063,7 +1063,7 @@ int main(int argc, char **argv) {
 	else
 	    fprintf(stderr, "Sample rate set to %d.\n", rtlsdr_get_sample_rate(dev)); // Unfortunately, doesn't return real rate
 
-	fprintf(stderr, "Bit detection level set to %d.\n", demod->level_limit);
+	fprintf(stderr, "Bit detection level set to %d%s.\n", demod->level_limit, (demod->level_limit ? "" : " (Auto)"));
 
 	if (0 == gain) {
 	    /* Enable automatic gain */

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -482,7 +482,7 @@ static void classify_signal() {
 
 static void pwm_analyze(struct dm_state *demod, int16_t *buf, uint32_t len) {
     unsigned int i;
-    int32_t threshold = (demod->level_limit ? demod->level_limit : DEFAULT_LEVEL_LIMIT);	// Fix for auto level
+    int32_t threshold = (demod->level_limit ? demod->level_limit : 8000);	// Does not support auto level. Use old default instead.
 
     for (i = 0; i < len; i++) {
         if (buf[i] > threshold) {


### PR DESCRIPTION
Making auto level (-l 0) the default broke the old analyzer (-a).
Minor documentation fixes.
Corrected documented level range to [0-16384] as maximum level for a unit phasor is 128*128. Anything above 16384 will be ripple due to saturation/overdrive (phasor outside unit circle). This is the reason 8000 has worked so well as a fixed detection threshold :-)