### PR TITLE
Clean up WIN32 include/ifdef

### DIFF
--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -13,17 +13,18 @@
 #include "bitbuffer.h"
 #include "data.h"
 
-#ifndef _WIN32
-#include <unistd.h>
-#else
+#ifdef _WIN32
 #include <windows.h>
 #include <io.h>
 #include <fcntl.h>
-#ifndef __MINGW32__
+#ifdef _MSC_VER
 #include "getopt/getopt.h"
-#else
-#include <getopt.h>
+#define F_OK 0
 #endif
+#endif
+#ifndef _MSC_VER
+#include <unistd.h>
+#include <getopt.h>
 #endif
 
 #define DEFAULT_SAMPLE_RATE     250000

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1032,9 +1032,13 @@ int main(int argc, char **argv) {
                 }
                 break;
             case 'U':
-#if !defined(__MINGW32__)
+#ifdef _WIN32
+                putenv("TZ=UTC+0");
+                _tzset();
+#else
                 utc_mode = setenv("TZ", "UTC", 1);
-                if(utc_mode != 0) fprintf(stderr, "Unable to set TZ to UTC; error code: %d\n", utc_mode);
+                if(utc_mode != 0)
+                    fprintf(stderr, "Unable to set TZ to UTC; error code: %d\n", utc_mode);
 #endif
                 break;
             case 'W':


### PR DESCRIPTION
By @gvanem in #641
use _WIN32 to address both MinGW and MSVC.
Cleaned up WIN32 includes in rtl_433.h.
MinGW's <unistd.h> includes <getopt.h>.