### PR TITLE
harmonize device data output

### DIFF
--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -915,7 +915,7 @@ static int acurite_00275rm_callback(bitbuffer_t *bitbuf) {
                     "battery",         "",             DATA_STRING,    battery_low ? "LOW" : "OK",
                     "temperature_C",   "Celcius",      DATA_FORMAT,    "%.1f C",  DATA_DOUBLE, tempc,
                     "humidity",        "Humidity",     DATA_INT,       humidity,
-                    "crc",             "",             DATA_STRING,    "ok",
+                    "mic",             "Integrity",    DATA_STRING,    "CRC",
 
                     NULL);
             //  Water probe (detects water leak)
@@ -930,7 +930,7 @@ static int acurite_00275rm_callback(bitbuffer_t *bitbuf) {
                     "temperature_C",   "Celcius",      DATA_FORMAT,    "%.1f C",  DATA_DOUBLE, tempc,
                     "humidity",        "Humidity",     DATA_INT,       humidity,
                     "water",           "",             DATA_INT,       water,
-                    "crc",             "",             DATA_STRING,    "ok",
+                    "mic",             "Integrity",    DATA_STRING,    "CRC",
                     NULL);
             //  Soil probe (detects temperature)
             } else if (probe==2) {
@@ -944,7 +944,7 @@ static int acurite_00275rm_callback(bitbuffer_t *bitbuf) {
                     "temperature_C",   "Celcius",      DATA_FORMAT,    "%.1f C",  DATA_DOUBLE, tempc,
                     "humidity",        "Humidity",     DATA_INT,       humidity,
                     "ptemperature_C",  "Celcius",      DATA_FORMAT,    "%.1f C",  DATA_DOUBLE, ptempc,
-                    "crc",             "",             DATA_STRING,    "ok",
+                    "mic",             "Integrity",    DATA_STRING,    "CRC",
                     NULL);
             //  Spot probe (detects temperature and humidity)
             } else if (probe==3) {
@@ -960,7 +960,7 @@ static int acurite_00275rm_callback(bitbuffer_t *bitbuf) {
                     "humidity",        "Humidity",     DATA_INT,       humidity,
                     "ptemperature_C",  "Celcius",      DATA_FORMAT,    "%.1f C",  DATA_DOUBLE, ptempc,
                     "phumidity",       "Humidity",     DATA_INT,       phumidity,
-                    "crc",             "",             DATA_STRING,    "ok",
+                    "mic",             "Integrity",    DATA_STRING,    "CRC",
                     NULL);
             }
             data_acquired_handler(data);

--- a/src/devices/akhan_100F14.c
+++ b/src/devices/akhan_100F14.c
@@ -43,7 +43,7 @@ static int akhan_rke_callback(bitbuffer_t *bitbuffer) {
 
 		if (isAkhan == 1) {
 			data = data_make(	"time",		"",				DATA_STRING,	time_str,
-									"device",	"",				DATA_STRING,	"Akhan 100F14 remote keyless entry",
+									"model",	"",				DATA_STRING,	"Akhan 100F14 remote keyless entry",
 									"id",			"ID (20bit)",	DATA_FORMAT, 	"0x%x", 	DATA_INT, ID,
 									"data",		"Data (4bit)",	DATA_STRING,	CMD,
 									NULL);
@@ -58,10 +58,9 @@ static int akhan_rke_callback(bitbuffer_t *bitbuffer) {
 
 static char *output_fields[] = {
     "time",
-    "device",
+    "model",
     "id",
     "data",
-    "other",
     NULL
 };
 

--- a/src/devices/alecto.c
+++ b/src/devices/alecto.c
@@ -133,6 +133,7 @@ static int alectov1_callback(bitbuffer_t *bitbuffer) {
 		  							"wind_speed",     "Wind speed", DATA_FORMAT, "%.2f m/s", DATA_DOUBLE, speed * 0.2F,
 									"wind_gust",      "Wind gust",  DATA_FORMAT, "%.2f m/s", DATA_DOUBLE, gust * 0.2F,
 									"wind_direction", "Direction",  DATA_INT,    direction,
+									"mic",           "Integrity",   DATA_STRING,    "CHECKSUM",
 							 	   	NULL);
 			    	data_acquired_handler(data);
                 }
@@ -146,6 +147,7 @@ static int alectov1_callback(bitbuffer_t *bitbuffer) {
 								"channel",       "Channel",    DATA_INT,    channel,
 		  						"battery",       "Battery",    DATA_STRING, battery_low ? "LOW" : "OK",
 							    "rain_total",    "Total Rain", DATA_FORMAT, "%.02f mm", DATA_DOUBLE, rain_mm,
+								"mic",           "Integrity",  DATA_STRING,    "CHECKSUM",
 							    NULL);
 			    data_acquired_handler(data);
             }
@@ -166,6 +168,7 @@ static int alectov1_callback(bitbuffer_t *bitbuffer) {
 							"battery",       "Battery",     DATA_STRING, battery_low ? "LOW" : "OK",
 							"temperature_C", "Temperature", DATA_FORMAT, "%.02f C", DATA_DOUBLE, (float) temp / 10.0F,
 							"humidity",      "Humidity",    DATA_FORMAT, "%u %%",   DATA_INT, humidity,
+							"mic",           "",            DATA_STRING,    "CHECKSUM",
 							NULL);
 			data_acquired_handler(data);
         }        
