### PR TITLE
adding Oil Ultrasonic STANDARD using ASK on 915MHz

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,9 @@ Supported device protocols:
     [78]  Fine Offset Electronics, WH25 Temperature/Humidity/Pressure Sensor
     [79]  Fine Offset Electronics, WH0530 Temperature/Rain Sensor
     [80]  IBIS beacon
-    [81]  Oil Ultrasonic STANDARD
+    [81]  Oil Ultrasonic STANDARD FSK
     [82]  Citroen TPMS
+    [83]  Oil Ultrasonic STANDARD ASK
 
 * Disabled by default, use -R n or -G
 

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -42,7 +42,7 @@
 
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           82
+#define MAX_PROTOCOLS           83
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -85,7 +85,8 @@
 		DECL(fineoffset_WH0530) \
 		DECL(ibis_beacon) \
 		DECL(oil_standard) \
-		DECL(tpms_citroen)
+		DECL(tpms_citroen) \
+		DECL(oil_standard_ask)
 
 typedef struct {
 	char name[256];

--- a/src/devices/oil_standard.c
+++ b/src/devices/oil_standard.c
@@ -1,8 +1,9 @@
-/* Oil tank monitor using manchester encoded FSK protocol
+/* Oil tank monitor using manchester encoded FSK/ASK protocol
  *
  * Tested devices:
- *  APOLLO ULTRASONIC STANDARD (maybe also VISUAL but not SMART)
- * Should apply to similar Watchman and Beckett devices too.
+ *  APOLLO ULTRASONIC STANDARD (maybe also VISUAL but not SMART, FSK)
+ *  Beckett Rocket TEK377A (915MHz, ASK)
+ * Should apply to similar Watchman, Beckett, and Apollo devices too.
  *
  * Copyright (C) 2017 Christian W. Zuckschwerdt <zany@triq.net>
  * based on code Copyright (C) 2015 David Woodhouse
@@ -44,8 +45,6 @@ static int oil_standard_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bi
 	uint8_t alarm;
 	bitbuffer_t databits = {0};
 
-	local_time_str(0, time_str);
-
 	bitpos = bitbuffer_manchester_decode(bitbuffer, row, bitpos, &databits, 33);
 
 	if (databits.bits_per_row[0] != 32)
@@ -79,6 +78,7 @@ static int oil_standard_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bi
 		// A depth reading of zero indicates no reading.
 		depth = ((b[2] & 0x02) << 7) | b[3];
 
+	local_time_str(0, time_str);
 	data = data_make(
 		"time",		"",				DATA_STRING,	time_str,
 		"model",	"",				DATA_STRING,	"Oil Ultrasonic STANDARD",
@@ -125,8 +125,19 @@ static char *output_fields[] = {
 };
 
 r_device oil_standard = {
-	.name			= "Oil Ultrasonic STANDARD",
+	.name			= "Oil Ultrasonic STANDARD FSK",
 	.modulation		= FSK_PULSE_PCM,
+	.short_limit	= 500,
+	.long_limit		= 500,
+	.reset_limit	= 2000,
+	.json_callback	= &oil_standard_callback,
+	.disabled		= 0,
+	.fields			= output_fields,
+};
+
+r_device oil_standard_ask = {
+	.name			= "Oil Ultrasonic STANDARD ASK",
+	.modulation		= OOK_PULSE_PCM_RZ,
 	.short_limit	= 500,
 	.long_limit		= 500,
 	.reset_limit	= 2000,


### PR DESCRIPTION
Easier than anticipated the 915MHz Oil Ultrasonic uses the same Standard-type protocol but using ASK. See also https://groups.google.com/forum/#!topic/rtl_433/J8bVqTZMXCo