### PR TITLE
LaCrosse TX29-IT / TX35DTH-IT weather sensor

### DIFF
--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -42,7 +42,7 @@
 
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           74
+#define MAX_PROTOCOLS           76
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -42,7 +42,7 @@
 
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           76
+#define MAX_PROTOCOLS           77
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -42,7 +42,7 @@
 
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           73
+#define MAX_PROTOCOLS           74
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -42,7 +42,7 @@
 
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           77
+#define MAX_PROTOCOLS           75
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -76,8 +76,8 @@
 		DECL(maverick_et73x) \
 		DECL(rftech) \
 		DECL(lacrosse_TX141TH_Bv2) \
-		DECL(acurite_00275rm)
-
+		DECL(acurite_00275rm) \
+		DECL(lacrosse_tx35)
 
 typedef struct {
 	char name[256];

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -77,7 +77,8 @@
 		DECL(rftech) \
 		DECL(lacrosse_TX141TH_Bv2) \
 		DECL(acurite_00275rm) \
-		DECL(lacrosse_tx35)
+		DECL(lacrosse_tx35) \
+		DECL(lacrosse_tx29)
 
 typedef struct {
 	char name[256];

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,7 @@ add_executable(rtl_433
 	pulse_detect.c
 	rtl_433.c
 	util.c
-        devices/acurite.c
+	devices/acurite.c
 	devices/alecto.c
 	devices/ambient_weather.c
 	devices/blyss.c
@@ -80,8 +80,8 @@ add_executable(rtl_433
 	devices/steelmate.c
 	devices/schraeder.c
 	devices/elro_db286a.c
-        devices/efergy_optical.c
-        devices/hondaremote.c
+	devices/efergy_optical.c
+	devices/hondaremote.c
 	devices/new_template.c
 	devices/radiohead_ask.c
 	devices/kerui.c
@@ -89,6 +89,7 @@ add_executable(rtl_433
 	devices/honeywell.c
 	devices/maverick_et73x.c
 	devices/rftech.c
+	devices/lacrosse_tx35.c
 
 )
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -42,6 +42,7 @@ rtl_433_SOURCES      = baseband.c \
                        devices/lacrosse.c \
                        devices/lacrosse_TX141TH_Bv2.c \
                        devices/lacrossews.c \
+		       devices/lacrosse_tx35.c \
                        devices/lightwave_rf.c \
                        devices/mebus.c \
                        devices/newkaku.c \

--- a/src/devices/lacrosse_tx35.c
+++ b/src/devices/lacrosse_tx35.c
@@ -41,7 +41,8 @@ one byte as the preamble. I own 3 sensors TX29, and two of them send a long prea
 So this decoder synchronize on the 0xaa 0x2d 0xd4 preamble, so many 0xaa can occurs before.
 Also, I added 0x9 in the preamble (the weather data length), because this decoder only handle 
 this type of message.
-TX29 and TX35 sahre the same protocol, but pulse are different length.
+TX29 and TX35 sahre the same protocol, but pulse are different length, thus this decoder
+handle the two signal and we use two r_device struct (only differing by the pulse width)
 
 How to make a decoder : https://enavarro.me/ajouter-un-decodeur-ask-a-rtl_433.html
 */
@@ -54,22 +55,25 @@ How to make a decoder : https://enavarro.me/ajouter-un-decodeur-ask-a-rtl_433.ht
 #define LACROSSE_TX35_CRC_POLY       0x31
 #define LACROSSE_TX35_CRC_INIT       0x00
 
-
+/**
+ ** Generic decoder for LaCrosse "IT+" (instant transmission) protocol
+ ** Param device29or35 contain "29" or "35" depending of the device.
+ **/
 static int lacrosse_it(bitbuffer_t *bitbuffer, uint8_t device29or35) {
 	char time_str[LOCAL_TIME_BUFLEN];
 	uint8_t *bb;
-    uint16_t brow, row_nbytes;
+	uint16_t brow, row_nbytes;
 	uint8_t msg_type, r_crc, c_crc;
 	int valid = 0;
 	data_t *data;
 	int events = 0;	
 	
 	static const uint8_t preamble[] = {
-      0xaa, // preamble
-      0x2d, // brand identifer
-      0xd4, // brand identifier
+	  0xaa, // preamble
+	  0x2d, // brand identifer
+	  0xd4, // brand identifier
 	  0x90, // data length (this decoder work only with data length of 9, so we hardcode it on the preamble)
-    };
+	};
 	
 	uint8_t out[8] = {0}; // array of byte to decode
 	local_time_str(0, time_str);
@@ -81,7 +85,7 @@ static int lacrosse_it(bitbuffer_t *bitbuffer, uint8_t device29or35) {
 		if(start_pos == bitbuffer->bits_per_row[brow])
 			continue; // no preamble detected, move to the next row
 		if (debug_output >= 1)
-			fprintf(stderr, "LaCrosse TX29 detected, buffer is %d bits length\n", bitbuffer->bits_per_row[brow]);
+			fprintf(stderr, "LaCrosse TX29/35 detected, buffer is %d bits length, device is TX%d\n", bitbuffer->bits_per_row[brow], device29or35);
 		// remove preamble and keep only 64 bits
 		bitbuffer_extract_bytes(bitbuffer, brow, start_pos, out, 64);
 
@@ -96,16 +100,16 @@ static int lacrosse_it(bitbuffer_t *bitbuffer, uint8_t device29or35) {
 		if (r_crc != c_crc) {
 			// example debugging output
 			if (debug_output >= 1)
-				fprintf(stderr, "%s LaCrosseTX35 bad CRC: calculated %02x, received %02x\n",
+				fprintf(stderr, "%s LaCrosse TX29/35 bad CRC: calculated %02x, received %02x\n",
 					time_str, c_crc, r_crc);
 			// reject row
 			continue;
-		}		
+		}
+
 		/*
 		 * Now that message "envelope" has been validated,
 		 * start parsing data.
 		 */
-	
 		uint8_t sensor_id, newbatt, battery_low;
 		uint8_t humidity; // in %. If > 100 : no humidity sensor
 		float temp_c; // in °C
@@ -117,46 +121,54 @@ static int lacrosse_it(bitbuffer_t *bitbuffer, uint8_t device29or35) {
 		//if (humidity == LACROSSE_TX29_NOHUMIDSENSOR) 
 		//	humidity = -1; // The TX29-IT sensor do not have humidity. It is replaced by a special value
 		
-			data = data_make("time",          "",            DATA_STRING, time_str,
-							 "brand",         "",            DATA_STRING, "LaCrosse",
-							 "model",         "",            DATA_STRING, (device29or35 == 29 ? "TX29-IT" : "TX35DTH-IT"),
-							 "id",            "",            DATA_INT,    sensor_id,
-							 "battery",       "Battery",     DATA_STRING, battery_low ? "LOW" : "OK",
-							 "newbattery",    "NewBattery",  DATA_INT,	  newbatt,
+			data = data_make("time",		  "",			DATA_STRING, time_str,
+							 "brand",		 "",			DATA_STRING, "LaCrosse",
+							 "model",		 "",			DATA_STRING, (device29or35 == 29 ? "TX29-IT" : "TX35DTH-IT"),
+							 "id",			"",			DATA_INT,	sensor_id,
+							 "battery",	   "Battery",	 DATA_STRING, battery_low ? "LOW" : "OK",
+							 "newbattery",	"NewBattery",  DATA_INT,	  newbatt,
 							 "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-							 "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, humidity,
-							 "crc",           "CRC",         DATA_STRING, "OK",
+							 "humidity",	  "Humidity",	DATA_FORMAT, "%u %%", DATA_INT, humidity,
+							 "crc",		   "CRC",		 DATA_STRING, "OK",
 							 NULL);
-		
+
 		data_acquired_handler(data);
 		events++;
 	}
 	return events;
 }
 
+/**
+ ** Wrapper for the TX29 device
+ **/
 static int lacrossetx29_callback(bitbuffer_t *bitbuffer) {
 	return lacrosse_it(bitbuffer, 29);
 }
 
+/**
+ ** Wrapper for the TX35 device
+ **/
 static int lacrossetx35_callback(bitbuffer_t *bitbuffer) {
 	return lacrosse_it(bitbuffer, 35);
 }
 
 static char *output_fields[] = {
-    "time",
+	"time",
 	"brand",
-    "model",
-    "id",
+	"model",
+	"id",
 	"battery",
 	"newbattery",
 	"status",
-    "temperature_C",
-    "humidity",
+	"temperature_C",
+	"humidity",
 	"crc",
-    NULL
+	NULL
 };
+
+// Receiver for the TX29 device
 r_device lacrosse_tx29 = {
-    .name           = "LaCrosse TX29IT Temperature snsor",
+	.name           = "LaCrosse TX29IT Temperature snsor",
 	.modulation     = FSK_PULSE_PCM,
 	.short_limit    = 55,
 	.long_limit     = 55,
@@ -167,11 +179,10 @@ r_device lacrosse_tx29 = {
 	.fields         = output_fields,
 };
 
+// Receiver for the TX29 device
 r_device lacrosse_tx35 = {
-    .name           = "LaCrosse TX35DTH-IT Temperature sensor",
+	.name           = "LaCrosse TX35DTH-IT Temperature sensor",
 	.modulation     = FSK_PULSE_PCM,
-	//.short_limit    = 55,
-	//.long_limit     = 55,
 	.short_limit    = 105,
 	.long_limit     = 105,
 	.reset_limit    = 4000,

--- a/src/devices/lacrosse_tx35.c
+++ b/src/devices/lacrosse_tx35.c
@@ -3,16 +3,11 @@
 #include "util.h"
 #include "data.h"
 
-#define LACROSSE_TX29_BITLENGH         65 // Message is 64 bits but rtl_433 detects 65
-#define LACROSSE_TX29_STARTBYTE1     0xaa
-#define LACROSSE_TX29_STARTBYTE2     0x2d
-#define LACROSSE_TX29_STARTBYTE3     0xd4
-#define LACROSSE_TX29_DATALENGH         9 // length, in nibbles, of usefull data
 #define LACROSSE_TX29_NOHUMIDSENSOR  0x6a // Sensor do not support humidty
 #define LACROSSE_TX29_CRC_POLY       0x31
 #define LACROSSE_TX29_CRC_INIT       0x00
 
-// LaCrosse TX-6u, TX-7u,  Temperature and Humidity Sensors
+// LaCrosse TX29IT,  Temperature and Humidity Sensors. Weather station WS-9160IT
 // Temperature and Humidity are sent in different messages bursts.
 static int lacrossetx35_callback(bitbuffer_t *bitbuffer) {
 	char time_str[LOCAL_TIME_BUFLEN];
@@ -23,37 +18,36 @@ static int lacrossetx35_callback(bitbuffer_t *bitbuffer) {
 	data_t *data;
 	int events = 0;	
 	
+	static const uint8_t preamble[] = {
+      0xaa, // preamble
+      0x2d, // brand identifer
+      0xd4, // brand identifier
+	  0x90, // data length (this decoder work only with data length of 9, so we hardcode it on the preamble)
+    };
+	
+	uint8_t out[8] = {0}; // array of byte to decode
+	
 	local_time_str(0, time_str);
 	for (brow = 0; brow < bitbuffer->num_rows; ++brow) {
 		bb = bitbuffer->bb[brow];
-		// Validate message and reject it as fast as possible
-		if (bitbuffer->bits_per_row[brow] != LACROSSE_TX29_BITLENGH) 
-			continue;
-		// Detect preamble : 0xaa (10101010) followed by a probably brand identifier (0x2d 0xd4)
-		if (bb[0] != LACROSSE_TX29_STARTBYTE1 
-			&& bb[1] != LACROSSE_TX29_STARTBYTE2
-			&& bb[2] != LACROSSE_TX29_STARTBYTE3) {
-			continue;
-		}
+		
+		// Validate message and reject it as fast as possible : check for preamble
+		unsigned int start_pos = bitbuffer_search(bitbuffer, brow, 0, preamble, 28);		
+		if(start_pos == bitbuffer->bits_per_row[brow])
+			continue; // no preamble detected, move to the next row
 		if (debug_output >= 1)
-			fprintf(stderr, "LaCrosse TX29 detected\n");
-		row_nbytes = (bitbuffer->bits_per_row[brow] + 7)/8;
+			fprintf(stderr, "LaCrosse TX29 detected, buffer is %d bits length\n", bitbuffer->bits_per_row[brow]);
+		// remove preamble and keep only 64 bits
+		bitbuffer_extract_bytes(bitbuffer, brow, start_pos, out, 64);
+
 		/*
 		 * Check message integrity (CRC/Checksum/parity)
 		 * Normally, it is computed on the whole message, from byte 0 (preamble) to byte 6,
 		 * but preamble is always the same, so we can speed the process by doing a crc check
 		 * only on byte 3,4,5,6
-		 */
-		int datalength = (bb[3] >> 4);
-		if ( datalength != LACROSSE_TX29_DATALENGH) {
-			if (debug_output >= 1)
-				fprintf(stderr, "%s LaCrosseTX35 bad data length: expected %d, received %d\n",
-					time_str, LACROSSE_TX29_DATALENGH, datalength);
-			// reject row
-			continue;
-		}
-		r_crc = bb[7];
-		c_crc = crc8(&bb[3], 4, LACROSSE_TX29_CRC_POLY, LACROSSE_TX29_CRC_INIT);
+		 */		
+		r_crc = out[7];
+		c_crc = crc8(&out[3], 4, LACROSSE_TX29_CRC_POLY, LACROSSE_TX29_CRC_INIT);
 		if (r_crc != c_crc) {
 			// example debugging output
 			if (debug_output >= 1)
@@ -66,55 +60,29 @@ static int lacrossetx35_callback(bitbuffer_t *bitbuffer) {
 		 * Now that message "envelope" has been validated,
 		 * start parsing data.
 		 */
-		/*
-		
-		int sensid;
-  int newbatt;
-  float temp;
-  float rel_hum;
-  int weakbatt;
-  if (len == 5) {
-    // the tm is correct
-    sensid = ((tm[3] & 0x0f) << 2) | ((tm[4]>>6) & 0x03);
-    newbatt = (tm[4] >> 5) & 1;
-    temp = 10.0 * (tm[4] & 0x0F) +  1.0 *((tm[5]>>4) & 0x0F) + 0.1 * (tm[5] & 0x0F) - 40.0;
-    weakbatt = (tm[6]>>7) & 1;
-    rel_hum = 1.0 * (tm[6] & 0x7F);
-  } else {
-    logging_warning( "Don't know how to handle data of length %i.\n", len );
-    return -5;
-  }
-  **/	
+	
 		uint8_t sensor_id, newbatt, battery_low;
 		uint8_t humidity; // in %. If > 100 : no humidity sensor
 		float temp_c; // in °C
-		sensor_id = ((bb[3] & 0x0f) << 2) | ((bb[4]>>6) & 0x03);
-		temp_c = 10.0 * (bb[4] & 0x0f) +  1.0 *((bb[5]>>4) & 0x0f) + 0.1 * (bb[5] & 0x0f) - 40.0;
-		newbatt = (bb[4] >> 5) & 1;
-		battery_low = (bb[6]>>7) & 1;
-		humidity = 1 * (bb[6] & 0x7F);
+		sensor_id = ((out[3] & 0x0f) << 2) | ((out[4]>>6) & 0x03);
+		temp_c = 10.0 * (out[4] & 0x0f) +  1.0 *((out[5]>>4) & 0x0f) + 0.1 * (out[5] & 0x0f) - 40.0;
+		newbatt = (out[4] >> 5) & 1;
+		battery_low = (out[6]>>7) & 1;
+		humidity = 1 * (out[6] & 0x7F);
 		if (humidity == LACROSSE_TX29_NOHUMIDSENSOR) 
 			humidity = -1;
-		//if (humidity == LACROSSE_TX29_NOHUMIDSENSOR) {
-			/**data = data_make("time",          "",            DATA_STRING, time_str,
-							 "model",         "",            DATA_STRING, "LaCrosse TX29 Sensor",
-							 "id",            "",            DATA_INT, sensor_id,
-							 "battery",       "Battery",     DATA_STRING, battery_low ? "LOW" : "OK",
-							 "newbattery"     "NewBattery",  DATA_STRING, newbatt ? "YES" : "NO",
-							 "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-							 NULL);**/
-		//} else {		
+		
 			data = data_make("time",          "",            DATA_STRING, time_str,
 							 "brand",         "",            DATA_STRING, "LaCrosse",
 							 "model",         "",            DATA_STRING, "TX29 Sensor",
 							 "id",            "",            DATA_INT,    sensor_id,
 							 "battery",       "Battery",     DATA_STRING, battery_low ? "LOW" : "OK",
-							 "newabttery",    "NewBattery",  DATA_INT,	  newbatt,
+							 "newbattery",    "NewBattery",  DATA_INT,	  newbatt,
 							 "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
 							 "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, humidity,
-							 "crc",           "CRC",         DATA_STRING,    "ok",
+							 "crc",           "CRC",         DATA_STRING, "OK",
 							 NULL);
-		//}
+		
 		data_acquired_handler(data);
 		events++;
 	}
@@ -127,7 +95,7 @@ static char *output_fields[] = {
     "model",
     "id",
 	"battery",
-	"newabttery",
+	"newbattery",
 	"status",
     "temperature_C",
     "humidity",
@@ -140,8 +108,8 @@ r_device lacrosse_tx35 = {
 	.modulation     = FSK_PULSE_PCM,
 	//.short_limit    = 55,
 	//.long_limit     = 55,
-	.short_limit    = 58,
-	.long_limit     = 58,
+	.short_limit    = 55,
+	.long_limit     = 55,
 	.reset_limit    = 5000,
 	.json_callback  = &lacrossetx35_callback,
 	.disabled       = 0,

--- a/src/devices/lacrosse_tx35.c
+++ b/src/devices/lacrosse_tx35.c
@@ -179,7 +179,7 @@ r_device lacrosse_tx29 = {
 	.fields         = output_fields,
 };
 
-// Receiver for the TX29 device
+// Receiver for the TX35 device
 r_device lacrosse_tx35 = {
 	.name           = "LaCrosse TX35DTH-IT Temperature sensor",
 	.modulation     = FSK_PULSE_PCM,

--- a/src/devices/lacrosse_tx35.c
+++ b/src/devices/lacrosse_tx35.c
@@ -42,6 +42,8 @@ So this decoder synchronize on the 0xaa 0x2d 0xd4 preamble, so many 0xaa can occ
 Also, I added 0x9 in the preamble (the weather data length), because this decoder only handle 
 this type of message.
 TX29 and TX35 sahre the same protocol, but pulse are different length.
+
+How to make a decoder : https://enavarro.me/ajouter-un-decodeur-ask-a-rtl_433.html
 */
 
 #include "rtl_433.h"

--- a/src/devices/lacrosse_tx35.c
+++ b/src/devices/lacrosse_tx35.c
@@ -3,101 +3,135 @@
 #include "util.h"
 #include "data.h"
 
-#define LACROSSE_TX_BITLEN	44
-#define LACROSSE_NYBBLE_CNT	11
-
-// Check for a valid LaCrosse TX Packet
-//
-// Return message nybbles broken out into bytes
-// for clarity.  The LaCrosse protocol is based
-// on 4 bit nybbles.
-// 
-// Domodulation
-// Long bits = 0
-// short bits = 1
-//
-static int lacrossetx_detect(uint8_t *pRow, uint8_t *msg_nybbles, int16_t rowlen) {
-	int i;
-	uint8_t rbyte_no, rbit_no, mnybble_no, mbit_no;
-	uint8_t bit, checksum, parity_bit, parity = 0;
-
-	// Actual Packet should start with 0x0A and be 6 bytes
-	// actual message is 44 bit, 11 x 4 bit nybbles.
-	if (rowlen == LACROSSE_TX_BITLEN && pRow[0] == 0x0a) {
-
-		for (i = 0; i < LACROSSE_NYBBLE_CNT; i++) {
-			msg_nybbles[i] = 0;
-		}
-
-		// Move nybbles into a byte array
-		// Compute parity and checksum at the same time.
-		for (i = 0; i < 44; i++) {
-			rbyte_no = i / 8;
-			rbit_no = 7 - (i % 8);
-			mnybble_no = i / 4;
-			mbit_no = 3 - (i % 4);
-			bit = (pRow[rbyte_no] & (1 << rbit_no)) ? 1 : 0;
-			msg_nybbles[mnybble_no] |= (bit << mbit_no);
-
-			// Check parity on three bytes of data value
-			// TX3U might calculate parity on all data including
-			// sensor id and redundant integer data
-			if (mnybble_no > 4 && mnybble_no < 8) {
-				parity += bit;
-			}
-
-			//	    fprintf(stdout, "recv: [%d/%d] %d -> msg [%d/%d] %02x, Parity: %d %s\n", rbyte_no, rbit_no,
-			//		    bit, mnybble_no, mbit_no, msg_nybbles[mnybble_no], parity,
-			//		    ( mbit_no == 0 ) ? "\n" : "" );
-		}
-
-		parity_bit = msg_nybbles[4] & 0x01;
-		parity += parity_bit;
-
-		// Validate Checksum (4 bits in last nybble)
-		checksum = 0;
-		for (i = 0; i < 10; i++) {
-			checksum = (checksum + msg_nybbles[i]) & 0x0F;
-		}
-
-		// fprintf(stdout,"Parity: %d, parity bit %d, Good %d\n", parity, parity_bit, parity % 2);
-
-		if (checksum == msg_nybbles[10] && (parity % 2 == 0)) {
-			return 1;
-		} else {
-			if (debug_output) {
-			fprintf(stdout,
-				"LaCrosse TX Checksum/Parity error: Comp. %d != Recv. %d, Parity %d\n",
-				checksum, msg_nybbles[10], parity);
-			}
-			return 0;
-		}
-	} else {
-	    if (debug_output) {
-		// Debug: This is very noisy
-		//fprintf(stderr,"LaCrosse TX Invalid packet: Start %02x, bit count %d\n",
-		//	pRow[0], rowlen);
-	    }
-	}
-
-	return 0;
-}
+#define LACROSSE_TX29_BITLENGH         65 // Message is 64 bits but rtl_433 detects 65
+#define LACROSSE_TX29_STARTBYTE1     0xaa
+#define LACROSSE_TX29_STARTBYTE2     0x2d
+#define LACROSSE_TX29_STARTBYTE3     0xd4
+#define LACROSSE_TX29_DATALENGH         9 // length, in nibbles, of usefull data
+#define LACROSSE_TX29_NOHUMIDSENSOR  0x6a // Sensor do not support humidty
+#define LACROSSE_TX29_CRC_POLY       0x31
+#define LACROSSE_TX29_CRC_INIT       0x00
 
 // LaCrosse TX-6u, TX-7u,  Temperature and Humidity Sensors
 // Temperature and Humidity are sent in different messages bursts.
 static int lacrossetx35_callback(bitbuffer_t *bitbuffer) {
-	fprintf(stderr,"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n LACROSSE TX35 [\nnew_tmplate callback:\n");
-    //bitbuffer_print(bitbuffer);
-	fprintf(stderr,"!!!! LACROSSE TX35 ]\n");
-	return 0;
+	char time_str[LOCAL_TIME_BUFLEN];
+	uint8_t *bb;
+    uint16_t brow, row_nbytes;
+	uint8_t msg_type, r_crc, c_crc;
+	int valid = 0;
+	data_t *data;
+	int events = 0;	
+	
+	local_time_str(0, time_str);
+	for (brow = 0; brow < bitbuffer->num_rows; ++brow) {
+		bb = bitbuffer->bb[brow];
+		// Validate message and reject it as fast as possible
+		if (bitbuffer->bits_per_row[brow] != LACROSSE_TX29_BITLENGH) 
+			continue;
+		// Detect preamble : 0xaa (10101010) followed by a probably brand identifier (0x2d 0xd4)
+		if (bb[0] != LACROSSE_TX29_STARTBYTE1 
+			&& bb[1] != LACROSSE_TX29_STARTBYTE2
+			&& bb[2] != LACROSSE_TX29_STARTBYTE3) {
+			continue;
+		}
+		if (debug_output >= 1)
+			fprintf(stderr, "LaCrosse TX29 detected\n");
+		row_nbytes = (bitbuffer->bits_per_row[brow] + 7)/8;
+		/*
+		 * Check message integrity (CRC/Checksum/parity)
+		 * Normally, it is computed on the whole message, from byte 0 (preamble) to byte 6,
+		 * but preamble is always the same, so we can speed the process by doing a crc check
+		 * only on byte 3,4,5,6
+		 */
+		int datalength = (bb[3] >> 4);
+		if ( datalength != LACROSSE_TX29_DATALENGH) {
+			if (debug_output >= 1)
+				fprintf(stderr, "%s LaCrosseTX35 bad data length: expected %d, received %d\n",
+					time_str, LACROSSE_TX29_DATALENGH, datalength);
+			// reject row
+			continue;
+		}
+		r_crc = bb[7];
+		c_crc = crc8(&bb[3], 4, LACROSSE_TX29_CRC_POLY, LACROSSE_TX29_CRC_INIT);
+		if (r_crc != c_crc) {
+			// example debugging output
+			if (debug_output >= 1)
+				fprintf(stderr, "%s LaCrosseTX35 bad CRC: calculated %02x, received %02x\n",
+					time_str, c_crc, r_crc);
+			// reject row
+			continue;
+		}		
+		/*
+		 * Now that message "envelope" has been validated,
+		 * start parsing data.
+		 */
+		/*
+		
+		int sensid;
+  int newbatt;
+  float temp;
+  float rel_hum;
+  int weakbatt;
+  if (len == 5) {
+    // the tm is correct
+    sensid = ((tm[3] & 0x0f) << 2) | ((tm[4]>>6) & 0x03);
+    newbatt = (tm[4] >> 5) & 1;
+    temp = 10.0 * (tm[4] & 0x0F) +  1.0 *((tm[5]>>4) & 0x0F) + 0.1 * (tm[5] & 0x0F) - 40.0;
+    weakbatt = (tm[6]>>7) & 1;
+    rel_hum = 1.0 * (tm[6] & 0x7F);
+  } else {
+    logging_warning( "Don't know how to handle data of length %i.\n", len );
+    return -5;
+  }
+  **/	
+		uint8_t sensor_id, newbatt, battery_low;
+		uint8_t humidity; // in %. If > 100 : no humidity sensor
+		float temp_c; // in °C
+		sensor_id = ((bb[3] & 0x0f) << 2) | ((bb[4]>>6) & 0x03);
+		temp_c = 10.0 * (bb[4] & 0x0f) +  1.0 *((bb[5]>>4) & 0x0f) + 0.1 * (bb[5] & 0x0f) - 40.0;
+		newbatt = (bb[4] >> 5) & 1;
+		battery_low = (bb[6]>>7) & 1;
+		humidity = 1 * (bb[6] & 0x7F);
+		if (humidity == LACROSSE_TX29_NOHUMIDSENSOR) 
+			humidity = -1;
+		//if (humidity == LACROSSE_TX29_NOHUMIDSENSOR) {
+			/**data = data_make("time",          "",            DATA_STRING, time_str,
+							 "model",         "",            DATA_STRING, "LaCrosse TX29 Sensor",
+							 "id",            "",            DATA_INT, sensor_id,
+							 "battery",       "Battery",     DATA_STRING, battery_low ? "LOW" : "OK",
+							 "newbattery"     "NewBattery",  DATA_STRING, newbatt ? "YES" : "NO",
+							 "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
+							 NULL);**/
+		//} else {		
+			data = data_make("time",          "",            DATA_STRING, time_str,
+							 "brand",         "",            DATA_STRING, "LaCrosse",
+							 "model",         "",            DATA_STRING, "TX29 Sensor",
+							 "id",            "",            DATA_INT,    sensor_id,
+							 "battery",       "Battery",     DATA_STRING, battery_low ? "LOW" : "OK",
+							 "newabttery",    "NewBattery",  DATA_INT,	  newbatt,
+							 "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
+							 "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, humidity,
+							 "crc",           "CRC",         DATA_STRING,    "ok",
+							 NULL);
+		//}
+		data_acquired_handler(data);
+		events++;
+	}
+	return events;
 }
 
 static char *output_fields[] = {
     "time",
+	"brand",
     "model",
     "id",
+	"battery",
+	"newabttery",
+	"status",
     "temperature_C",
     "humidity",
+	"crc",
     NULL
 };
 
@@ -106,8 +140,8 @@ r_device lacrosse_tx35 = {
 	.modulation     = FSK_PULSE_PCM,
 	//.short_limit    = 55,
 	//.long_limit     = 55,
-	.short_limit    = 55,
-	.long_limit     = 55,
+	.short_limit    = 58,
+	.long_limit     = 58,
 	.reset_limit    = 5000,
 	.json_callback  = &lacrossetx35_callback,
 	.disabled       = 0,

--- a/src/devices/lacrosse_tx35.c
+++ b/src/devices/lacrosse_tx35.c
@@ -5,7 +5,7 @@
 *
 Protocol
 ========
-Example Data (gfile-tx29.data) : 
+Example Data (gfile-tx29.data : https://github.com/merbanan/rtl_433_tests/tree/master/tests/lacrosse/06)
    a    a    2    d    d    4    9    2    8    4    4    8    6    a    e    c
 Bits :
 1010 1010 0010 1101 1101 0100 1001 0010 1000 0100 0100 1000 0110 1010 1110 1100
@@ -41,7 +41,7 @@ one byte as the preamble. I own 3 sensors TX29, and two of them send a long prea
 So this decoder synchronize on the 0xaa 0x2d 0xd4 preamble, so many 0xaa can occurs before.
 Also, I added 0x9 in the preamble (the weather data length), because this decoder only handle 
 this type of message.
-TX29 and TX35 sahre the same protocol, but pulse are different length, thus this decoder
+TX29 and TX35 share the same protocol, but pulse are different length, thus this decoder
 handle the two signal and we use two r_device struct (only differing by the pulse width)
 
 How to make a decoder : https://enavarro.me/ajouter-un-decodeur-ask-a-rtl_433.html
@@ -54,6 +54,8 @@ How to make a decoder : https://enavarro.me/ajouter-un-decodeur-ask-a-rtl_433.ht
 #define LACROSSE_TX29_NOHUMIDSENSOR  0x6a // Sensor do not support humidty
 #define LACROSSE_TX35_CRC_POLY       0x31
 #define LACROSSE_TX35_CRC_INIT       0x00
+#define LACROSSE_TX29_MODEL          29; // Model number
+#define LACROSSE_TX35_MODEL          35;
 
 /**
  ** Generic decoder for LaCrosse "IT+" (instant transmission) protocol
@@ -64,6 +66,9 @@ static int lacrosse_it(bitbuffer_t *bitbuffer, uint8_t device29or35) {
 	uint8_t *bb;
 	uint16_t brow, row_nbytes;
 	uint8_t msg_type, r_crc, c_crc;
+	uint8_t sensor_id, newbatt, battery_low;
+	uint8_t humidity; // in %. If > 100 : no humidity sensor
+	float temp_c; // in °C
 	int valid = 0;
 	data_t *data;
 	int events = 0;	
@@ -110,17 +115,23 @@ static int lacrosse_it(bitbuffer_t *bitbuffer, uint8_t device29or35) {
 		 * Now that message "envelope" has been validated,
 		 * start parsing data.
 		 */
-		uint8_t sensor_id, newbatt, battery_low;
-		uint8_t humidity; // in %. If > 100 : no humidity sensor
-		float temp_c; // in °C
 		sensor_id = ((out[3] & 0x0f) << 2) | ((out[4]>>6) & 0x03);
 		temp_c = 10.0 * (out[4] & 0x0f) +  1.0 *((out[5]>>4) & 0x0f) + 0.1 * (out[5] & 0x0f) - 40.0;
 		newbatt = (out[4] >> 5) & 1;
 		battery_low = (out[6]>>7) & 1;
 		humidity = 1 * (out[6] & 0x7F); // Bit 1 to 7 of byte 6
-		//if (humidity == LACROSSE_TX29_NOHUMIDSENSOR) 
-		//	humidity = -1; // The TX29-IT sensor do not have humidity. It is replaced by a special value
-		
+		if (humidity == LACROSSE_TX29_NOHUMIDSENSOR) {
+			data = data_make("time",		  "",			DATA_STRING, time_str,
+							 "brand",		 "",			DATA_STRING, "LaCrosse",
+							 "model",		 "",			DATA_STRING, (device29or35 == 29 ? "TX29-IT" : "TX35DTH-IT"),
+							 "id",			"",			DATA_INT,	sensor_id,
+							 "battery",	   "Battery",	 DATA_STRING, battery_low ? "LOW" : "OK",
+							 "newbattery",	"NewBattery",  DATA_INT,	  newbatt,
+							 "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
+							 "crc",		   "CRC",		 DATA_STRING, "OK",
+							 NULL);
+        }
+        else {
 			data = data_make("time",		  "",			DATA_STRING, time_str,
 							 "brand",		 "",			DATA_STRING, "LaCrosse",
 							 "model",		 "",			DATA_STRING, (device29or35 == 29 ? "TX29-IT" : "TX35DTH-IT"),
@@ -131,6 +142,9 @@ static int lacrosse_it(bitbuffer_t *bitbuffer, uint8_t device29or35) {
 							 "humidity",	  "Humidity",	DATA_FORMAT, "%u %%", DATA_INT, humidity,
 							 "crc",		   "CRC",		 DATA_STRING, "OK",
 							 NULL);
+        }
+		//	humidity = -1; // The TX29-IT sensor do not have humidity. It is replaced by a special value
+		
 
 		data_acquired_handler(data);
 		events++;
@@ -142,17 +156,17 @@ static int lacrosse_it(bitbuffer_t *bitbuffer, uint8_t device29or35) {
  ** Wrapper for the TX29 device
  **/
 static int lacrossetx29_callback(bitbuffer_t *bitbuffer) {
-	return lacrosse_it(bitbuffer, 29);
+	return lacrosse_it(bitbuffer, LACROSSE_TX29_MODEL);
 }
 
 /**
  ** Wrapper for the TX35 device
  **/
 static int lacrossetx35_callback(bitbuffer_t *bitbuffer) {
-	return lacrosse_it(bitbuffer, 35);
+	return lacrosse_it(bitbuffer, LACROSSE_TX35_MODEL);
 }
 
-static char *output_fields[] = {
+static char *output_fields_TX35[] = {
 	"time",
 	"brand",
 	"model",
@@ -166,6 +180,20 @@ static char *output_fields[] = {
 	NULL
 };
 
+static char *output_fields_TX29[] = {
+	"time",
+	"brand",
+	"model",
+	"id",
+	"battery",
+	"newbattery",
+	"status",
+	"temperature_C",
+	"crc",
+	NULL
+};
+
+
 // Receiver for the TX29 device
 r_device lacrosse_tx29 = {
 	.name           = "LaCrosse TX29IT Temperature snsor",
@@ -176,7 +204,7 @@ r_device lacrosse_tx29 = {
 	.json_callback  = &lacrossetx29_callback,
 	.disabled       = 0,
 	.demod_arg      = 0,
-	.fields         = output_fields,
+	.fields         = output_fields_TX29,
 };
 
 // Receiver for the TX35 device
@@ -189,5 +217,5 @@ r_device lacrosse_tx35 = {
 	.json_callback  = &lacrossetx35_callback,
 	.disabled       = 0,
 	.demod_arg      = 0,
-	.fields         = output_fields,
+	.fields         = output_fields_TX35,
 };

--- a/src/devices/lacrosse_tx35.c
+++ b/src/devices/lacrosse_tx35.c
@@ -1,0 +1,116 @@
+
+#include "rtl_433.h"
+#include "util.h"
+#include "data.h"
+
+#define LACROSSE_TX_BITLEN	44
+#define LACROSSE_NYBBLE_CNT	11
+
+// Check for a valid LaCrosse TX Packet
+//
+// Return message nybbles broken out into bytes
+// for clarity.  The LaCrosse protocol is based
+// on 4 bit nybbles.
+// 
+// Domodulation
+// Long bits = 0
+// short bits = 1
+//
+static int lacrossetx_detect(uint8_t *pRow, uint8_t *msg_nybbles, int16_t rowlen) {
+	int i;
+	uint8_t rbyte_no, rbit_no, mnybble_no, mbit_no;
+	uint8_t bit, checksum, parity_bit, parity = 0;
+
+	// Actual Packet should start with 0x0A and be 6 bytes
+	// actual message is 44 bit, 11 x 4 bit nybbles.
+	if (rowlen == LACROSSE_TX_BITLEN && pRow[0] == 0x0a) {
+
+		for (i = 0; i < LACROSSE_NYBBLE_CNT; i++) {
+			msg_nybbles[i] = 0;
+		}
+
+		// Move nybbles into a byte array
+		// Compute parity and checksum at the same time.
+		for (i = 0; i < 44; i++) {
+			rbyte_no = i / 8;
+			rbit_no = 7 - (i % 8);
+			mnybble_no = i / 4;
+			mbit_no = 3 - (i % 4);
+			bit = (pRow[rbyte_no] & (1 << rbit_no)) ? 1 : 0;
+			msg_nybbles[mnybble_no] |= (bit << mbit_no);
+
+			// Check parity on three bytes of data value
+			// TX3U might calculate parity on all data including
+			// sensor id and redundant integer data
+			if (mnybble_no > 4 && mnybble_no < 8) {
+				parity += bit;
+			}
+
+			//	    fprintf(stdout, "recv: [%d/%d] %d -> msg [%d/%d] %02x, Parity: %d %s\n", rbyte_no, rbit_no,
+			//		    bit, mnybble_no, mbit_no, msg_nybbles[mnybble_no], parity,
+			//		    ( mbit_no == 0 ) ? "\n" : "" );
+		}
+
+		parity_bit = msg_nybbles[4] & 0x01;
+		parity += parity_bit;
+
+		// Validate Checksum (4 bits in last nybble)
+		checksum = 0;
+		for (i = 0; i < 10; i++) {
+			checksum = (checksum + msg_nybbles[i]) & 0x0F;
+		}
+
+		// fprintf(stdout,"Parity: %d, parity bit %d, Good %d\n", parity, parity_bit, parity % 2);
+
+		if (checksum == msg_nybbles[10] && (parity % 2 == 0)) {
+			return 1;
+		} else {
+			if (debug_output) {
+			fprintf(stdout,
+				"LaCrosse TX Checksum/Parity error: Comp. %d != Recv. %d, Parity %d\n",
+				checksum, msg_nybbles[10], parity);
+			}
+			return 0;
+		}
+	} else {
+	    if (debug_output) {
+		// Debug: This is very noisy
+		//fprintf(stderr,"LaCrosse TX Invalid packet: Start %02x, bit count %d\n",
+		//	pRow[0], rowlen);
+	    }
+	}
+
+	return 0;
+}
+
+// LaCrosse TX-6u, TX-7u,  Temperature and Humidity Sensors
+// Temperature and Humidity are sent in different messages bursts.
+static int lacrossetx35_callback(bitbuffer_t *bitbuffer) {
+	fprintf(stderr,"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n LACROSSE TX35 [\nnew_tmplate callback:\n");
+    //bitbuffer_print(bitbuffer);
+	fprintf(stderr,"!!!! LACROSSE TX35 ]\n");
+	return 0;
+}
+
+static char *output_fields[] = {
+    "time",
+    "model",
+    "id",
+    "temperature_C",
+    "humidity",
+    NULL
+};
+
+r_device lacrosse_tx35 = {
+    .name           = "LaCrosse TX35 Temperature / Humidity Sensor",
+	.modulation     = FSK_PULSE_PCM,
+	//.short_limit    = 55,
+	//.long_limit     = 55,
+	.short_limit    = 55,
+	.long_limit     = 55,
+	.reset_limit    = 5000,
+	.json_callback  = &lacrossetx35_callback,
+	.disabled       = 0,
+	.demod_arg      = 0,
+	.fields         = output_fields,
+};


### PR DESCRIPTION
Here is a decoder for the LaCrosse TX29-IT / TX35DTH-IT weather sensor, also compatible with sensor made by Conrad and by StarMétéo. This sensors transmit on 868,2Mhz, i successfully decode 4 sensors at the same time with this decoder, tuning at 868240000Hz.
Theses devices use the same bit-level protocol, but RF signal is different (pulse length is 55us or 105us depending of the device), this pull-request add two decoders in rtl_433_devices.h and only one decoder in devices/lacrosse_tx35.c .

See issue https://github.com/merbanan/rtl_433/issues/477

I hope you will like it ;) !

Jerome.