### PR TITLE
LaCrosse TX6/7 minor cleanup 

### DIFF
--- a/src/devices/lacrosse.c
+++ b/src/devices/lacrosse.c
@@ -49,157 +49,157 @@
 #define LACROSSE_TX_BITLEN	44
 #define LACROSSE_NYBBLE_CNT	11
 
+
 // Check for a valid LaCrosse TX Packet
 //
 // Return message nybbles broken out into bytes
 // for clarity.  The LaCrosse protocol is based
 // on 4 bit nybbles.
-// 
+//
 // Domodulation
 // Long bits = 0
 // short bits = 1
 //
 static int lacrossetx_detect(uint8_t *pRow, uint8_t *msg_nybbles, int16_t rowlen) {
-	int i;
-	uint8_t rbyte_no, rbit_no, mnybble_no, mbit_no;
-	uint8_t bit, checksum, parity_bit, parity = 0;
+    int i;
+    uint8_t rbyte_no, rbit_no, mnybble_no, mbit_no;
+    uint8_t bit, checksum, parity_bit, parity = 0;
 
-	// Actual Packet should start with 0x0A and be 6 bytes
-	// actual message is 44 bit, 11 x 4 bit nybbles.
-	if (rowlen == LACROSSE_TX_BITLEN && pRow[0] == 0x0a) {
+    // Actual Packet should start with 0x0A and be 6 bytes
+    // actual message is 44 bit, 11 x 4 bit nybbles.
+    if (rowlen == LACROSSE_TX_BITLEN && pRow[0] == 0x0a) {
 
-		for (i = 0; i < LACROSSE_NYBBLE_CNT; i++) {
-			msg_nybbles[i] = 0;
-		}
-
-		// Move nybbles into a byte array
-		// Compute parity and checksum at the same time.
-		for (i = 0; i < 44; i++) {
-			rbyte_no = i / 8;
-			rbit_no = 7 - (i % 8);
-			mnybble_no = i / 4;
-			mbit_no = 3 - (i % 4);
-			bit = (pRow[rbyte_no] & (1 << rbit_no)) ? 1 : 0;
-			msg_nybbles[mnybble_no] |= (bit << mbit_no);
-
-			// Check parity on three bytes of data value
-			// TX3U might calculate parity on all data including
-			// sensor id and redundant integer data
-			if (mnybble_no > 4 && mnybble_no < 8) {
-				parity += bit;
-			}
-
-			//	    fprintf(stdout, "recv: [%d/%d] %d -> msg [%d/%d] %02x, Parity: %d %s\n", rbyte_no, rbit_no,
-			//		    bit, mnybble_no, mbit_no, msg_nybbles[mnybble_no], parity,
-			//		    ( mbit_no == 0 ) ? "\n" : "" );
-		}
-
-		parity_bit = msg_nybbles[4] & 0x01;
-		parity += parity_bit;
-
-		// Validate Checksum (4 bits in last nybble)
-		checksum = 0;
-		for (i = 0; i < 10; i++) {
-			checksum = (checksum + msg_nybbles[i]) & 0x0F;
-		}
-
-		// fprintf(stdout,"Parity: %d, parity bit %d, Good %d\n", parity, parity_bit, parity % 2);
-
-		if (checksum == msg_nybbles[10] && (parity % 2 == 0)) {
-			return 1;
-		} else {
-			if (debug_output > 1) {
-			fprintf(stdout,
-				"LaCrosse TX Checksum/Parity error: Comp. %d != Recv. %d, Parity %d\n",
-				checksum, msg_nybbles[10], parity);
-			}
-			return 0;
-		}
+	for (i = 0; i < LACROSSE_NYBBLE_CNT; i++) {
+	    msg_nybbles[i] = 0;
 	}
 
-	return 0;
+	// Move nybbles into a byte array
+	// Compute parity and checksum at the same time.
+	for (i = 0; i < 44; i++) {
+	    rbyte_no = i / 8;
+	    rbit_no = 7 - (i % 8);
+	    mnybble_no = i / 4;
+	    mbit_no = 3 - (i % 4);
+	    bit = (pRow[rbyte_no] & (1 << rbit_no)) ? 1 : 0;
+	    msg_nybbles[mnybble_no] |= (bit << mbit_no);
+
+	    // Check parity on three bytes of data value
+	    // TX3U might calculate parity on all data including
+	    // sensor id and redundant integer data
+	    if (mnybble_no > 4 && mnybble_no < 8) {
+		parity += bit;
+	    }
+
+	    //	    fprintf(stdout, "recv: [%d/%d] %d -> msg [%d/%d] %02x, Parity: %d %s\n", rbyte_no, rbit_no,
+	    //		    bit, mnybble_no, mbit_no, msg_nybbles[mnybble_no], parity,
+	    //		    ( mbit_no == 0 ) ? "\n" : "" );
+	}
+
+	parity_bit = msg_nybbles[4] & 0x01;
+	parity += parity_bit;
+
+	// Validate Checksum (4 bits in last nybble)
+	checksum = 0;
+	for (i = 0; i < 10; i++) {
+	    checksum = (checksum + msg_nybbles[i]) & 0x0F;
+	}
+
+	// fprintf(stdout,"Parity: %d, parity bit %d, Good %d\n", parity, parity_bit, parity % 2);
+
+	if (checksum == msg_nybbles[10] && (parity % 2 == 0)) {
+	    return 1;
+	} else {
+	    if (debug_output > 1) {
+		fprintf(stdout,
+			"LaCrosse TX Checksum/Parity error: Comp. %d != Recv. %d, Parity %d\n",
+			checksum, msg_nybbles[10], parity);
+	    }
+	    return 0;
+	}
+    }
+
+    return 0;
 }
 
 // LaCrosse TX-6u, TX-7u,  Temperature and Humidity Sensors
 // Temperature and Humidity are sent in different messages bursts.
 static int lacrossetx_callback(bitbuffer_t *bitbuffer) {
-	bitrow_t *bb = bitbuffer->bb;
+    bitrow_t *bb = bitbuffer->bb;
 
-	int i, m, valid = 0;
-	int events = 0;
-	uint8_t *buf;
-	uint8_t msg_nybbles[LACROSSE_NYBBLE_CNT];
-	uint8_t sensor_id, msg_type, msg_len, msg_parity, msg_checksum;
-	int msg_value_int;
-	float msg_value = 0, temp_c = 0;
-	time_t time_now;
-	char time_str[LOCAL_TIME_BUFLEN];
-	data_t *data;
+    int i, m, valid = 0;
+    int events = 0;
+    uint8_t *buf;
+    uint8_t msg_nybbles[LACROSSE_NYBBLE_CNT];
+    uint8_t sensor_id, msg_type, msg_len, msg_parity, msg_checksum;
+    int msg_value_int;
+    float msg_value = 0, temp_c = 0;
+    time_t time_now;
+    char time_str[LOCAL_TIME_BUFLEN];
+    data_t *data;
 
-	for (m = 0; m < BITBUF_ROWS; m++) {
-		valid = 0;
-		// break out the message nybbles into separate bytes
-		if (lacrossetx_detect(bb[m], msg_nybbles, bitbuffer->bits_per_row[m])) {
+    for (m = 0; m < BITBUF_ROWS; m++) {
+	valid = 0;
+	// break out the message nybbles into separate bytes
+	if (lacrossetx_detect(bb[m], msg_nybbles, bitbuffer->bits_per_row[m])) {
 
-			msg_len = msg_nybbles[1];
-			msg_type = msg_nybbles[2];
-			sensor_id = (msg_nybbles[3] << 3) + (msg_nybbles[4] >> 1);
-			msg_parity = msg_nybbles[4] & 0x01;
-			msg_value = msg_nybbles[5] * 10 + msg_nybbles[6]
-					+ msg_nybbles[7] / 10.0;
-			msg_value_int = msg_nybbles[8] * 10 + msg_nybbles[9];
-			msg_checksum = msg_nybbles[10];
+	    msg_len = msg_nybbles[1];
+	    msg_type = msg_nybbles[2];
+	    sensor_id = (msg_nybbles[3] << 3) + (msg_nybbles[4] >> 1);
+	    msg_parity = msg_nybbles[4] & 0x01;
+	    msg_value = msg_nybbles[5] * 10 + msg_nybbles[6]
+		+ msg_nybbles[7] / 10.0;
+	    msg_value_int = msg_nybbles[8] * 10 + msg_nybbles[9];
+	    msg_checksum = msg_nybbles[10];
 
-			time(&time_now);
+	    time(&time_now);
+	    local_time_str(0, time_str);
 
-			local_time_str(0, time_str);
-
-			// Check Repeated data values as another way of verifying
-			// message integrity.
-			if (msg_nybbles[5] != msg_nybbles[8] || 
-			    msg_nybbles[6] != msg_nybbles[9]) {
-			    if (debug_output) {
-				fprintf(stderr,
-					"LaCrosse TX Sensor %02x, type: %d: message value mismatch int(%3.1f) != %d?\n",
-					sensor_id, msg_type, msg_value, msg_value_int);
-			    }
-			    continue;
-			}
-
-			switch (msg_type) {
-			case 0x00:
-				temp_c = msg_value - 50.0;
-				data = data_make("time",          "",            DATA_STRING, time_str,
-								 "model",         "",            DATA_STRING, "LaCrosse TX Sensor",
-								 "id",            "",            DATA_INT, sensor_id,
-								 "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-								 NULL);
-				data_acquired_handler(data);
-				events++;
-				break;
-
-			case 0x0E:
-				data = data_make("time",          "",            DATA_STRING, time_str,
-								 "model",         "",            DATA_STRING, "LaCrosse TX Sensor",
-								 "id",            "",            DATA_INT, sensor_id,
-								 "humidity",      "Humidity", DATA_FORMAT, "%.1f %%", DATA_DOUBLE, msg_value,
-								 NULL);
-				data_acquired_handler(data);
-				events++;
-				break;
-
-			default:
-			    // @todo this should be reported/counted as exception, not considered debug
-			    if (debug_output) {
-				fprintf(stderr,
-					"%s LaCrosse Sensor %02x: Unknown Reading type %d, % 3.1f (%d)\n",
-					time_str, sensor_id, msg_type, msg_value, msg_value_int);
-			    }
-			}
+	    // Check Repeated data values as another way of verifying
+	    // message integrity.
+	    if (msg_nybbles[5] != msg_nybbles[8] ||
+		msg_nybbles[6] != msg_nybbles[9]) {
+		if (debug_output) {
+		    fprintf(stderr,
+			    "LaCrosse TX Sensor %02x, type: %d: message value mismatch int(%3.1f) != %d?\n",
+			    sensor_id, msg_type, msg_value, msg_value_int);
 		}
-	}
+		continue;
+	    }
 
-	return events;
+	    switch (msg_type) {
+	    case 0x00:
+		temp_c = msg_value - 50.0;
+		data = data_make("time",          "",            DATA_STRING, time_str,
+				 "model",         "",            DATA_STRING, "LaCrosse TX Sensor",
+				 "id",            "",            DATA_INT, sensor_id,
+				 "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
+				 NULL);
+		data_acquired_handler(data);
+		events++;
+		break;
+
+	    case 0x0E:
+		data = data_make("time",          "",            DATA_STRING, time_str,
+				 "model",         "",            DATA_STRING, "LaCrosse TX Sensor",
+				 "id",            "",            DATA_INT, sensor_id,
+				 "humidity",      "Humidity", DATA_FORMAT, "%.1f %%", DATA_DOUBLE, msg_value,
+				 NULL);
+		data_acquired_handler(data);
+		events++;
+		break;
+
+	    default:
+		// @todo this should be reported/counted as exception, not considered debug
+		if (debug_output) {
+		    fprintf(stderr,
+			    "%s LaCrosse Sensor %02x: Unknown Reading type %d, % 3.1f (%d)\n",
+			    time_str, sensor_id, msg_type, msg_value, msg_value_int);
+		}
+	    }
+	}
+    }
+
+    return events;
 }
 
 static char *output_fields[] = {
@@ -212,14 +212,14 @@ static char *output_fields[] = {
 };
 
 r_device lacrossetx = {
- .name           = "LaCrosse TX Temperature / Humidity Sensor",
- .modulation     = OOK_PULSE_PWM_RAW,
- .short_limit    = 952,
- .long_limit     = 3000,
-/// .reset_limit    = 32000,
- .reset_limit    = 8000,
- .json_callback  = &lacrossetx_callback, 
- .disabled       = 0,
- .demod_arg      = 0, 	// No Startbit removal
- .fields = output_fields,
+    .name           = "LaCrosse TX Temperature / Humidity Sensor",
+    .modulation     = OOK_PULSE_PWM_RAW,
+    .short_limit    = 952,
+    .long_limit     = 3000,
+    /// .reset_limit    = 32000,
+    .reset_limit    = 8000,
+    .json_callback  = &lacrossetx_callback,
+    .disabled       = 0,
+    .demod_arg      = 0, 	// No Startbit removal
+    .fields = output_fields,
 };


### PR DESCRIPTION
Functional change:
* Eliminate duplicate suppression.
  * This is in-line with the move to not keep state in rtl_433 and is consistent with a number of other devices.
  * works better with the new "unknown analyzer" functionality,  (The suppressed messages weren't getting counted as handled and reported as unknown signals.)

Cosmetics:
* fixed some indentation that was broken by adding debug checks.
* eliminated some debug code that should no longer be necessary.
* Reindented the whole file with consistent 4 column spacing.  Was a mix of tabs/8 cols and 4 cols. 