### PR TITLE
Update rtl_433.h

### DIFF
--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -42,7 +42,7 @@
 
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           78
+#define MAX_PROTOCOLS           79
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */


### PR DESCRIPTION
MAX_PROTOCOLS incremented to 79. 

Without this change, starting with the -G option fails with an error.