### PR TITLE
fix sample_file_pos to actually count seconds

### DIFF
--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1186,7 +1186,7 @@ int main(int argc, char **argv) {
             if (n_read == 0) break;	// rtlsdr_callback() will Segmentation Fault with len=0
             rtlsdr_callback(test_mode_buf, n_read, demod);
             i++;
-	    sample_file_pos = (float)i * n_read / samp_rate;
+	    sample_file_pos = (float)i * n_read / samp_rate / 2;
         } while (n_read != 0);
 
         // Call a last time with cleared samples to ensure EOP detection


### PR DESCRIPTION
Anyone ever notice that the file position ouput in test mode isn't actually seconds but twice that? I didn't…
Each sample is 16 bits (I+Q uint8's).

I'll prepare a PR for rtl_433_tests to adjust the timestamps in json files too.