### PR TITLE
change grab file name to gNNN_FFFM_RRRk.cu8

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Examples:
 | `rtl_433 -p NN -R 1 -R 9 -R 36 -R 40` | Typical usage: Enable device decoders for desired devices. Correct rtl-sdr tuning error (ppm offset).
 | `rtl_433 -a` | Will run in analyze mode and you will get a text description of the received signal.
 | `rtl_433 -A` | Enable pulse analyzer. Summarizes the timings of pulses, gaps, and periods. Can be used in either the normal decode mode, or analyze mode.
-| `rtl_433 -a -t` | Will run in analyze mode and save a test file per detected signal (gfile###.data). Format is uint8, 2 channels.
+| `rtl_433 -a -t` | Will run in analyze mode and save a test file per detected signal (`g###_###M_###k.cu8`). Format is uint8, 2 channels.
 | `rtl_433 -r file_name` | Play back a saved data file.
 | `rtl_433 file_name` | Will save everything received from the rtl-sdr during the session into a single file. The saves file may become quite large depending on how long rtl_433 is left running. Note: saving signals into individual files wint `rtl_433 -a -t` is preferred.
 | `rtl_433 -F json -U \| mosquitto_pub -t home/rtl_433 -l` | Will pipe the output to network as JSON formatted MQTT messages. A test MQTT client can be found in `tests/mqtt_rtl_433_test.py`.
@@ -215,10 +215,10 @@ Note: Not all device protocol decoders are enabled by default. When testing to s
 is decoded by rtl_433, use `-G` to enable all device protocols.
 
 The first step in decoding new devices is to record the signals using `-a -t`. The signals will be
-stored individually in files named gfileNNN.data that can be played back with `rtl_433 -r gfileNNN.data`.
+stored individually in files named gNNN_FFFM_RRRk.cu8 that can be played back with `rtl_433 -r gNNN_FFFM_RRRk.cu8`.
 
 These files are vital for understanding the signal format as well as the message data.  Use both analyzers
-`-a` and `-A` to look at the recorded signal and determine the pulse characteristics, e.g. `rtl_433 -r gfileNNN.data -a -A`.
+`-a` and `-A` to look at the recorded signal and determine the pulse characteristics, e.g. `rtl_433 -r gNNN_FFFM_RRRk.cu8 -a -A`.
 
 Make sure you have recorded a proper set of test signals representing different conditions together
 with any and all information about the values that the signal should represent. For example, make a

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -34,6 +34,7 @@
 static int do_exit = 0;
 static int do_exit_async = 0, frequencies = 0;
 uint32_t frequency[MAX_PROTOCOLS];
+uint32_t center_frequency = 0;
 time_t rawtime_old;
 int duration = 0;
 time_t stop_time;
@@ -542,7 +543,7 @@ static void pwm_analyze(struct dm_state *demod, int16_t *buf, uint32_t len) {
                     FILE *sgfp;
 
             while (1) {
-            sprintf(sgf_name, "gfile%03d.data", demod->signal_grabber);
+            sprintf(sgf_name, "g%03d_%gM_%gk.cu8", demod->signal_grabber, frequency[0]/1000000.0, samp_rate/1000.0);
             demod->signal_grabber++;
             if (access(sgf_name, F_OK) == -1 || overwrite_mode) {
                 break;
@@ -1345,7 +1346,8 @@ int main(int argc, char **argv) {
     }
         while (!do_exit) {
             /* Set the frequency */
-            r = rtlsdr_set_center_freq(dev, frequency[frequency_current]);
+            center_frequency = frequency[frequency_current];
+            r = rtlsdr_set_center_freq(dev, center_frequency);
             if (r < 0)
                 fprintf(stderr, "WARNING: Failed to set center freq.\n");
             else


### PR DESCRIPTION
This changes the grab file name from "gfile001.data" to a recognizable pattern like "g001_433.92M_1024k.cu8":
- "g001" grab no. 1
- "433.92M" base freq. always suffixed with "M", should work well for the whole range of e.g. 0.1M to 2400M. (maybe "MHz" so other SI-prefixes could be used?)
- "1024k" sample rate. always suffixed with "k", should work well for the whole range of e.g. 50k to 3200k. (maybe "ks" (kilosamples) so other SI-prefixes could be used?)
- "cu8" universallay agreed to signify complex-unsigned-8

Did I miss something? Any other ideas? Comments very welcome!

(rtl-sdr samplerates are 250k, 1000k, 1024k, 1536k, 1792k, 1920k, 2048k, 2160k, 2560k, 2880k, 3200k -- and look all nice and recognizable, I don't know about other hardware though.)