### PR TITLE
reduce false positives, require at least 5 repeats

### DIFF
--- a/src/devices/lacrosse_TX141TH_Bv2.c
+++ b/src/devices/lacrosse_TX141TH_Bv2.c
@@ -169,6 +169,11 @@ static int lacrosse_tx141th_bv2_callback(bitbuffer_t *bitbuffer) {
         }
     }
 
+    // reduce false positives, require at least 5 out of 12 repeats.
+    if (dnc[kmax].count < 5) {
+        return 0;
+    }
+
     // Unpack the data bytes back to eliminate dependence on the platform endiannes!
     uint8_t *bytes=(uint8_t*)(&(dnc[kmax].data));
     id=bytes[0];


### PR DESCRIPTION
Reduce false positives by requiring at least 5 out of 12 repeats for LaCrosse TX141TH-Bv2 data.
(There is no MIC and the decoder will match most bitbuffers.)
Samples with false positives are e.g. `rtl_433_tests/tests/acurite/03/`.

Checked against test data in `rtl_433_tests/tests/lacrosse/04/`.