### PR TITLE
New Device (WG-PB12V1)

### DIFF
--- a/include/data.h
+++ b/include/data.h
@@ -26,8 +26,8 @@
 typedef enum {
 	DATA_DATA,		/* pointer to data is stored */
 	DATA_INT,		/* pointer to integer is stored */
-	DATA_DOUBLE,	/* pointer to a double is stored */
-	DATA_STRING,	/* pointer to a string is stored */
+	DATA_DOUBLE,		/* pointer to a double is stored */
+	DATA_STRING,		/* pointer to a string is stored */
 	DATA_ARRAY,		/* pointer to an array of values is stored */
 	DATA_COUNT,		/* invalid */
 	DATA_FORMAT		/* indicates the following value is formatted */

--- a/include/data.h
+++ b/include/data.h
@@ -26,8 +26,8 @@
 typedef enum {
 	DATA_DATA,		/* pointer to data is stored */
 	DATA_INT,		/* pointer to integer is stored */
-	DATA_DOUBLE,		/* pointer to a double is stored */
-	DATA_STRING,		/* pointer to a string is stored */
+	DATA_DOUBLE,	/* pointer to a double is stored */
+	DATA_STRING,	/* pointer to a string is stored */
 	DATA_ARRAY,		/* pointer to an array of values is stored */
 	DATA_COUNT,		/* invalid */
 	DATA_FORMAT		/* indicates the following value is formatted */

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -42,7 +42,7 @@
 
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           76
+#define MAX_PROTOCOLS           77
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -42,7 +42,7 @@
 
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           75
+#define MAX_PROTOCOLS           76
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -42,6 +42,7 @@
 		DECL(efergy_e2_classic) \
 		DECL(kw9015b) \
 		DECL(generic_temperature_sensor) \
+        DECL(wg_pb12v1) \
 		DECL(acurite_txr) \
 		DECL(acurite_986) \
 		DECL(hideki_ts04) \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(rtl_433
 	devices/fineoffset_wh1080.c
 	devices/generic_remote.c
 	devices/generic_temperature_sensor.c
+    devices/wg_pb12v1.c
 	devices/gt_wt_02.c
 	devices/hideki.c
 	devices/ht680.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,7 +44,6 @@ add_executable(rtl_433
 	devices/fineoffset_wh1080.c
 	devices/generic_remote.c
 	devices/generic_temperature_sensor.c
-    devices/wg_pb12v1.c
 	devices/gt_wt_02.c
 	devices/hideki.c
 	devices/ht680.c
@@ -70,6 +69,7 @@ add_executable(rtl_433
 	devices/tfa_pool_thermometer.c
 	devices/valeo.c
 	devices/waveman.c
+	devices/wg_pb12v1.c
 	devices/wt450.c
 	devices/x10_rf.c
 	devices/s3318p.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -32,6 +32,7 @@ rtl_433_SOURCES      = baseband.c \
                        devices/fineoffset_wh1080.c \
                        devices/generic_remote.c \
                        devices/generic_temperature_sensor.c \
+                       devices/generic_temperature_sensor_2.c \
                        devices/gt_wt_02.c \
                        devices/hideki.c \
                        devices/hondaremote.c \

--- a/src/devices/wg_pb12v1.c
+++ b/src/devices/wg_pb12v1.c
@@ -1,0 +1,136 @@
+/* WG-PB12V1 Temperature Sensor
+ * ---
+ * Device method to decode a generic wireless temperature probe. Probe marked
+ * with WG-PB12V1-2016/11.
+ * 
+ * Format of Packets
+ * ---
+ * The packet format appears to be similar those the Lacrosse format.
+ * (http://fredboboss.free.fr/articles/tx29.php)
+ * 
+ * AAAAAAAA ????TTTT TTTTTTTT ???IIIII HHHHHHHH CCCCCCCC
+ * 
+ * A = Preamble - 11111111
+ * ? = Unknown - possibly battery charge
+ * T = Temperature - see below
+ * I = ID of probe is set randomly each time the device is powered off-on, 
+ *     Note, base station has and unused "123" symbol, but ID values can be 
+ *     higher than this.
+ * H = Humidity - not used, is always 11111111
+ * C = Checksum - CRC8, polynomial 0x31, initial value 0x0, final value 0x0
+ * 
+ * Temperature
+ * ---
+ * Temperature value is "milli-celcius", ie 1000 mC = 1C, offset by -40 C.
+ * 
+ * 0010 01011101 = 605 mC => 60.5 C
+ * Remove offset => 60.5 C - 40 C = 20.5 C
+ * 
+ * Unknown
+ * ---
+ * Possbible uses could be weak battey, or new battery.
+ * 
+ * At the moment it this device cannot distinguish between a Fine Offset 
+ * device, see fineoffset.c.
+ * 
+ * Copyright (C) 2015 Tommy Vestermark
+ * Modifications Copyright (C) 2017 Ciarán Mooney
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "rtl_433.h"
+#include "data.h"
+#include "util.h"
+
+static int wg_pb12v1_callback(bitbuffer_t *bitbuffer) {
+    /* This function detects if the packet (bitbuffer) is from a WG-PB12V1
+     * sensor, and decodes it if it passes the checks.
+     */
+     
+    bitrow_t *bb = bitbuffer->bb;
+    data_t *data;
+
+    char time_str[LOCAL_TIME_BUFLEN];
+
+    uint8_t id;
+    int16_t temp;
+    float temperature;
+    uint8_t humidity;
+    char io[49];
+
+    const uint8_t polynomial = 0x31;    // x8 + x5 + x4 + 1 (x8 is implicit)
+    
+    // Validate package
+    if (bitbuffer->bits_per_row[0] >= 48 &&              // Don't waste time on a short packages
+        bb[0][0] == 0xFF &&                              // Preamble
+        bb[0][5] == crc8(&bb[0][1], 4, polynomial, 0) && // CRC (excluding preamble)
+        bb[0][4] == 0xFF                                 // Humitidy set to 11111111
+        ){
+    
+        /* Get time now */
+        local_time_str(0, time_str);
+        
+         // Nibble 7,8 contains id
+        id = ((bb[0][3]&0x1F));
+
+        // Nibble 5,6,7 contains 12 bits of temperature
+        // The temperature is "milli-celcius", ie 1000 mC = 1C, offset by -40 C.
+        temp = ((bb[0][1] & 0x0F) << 8) | bb[0][2];
+        temperature = ((float)temp / 10)-40;
+
+        // Populate string array with raw packet bits.
+        for (uint16_t bit = 0; bit < bitbuffer->bits_per_row[0]; ++bit){
+            if (bb[0][bit/8] & (0x80 >> (bit % 8))){
+                io[bit] = 49; // 1
+               } 
+            else {
+                io[bit] = 48; // 0
+                }
+            }
+        io[49] = 0; // terminate string array.
+        
+        if (debug_output > 1) {
+           fprintf(stderr, "ID          = 0x%2X\n",  id);
+           fprintf(stderr, "temperature = %.1f C\n", temperature);
+        }
+
+        data = data_make("time",          "",            DATA_STRING, time_str,
+                         "model",         "",            DATA_STRING, "WG-PB12V1",
+                         "id",            "ID",          DATA_INT, id,
+                         "temperature_C", "Temperature", DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
+                         "io",            "io",          DATA_STRING, io,
+                          NULL);
+        data_acquired_handler(data);
+        return 1;
+    }
+    return 0;
+}
+
+static char *output_fields[] = {
+    /* Defines the output files for this device function.
+     */
+    "time",
+    "model",
+    "id",
+    "temperature_C",
+    "io",
+    NULL
+};
+
+r_device wg_pb12v1 = {
+    /* Defines object information for use in other parts of RTL_433.
+     */
+     .name           = "WG-PB12V1",
+    .modulation     = OOK_PULSE_PWM_RAW,
+    .short_limit    = 650,	// Short pulse 564µs, long pulse 1476µs, fixed gap 960µs
+    .long_limit     = 1550,	// Maximum pulse period (long pulse + fixed gap)
+    .reset_limit    = 2500,	// We just want 1 package
+    .json_callback  = &wg_pb12v1_callback,
+    .disabled       = 0,
+    .demod_arg      = 0,
+    .fields         = output_fields
+};

--- a/src/devices/wg_pb12v1.c
+++ b/src/devices/wg_pb12v1.c
@@ -91,7 +91,7 @@ static int wg_pb12v1_callback(bitbuffer_t *bitbuffer) {
                 io[bit] = 48; // 0
                 }
             }
-        io[49] = 0; // terminate string array.
+        io[48] = 0; // terminate string array.
         
         if (debug_output > 1) {
            fprintf(stderr, "ID          = 0x%2X\n",  id);


### PR DESCRIPTION
This code started is a modified version of fineoffset.c which is included with rtl_433. The fineoffset.c device does not correctly decode the information in the packet.

The format of the packet seems to be similar to LaCrosse, but with no humidity data included. http://fredboboss.free.fr/articles/tx29.php

I have added the packet bits to the formatted output ("io"), as I am still decoding some of the unknown bits.

I have begun adding data to the rtl_433_tests repository but do not have a complete collection of data dumps.