### PR TITLE
Don't convert channel 4 to 3 for the sensor Oregon THGR810

### DIFF
--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -80,7 +80,7 @@ unsigned int get_os_channel(unsigned char *message, unsigned int sensor_id) {
   // sensor ID included to support sensors with channel in different position
   int channel = 0;
   channel = ((message[2] >> 4)&0x0f);
-  if ((channel == 4) && (sensor_id & 0x0fff) != ID_RTGN318)
+  if ((channel == 4) && (sensor_id & 0x0fff) != ID_RTGN318 && sensor_id != ID_THGR810)
     channel = 3; // sensor 3 channel number is 0x04
   return channel;
 }


### PR DESCRIPTION
It seems the conversion is only required for devices with 3 channels,
but not for devices with 10 channels, such as THGR810, where channel 3
is reported as 3 and channel 4 is reported as 4