### PR TITLE
Acurite 5n1 changes

### DIFF
--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -12,7 +12,6 @@
 		DECL(elv_em1000) \
 		DECL(elv_ws2000) \
 		DECL(lacrossetx) \
-		DECL(acurite5n1) \
 		DECL(acurite_rain_gauge) \
 		DECL(acurite_th) \
 		DECL(oregon_scientific) \

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -12,6 +12,7 @@
 		DECL(elv_em1000) \
 		DECL(elv_ws2000) \
 		DECL(lacrossetx) \
+		DECL(template) \
 		DECL(acurite_rain_gauge) \
 		DECL(acurite_th) \
 		DECL(oregon_scientific) \

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -435,6 +435,10 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf) {
 
 	// The 5-n-1 weather sensor messages are 8 bytes.
 	if (browlen == ACURITE_5N1_BITLEN / 8) {
+        if (debug_output) {
+            fprintf(stderr, "Acurite 5n1 raw msg: %02X %02X %02X %02X %02X %02X %02X %02X\n",
+                bb[0], bb[1], bb[2], bb[3], bb[4], bb[5], bb[6], bb[7]);
+        }
 	    channel = acurite_getChannel(bb[0]);
         sprintf(channel_str, "%c", channel);        
 	    sensor_id = acurite_5n1_getSensorId(bb[0],bb[1]);

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -437,7 +437,7 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf) {
 	    sensor_id = acurite_5n1_getSensorId(bb[0],bb[1]);
 	    repeat_no = acurite_5n1_getMessageCaught(bb[0]);
 	    message_type = bb[2] & 0x3f;
-        
+        battery_low = bb[3] & 0x40 >> 6;
 
 	    if (message_type == 0x31) {
             // Wind speed, wind direction, and rain fall
@@ -468,6 +468,7 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf) {
                 "model",        "",   DATA_STRING,    "Acurite 5n1 sensor",
                 "sensor_id",    NULL,   DATA_FORMAT,    "0x%02X",   DATA_INT,       sensor_id,   
                 "channel",      NULL,   DATA_STRING,    &channel_str,
+                "battery",      NULL,   DATA_STRING,    battery_low ? "OK" : "LOW",                
                 "message_type", NULL,   DATA_INT,       message_type,
                 "wind_speed",   NULL,   DATA_FORMAT,    "%d",   DATA_INT,       wind_speed,
                 "wind_dir_deg", NULL,   DATA_FORMAT,    "%.1f", DATA_DOUBLE,    wind_dird,
@@ -490,6 +491,7 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf) {
                 "model",        "",   DATA_STRING,    "Acurite 5n1 sensor",
                 "sensor_id",    NULL,   DATA_FORMAT,    "0x%02X",   DATA_INT,       sensor_id,   
                 "channel",      NULL,   DATA_STRING,    &channel_str,
+                "battery",      NULL,   DATA_STRING,    battery_low ? "OK" : "LOW",                
                 "message_type", NULL,   DATA_INT,       message_type,
                 "wind_speed",   NULL,   DATA_FORMAT,    "%d",   DATA_INT,       wind_speed,
                 "temperature_C", 	"temperature",	DATA_FORMAT,    "%.1f C", DATA_DOUBLE,    tempc,

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -145,8 +145,8 @@ static float acurite_getTemp (uint8_t highbyte, uint8_t lowbyte) {
     int highbits = (highbyte & 0x0F) << 7 ;
     int lowbits = lowbyte & 0x7F;
     int rawtemp = highbits | lowbits;
-    float temp = (rawtemp - 400) / 10.0;
-    return temp;
+    float temp_F = (rawtemp - 400) / 10.0;
+    return temp_F;
 }
 
 static float acurite_getWindSpeed_kph (uint8_t highbyte, uint8_t lowbyte) {
@@ -466,7 +466,7 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf) {
                 "channel",      NULL,   DATA_STRING,    &channel_str,
                 "battery",      NULL,   DATA_STRING,    battery_low ? "OK" : "LOW",
                 "message_type", NULL,   DATA_INT,       message_type,
-                "wind_speed",   NULL,   DATA_FORMAT,    "%.1f km/h", DATA_DOUBLE,     wind_speed,
+                "wind_speed",   NULL,   DATA_FORMAT,    "%.1f mph", DATA_DOUBLE,     wind_speedmph,
                 "wind_dir_deg", NULL,   DATA_FORMAT,    "%.1f", DATA_DOUBLE,    wind_dird,
                 "wind_dir",     NULL,   DATA_STRING,    wind_dirstr,
                 "rainfall_accumulation",     NULL,   DATA_FORMAT,    "%.2f in", DATA_DOUBLE,    rainfall,
@@ -490,8 +490,8 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf) {
                 "channel",      NULL,   DATA_STRING,    &channel_str,
                 "battery",      NULL,   DATA_STRING,    battery_low ? "OK" : "LOW",
                 "message_type", NULL,   DATA_INT,       message_type,
-                "wind_speed",   NULL,   DATA_FORMAT,    "%.1f km/h", DATA_DOUBLE,     wind_speed,
-                "temperature_C", 	"temperature",	DATA_FORMAT,    "%.1f C", DATA_DOUBLE,    tempc,
+                "wind_speed",   NULL,   DATA_FORMAT,    "%.1f mph", DATA_DOUBLE,     wind_speedmph,
+                "temperature_F", 	"temperature",	DATA_FORMAT,    "%.1f F", DATA_DOUBLE,    tempf,
                 "humidity",     NULL,	DATA_FORMAT,    "%d",   DATA_INT,   humidity,
                 NULL);
             data_acquired_handler(data);

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -492,7 +492,7 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf) {
                 "channel",      NULL,   DATA_STRING,    &channel_str,
                 "message_type", NULL,   DATA_INT,       message_type,
                 "wind_speed",   NULL,   DATA_FORMAT,    "%d",   DATA_INT,       wind_speed,
-                "temperature", 	NULL,	DATA_FORMAT,    "%.1f C", DATA_DOUBLE,    tempc,
+                "temperature_C", 	"temperature",	DATA_FORMAT,    "%.1f C", DATA_DOUBLE,    tempc,
                 "humidity",     NULL,	DATA_FORMAT,    "%d",   DATA_INT,   humidity,
                 NULL);
             data_acquired_handler(data);

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -444,7 +444,7 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf) {
 	    sensor_id = acurite_5n1_getSensorId(bb[0],bb[1]);
 	    repeat_no = acurite_5n1_getMessageCaught(bb[0]);
 	    message_type = bb[2] & 0x3f;
-        battery_low = bb[3] & 0x40 >> 6;
+        battery_low = (bb[2] & 0x40) >> 6;
 
 	    if (message_type == 0x31) {
             // Wind speed, wind direction, and rain fall

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -327,7 +327,7 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf) {
     int browlen, valid = 0;
     uint8_t *bb;
     float tempc, tempf, wind_dird, rainfall = 0.0, wind_speed, wind_speedmph;
-    uint8_t humidity, sensor_status, repeat_no, message_type;
+    uint8_t humidity, sensor_status, sequence_num, message_type;
     char channel, *wind_dirstr = "";
     char channel_str[2];
     uint16_t sensor_id;
@@ -418,7 +418,7 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf) {
 	    channel = acurite_getChannel(bb[0]);
         sprintf(channel_str, "%c", channel);        
 	    sensor_id = acurite_5n1_getSensorId(bb[0],bb[1]);
-	    repeat_no = acurite_5n1_getMessageCaught(bb[0]);
+	    sequence_num = acurite_5n1_getMessageCaught(bb[0]);
 	    message_type = bb[2] & 0x3f;
         battery_low = (bb[2] & 0x40) >> 6;
 
@@ -451,6 +451,7 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf) {
                 "model",        "",   DATA_STRING,    "Acurite 5n1 sensor",
                 "sensor_id",    NULL,   DATA_FORMAT,    "0x%02X",   DATA_INT,       sensor_id,   
                 "channel",      NULL,   DATA_STRING,    &channel_str,
+                "sequence_num",  NULL,   DATA_INT,      sequence_num,
                 "battery",      NULL,   DATA_STRING,    battery_low ? "OK" : "LOW",
                 "message_type", NULL,   DATA_INT,       message_type,
                 "wind_speed",   NULL,   DATA_FORMAT,    "%.1f mph", DATA_DOUBLE,     wind_speedmph,
@@ -475,6 +476,7 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf) {
                 "model",        "",   DATA_STRING,    "Acurite 5n1 sensor",
                 "sensor_id",    NULL,   DATA_FORMAT,    "0x%02X",   DATA_INT,       sensor_id,   
                 "channel",      NULL,   DATA_STRING,    &channel_str,
+                "sequence_num",  NULL,   DATA_INT,      sequence_num,
                 "battery",      NULL,   DATA_STRING,    battery_low ? "OK" : "LOW",
                 "message_type", NULL,   DATA_INT,       message_type,
                 "wind_speed",   NULL,   DATA_FORMAT,    "%.1f mph", DATA_DOUBLE,     wind_speedmph,

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -26,6 +26,10 @@
 #define ACURITE_5N1_BITLEN		64
 #define ACURITE_6045_BITLEN		72
 
+// ** Acurite known message types
+#define ACURITE_MSGTYPE_WINDSPEED_WINDDIR_RAINFALL  0x31
+#define ACURITE_MSGTYPE_WINDSPEED_TEMP_HUMIDITY     0x38
+
 static char time_str[LOCAL_TIME_BUFLEN];
 
 
@@ -431,7 +435,7 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf) {
 	    message_type = bb[2] & 0x3f;
         battery_low = (bb[2] & 0x40) >> 6;
 
-	    if (message_type == 0x31) {
+	    if (message_type == ACURITE_MSGTYPE_WINDSPEED_WINDDIR_RAINFALL) {
             // Wind speed, wind direction, and rain fall
             wind_speed = acurite_getWindSpeed_kph(bb[3], bb[4]);
             wind_speedmph = kmph2mph(wind_speed);
@@ -465,12 +469,13 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf) {
                 "wind_speed",   NULL,   DATA_FORMAT,    "%.1f km/h", DATA_DOUBLE,     wind_speed,
                 "wind_dir_deg", NULL,   DATA_FORMAT,    "%.1f", DATA_DOUBLE,    wind_dird,
                 "wind_dir",     NULL,   DATA_STRING,    wind_dirstr,
-                "rainfall",     NULL,   DATA_FORMAT,    "%.2f in", DATA_DOUBLE,    rainfall,
+                "rainfall_accumulation",     NULL,   DATA_FORMAT,    "%.2f in", DATA_DOUBLE,    rainfall,
+                "raincounter_raw",  NULL,   DATA_INT,   raincounter,
                 NULL);
 
             data_acquired_handler(data);
 
-	    } else if (message_type == 0x38) {
+	    } else if (message_type == ACURITE_MSGTYPE_WINDSPEED_TEMP_HUMIDITY) {
             // Wind speed, temperature and humidity
             wind_speed = acurite_getWindSpeed_kph(bb[3], bb[4]);
             wind_speedmph = kmph2mph(wind_speed);

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -61,14 +61,6 @@ static char time_str[LOCAL_TIME_BUFLEN];
 //     E,  7,  NNE,   22.5
 //     F,  C,    S,  180.0
 
-
-
-// original 5-n-1 wind direction values
-// from Jens/Helge
-const float acurite_winddirections[] =
-    { 337.5, 315.0, 292.5, 270.0, 247.5, 225.0, 202.5, 180,
-      157.5, 135.0, 112.5, 90.0, 67.5, 45.0, 22.5, 0.0 };
-
 // From draythomp/Desert-home-rtl_433
 // matches acu-link internet bridge values
 // The mapping isn't circular, it jumps around.
@@ -103,7 +95,7 @@ const float acurite_5n1_winddirections[] =
       67.5,  // 8 - ENE
       135.0, // 9 - SE
       90.0,  // a - E
-      112.5, // b - 112.5
+      112.5, // b - ESE
       45.0,  // c - NE
       157.5, // d - SSE
       22.5,  // e - NNE
@@ -165,13 +157,6 @@ static float acurite_getWindSpeed_kph (uint8_t highbyte, uint8_t lowbyte) {
         speed_kph = rawspeed * 0.8278 + 1.0;
     }
     return speed_kph;
-}
-
-// For the 5n1 based on a linear/circular encoding.
-static float acurite_getWindDirection (uint8_t byte) {
-    // 16 compass points, ccw from (NNW) to 15 (N)
-    int direction = byte & 0x0F;
-    return acurite_winddirections[direction];
 }
 
 static int acurite_getHumidity (uint8_t byte) {

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -125,19 +125,6 @@ static int acurite_checksum(uint8_t row[BITBUF_COLS], int cols) {
         return 0;
 }
 
-static int acurite_detect(uint8_t *pRow) {
-    int i;
-    if ( pRow[0] != 0x00 ) {
-        // invert bits due to wierd issue
-        for (i = 0; i < 8; i++)
-            pRow[i] = ~pRow[i] & 0xFF;
-        pRow[0] |= pRow[8];  // fix first byte that has mashed leading bit
-
-        if (acurite_checksum(pRow, 7))
-            return 1;  // valid checksum
-    }
-    return 0;
-}
 
 // Temperature encoding for 5-n-1 sensor and possibly others
 static float acurite_getTemp (uint8_t highbyte, uint8_t lowbyte) {


### PR DESCRIPTION
* cleanup (remove) acurite5n1, no longer needed as acurite_txr decodes this
* move acurite_txr::5n1 output to new internal format (to allow output formatting, e.g. in json)
* output battery status
* correct wind speed formula
