### PR TITLE
fix Company name, output flags and data code

### DIFF
--- a/src/devices/schraeder.c
+++ b/src/devices/schraeder.c
@@ -1,6 +1,7 @@
-/* Schraeder TPMS protocol
+/* Schrader TPMS protocol
  *
- * Copyright © 2016 Benjamin Larsson
+ * Copyright (C) 2016 Benjamin Larsson
+ * and 2017 Christian W. Zuckschwerdt <zany@triq.net>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -9,16 +10,18 @@
  */
 
 /**
- * Packet payload: 8,5 bytes, 17 nibbles
+ * Packet payload: 1 sync nibble and 8 bytes data, 17 nibbles
  *
- *           01 23 45 67 89 AB CD EF 0
- * [00] {68} 7f 67 03 a3 8b 20 04 94 9
- *           SP UU UI II II IU UU UC C
+ * 0 12 34 56 78 9A BC DE F0
+ * 7 f6 70 3a 38 b2 00 49 49
+ * S PF FI II II II PP TT CC
  *
  * S = sync
  * P = preamble (0xf)
- * U = unknown
- * I = id
+ * F = flags
+ * I = id (28 bit)
+ * P = pressure from 0 bar to 6.375 bar, resolution of 25mbar per bit
+ * T = temperature from -50 C to 205 C (1 bit = 1 temperature count 1 C)
  * C = CRC8 from nibble 1 to E
  */
 
@@ -26,46 +29,54 @@
 #include "pulse_demod.h"
 #include "util.h"
 
-
 static int schraeder_callback(bitbuffer_t *bitbuffer) {
 	char time_str[LOCAL_TIME_BUFLEN];
-	bitrow_t *bb = bitbuffer->bb;
-	uint32_t serial_id = 0;
 	data_t *data;
-	char hexid[20] = {0};
-	uint8_t work_buffer[9];
-	int i;
+	uint8_t b[8];
+	uint32_t serial_id;
+	char id_str[9];
+	int flags;
+	char flags_str[3];
+	int pressure; // mbar
+	int temperature; // deg C
 
 	/* Reject wrong amount of bits */
 	if ( bitbuffer->bits_per_row[0] != 68)
 		return 0;
 
-	/* shift the buffer 4 bits for the crc8 calculation */
-	for (i=0 ; i<8 ; i++)
-		work_buffer[i] = (bb[0][i]&0x0F)<<4 | (bb[0][i+1]&0xF0) >> 4;
+	/* shift the buffer 4 bits to remove the sync bits */
+	bitbuffer_extract_bytes(bitbuffer, 0, 4, b, 64);
 
 	/* Calculate the crc */
-	if (work_buffer[7] != crc8(work_buffer, 7, 0x07, 0xf0)) {
+	if (b[7] != crc8(b, 7, 0x07, 0xf0)) {
 		return 0;
 	}
 
 	local_time_str(0, time_str);
 
 	/* Get serial number id */
-	serial_id = (bb[0][2]&0x0F) << 20 | bb[0][3] << 12 | bb[0][4] << 4 | (bb[0][5]&0xF0) >> 4;
-	sprintf(hexid, "%X", serial_id);
+	serial_id = (b[1]&0x0F) << 24 | b[2] << 16 | b[3] << 8 | b[4];
+	sprintf(id_str, "%07X", serial_id);
+	flags = (b[0]&0x0F) << 4 | b[1] >> 4;
+	sprintf(flags_str, "%02x", flags);
+
+	pressure = b[5] * 25;
+	temperature = b[6] - 50;
 
 	if (debug_output >= 1) {
-		fprintf(stderr, "Schraeder TPMS decoder\n");
+		fprintf(stderr, "Schrader TPMS decoder\n");
 		bitbuffer_print(bitbuffer);
 		fprintf(stderr, "id = 0x%X\n", serial_id);
-		fprintf(stderr, "CRC = %x\n", crc8(work_buffer, 7, 0x07, 0xf0));
+		fprintf(stderr, "CRC = %x\n", crc8(b, 7, 0x07, 0xf0));
 	}
 
 	data = data_make("time", "", DATA_STRING, time_str,
-					"model", "", DATA_STRING, "Schraeder",
+					"model", "", DATA_STRING, "Schrader",
 					"type", "", DATA_STRING, "TPMS",
- 					"id", "ID", DATA_STRING, hexid,
+					"flags", "", DATA_STRING, flags_str,
+ 					"id", "ID", DATA_STRING, id_str,
+					"pressure",      "Pressure",    DATA_FORMAT, "%.03f bar", DATA_DOUBLE, (double)pressure/1000.0,
+					"temperature_C", "Temperature", DATA_FORMAT, "%.0f C", DATA_DOUBLE, (double)temperature,
 					"mic", "Integrity", DATA_STRING, "CRC",
 					NULL);
 
@@ -78,16 +89,19 @@ static char *output_fields[] = {
 	"model",
 	"type",
 	"id",
+	"flags",
+	"pressure",
+	"temperature_C",
 	"mic",
 	NULL
 };
 
 r_device schraeder = {
-	.name			= "Schraeder TPMS",
+	.name			= "Schrader TPMS",
 	.modulation		= OOK_PULSE_MANCHESTER_ZEROBIT,
-	.short_limit	= 30*4,
+	.short_limit	= 120,
 	.long_limit     = 0,
-	.reset_limit    = 120*4,
+	.reset_limit    = 480,
 	.json_callback	= &schraeder_callback,
 	.disabled		= 0,
 	.fields			= output_fields,


### PR DESCRIPTION
The company is named "Schrader" not "Schraeder". Adds output of flags, pressure, and temperature in undecoded format. Include the high nibble of the ID. The ID is given on the device with 8 hex digits not just 7, but that might be omitted in the protocol.