### PR TITLE
WH1050 weather station based on WH1080 module.

### DIFF
--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -42,7 +42,7 @@
 
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           67
+#define MAX_PROTOCOLS           68
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -70,7 +70,8 @@
 		DECL(template) \
 		DECL(fineoffset_XC0400) \
 		DECL(radiohead_ask) \
-		DECL(kerui)
+		DECL(kerui) \
+		DECL(fineoffset_wh1050)
 
 
 typedef struct {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,6 +84,7 @@ add_executable(rtl_433
 	devices/new_template.c
 	devices/radiohead_ask.c
 	devices/kerui.c
+	devices/fineoffset_wh1050.c
 
 )
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -69,6 +69,7 @@ rtl_433_SOURCES      = baseband.c \
                        devices/schraeder.c \
                        devices/new_template.c \
                        devices/radiohead_ask.c \
-                       devices/kerui.c
+                       devices/kerui.c \
+                       devices/fineoffset_wh1050.c
 
 rtl_433_LDADD        = $(LIBRTLSDR) $(LIBM)

--- a/src/devices/fineoffset_wh1050.c
+++ b/src/devices/fineoffset_wh1050.c
@@ -1,0 +1,257 @@
+
+/*
+ * *** Fine Offset WH1050 Weather Station ***
+ * (aka )
+ * (aka .....)
+ *
+ * This module is a cut-down version of the WH1080 decoder.
+ * The WH1050 sensor unit is like the WH1080 unit except it has no
+ * wind direction sensor or time receiver.
+ * Other than omitting the ynused code, the differences are the message length
+ * and the location of the battery-low bit.
+ *
+ * The original module was by
+ *
+ * 2016 Nicola Quiriti ('ovrheat')
+ *
+ * Modifications by
+ *
+ * 2016 Don More
+ *
+ *********************
+ *
+ * This weather station is based on an indoor touchscreen receiver, and on a 5+1 outdoor wireless sensors group
+ * (rain, wind speed, temperature, humidity.
+ * See the product page here: http://www.foshk.com/Weather_Professional/WH1070.html (The 1050 model has no radio clock)
+ *
+ * Please note that the pressure sensor (barometer) is enclosed in the indoor console unit, NOT in the outdoor
+ * wireless sensors group.
+ * That's why it's NOT possible to get pressure data by wireless communication. If you need pressure data you should try
+ * an Arduino/Raspberry solution wired with a BMP180 or BMP085 sensor.
+ *
+ * Data are trasmitted in a 48 seconds cycle (data packet, then wait 48 seconds, then data packet...).
+ *
+ * The 'Total rainfall' field is a cumulative counter, increased by 0.3 millimeters of rain at once.
+ *
+ *
+ *
+ *
+ */
+
+
+#include "data.h"
+#include "rtl_433.h"
+#include "util.h"
+#include "math.h"
+
+#define CRC_POLY 0x31
+#define CRC_INIT 0xff
+
+static unsigned short get_device_id(const uint8_t* br) {
+	return (br[1] << 4 & 0xf0 ) | (br[2] >> 4);
+}
+
+static char* get_battery(const uint8_t* br) {
+	if (!(br[2] & 0x04)) {
+		return "OK";
+	} else {
+		return "LOW";
+	}
+}
+
+// ------------ WEATHER SENSORS DECODING ----------------------------------------------------
+
+static float get_temperature(const uint8_t* br) {
+    const int temp_raw = (br[2] << 8) + br[3];
+    return ((temp_raw & 0x03ff) - 0x190) / 10.0;
+}
+
+static int get_humidity(const uint8_t* br) {
+    return br[4];
+}
+
+static float get_wind_speed_raw(const uint8_t* br) {
+    return br[5]; // Raw
+}
+
+static float get_wind_avg_ms(const uint8_t* br) {
+    return (br[5] * 34.0f) / 100; // Meters/sec.
+}
+
+static float get_wind_avg_mph(const uint8_t* br) {
+    return ((br[5] * 34.0f) / 100) * 2.23693629f; // Mph
+}
+
+static float get_wind_avg_kmh(const uint8_t* br) {
+    return ((br[5] * 34.0f) / 100) * 3.6f; // Km/h
+}
+
+static float get_wind_avg_knot(const uint8_t* br) {
+    return ((br[5] * 34.0f) / 100) * 1.94384f; // Knots
+}
+
+static float get_wind_gust_raw(const uint8_t* br) {
+    return br[6]; // Raw
+}
+
+static float get_wind_gust_ms(const uint8_t* br) {
+    return (br[6] * 34.0f) / 100; // Meters/sec.
+}
+
+static float get_wind_gust_mph(const uint8_t* br) {
+    return ((br[6] * 34.0f) / 100) * 2.23693629f; // Mph
+
+}
+
+static float get_wind_gust_kmh(const uint8_t* br) {
+    return ((br[6] * 34.0f) / 100) * 3.6f; // Km/h
+}
+
+static float get_wind_gust_knot(const uint8_t* br) {
+    return ((br[6] * 34.0f) / 100) * 1.94384f; // Knots
+}
+
+static float get_rainfall(const uint8_t* br) {
+	return ((((unsigned short)br[7] & 0x0f) << 8) | br[8]) * 0.3f;
+}
+
+
+//----------------- TIME DECODING ----------------------------------------------------
+
+static int get_hours(const uint8_t* br) {
+	return ((br[3] >> 4 & 0x03) * 10) + (br[3] & 0x0F);
+}
+
+static int get_minutes(const uint8_t* br) {
+	return (((br[4] & 0xF0) >> 4) * 10) + (br[4] & 0x0F);
+}
+
+static int get_seconds(const uint8_t* br) {
+	return (((br[5] & 0xF0) >> 4) * 10) + (br[5] & 0x0F);
+}
+
+static int get_year(const uint8_t* br) {
+	return (((br[6] & 0xF0) >> 4) * 10) + (br[6] & 0x0F);
+}
+
+static int get_month(const uint8_t* br) {
+	return ((br[7] >> 4 & 0x01) * 10) + (br[7] & 0x0F);
+}
+
+static int get_day(const uint8_t* br) {
+	return (((br[8] & 0xF0) >> 4) * 10) + (br[8] & 0x0F);
+}
+
+//-------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------
+
+
+
+static int fineoffset_wh1050_callback(bitbuffer_t *bitbuffer) {
+    data_t *data;
+    char time_str[LOCAL_TIME_BUFLEN];
+    local_time_str(0, time_str);
+
+    if (bitbuffer->num_rows != 1) {
+        return 0;
+    }
+    if (bitbuffer->bits_per_row[0] != 80) {
+        return 0;
+    }
+
+    const uint8_t *br = bitbuffer->bb[0];
+
+    if (br[0] != 0xff) {
+        // preamble missing
+        return 0;
+    }
+
+    if (br[9] != crc8(br, 9, CRC_POLY, CRC_INIT)) {
+        // crc mismatch
+        return 0;
+    }
+
+//---------------------------------------------------------------------------------------
+//-------- GETTING WEATHER SENSORS DATA -------------------------------------------------
+
+    const float temperature = get_temperature(br);
+    const int humidity = get_humidity(br);
+
+	// Select which metric system for *wind avg speed* and *wind gust* :
+
+	// Wind average speed :
+
+	//const float speed = get_wind_avg_ms((br)   // <--- Data will be shown in Meters/sec.
+	//const float speed = get_wind_avg_mph((br)  // <--- Data will be shown in Mph
+	const float speed = get_wind_avg_kmh(br);  // <--- Data will be shown in Km/h
+	//const float speed = get_wind_avg_knot((br) // <--- Data will be shown in Knots
+
+
+	// Wind gust speed :
+
+    //const float gust = get_wind_gust_ms(br);   // <--- Data will be shown in Meters/sec.
+	//const float gust = get_wind_gust_mph(br);  // <--- Data will be shown in Mph
+	const float gust = get_wind_gust_kmh(br);  // <--- Data will be shown in km/h
+	//const float gust = get_wind_gust_knot(br); // <--- Data will be shown in Knots
+
+    const float rain = get_rainfall(br);
+    const int device_id = get_device_id(br);
+	const char* battery = get_battery(br);
+
+//---------------------------------------------------------------------------------------
+//-------- GETTING TIME DATA ------------------------------------------------------------
+
+	const int the_hours = get_hours(br);
+	const int the_minutes =	get_minutes(br);
+	const int the_seconds = get_seconds(br);
+	const int the_year = 2000 + get_year(br);
+	const int the_month = get_month(br);
+	const int the_day = get_day(br);
+
+
+//--------- PRESENTING DATA --------------------------------------------------------------
+
+    data = data_make("time", 		"", 		DATA_STRING, time_str,
+                     "model", 		"", 		DATA_STRING, "Fine Offset WH1050 weather station",
+                     "id",            "StationID",	DATA_FORMAT, "%04X",	DATA_INT,    device_id,
+                     "temperature_C", "Temperature",	DATA_FORMAT, "%.01f C",	DATA_DOUBLE, temperature,
+                     "humidity",      "Humidity",	DATA_FORMAT, "%u %%",	DATA_INT,    humidity,
+                     "speed",         "Wind avg speed",	DATA_FORMAT, "%.02f",	DATA_DOUBLE, speed,
+                     "gust",          "Wind gust",	DATA_FORMAT, "%.02f",	DATA_DOUBLE, gust,
+                     "rain",          "Total rainfall",	DATA_FORMAT, "%.01f",	DATA_DOUBLE, rain,
+		     "battery",       "Battery",	DATA_STRING, battery, // Unsure about Battery byte...
+                     NULL);
+    data_acquired_handler(data);
+    return 1;
+}
+
+static char *output_fields[] = {
+	"time",
+	"model",
+	"id",
+	"temperature_C",
+	"humidity",
+	"speed",
+	"gust",
+	"rain",
+	"hours",
+	"minutes",
+	"seconds",
+	"year",
+	"month",
+	"day",
+	"battery",
+	NULL
+};
+
+r_device fineoffset_wh1050 = {
+    .name           = "Fine Offset WH1050 Weather Station",
+    .modulation     = OOK_PULSE_PWM_RAW,
+    .short_limit    = 976,
+    .long_limit     = 2400,
+    .reset_limit    = 10520,
+    .json_callback  = &fineoffset_wh1050_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
+    .fields         = output_fields,
+};


### PR DESCRIPTION
This is a copy of the WH1080 decoder to handle the similar WH1050 weather station.
The WH1050 differs in that it has no wind direction sensor and no radio clock.
The message size is different and the battery-low bit has consequently moved. The rest of the decoding is the same.