### PR TITLE
Make LaCrosse TX141TH sensors return temperature_C so that they are more consistent with other temperature sensors

### DIFF
--- a/src/devices/lacrosse_TX141TH_Bv2.c
+++ b/src/devices/lacrosse_TX141TH_Bv2.c
@@ -182,6 +182,7 @@ static int lacrosse_tx141th_bv2_callback(bitbuffer_t *bitbuffer) {
     if (0==id || 0==humidity || humidity > 100 || temp_f < -40.0 || temp_f > 140.0) {
         if (debug_output) {
             fprintf(stderr, "LaCrosse TX141TH-Bv2 data error\n");
+            fprintf(stderr, "id: %i, humidity:%i, temp_f:%f\n", id, humidity, temp_f);
         }
         return 0;
     }
@@ -190,6 +191,7 @@ static int lacrosse_tx141th_bv2_callback(bitbuffer_t *bitbuffer) {
                      "model",   "", DATA_STRING,    "LaCrosse TX141TH-Bv2 sensor",
                      "id",      "Sensor ID",  DATA_FORMAT, "%02x", DATA_INT, id,
                      "temperature", "Temperature in deg F", DATA_FORMAT, "%.2f F", DATA_DOUBLE, temp_f,
+                     "temperature_C", "Temperature in deg C", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_f,
                      "humidity",    "Humidity", DATA_FORMAT, "%u %%", DATA_INT, humidity,
                      "battery", "Battery",  DATA_STRING, battery_low ? "LOW" : "OK",
                      "test",    "Test?",  DATA_STRING, test ? "Yes" : "No",
@@ -205,6 +207,7 @@ static char *output_fields[] = {
     "model",
     "id",
     "temperature",
+    "temperature_C",
     "humidity",
     "battery",
     "test",

--- a/src/devices/lacrosse_TX141TH_Bv2.c
+++ b/src/devices/lacrosse_TX141TH_Bv2.c
@@ -119,7 +119,7 @@ static int lacrosse_tx141th_bv2_callback(bitbuffer_t *bitbuffer) {
     int i,j,k,nbytes,npacket,kmax;
     uint8_t id=0,status=0,battery_low=0,test=0,humidity=0,maxcount;
     uint16_t temp_raw=0;
-    float temp_f=0.0;
+    float temp_f,temp_c=0.0;
     data_and_count dnc[LACROSSE_TX141TH_PACKETCOUNT] = {0};
 
     if (debug_output) {
@@ -182,6 +182,7 @@ static int lacrosse_tx141th_bv2_callback(bitbuffer_t *bitbuffer) {
     test=(status & 0x40) >> 6;
     temp_raw=((status & 0x0F) << 8) + bytes[2];
     temp_f = 9.0*((float)temp_raw)/50.0-58.0; // Temperature in F
+    temp_c = ((float)temp_raw)/10.0-50.0; // Temperature in C
     humidity = bytes[3];
 
     if (0==id || 0==humidity || humidity > 100 || temp_f < -40.0 || temp_f > 140.0) {
@@ -196,7 +197,7 @@ static int lacrosse_tx141th_bv2_callback(bitbuffer_t *bitbuffer) {
                      "model",   "", DATA_STRING,    "LaCrosse TX141TH-Bv2 sensor",
                      "id",      "Sensor ID",  DATA_FORMAT, "%02x", DATA_INT, id,
                      "temperature", "Temperature in deg F", DATA_FORMAT, "%.2f F", DATA_DOUBLE, temp_f,
-                     "temperature_C", "Temperature in deg C", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_f,
+                     "temperature_C", "Temperature in deg C", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
                      "humidity",    "Humidity", DATA_FORMAT, "%u %%", DATA_INT, humidity,
                      "battery", "Battery",  DATA_STRING, battery_low ? "LOW" : "OK",
                      "test",    "Test?",  DATA_STRING, test ? "Yes" : "No",


### PR DESCRIPTION
Most other temperature sensors in RTL_433 return temperature_C, but this LaCrosse TX141TH sensor was only returning the Fahrenheit temperature in the "temperature" field, so this adds the Celsius temperature in the temperature_C field.

This is helpful for other programs like Domoticz which requests a CSV output from RTL_433 and only looks for data in the temperature_C field.