### PR TITLE
add Maverick ET-73x BBQ Sensor

### DIFF
--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -65,8 +65,8 @@
 		DECL(schraeder) \
 		DECL(lightwave_rf) \
 		DECL(elro_db286a) \
-		DECL(efergy_optical) \
-		DECL(hondaremote) \
+                DECL(efergy_optical) \
+                DECL(hondaremote) \
 		DECL(template) \
 		DECL(fineoffset_XC0400) \
 		DECL(radiohead_ask) \

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -65,8 +65,8 @@
 		DECL(schraeder) \
 		DECL(lightwave_rf) \
 		DECL(elro_db286a) \
-                DECL(efergy_optical) \
-                DECL(hondaremote) \
+		DECL(efergy_optical) \
+		DECL(hondaremote) \
 		DECL(template) \
 		DECL(fineoffset_XC0400) \
 		DECL(radiohead_ask) \

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -65,14 +65,15 @@
 		DECL(schraeder) \
 		DECL(lightwave_rf) \
 		DECL(elro_db286a) \
-                DECL(efergy_optical) \
-                DECL(hondaremote) \
+        DECL(efergy_optical) \
+        DECL(hondaremote) \
 		DECL(template) \
 		DECL(fineoffset_XC0400) \
 		DECL(radiohead_ask) \
