### PR TITLE
replace binary literals with hex

### DIFF
--- a/src/devices/current_cost.c
+++ b/src/devices/current_cost.c
@@ -13,12 +13,12 @@ static int current_cost_callback(bitbuffer_t *bitbuffer) {
     local_time_str(0, time_str);
 
     uint8_t init_pattern[] = {
-        0b11001100, //8
-        0b11001100, //16
-        0b11001100, //24
-        0b11001110, //32
-        0b10010001, //40
-        0b01011101, //45 (! last 3 bits is not init)
+        0xcc, //8
+        0xcc, //16
+        0xcc, //24
+        0xce, //32
+        0x91, //40
+        0x5d, //45 (! last 3 bits is not init)
     };
     unsigned int start_pos = bitbuffer_search(bitbuffer, 0, 0, init_pattern, 45);
 

--- a/src/devices/intertechno.c
+++ b/src/devices/intertechno.c
@@ -15,9 +15,9 @@ static int intertechno_callback(bitbuffer_t *bitbuffer) {
         fprintf(stdout, "rid            = %x\n",bb[1][5]);
         fprintf(stdout, "rid            = %x\n",bb[1][6]);
         fprintf(stdout, "rid            = %x\n",bb[1][7]);
-        fprintf(stdout, "ADDR Slave     = %i\n",bb[1][7] & 0b00001111);
-        fprintf(stdout, "ADDR Master    = %i\n",(bb[1][7] & 0b11110000) >> 4);
-        fprintf(stdout, "command        = %i\n",(bb[1][6] & 0b00000111));
+        fprintf(stdout, "ADDR Slave     = %i\n",bb[1][7] & 0x0f);
+        fprintf(stdout, "ADDR Master    = %i\n",(bb[1][7] & 0xf0) >> 4);
+        fprintf(stdout, "command        = %i\n",(bb[1][6] & 0x07));
         fprintf(stdout, "%02x %02x %02x %02x %02x\n",bb[1][0],bb[1][1],bb[1][2],bb[1][3],bb[1][4]);
 
         return 1;

--- a/src/devices/mebus.c
+++ b/src/devices/mebus.c
@@ -13,15 +13,15 @@ static int mebus433_callback(bitbuffer_t *bitbuffer) {
     uint8_t unknown2;
     data_t *data;
 
-    if (bb[0][0] == 0 && bb[1][4] !=0 && (bb[1][0] & 0b01100000) && bb[1][3]==bb[5][3] && bb[1][4] == bb[12][4]){
+    if (bb[0][0] == 0 && bb[1][4] !=0 && (bb[1][0] & 0x60) && bb[1][3]==bb[5][3] && bb[1][4] == bb[12][4]){
         local_time_str(0, time_str);
 
-        address = bb[1][0] & 0b00011111;
+        address = bb[1][0] & 0x1f;
 
-        channel = ((bb[1][1] & 0b00110000) >> 4) + 1;
+        channel = ((bb[1][1] & 0x30) >> 4) + 1;
         // Always 0?
-        unknown1 = (bb[1][1] & 0b01000000) >> 6;
-        battery = bb[1][1] & 0b10000000;
+        unknown1 = (bb[1][1] & 0x40) >> 6;
+        battery = bb[1][1] & 0x80;
 
         // Upper 4 bits are stored in nibble 1, lower 8 bits are stored in nibble 2
         // upper 4 bits of nibble 1 are reserved for other usages.
@@ -32,7 +32,7 @@ static int mebus433_callback(bitbuffer_t *bitbuffer) {
         hum  = (bb[1][3] << 4 | bb[1][4] >> 4);
 
         // Always 0b1111?
-        unknown2 = (bb[1][3] & 0b11110000) >> 4;
+        unknown2 = (bb[1][3] & 0xf0) >> 4;
 
         data = data_make("time",          "",            DATA_STRING, time_str,
                          "model",         "",            DATA_STRING, "Mebus/433",


### PR DESCRIPTION
Since we are targeting C99 (or rather gnu99) we can not use binary literals. It will work with recent GCC (and Clang) but I still have older (Clang) releases that do not support this extension.

Perhaps we'd need to target the C++14 standard which includes binary literals, but that seems to harsh for the few odd places where binary numbers are used and easily replaced with hex.