### PR TITLE
Fix compile error on ARM with GCC with lack of parens.

### DIFF
--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -727,12 +727,12 @@ static int acurite_606_callback(bitbuffer_t *bitbuf) {
 	    // Processing the temperature: 
             // Upper 4 bits are stored in nibble 1, lower 8 bits are stored in nibble 2
             // upper 4 bits of nibble 1 are reserved for other usages (e.g. battery status)
-      	    temp = (int16_t)((uint16_t)(bb[1][1] << 12) | bb[1][2] << 4);
+      	    temp = (int16_t)((uint16_t)(bb[1][1] << 12) | (bb[1][2] << 4));
       	    temp = temp >> 4;
 
       	    temperature = temp / 10.0;
 	    sensor_id = bb[1][0];
-	    battery = bb[1][1] & 0x8f >> 7;
+	    battery = (bb[1][1] & 0x80) >> 7;
 
 	    data = data_make("time",          "",            DATA_STRING, time_str,
                              "model",         "",            DATA_STRING, "Acurite 606TX Sensor",


### PR DESCRIPTION
I'm using rtl_433 on a BeagleBone Black and gcc does not compile `battery = bb[1][1] & 0x8f >> 7;` correctly.
It executes as if it was written `battery = bb[1][1] & (0x8f >> 7);` Resulting in the application always printing "Low".

Solution: add explicit parens.

The change to the earlier statement was just added for explicit behavior even though it was compiling correctly.

Linux arm 4.4.9-ti-r25 #1 SMP Thu May 5 23:08:13 UTC 2016 armv7l GNU/Linux
$ gcc --version
gcc (Debian 4.9.2-10) 4.9.2