@@ -194,6 +197,7 @@ static char *output_fields[] = {
 	"wind_speed",
 	"wind_gust",
 	"wind_direction",
+	"mic",
 	NULL
 };
 

--- a/src/devices/blyss.c
+++ b/src/devices/blyss.c
@@ -33,9 +33,8 @@ static int blyss_dc5_uk_wh(bitbuffer_t *bitbuffer)
 			local_time_str(0, time_str);
 
 			data = data_make("time", "", DATA_STRING, time_str,
+				"model", "", DATA_STRING, "blyss dc5-uk-wh",
 				"type", "", DATA_STRING, "doorbell",
-				"make", "", DATA_STRING, "blyss",
-				"model", "", DATA_STRING, "dc5-uk-wh",
 				"mode", "", DATA_STRING, "ringing",
 				NULL);
 			data_acquired_handler(data);
@@ -50,9 +49,8 @@ static int blyss_dc5_uk_wh(bitbuffer_t *bitbuffer)
 
 static char *output_fields[] = {
 	"time",
-	"type",
-	"make",
 	"model",
+	"type",
 	"mode",
 	NULL
 };

--- a/src/devices/calibeur.c
+++ b/src/devices/calibeur.c
@@ -85,6 +85,7 @@ static int calibeur_rf104_callback(bitbuffer_t *bitbuffer) {
 						"id",            "ID",          DATA_INT, ID,
 						"temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
 						"humidity",      "Humidity",    DATA_FORMAT, "%2.0f %%", DATA_DOUBLE, humidity,
+						"mic",           "Integrity",   DATA_STRING,    "CRC",
 						NULL);
 		data_acquired_handler(data);
 		return 1;
@@ -98,6 +99,7 @@ static char *output_fields[] = {
 	"id",
 	"temperature_C",
 	"humidity",
+	"mic",
 	NULL
 };
 

--- a/src/devices/danfoss.c
+++ b/src/devices/danfoss.c
@@ -142,7 +142,7 @@ static int danfoss_CFR_callback(bitbuffer_t *bitbuffer) {
 		     "temperature_C", 	"Temperature",	DATA_FORMAT,	"%.2f C", DATA_DOUBLE, temp_meas,
 		     "setpoint_C",	"Setpoint",	DATA_FORMAT,	"%.2f C", DATA_DOUBLE, temp_setp,
 		     "switch",		"Switch",	DATA_STRING,	str_sw,
-		     "crc", "", DATA_STRING, "ok",
+			"mic",           "Integrity",            DATA_STRING,    "CRC",
 		     NULL);
 		data_acquired_handler(data);
 
@@ -160,7 +160,7 @@ static char *output_fields[] = {
     "temperature_C",
     "setpoint_C",
     "switch",
-    "crc",
+    "mic",
     NULL
 };
 

