### PR TITLE
change PWM_Precise_Parameters pulse_tolerance to use us units

### DIFF
--- a/include/pulse_demod.h
+++ b/include/pulse_demod.h
@@ -65,8 +65,8 @@ int pulse_demod_pwm(const pulse_data_t *pulses, struct protocol_state *device);
 
 /// Parameters for pulse_demod_pwm_precise
 typedef struct {
-	int	pulse_sync_width;		// Width of a sync pulse [samples] (optional, ignored if 0)
-	int	pulse_tolerance;		// Tolerance of pulse widths [samples]
+	int	pulse_sync_width;		// Width of a sync pulse [us] (optional, ignored if 0)
+	int	pulse_tolerance;		// Tolerance of pulse widths [us]
 } PWM_Precise_Parameters;
 
 

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -1039,8 +1039,8 @@ r_device acurite_txr = {
 // with a range of signal levels
 //
 // PWM_Precise_Parameters pwm_precise_param_acurite_txr = {
-// 	.pulse_tolerance	= 50,
-// 	.pulse_sync_width	= 170,
+// 	.pulse_tolerance	= 200, // us
+// 	.pulse_sync_width	= 680, // us
 // };
 
 //r_device acurite_txr = {

--- a/src/devices/akhan_100F14.c
+++ b/src/devices/akhan_100F14.c
@@ -65,7 +65,7 @@ static char *output_fields[] = {
 };
 
 PWM_Precise_Parameters pwm_precise_parameters_akhan = {
-	.pulse_tolerance	= 20,
+	.pulse_tolerance	= 80, // us
 	.pulse_sync_width	= 0,
 };
 

--- a/src/devices/chuango.c
+++ b/src/devices/chuango.c
@@ -85,7 +85,7 @@ static char *output_fields[] = {
 };
 
 PWM_Precise_Parameters pwm_precise_parameters = {
-	.pulse_tolerance	= 40,
+	.pulse_tolerance	= 160, // us
 	.pulse_sync_width	= 0,	// No sync bit used
 };
 

--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -321,7 +321,7 @@ r_device fineoffset_WH25 = {
 
 
 PWM_Precise_Parameters pwm_precise_parameters_fo_wh0530 = {
-    .pulse_tolerance    = 40,
+    .pulse_tolerance    = 160, // us
     .pulse_sync_width   = 0,    // No sync bit used
 };
 

--- a/src/devices/generic_remote.c
+++ b/src/devices/generic_remote.c
@@ -91,7 +91,7 @@ static int generic_remote_callback(bitbuffer_t *bitbuffer) {
 
 
 PWM_Precise_Parameters pwm_precise_parameters_generic = {
-	.pulse_tolerance	= 50,
+	.pulse_tolerance	= 200, // us
 	.pulse_sync_width	= 0,	// No sync bit used
 };
 

--- a/src/devices/hideki.c
+++ b/src/devices/hideki.c
@@ -118,7 +118,7 @@ static int hideki_ts04_callback(bitbuffer_t *bitbuffer) {
 }
 
 PWM_Precise_Parameters hideki_ts04_clock_bits_parameters = {
-    .pulse_tolerance    = 60,
+    .pulse_tolerance    = 240, // us
     .pulse_sync_width    = 0,    // No sync bit used
 };
 

--- a/src/devices/kerui.c
+++ b/src/devices/kerui.c
@@ -65,7 +65,7 @@ static char *output_fields[] = {
 };
 
 PWM_Precise_Parameters pwm_precise_parameters_kerui = {
-	.pulse_tolerance	= 20,
+	.pulse_tolerance	= 80, // us
 	.pulse_sync_width	= 0,
 };
 

--- a/src/devices/quhwa.c
+++ b/src/devices/quhwa.c
@@ -56,7 +56,7 @@ static char *output_fields[] = {
 };
 
 PWM_Precise_Parameters pwm_precise_parameters_quhwa = {
-	.pulse_tolerance	= 20,
+	.pulse_tolerance	= 80, // us
 	.pulse_sync_width	= 0,	// No sync bit used
 };
 

--- a/src/devices/vaillant_vrt340f.c
+++ b/src/devices/vaillant_vrt340f.c
@@ -202,7 +202,7 @@ vaillant_vrt340_callback (bitbuffer_t *bitbuffer)
 }
 
 PWM_Precise_Parameters vaillant_vrt340_clock_bits_parameters = {
-    .pulse_tolerance    = 30,
+    .pulse_tolerance    = 120, // us
     .pulse_sync_width    = 0,    // No sync bit used
 };
 

--- a/src/devices/wt450.c
+++ b/src/devices/wt450.c
@@ -134,7 +134,7 @@ static int wt450_callback(bitbuffer_t *bitbuffer) {
 }
 
 PWM_Precise_Parameters clock_bits_parameters_generic = {
-    .pulse_tolerance	= 20,
+    .pulse_tolerance	= 80, // us
     .pulse_sync_width	= 0,	// No sync bit used
 };
 

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -189,6 +189,10 @@ static void register_protocol(struct dm_state *demod, r_device *t_dev) {
     p->callback = t_dev->json_callback;
     p->name = t_dev->name;
     p->demod_arg = t_dev->demod_arg;
+    if (p->modulation == OOK_PULSE_PWM_PRECISE) {
+        PWM_Precise_Parameters *pwm_precise_parameters = (PWM_Precise_Parameters *)p->demod_arg;
+        pwm_precise_parameters->pulse_tolerance = (float)pwm_precise_parameters->pulse_tolerance / ((float)1000000 / (float)samp_rate);
+    }
     bitbuffer_clear(&p->bits);
 
     demod->r_devs[demod->r_dev_num] = p;


### PR DESCRIPTION
finally got around to change the pulse_tolerance from samples (250k) to µs, which allows the `OOK_PULSE_PWM_PRECISE` decoders to work at other sample rates.