### PR TITLE
Efergy optical changes for other std pulse-per kwh

### DIFF
--- a/src/devices/hondaremote.c
+++ b/src/devices/hondaremote.c
@@ -23,31 +23,35 @@ static int hondaremote_callback(bitbuffer_t *bitbuffer) {
         uint8_t *bytes = bitbuffer->bb[0];
 	char time_str[LOCAL_TIME_BUFLEN];
 	data_t *data;
+	uint16_t device_id;
 
  for (int i = 0; i < bitbuffer->num_rows; i++)
 {
 	// Validate package
-	if (bitbuffer->bits_per_row[i] != 386)
-	continue;
-	if ((bytes[0] ==0xFF ) && (bytes[38] == 0xFF)) 
+		if (((bitbuffer->bits_per_row[i] >385) && (bitbuffer->bits_per_row[i] <=394)) &&
+	 ((bytes[0] == 0xFF ) && (bytes[38] == 0xFF))) 
 	 {
+
 	if (debug_output) {
+	fprintf (stdout,"passed validation bits per row %02d\n",(bitbuffer->bits_per_row[i]));
 			for (unsigned n=40; n<(50); ++n) 
 				{
 				fprintf(stdout,"Byte %02d", n);
 				fprintf(stdout,"= %02X\n", bytes[n]);
 				}
 			}
-}
+
 //call function to lookup what button was pressed	
 	const char* code = get_command_codes(bytes);
-
-	 /* Get time now */
+	device_id = (bytes[44]>>8|bytes[45]);
+	
+ /* Get time now */
 	local_time_str(0, time_str);
      data = data_make(
                         "time",         "",     DATA_STRING, time_str,
                         "model",        "",     DATA_STRING, "Honda Remote",
-                        "code",          "",    DATA_STRING, code,
+                        "device id",    "",    DATA_INT, device_id,
+                        "code",         "",    DATA_STRING, code,
                       NULL);
 
        data_acquired_handler(data);
@@ -55,10 +59,12 @@ static int hondaremote_callback(bitbuffer_t *bitbuffer) {
         }
 return 0;
 }
-
+return 0;
+}
 static char *output_fields[] = {
         "time",
         "model",
+        "device id",
         "code",
         NULL
         };


### PR DESCRIPTION
I have added output for a range of common pulse per kwh values.  
3200 pulses per kwh
2000 pulses per kwh
1000 pulses per kwh
500 pulses per kwh

/rtl_433 -r gfile001.data -F csv

Test mode active. Reading samples from file: gfile001.data
Input format: uint8
@0.000000s,Efergy Optical,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,3200,0.112,,,,,,,,,,,,,,,
@0.000000s,Efergy Optical,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,2000,0.180,,,,,,,,,,,,,,,
@0.000000s,Efergy Optical,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,1000,0.360,,,,,,,,,,,,,,,
@0.000000s,Efergy Optical,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,500,0.720,,,,,,,,,,,,,,,

/rtl_433 -r gfile001.data

Test mode active. Reading samples from file: gfile001.data
Input format: uint8
 @0.000000s
:        Efergy Optical
        Pulse-rate:      3200
        Energy:  0.112 KWh
 @0.000000s
:        Efergy Optical
        Pulse-rate:      2000
        Energy:  0.180 KWh
 @0.000000s
:        Efergy Optical
        Pulse-rate:      1000
        Energy:  0.360 KWh
 @0.000000s
:        Efergy Optical
        Pulse-rate:      500
        Energy:  0.720 KWh
Test mode file issued 1 packets
