### PR TITLE
Fix #503

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -114,7 +114,7 @@ char* local_time_str(time_t time_secs, char *buf) {
 		extern float sample_file_pos;
 		if (sample_file_pos != -1.0) {
 			snprintf(buf, LOCAL_TIME_BUFLEN, "@%fs", sample_file_pos);
-			return 0;
+			return buf;
 		}
 		time(&etime);
 	} else {

--- a/src/util.c
+++ b/src/util.c
@@ -114,7 +114,7 @@ char* local_time_str(time_t time_secs, char *buf) {
 		extern float sample_file_pos;
 		if (sample_file_pos != -1.0) {
 			snprintf(buf, LOCAL_TIME_BUFLEN, "@%fs", sample_file_pos);
-			return;
+			return 0;
 		}
 		time(&etime);
 	} else {


### PR DESCRIPTION
It compiles well returning `0` but I don't know if this is right.

# Edit:
 
I didn't read the function previously. Sorry. I only done a diagonal read of the code and thought that it was only to exit prematurely from the function in case of error.
Now it returns `buf`as pointed by @zuckschwerdt and @rct.
