### PR TITLE
Add support for FT-004-B

### DIFF
--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -42,7 +42,7 @@
 
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           91
+#define MAX_PROTOCOLS           92
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -94,7 +94,8 @@
 		DECL(tpms_toyota) \
 		DECL(tpms_ford) \
 		DECL(tpms_renault) \
-		DECL(infactory)
+		DECL(infactory) \
+		DECL(ft004b)
 
 typedef struct {
 	char name[256];

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(rtl_433
 	devices/esperanza_ews.c
 	devices/fineoffset.c
 	devices/fineoffset_wh1080.c
+	devices/ft004b.c
 	devices/generic_remote.c
 	devices/generic_temperature_sensor.c
 	devices/gt_wt_02.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -30,6 +30,7 @@ rtl_433_SOURCES      = baseband.c \
                        devices/esperanza_ews.c \
                        devices/fineoffset.c \
                        devices/fineoffset_wh1080.c \
+                       devices/ft004b.c \
                        devices/generic_remote.c \
                        devices/generic_temperature_sensor.c \
                        devices/gt_wt_02.c \

--- a/src/devices/ft004b.c
+++ b/src/devices/ft004b.c
@@ -1,0 +1,91 @@
+/*
+ * FT-004-B Temperature Sensor
+ *
+ * The sensor sends a packet every 60 seconds. Each frame of 46 bits
+ * is sent 3 times without padding/pauses.
+ * Format: ???????? ???????? ??????? TTTTTTTT TTT????? ??????
+ *         Temperature (T), Unknown (?)
+ *
+ * Copyright (C) 2017 George Hopkins <george-hopkins@null.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "rtl_433.h"
+#include "data.h"
+#include "util.h"
+
+static float
+get_temperature (uint8_t * msg)
+{
+    uint16_t temp_c = ((msg[4] & 0x7) << 8) | msg[3];
+    return (temp_c * 0.05f) - 40.0f;
+}
+
+static int
+ft004b_callback (bitbuffer_t *bitbuffer)
+{
+    uint8_t* msg;
+    float temperature;
+    char time_str[LOCAL_TIME_BUFLEN];
+    data_t *data;
+
+    if(bitbuffer->bits_per_row[0] != 137 && bitbuffer->bits_per_row[0] != 138) {
+        return 0;
+    }
+
+    /* take the majority of all 46 bits (pattern is sent 3 times) and reverse them */
+    msg = bitbuffer->bb[0];
+    for (int i = 0; i < (46 + 7) / 8; i++) {
+        uint8_t a = bitrow_get_byte(msg, i * 8);
+        uint8_t b = bitrow_get_byte(msg, i * 8 + 46);
+        uint8_t c = bitrow_get_byte(msg, i * 8 + 46 * 2);
+        msg[i] = reverse8((a & b) | (b & c) | (a & c));
+    }
+
+    if (msg[0] == 0xf4) {
+        temperature = get_temperature(msg);
+
+        local_time_str(0, time_str);
+        data = data_make(
+            "time", "", DATA_STRING, time_str,
+            "model", "", DATA_STRING, "FT-004-B Temperature Sensor",
+            "temperature_C", "Temperature", DATA_FORMAT, "%.1f", DATA_DOUBLE, temperature,
+            NULL);
+        data_acquired_handler(data);
+
+        return 1;
+    }
+
+    return 0;
+}
+
+static char *output_fields[] = {
+    "time",
+    "model",
+    "temperature_C",
+    NULL
+};
+
+r_device ft004b = {
+    .name          = "FT-004-B Temperature Sensor",
+    .modulation    = OOK_PULSE_PPM_RAW,
+    .short_limit   = (1956 + 3900) / 2,
+    .long_limit    = 4000,
+    .reset_limit   = 4000,
+    .json_callback = &ft004b_callback,
+    .disabled      = 0,
+    .demod_arg     = 0,
+    .fields        = output_fields
+};


### PR DESCRIPTION
This patch adds support for FT-004-B, a temperature sensor. Unfortunately, I was not able to calculate a checksum or decode any of the remaining bits. I wonder what all these bits are for, given that the display only shows the temperature (in °C) and has no buttons.

Samples: merbanan/rtl_433_tests#181