-		DECL(kerui)                                                    \
-        DECL(maverick_et73x)                                           \
-		DECL(fineoffset_wh1050)
+		DECL(kerui) \
+		DECL(fineoffset_wh1050) \
+		DECL(honeywell)\
+		DECL(maverick_et73x)
 
 
 typedef struct {

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -70,9 +70,9 @@
 		DECL(template) \
 		DECL(fineoffset_XC0400) \
 		DECL(radiohead_ask) \
-		DECL(kerui) \
-		DECL(fineoffset_wh1050) \
-		DECL(honeywell)
+		DECL(kerui)                                                    \
+        DECL(maverick_et73x)                                           \
+		DECL(fineoffset_wh1050)
 
 
 typedef struct {

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -65,14 +65,14 @@
 		DECL(schraeder) \
 		DECL(lightwave_rf) \
 		DECL(elro_db286a) \
-		DECL(efergy_optical) \
-		DECL(hondaremote) \
+                DECL(efergy_optical) \
+                DECL(hondaremote) \
 		DECL(template) \
 		DECL(fineoffset_XC0400) \
 		DECL(radiohead_ask) \
 		DECL(kerui) \
 		DECL(fineoffset_wh1050) \
-		DECL(honeywell)\
+		DECL(honeywell) \
 		DECL(maverick_et73x)
 
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -65,8 +65,8 @@
 		DECL(schraeder) \
 		DECL(lightwave_rf) \
 		DECL(elro_db286a) \
-        DECL(efergy_optical) \
-        DECL(hondaremote) \
+		DECL(efergy_optical) \
+		DECL(hondaremote) \
 		DECL(template) \
 		DECL(fineoffset_XC0400) \
 		DECL(radiohead_ask) \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,7 @@ add_executable(rtl_433
 	pulse_detect.c
 	rtl_433.c
 	util.c
-        devices/acurite.c
+	devices/acurite.c
 	devices/alecto.c
 	devices/ambient_weather.c
 	devices/blyss.c
@@ -76,11 +76,11 @@ add_executable(rtl_433
 	devices/proove.c
 	devices/bresser_3ch.c
 	devices/oregon_scientific_sl109h.c
-		devices/steelmate.c
+	devices/steelmate.c
 	devices/schraeder.c
 	devices/elro_db286a.c
-        devices/efergy_optical.c
-        devices/hondaremote.c
+	devices/efergy_optical.c
+	devices/hondaremote.c
 	devices/new_template.c
 	devices/radiohead_ask.c
 	devices/kerui.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,7 +76,7 @@ add_executable(rtl_433
 	devices/proove.c
 	devices/bresser_3ch.c
 	devices/oregon_scientific_sl109h.c
-	devices/steelmate.c
+		devices/steelmate.c
 	devices/schraeder.c
 	devices/elro_db286a.c
         devices/efergy_optical.c
@@ -84,8 +84,9 @@ add_executable(rtl_433
 	devices/new_template.c
 	devices/radiohead_ask.c
 	devices/kerui.c
-    devices/maverick_et73x.c
 	devices/fineoffset_wh1050.c
+	devices/honeywell.c
+	devices/maverick_et73x.c
 
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,8 +84,8 @@ add_executable(rtl_433
 	devices/new_template.c
 	devices/radiohead_ask.c
 	devices/kerui.c
+    devices/maverick_et73x.c
 	devices/fineoffset_wh1050.c
-	devices/honeywell.c
 
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,7 @@ add_executable(rtl_433
 	pulse_detect.c
 	rtl_433.c
 	util.c
-        devices/acurite.c
+	devices/acurite.c
 	devices/alecto.c
 	devices/ambient_weather.c
 	devices/blyss.c
@@ -79,8 +79,8 @@ add_executable(rtl_433
 	devices/steelmate.c
 	devices/schraeder.c
 	devices/elro_db286a.c
-        devices/efergy_optical.c
-        devices/hondaremote.c
+	devices/efergy_optical.c
+	devices/hondaremote.c
 	devices/new_template.c
 	devices/radiohead_ask.c
 	devices/kerui.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,7 @@ add_executable(rtl_433
 	pulse_detect.c
 	rtl_433.c
 	util.c
-	devices/acurite.c
+        devices/acurite.c
 	devices/alecto.c
 	devices/ambient_weather.c
 	devices/blyss.c
@@ -79,8 +79,8 @@ add_executable(rtl_433
 	devices/steelmate.c
 	devices/schraeder.c
 	devices/elro_db286a.c
-	devices/efergy_optical.c
-	devices/hondaremote.c
+        devices/efergy_optical.c
+        devices/hondaremote.c
 	devices/new_template.c
 	devices/radiohead_ask.c
 	devices/kerui.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -72,6 +72,6 @@ rtl_433_SOURCES      = baseband.c \
                        devices/kerui.c \
                        devices/fineoffset_wh1050.c \
                        devices/honeywell.c \
-					   devices/maverick_et73x.c
+                       devices/maverick_et73x.c
 
 rtl_433_LDADD        = $(LIBRTLSDR) $(LIBM)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -71,7 +71,7 @@ rtl_433_SOURCES      = baseband.c \
                        devices/radiohead_ask.c \
                        devices/kerui.c \
                        devices/fineoffset_wh1050.c \
-                       devices/honeywell.c \
+                       devices/honeywell.c\
                        devices/maverick_et73x.c
 
 rtl_433_LDADD        = $(LIBRTLSDR) $(LIBM)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -71,7 +71,7 @@ rtl_433_SOURCES      = baseband.c \
                        devices/radiohead_ask.c \
                        devices/kerui.c \
                        devices/fineoffset_wh1050.c \
-                       devices/honeywell.c\
+                       devices/honeywell.c \
                        devices/maverick_et73x.c
 
 rtl_433_LDADD        = $(LIBRTLSDR) $(LIBM)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -70,7 +70,7 @@ rtl_433_SOURCES      = baseband.c \
                        devices/new_template.c \
                        devices/radiohead_ask.c \
                        devices/kerui.c \
-                       devices/fineoffset_wh1050.c \
-                       devices/honeywell.c
+                       devices/maverick_et73x.c \
+                       devices/fineoffset_wh1050.c
 
 rtl_433_LDADD        = $(LIBRTLSDR) $(LIBM)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -70,7 +70,8 @@ rtl_433_SOURCES      = baseband.c \
                        devices/new_template.c \
                        devices/radiohead_ask.c \
                        devices/kerui.c \
-                       devices/maverick_et73x.c \
-                       devices/fineoffset_wh1050.c
+                       devices/fineoffset_wh1050.c \
+                       devices/honeywell.c \
+					   devices/maverick_et73x.c
 
 rtl_433_LDADD        = $(LIBRTLSDR) $(LIBM)

--- a/src/devices/maverick_et73x.c
+++ b/src/devices/maverick_et73x.c
@@ -1,0 +1,253 @@
+//some hints from http://www.osengr.org/WxShield/Downloads/OregonScientific-RF-Protocols-II.pdf
+
+#include "rtl_433.h"
+#include "util.h"
+
+#define MAV_MESSAGE_LENGTH 104
+#define TEMPERATURE_START_POSITION_S1 8
+#define TEMPERATURE_START_POSITION_S2 13
+#define TEMPERATURE_BIT_COUNT 5
+
+static unsigned int msg_converted[26];
+static char msg_hex_combined[26];
+static time_t time_now_t, last_time_t;
+static int32_t session_id;
+
+// quarternary convertion
+int quart(unsigned char param) {
+    int retval = 0;
+
+    if (param=='5')
+        retval = 0;
+    if (param=='6')
+        retval = 1;
+    if (param=='9')
+        retval = 2;
+    if (param=='a' || param=='A')
+        retval = 3;
+
+    return retval;
+}
+
+//here we extract bitbuffer values, for easy data handling
+static void convert_bitbuffer(bitbuffer_t *bitbuffer) {
+        int i;
+        for(i = 0; i < 13; i++) {
+            char temp[2];
+            sprintf(temp, "%02x", bitbuffer->bb[0][i]);
+            msg_hex_combined[i*2] = temp[0];
+            msg_hex_combined[i*2+1] = temp[1];
+        }
+
+        for(i = 0; i <= 25; i++) {
+           msg_converted[i] = quart(msg_hex_combined[i]);
+        }
+
+        if(debug_output) {
+            fprintf(stderr, "final hex string: %s\n",msg_hex_combined);
+            fprintf(stderr, "final converted message: ");
+            for(i = 0; i <= 25; i++) fprintf(stderr, "%d",msg_converted[i]);
+            fprintf(stderr, "\n");
+        }
+}
+
+static float get_temperature(unsigned int temp_start_index){
+	//default offset
+	float temp_c = -532.0;
+	int i;
+	
+	for(i=0; i < TEMPERATURE_BIT_COUNT; i++) {
+		temp_c += msg_converted[temp_start_index+i] * (1<<(2*(4-i)));
+	}
+
+	return temp_c;
+}
+
+
+//changes when thermometer reset button is pushed or powered on.
+static char* get_status() {
+    int stat = 0;
+	char* retval = "unknown";
+	
+	//nibble 6 - 7 used for status
+    stat += msg_converted[6] * (1<<(2*(1)));
+    stat += msg_converted[7] * (1<<(2*(0)));
+
+    if(stat == 2)
+		retval = "default";
+
+    if(stat == 7)
+		retval = "init";
+
+	if(debug_output)
+        fprintf(stderr, "device status: \"%s\" (%d)\n", retval, stat);
+	
+    return retval;
+}
+
+
+static uint32_t checksum_data() {
+    int32_t checksum = 0;
+    int i;
+
+    //nibble 6 - 17 used for checksum
+    for(i=0; i<=11; i++) {
+        checksum |= msg_converted[6+i] << (22 - 2*i);
+    }
+
+    if(debug_output)
+        fprintf(stderr, "checksum data = %x\n", checksum);
+
+    return checksum;
+}
+
+
+static uint32_t checksum_received() {
+    uint32_t checksum = 0;
+    int i;
+	
+    //nibble 18 - 25 checksum info from device
+    for(i=0; i<=7; i++) {
+         checksum |= msg_converted[18+i] << (14 - 2*i);
+    }
+
+    if(msg_hex_combined[24]=='1' || msg_hex_combined[24]=='2') {
+        checksum |= (msg_converted[25]&1) << 3;
+        checksum |= (msg_converted[25]&2) << 1;
+
+        if(msg_hex_combined[24]=='2')
+            checksum |= 0x02;
+    }
+    else {
+        checksum |= msg_converted[24] << 2;
+        checksum |= msg_converted[25];
+    }
+
+    if(debug_output)
+        fprintf(stderr, "checksum received= %x\n", checksum);
+
+    return checksum;
+}
+
+static uint16_t shiftreg(uint16_t currentValue) {
+	uint8_t msb = (currentValue >> 15) & 1;
+	currentValue <<= 1;
+	
+	// Toggle pattern for feedback bits
+	// Toggle, if MSB is 1
+	if (msb == 1)
+		currentValue ^= 0x1021;
+	
+	return currentValue;
+}
+
+static uint16_t calculate_checksum(uint32_t data) {
+	//initial value of linear feedback shift register
+	uint16_t mask = 0x3331; 
+	uint16_t csum = 0x0;
+	int i;
+	for(i = 0; i < 24; ++i)	{
+		//data bit at current position is "1"
+		//do XOR with mask
+		if((data >> i) & 0x01)
+			csum ^= mask;
+		
+		mask = shiftreg(mask);
+	}
+	return csum;
+}
+
+static int maverick_et73x_callback(bitbuffer_t *bitbuffer) {
+    data_t *data;
+    char time_str[LOCAL_TIME_BUFLEN];
+	double diff_t = 0.0;
+	int8_t b_use_message = 0;
+	int32_t chk_xor;
+	char* dev_state;
+
+    //we need an inverted bitbuffer
+    bitbuffer_invert(bitbuffer);
+
+    if(bitbuffer->num_rows != 1)
+        return 0;
+
+    //check correct data length
+    if(bitbuffer->bits_per_row[0] != MAV_MESSAGE_LENGTH)
+        return 0;
+
+    //check for correct header (0xAA9995)
+    if((bitbuffer->bb[0][0] != 0xAA || bitbuffer->bb[0][0] != 0xaa ) || bitbuffer->bb[0][1] != 0x99 || bitbuffer->bb[0][2] != 0x95)
+        return 0;
+	
+	//convert hex values into quardinary values
+    convert_bitbuffer(bitbuffer);
+	
+	//checksum is used to represent a session. This means, we get a new session_id if a reset or battery exchange is done. 
+	chk_xor = (calculate_checksum(checksum_data()) & 0xffff) ^ checksum_received();
+	
+	
+	dev_state = get_status();
+	
+	//if the transmitter is in init state, we take the session_id for further checks. 
+	if(strncmp(dev_state, "init", 4) == 0)
+	{
+		//assuming that having two times the same checksum, means there was no error in sending first message
+		if(session_id != chk_xor)
+			b_use_message = 1;
+	}
+
+	//second message
+	if(session_id > 0) {
+		time(&time_now_t);
+		diff_t = difftime(time_now_t, last_time_t);
+
+		//checksum error
+		if(session_id != chk_xor && b_use_message == 0 && diff_t > 8)
+			return 0;
+	}
+	
+
+	//one message (of four) is enough for output
+	if (diff_t < 8 && session_id > 0 && b_use_message == 0)
+		return 0;
+	
+	session_id = chk_xor;
+	time(&last_time_t);
+
+    local_time_str(0, time_str);
+
+    if(debug_output)
+        fprintf(stderr, "checksum xor: %x\n", chk_xor);
+
+    data = data_make("time",           "",                      DATA_STRING,                         time_str,
+                     "id",             "Session_ID",            DATA_INT,                            chk_xor,
+                     "temperature_C1", "TemperatureSensor1",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, get_temperature(TEMPERATURE_START_POSITION_S1),
+                     "temperature_C2", "TemperatureSensor2",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, get_temperature(TEMPERATURE_START_POSITION_S2),
+                     "status",         "Status",                DATA_STRING,                         dev_state,
+                     NULL);
+    data_acquired_handler(data);
+
+    return bitbuffer->num_rows;
+}
+
+static char *output_fields[] = {
+    "time",
+    "session_id"
+    "temperature_C1",
+    "temperature_C2",
+    "status",
+    NULL
+};
+
+
+r_device maverick_et73x = {
+    .name           = "Maverick ET-732/733 BBQ Sensor",
+    .modulation     = OOK_PULSE_MANCHESTER_ZEROBIT,
+    .short_limit    = 250,
+    .long_limit     = 500,
+    .reset_limit    = 4000,
+    .json_callback  = &maverick_et73x_callback,
+    .disabled       = 0,
+    .demod_arg     = 0,
+    .fields         = output_fields
+};

--- a/src/devices/maverick_et73x.c
+++ b/src/devices/maverick_et73x.c
@@ -1,4 +1,4 @@
-//for further information please refere to https://forums.adafruit.com/viewtopic.php?f=8&t=25414
+//for further information please referre to https://forums.adafruit.com/viewtopic.php?f=8&t=25414
 
 #include "rtl_433.h"
 #include "util.h"

--- a/src/devices/maverick_et73x.c
+++ b/src/devices/maverick_et73x.c
@@ -1,4 +1,4 @@
-//some hints from http://www.osengr.org/WxShield/Downloads/OregonScientific-RF-Protocols-II.pdf
+//for further information please refere to https://forums.adafruit.com/viewtopic.php?f=8&t=25414
 
 #include "rtl_433.h"
 #include "util.h"

--- a/src/devices/maverick_et73x.c
+++ b/src/devices/maverick_et73x.c
@@ -45,7 +45,7 @@
 #define MAV_MESSAGE_LENGTH 104
 #define TEMPERATURE_START_POSITION_S1 8
 #define TEMPERATURE_START_POSITION_S2 13
-#define TEMPERATURE_BIT_COUNT 5
+#define TEMPERATURE_NIBBLE_COUNT 5
 
 
 //here we extract bitbuffer values, for easy data handling
@@ -76,8 +76,8 @@ static float get_temperature(unsigned int *msg_converted, unsigned int temp_star
     //default offset
     float temp_c = -532.0;
     int i;
-    
-    for(i=0; i < TEMPERATURE_BIT_COUNT; i++) {
+
+    for(i=0; i < TEMPERATURE_NIBBLE_COUNT; i++) {
         temp_c += msg_converted[temp_start_index+i] * (1<<(2*(4-i)));
     }
 
@@ -211,10 +211,12 @@ static int maverick_et73x_callback(bitbuffer_t *bitbuffer) {
     local_time_str(0, time_str);
 
     data = data_make("time",           "",                      DATA_STRING,                         time_str,
+                     "brand",          "",                      DATA_STRING,                         "Maverick",
+                     "model",          "",                      DATA_STRING,                         "ET-732/ET-733",
                      "id",             "Session_ID",            DATA_INT,                            session_id,
+                     "status",         "Status",                DATA_STRING,                         get_status(msg_converted),
                      "temperature_C1", "TemperatureSensor1",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, get_temperature(msg_converted,TEMPERATURE_START_POSITION_S1),
                      "temperature_C2", "TemperatureSensor2",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, get_temperature(msg_converted,TEMPERATURE_START_POSITION_S2),
-                     "status",         "Status",                DATA_STRING,                         get_status(msg_converted),
                      NULL);
     data_acquired_handler(data);
 
@@ -223,10 +225,12 @@ static int maverick_et73x_callback(bitbuffer_t *bitbuffer) {
 
 static char *output_fields[] = {
     "time",
-    "session_id"
+    "brand"
+    "model"
+    "id"
+    "status",
     "temperature_C1",
     "temperature_C2",
-    "status",
     NULL
 };
 


### PR DESCRIPTION
Up to now, there is no support for Maverick ET-73x BBQ sensors. 

The implementation is based on a forum discussion:
https://forums.adafruit.com/viewtopic.php?f=8&t=25414

The reason for the bad code style: I'm no coder! Sorry

cheers
