### PR TITLE
Updated "quadrant" code for WGR968

### DIFF
--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -252,7 +252,7 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
       return 1;
     } else if (sensor_id == ID_WGR968) {
       if (validate_os_v2_message(msg, 189, num_valid_v2_bits, 17) == 0) {
-        float quadrant = (((msg[4] &0x0f)*100)+((msg[4]>>4)*10) + ((msg[5]>>4)&0x0f));
+        float quadrant = (((msg[4] &0x0f)*10) + ((msg[4]>>4)&0x0f) + (((msg[5]>>4)&0x0f) * 100));
         float avgWindspeed = ((msg[7]>>4)&0x0f) / 10.0F + (msg[7]&0x0f) *1.0F + ((msg[8]>>4)&0x0f) / 10.0F;
         float gustWindspeed = (msg[5]&0x0f) /10.0F + ((msg[6]>>4)&0x0f) *1.0F + (msg[6]&0x0f) / 10.0F;
         data = data_make(


### PR DESCRIPTION
A nibble ordering problem was causing wind direction degrees to register impossible values (over 900 in some cases).  This fix re-orders the three-digit wind direction (quadrant) reading to match the output from the Oregon Scientific weather station display.