### PR TITLE
fix misc typos and reduce efergy false positives

### DIFF
--- a/src/devices/efergy_e2_classic.c
+++ b/src/devices/efergy_e2_classic.c
@@ -64,6 +64,9 @@ static int efergy_e2_classic_callback(bitbuffer_t *bitbuffer) {
 	for (unsigned i = 0; i < 7; ++i) {
 		checksum += bytes[i];
 	}
+	if (checksum == 0) {
+		return 0; // reduce false positives
+	}
 	checksum &= 0xff;
 	if (checksum != bytes[7]) {
 		return 0;
@@ -77,7 +80,7 @@ static int efergy_e2_classic_callback(bitbuffer_t *bitbuffer) {
 	float current_adc = (float)((bytes[4] << 8 | bytes[5])) / (1 << fact);
 
 	local_time_str(0, time_str);
-	
+
 	// Output data
 	data = data_make(
 		"time",			"Time",		DATA_STRING,	time_str,
@@ -86,12 +89,12 @@ static int efergy_e2_classic_callback(bitbuffer_t *bitbuffer) {
 		"current",		"",			DATA_FORMAT,	"%.2f", 	DATA_DOUBLE, current_adc,
 		"interval", 	"",			DATA_INT,		interval,
 		"battery",      "Battery",  DATA_STRING, 	battery ? "OK" : "LOW",
-		"learn",		"",			DATA_STRING, 	battery ? "NO" : "YES",
+		"learn",		"",			DATA_STRING, 	learn ? "NO" : "YES",
 		NULL
-	); 
+	);
 
 	data_acquired_handler(data);
-	
+
 	return 1;
 }
 

--- a/src/devices/ibis_beacon.c
+++ b/src/devices/ibis_beacon.c
@@ -22,7 +22,7 @@ static int ibis_beacon_callback(bitbuffer_t *bitbuffer) {
 	uint8_t msg[32];
 	unsigned len;
 	unsigned pos;
-	int i;
+	unsigned i;
 	int id;
 	int counter;
 	int crc;

--- a/src/devices/oil_standard.c
+++ b/src/devices/oil_standard.c
@@ -61,8 +61,8 @@ static int oil_standard_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bi
 	// 0x04: (always zero?)
 	// 0x08: Leak/theft alarm
 	// 0x10: (unkown toggle)
+	// 0x20: (unkown toggle)
 	// 0x40: (unkown toggle)
-	// 0x10: (unkown toggle)
 	// 0x80: (always zero?)
 	flags = b[2] & ~0x0A;
 	alarm = (b[2] & 0x08) >> 3;


### PR DESCRIPTION
fixes typos (and trailing whitespace around those lines) and rejects completly empty rows (checksum=0) in Efergy E2 classic.