### PR TITLE
define _GNU_SOURCE for strdup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ if(CMAKE_COMPILER_IS_GNUCC AND NOT WIN32)
     ADD_DEFINITIONS(-Wsign-compare)
     ADD_DEFINITIONS(-g3 -O0)
     ADD_DEFINITIONS(-std=gnu99)
+    # for strdup
+    ADD_DEFINITIONS(-D_GNU_SOURCE)
     #http://gcc.gnu.org/wiki/Visibility
     add_definitions(-fvisibility=hidden)
 endif()


### PR DESCRIPTION
Somehow I now get `src/data.c:101:62: error: 'strdup' undeclared here (not in a function)` on
`gcc (Debian 4.9.2-10) 4.9.2` with `ldd (Debian GLIBC 2.19-18+deb8u10) 2.19`.
Not sure what changed or why it worked before. But `strdup` prototype needs `_GNU_SOURCE` to get defined.
A more portable alternative would be to create a simple `strdup` replacement.