--- a/src/devices/kerui.c
+++ b/src/devices/kerui.c
@@ -41,7 +41,7 @@ static int kerui_callback(bitbuffer_t *bitbuffer) {
 
 		if (isKerui == 1) {
 			data = data_make(	"time",		"",				DATA_STRING,	time_str,
-									"device",	"",				DATA_STRING,	"Kerui PIR Sensor",
+									"model",	"",				DATA_STRING,	"Kerui PIR Sensor",
 									"id",			"ID (20bit)",	DATA_FORMAT, 	"0x%x", 	DATA_INT, ID,
 									"data",		"Data (4bit)",	DATA_STRING,	CMD,
 									NULL);
@@ -58,10 +58,9 @@ static int kerui_callback(bitbuffer_t *bitbuffer) {
 
 static char *output_fields[] = {
     "time",
-    "device",
+    "model",
     "id",
     "data",
-    "other",
     NULL
 };
 

--- a/src/devices/lacrosse_tx35.c
+++ b/src/devices/lacrosse_tx35.c
@@ -128,7 +128,7 @@ static int lacrosse_it(bitbuffer_t *bitbuffer, uint8_t device29or35) {
 							 "battery",	   "Battery",	 DATA_STRING, battery_low ? "LOW" : "OK",
 							 "newbattery",	"NewBattery",  DATA_INT,	  newbatt,
 							 "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-							 "crc",		   "CRC",		 DATA_STRING, "OK",
+							 "mic",		   "Integrity",		 DATA_STRING, "CRC",
 							 NULL);
         }
         else {
@@ -140,7 +140,7 @@ static int lacrosse_it(bitbuffer_t *bitbuffer, uint8_t device29or35) {
 							 "newbattery",	"NewBattery",  DATA_INT,	  newbatt,
 							 "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
 							 "humidity",	  "Humidity",	DATA_FORMAT, "%u %%", DATA_INT, humidity,
-							 "crc",		   "CRC",		 DATA_STRING, "OK",
+							 "mic",		   "Integrity",		 DATA_STRING, "CRC",
 							 NULL);
         }
 		//	humidity = -1; // The TX29-IT sensor do not have humidity. It is replaced by a special value
@@ -176,7 +176,7 @@ static char *output_fields[] = {
 	"status",
 	"temperature_C",
 	"humidity",
-	"crc",
+	"mic",
 	NULL
 };
 

--- a/src/devices/maverick_et73x.c
+++ b/src/devices/maverick_et73x.c
@@ -217,7 +217,7 @@ static int maverick_et73x_callback(bitbuffer_t *bitbuffer) {
                      "status",         "Status",                DATA_STRING,                         get_status(msg_converted),
                      "temperature_C1", "TemperatureSensor1",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, get_temperature(msg_converted,TEMPERATURE_START_POSITION_S1),
                      "temperature_C2", "TemperatureSensor2",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, get_temperature(msg_converted,TEMPERATURE_START_POSITION_S2),
-                     "crc", "", DATA_STRING, "ok",
+                     "mic", "Integrity", DATA_STRING, "CHECKSUM",
                      NULL);
     data_acquired_handler(data);
 
@@ -232,7 +232,7 @@ static char *output_fields[] = {
     "status",
     "temperature_C1",
     "temperature_C2",
-    "crc",
+    "mic",
     NULL
 };
 

--- a/src/devices/radiohead_ask.c
+++ b/src/devices/radiohead_ask.c
@@ -137,13 +137,13 @@ static int radiohead_ask_callback(bitbuffer_t *bitbuffer) {
     }
     data = data_make("time", "",              DATA_STRING, time_str,
             "model",         "",              DATA_STRING, "RadioHead ASK",
-            "crc",           "",              DATA_STRING, "OK",
             "len",           "Data len",      DATA_INT, data_len,
             "to",            "To",            DATA_INT, header_to,
             "from",          "From",          DATA_INT, header_from,
             "id",            "Id",            DATA_INT, header_id,
             "flags",         "Flags",         DATA_INT, header_flags,
             "payload",       "Payload",       DATA_ARRAY, data_array(data_len, DATA_INT, data_payload),
+            "mic",           "Integrity",     DATA_STRING, "CRC",
     NULL);
     data_acquired_handler(data);
 
@@ -153,13 +153,13 @@ static int radiohead_ask_callback(bitbuffer_t *bitbuffer) {
 static char *output_fields[] = {
     "time",
     "model",
-    "crc",
     "len",
     "to",
     "from",
     "id",
     "flags",
     "payload",
+    "mic",
     NULL
 };
 

--- a/src/devices/rubicson.c
+++ b/src/devices/rubicson.c
@@ -98,7 +98,7 @@ static int rubicson_callback(bitbuffer_t *bitbuffer) {
                         "channel",       "Channel",     DATA_INT,    channel,
                         "battery",       "Battery",     DATA_STRING, battery ? "OK" : "LOW",
                         "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-                        "crc",           "CRC",         DATA_STRING, "OK",
+                        "mic",           "Integrity",   DATA_STRING, "CRC",
                         NULL);
 	data_acquired_handler(data);
 
@@ -114,7 +114,7 @@ static char *output_fields[] = {
 	"channel",
 	"battery",
 	"temperature_C",
-        "crc",
+	"mic",
 	NULL
 };
 

--- a/src/devices/schraeder.c
+++ b/src/devices/schraeder.c
@@ -66,7 +66,7 @@ static int schraeder_callback(bitbuffer_t *bitbuffer) {
 					"model", "", DATA_STRING, "Schraeder",
 					"type", "", DATA_STRING, "TPMS",
  					"id", "ID", DATA_STRING, hexid,
-					"crc", "", DATA_STRING, "OK",
+					"mic", "Integrity", DATA_STRING, "CRC",
 					NULL);
 
 	data_acquired_handler(data);
@@ -76,11 +76,9 @@ static int schraeder_callback(bitbuffer_t *bitbuffer) {
 static char *output_fields[] = {
 	"time",
 	"model",
+	"type",
 	"id",
-	"flags",
-	"pressure",
-	"temperature_C",
-	"depth",
+	"mic",
 	NULL
 };
 

--- a/src/devices/steelmate.c
+++ b/src/devices/steelmate.c
@@ -87,7 +87,7 @@ static int steelmate_callback(bitbuffer_t *bitbuffer) {
 
 		data = data_make("time", "", DATA_STRING, time_str,
 			"type", "", DATA_STRING, "TPMS",
-			"make", "", DATA_STRING, "Steelmate",
+			"model", "", DATA_STRING, "Steelmate",
 			"id", "", DATA_STRING, sensorIDhex,
 			"pressure_PSI", "", DATA_DOUBLE, pressurePSI,
 			"temperature_F", "", DATA_DOUBLE, (float)tempFahrenheit,
@@ -106,7 +106,7 @@ static int steelmate_callback(bitbuffer_t *bitbuffer) {
 static char *output_fields[] = {
 	"time",
 	"type",
-	"make",
+	"model",
 	"id",
 	"pressure_PSI",
 	"temperature_F",

--- a/src/devices/steelmate.c
+++ b/src/devices/steelmate.c
@@ -92,7 +92,7 @@ static int steelmate_callback(bitbuffer_t *bitbuffer) {
 			"pressure_PSI", "", DATA_DOUBLE, pressurePSI,
 			"temperature_F", "", DATA_DOUBLE, (float)tempFahrenheit,
 			"battery_mV", "", DATA_INT, battery_mV,
-			"checksum", "", DATA_STRING, "OK",
+			"mic", "Integrity", DATA_STRING, "CHECKSUM",
 			NULL);
 		data_acquired_handler(data);
 
@@ -111,7 +111,7 @@ static char *output_fields[] = {
 	"pressure_PSI",
 	"temperature_F",
 	"battery_mV",
-	"checksum",
+	"mic",
 	NULL
 };
 


### PR DESCRIPTION
Harmonize device data output to `model` instead of `device` or `make`, and `crc` instead of `checksum`. All devices should now use a common set of basic data output: `time`, `model`, `id`, and sometimes `type` as well as `crc`: `OK` for checksummed transmissions. Mostly it's just a single out of ~79 devices that isn't in line with common output naming. This will make post-processing easier and give new device authors a fixed starting point no matter which example code they are looking at.