### PR TITLE
fixing schraeder data types

### DIFF
--- a/src/devices/schraeder.c
+++ b/src/devices/schraeder.c
@@ -33,7 +33,7 @@ static int schraeder_callback(bitbuffer_t *bitbuffer) {
 	char time_str[LOCAL_TIME_BUFLEN];
 	data_t *data;
 	uint8_t b[8];
-	uint32_t serial_id;
+	int serial_id;
 	char id_str[9];
 	int flags;
 	char flags_str[3];
@@ -104,9 +104,9 @@ static int schrader_EG53MA4_callback(bitbuffer_t *bitbuffer) {
 	char time_str[LOCAL_TIME_BUFLEN];
 	data_t *data;
 	uint8_t b[10];
-	uint32_t serial_id;
+	int serial_id;
 	char id_str[9];
-	uint flags;
+	int flags;
 	char flags_str[9];
 	int pressure;		// mbar
 	int temperature;	// degree Fahrenheit


### PR DESCRIPTION
a quick fix for the unknown data type `uint`. Also changes 32-bit uint on serial id to platform int (as 64-bit is fine too here). Fixes:
```
rtl_433/src/devices/schraeder.c:109:2: error: use of undeclared identifier 'uint'; did you mean 'int'?
```
This fix is also in #609 but I reason it needs to be applied asap as the build is currently broken.