### PR TITLE
fix compiler warnings; possible undef bug

### DIFF
--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -962,6 +962,8 @@ static int acurite_00275rm_callback(bitbuffer_t *bitbuf) {
                     "phumidity",       "Humidity",     DATA_INT,       phumidity,
                     "mic",             "Integrity",    DATA_STRING,    "CRC",
                     NULL);
+            } else { // suppress compiler warning
+                return 0;
             }
             data_acquired_handler(data);
             valid=1;

--- a/src/devices/fineoffset_wh1080.c
+++ b/src/devices/fineoffset_wh1080.c
@@ -318,6 +318,8 @@ static int fineoffset_wh1080_callback(bitbuffer_t *bitbuffer) {
     msg_type = 1; // WH1080/3080 Datetime msg
     } else if (br[0] == 0xff && (br[1] >> 4) == 0x07) {
     msg_type = 2; // WH3080 UV/Light msg
+    } else {
+        msg_type = -1;
     }
 
 

--- a/src/devices/lacrosse_TX141TH_Bv2.c
+++ b/src/devices/lacrosse_TX141TH_Bv2.c
@@ -107,8 +107,8 @@
 #define LACROSSE_TX141TH_PACKETCOUNT 12
 
 typedef struct {
-    int32_t data;  // First 4 data bytes compressed into 32-bit integer
-    int8_t count;  // Count
+    uint32_t data;  // First 4 data bytes compressed into 32-bit integer
+    uint8_t count;  // Count
 } data_and_count;
 
 static int lacrosse_tx141th_bv2_callback(bitbuffer_t *bitbuffer) {


### PR DESCRIPTION
fix a compiler warning about a missing if-branch leading to undefined variables and a possible undefined variable bug. I.e.
```
src/devices/acurite.c:950:24: warning:
variable 'data' is used uninitialized whenever 'if' condition is false
```
and
```
src/devices/fineoffset_wh1080.c:319:16: warning:
variable 'msg_type' is used uninitialized whenever 'if' condition is false
```