### PR TITLE
Add option to verify simulated decoding of demodulated data

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Usage:	= Tuner options =
 	[-D] Print debug info on event (repeat for more info)
 	[-q] Quiet mode, suppress non-data messages
 	[-W] Overwrite mode, disable checks to prevent files from being overwritten
+	[-y <code>] Verify decoding of raw data (e.g. "{25}fb2dd58") with enabled devices
 	= File I/O options =
 	[-t] Test signal auto save. Use it together with analyze mode (-a -t). Creates one file per signal
 		 Note: Saves raw I/Q samples (uint8 pcm, 2 channel). Preferred mode for generating test files

--- a/include/pulse_demod.h
+++ b/include/pulse_demod.h
@@ -138,4 +138,14 @@ int pulse_demod_clock_bits(const pulse_data_t *pulses, struct protocol_state *de
 
 int pulse_demod_osv1(const pulse_data_t *pulses, struct protocol_state *device);
 
+
+/// Simulate demodulation using a given signal code string
+///
+/// The (optionally "0x" prefixed) hex code is processed into a bitbuffer_t.
+/// Each row is optionally prefixed with a length enclosed in braces "{}" or
+/// separated with a slash "/" character. Whitespace is ignored.
+/// Device params are disregarded.
+/// @return number of events processed
+int pulse_demod_string(const char *code, struct protocol_state *device);
+
 #endif /* INCLUDE_PULSE_DEMOD_H_ */


### PR DESCRIPTION
Adds a mode to verify decoding of demodulated data with enabled devices.

The (optionally "0x" prefixed) hex code is processed into a bitbuffer_t.
Each row is optionally prefixed with a length enclosed in braces "{}" or
separated with a slash "/" character. Whitespace is ignored.
Device params are disregarded, every enabled device is called with the buffer.
The exit code is 0 if at least one device decoded the data, otherwise 1.

This allows to try demodulated but raw capture data, re-run known data for verification and possibly automated fuzzing to spot bugs, too.
(The whitespace change in rtl_433.c is a stray tab changed to spaces)