### PR TITLE
Update pulse_detect.c

### DIFF
--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -544,8 +544,8 @@ void pulse_analyzer(pulse_data_t *data, uint32_t samp_rate)
 	} else if(hist_pulses.bins_count == 1 && hist_gaps.bins_count > 1) {
 		fprintf(stderr, "Pulse Position Modulation with fixed pulse width\n");
 		device.modulation	= OOK_PULSE_PPM_RAW;
-		device.short_limit	= (hist_gaps.bins[0].mean + hist_gaps.bins[1].mean) / 2;	// Set limit between two lowest gaps
-		device.long_limit	= hist_gaps.bins[1].max + 1;								// Set limit above next lower gap
+		device.short_limit	= (hist_gaps.bins[hist_gaps.bins_count-3].mean + hist_gaps.bins[hist_gaps.bins_count-2].mean) / 2;	// Set limit between two lowest gaps
+		device.long_limit	= hist_gaps.bins[hist_gaps.bins_count-2].max + 1;			// Counting down may help ignore extraneous short pulses					// Set limit above next lower gap
 		device.reset_limit	= hist_gaps.bins[hist_gaps.bins_count-1].max + 1;			// Set limit above biggest gap
 	} else if(hist_pulses.bins_count == 2 && hist_gaps.bins_count == 1) {
 		fprintf(stderr, "Pulse Width Modulation with fixed gap\n");


### PR DESCRIPTION
Counting down in the gaps histogram, from longest to shorter detected gaps, should help to make the PPM_RAW pulse detection more robust. If there are accidentally some too-short gaps in the transmission, they will now be ignored rather than used for parsing the transmission.

A more detailed description and sample transmissions which get fixed by this change are [here.](https://groups.google.com/forum/#!topic/rtl_433/4ICr3h6ZE-M)