### PR TITLE
Revert "Update pulse_detect.c"

### DIFF
--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -544,8 +544,8 @@ void pulse_analyzer(pulse_data_t *data, uint32_t samp_rate)
 	} else if(hist_pulses.bins_count == 1 && hist_gaps.bins_count > 1) {
 		fprintf(stderr, "Pulse Position Modulation with fixed pulse width\n");
 		device.modulation	= OOK_PULSE_PPM_RAW;
-		device.short_limit	= (hist_gaps.bins[hist_gaps.bins_count-3].mean + hist_gaps.bins[hist_gaps.bins_count-2].mean) / 2;	// Set limit between two lowest gaps
-		device.long_limit	= hist_gaps.bins[hist_gaps.bins_count-2].max + 1;			// Counting down may help ignore extraneous short pulses					// Set limit above next lower gap
+		device.short_limit	= (hist_gaps.bins[0].mean + hist_gaps.bins[1].mean) / 2;	// Set limit between two lowest gaps
+		device.long_limit	= hist_gaps.bins[1].max + 1;								// Set limit above next lower gap
 		device.reset_limit	= hist_gaps.bins[hist_gaps.bins_count-1].max + 1;			// Set limit above biggest gap
 	} else if(hist_pulses.bins_count == 2 && hist_gaps.bins_count == 1) {
 		fprintf(stderr, "Pulse Width Modulation with fixed gap\n");


### PR DESCRIPTION
This reverts commit ef163f9d575a5322df46c8c87eb9565802d4f7af.

This commit is faulty and generates segmentation faults. If hist_gaps.bins_count is 2 the index will go negative. The code assumes there will allways be both short and long gaps (messages with multiple rows),
and will fail when it is a pure PPM signal. The precense of too-short gaps will also fool the PPM demodulator and insert spurious bits. If possible it should be fixed by making the pulse-detector
more resilient to too-short gaps (test signals needed).