### PR TITLE
Fix hex output padding for unit ID field for lightwaverf.

### DIFF
--- a/src/devices/lightwave_rf.c
+++ b/src/devices/lightwave_rf.c
@@ -106,7 +106,7 @@ static int lightwave_rf_callback(bitbuffer_t *bitbuffer) {
 		// Print out generic decode
 		// Decoded nibbles are in row 3
 		fprintf(stdout, "LightwaveRF:\n");
-		fprintf(stdout, "ID = 0x%X%X%X\n", bb[3][2], bb[3][3], bb[3][4]);
+		fprintf(stdout, "ID = 0x%02X%02X%02X\n", bb[3][2], bb[3][3], bb[3][4]);
 		fprintf(stdout, "Subunit = %u\n", (bb[3][1] & 0xF0) >> 4);
 		fprintf(stdout, "Command = %u\n", bb[3][1] & 0x0F);
 		fprintf(stdout, "Parameter = %u\n", bb[3][0]);


### PR DESCRIPTION
When printing the unit ID hex value for lightwaverf devices there is no padding to handle any leading '0's of the individual bytes that make up the ID. If any of the bytes have a value less than 0x0F only a single character is printed, as these are then concatenated together an incorrect value is produced.

Example:
Correct Unit ID: F10F6F is incorrectly printed as: F1F6F (missing '0')