### PR TITLE
Update rtl_433.h

### DIFF
--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -42,7 +42,7 @@
 
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           94
+#define MAX_PROTOCOLS           95
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */


### PR DESCRIPTION
Change the size of MAX_PROTOCOLS. 

If you try to run rtl_433 -G you get the following error: 

Max number of protocols reached 94
Increase MAX_PROTOCOLS and recompile

Correct value should be 95 now that new protocol has been added.