### PR TITLE
Use default number of buffers to fix crash of two rtl_433 instances

### DIFF
--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -30,7 +30,7 @@
 #define DEFAULT_FREQUENCY       433920000
 #define DEFAULT_HOP_TIME        (60*10)
 #define DEFAULT_HOP_EVENTS      2
-#define DEFAULT_ASYNC_BUF_NUMBER    32
+#define DEFAULT_ASYNC_BUF_NUMBER    0 // Force use of default value (was : 32)
 #define DEFAULT_BUF_LENGTH      (16 * 16384)
 
 /*

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1306,7 +1306,7 @@ int main(int argc, char **argv) {
             r = rtlsdr_read_async(dev, rtlsdr_callback, (void *) demod,
                     DEFAULT_ASYNC_BUF_NUMBER, out_block_size);
             if (r < 0) {
-                fprintf(stderr, "WARNING: async read failed.\n");
+                fprintf(stderr, "WARNING: async read failed (%i).\n", r);
                 break;
             }
 #ifndef _WIN32


### PR DESCRIPTION
Hi,
Thanks for wonderful rtl_433 !  
I wanted to use it simultaneously two usb dongles, but the second keeps failing with "Failed to submit transfer 31!  WARNING: async read failed.".
I noticed that it works ok with the default number of USB buffers instead of 32 (keeps crashing with 31). This may be something due to my hardware, and seems related to bandwidth, as if I lower the size of buffers I can grow the number of buffers accordingly. But as I cannot see the use of a higher number of buffers as the default one and that other users could have the same issue, I suggest you this ridiculously mall change.
Thanks again.