### PR TITLE
Add protocol definition for oregon scientific THN129 temp only sensor.

### DIFF
--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -19,6 +19,7 @@
 #define ID_WGR800   0x1984
 #define ID_WGR968   0x3d00
 #define ID_UV800    0xd874
+#define ID_THN129   0xcc43  // THN129 Temp only
 
 float get_os_temperature(unsigned char *message, unsigned int sensor_id) {
   // sensor ID included  to support sensors with temp in different position
@@ -351,6 +352,23 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
 
         // RF Clock message ??
       }
+      return 1;
+    } else if (sensor_id  == ID_THN129) {
+      if ((validate_os_v2_message(msg, 137, num_valid_v2_bits, 12) == 0)) {
+        float temp_c = get_os_temperature(msg, sensor_id);
+        data = data_make(
+            "time",          "",            DATA_STRING, time_str,
+            "brand",         "",            DATA_STRING, "OS",
+            "model",         "",            DATA_STRING, "THN129",
+            "id",            "House Code",  DATA_INT,    get_os_rollingcode(msg, sensor_id),
+            "channel",       "Channel",     DATA_INT,    get_os_channel(msg, sensor_id), // 1 to 5
+            "battery",       "Battery",     DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
+            "temperature_C",  "Celcius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
+            "temperature_F",  "Fahrenheit", DATA_FORMAT, "%.02f F", DATA_DOUBLE, ((temp_c*9)/5)+32,
+            NULL);
+        data_acquired_handler(data);
+      }
+       
       return 1;
     } else if (num_valid_v2_bits > 16) {
       if(debug_output) {

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -364,7 +364,6 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
             "channel",       "Channel",     DATA_INT,    get_os_channel(msg, sensor_id), // 1 to 5
             "battery",       "Battery",     DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
             "temperature_C",  "Celcius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
-            "temperature_F",  "Fahrenheit", DATA_FORMAT, "%.02f F", DATA_DOUBLE, ((temp_c*9)/5)+32,
             NULL);
         data_acquired_handler(data);
       }


### PR DESCRIPTION
Added THN129 sensor. Sensor follows the v2.1 protocol, and only has 1 temp measurement.