### PR TITLE
Fix unit conversions for Acurite 5n1

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -1,6 +1,6 @@
 /**
  * Various utility functions for use by device drivers
- * 
+ *
  * Copyright (C) 2015 Tommy Vestermark
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -119,5 +119,29 @@ float kmph2mph(float kph);
 /// @return speed in kilometers per hour
 float mph2kmph(float kph);
 
+
+/// Convert millimeters (mm) to inches (inch)
+///
+/// @param mm: measurement in millimeters
+/// @return measurement in inches
+float mm2inch(float mm);
+
+/// Convert inches (inch) to millimeters (mm)
+///
+/// @param inch: measurement in inches
+/// @return measurement in millimeters
+float inch2mm(float inch);
+
+
+
+
+/// Replace a pattern in a string. This utility function is
+/// useful when converting native units to si or customary.
+///
+/// @param orig: string to search for patterns
+/// @param rep: the pattern to replace
+/// @param with: the replacement pattern
+/// @return a new string that has rep replaced with with
+char *str_replace(char *orig, char *rep, char *with);
 
 #endif /* INCLUDE_UTIL_H_ */

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -459,7 +459,7 @@ static int acurite_6045_decode (bitrow_t bb, int browlen) {
 static int acurite_txr_callback(bitbuffer_t *bitbuf) {
     int browlen, valid = 0;
     uint8_t *bb;
-    float tempc, tempf, wind_dird, rainfall = 0.0, wind_speed, wind_speedmph;
+    float tempc, tempf, wind_dird, rainfall = 0.0, wind_speed_kph, wind_speed_mph;
     uint8_t humidity, sensor_status, sequence_num, message_type;
     char channel, *wind_dirstr = "";
     char channel_str[2];
@@ -557,8 +557,8 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf) {
 
 	    if (message_type == ACURITE_MSGTYPE_WINDSPEED_WINDDIR_RAINFALL) {
             // Wind speed, wind direction, and rain fall
-            wind_speed = acurite_getWindSpeed_kph(bb[3], bb[4]);
-            wind_speedmph = kmph2mph(wind_speed);
+            wind_speed_kph = acurite_getWindSpeed_kph(bb[3], bb[4]);
+            wind_speed_mph = kmph2mph(wind_speed_kph);
             wind_dird = acurite_5n1_winddirections[bb[4] & 0x0f];
             wind_dirstr = acurite_5n1_winddirection_str[bb[4] & 0x0f];
             raincounter = acurite_getRainfallCounter(bb[5], bb[6]);
@@ -587,10 +587,10 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf) {
                 "sequence_num",  NULL,   DATA_INT,      sequence_num,
                 "battery",      NULL,   DATA_STRING,    battery_low ? "OK" : "LOW",
                 "message_type", NULL,   DATA_INT,       message_type,
-                "wind_speed",   NULL,   DATA_FORMAT,    "%.1f mph", DATA_DOUBLE,     wind_speedmph,
+                "wind_speed_mph",   "wind_speed",   DATA_FORMAT,    "%.1f mph", DATA_DOUBLE,     wind_speed_mph,
                 "wind_dir_deg", NULL,   DATA_FORMAT,    "%.1f", DATA_DOUBLE,    wind_dird,
                 "wind_dir",     NULL,   DATA_STRING,    wind_dirstr,
-                "rainfall_accumulation",     NULL,   DATA_FORMAT,    "%.2f in", DATA_DOUBLE,    rainfall,
+                "rainfall_accumulation_inch", "rainfall_accumulation",   DATA_FORMAT,    "%.2f in", DATA_DOUBLE,    rainfall,
                 "raincounter_raw",  NULL,   DATA_INT,   raincounter,
                 NULL);
 
@@ -598,8 +598,8 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf) {
 
 	    } else if (message_type == ACURITE_MSGTYPE_WINDSPEED_TEMP_HUMIDITY) {
             // Wind speed, temperature and humidity
-            wind_speed = acurite_getWindSpeed_kph(bb[3], bb[4]);
-            wind_speedmph = kmph2mph(wind_speed);
+            wind_speed_kph = acurite_getWindSpeed_kph(bb[3], bb[4]);
+            wind_speed_mph = kmph2mph(wind_speed_kph);
             tempf = acurite_getTemp(bb[4], bb[5]);
             tempc = fahrenheit2celsius(tempf);
             humidity = acurite_getHumidity(bb[6]);
@@ -612,7 +612,7 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf) {
                 "sequence_num",  NULL,   DATA_INT,      sequence_num,
                 "battery",      NULL,   DATA_STRING,    battery_low ? "OK" : "LOW",
                 "message_type", NULL,   DATA_INT,       message_type,
-                "wind_speed",   NULL,   DATA_FORMAT,    "%.1f mph", DATA_DOUBLE,     wind_speedmph,
+                "wind_speed_mph",   "wind_speed",   DATA_FORMAT,    "%.1f mph", DATA_DOUBLE,     wind_speed_mph,
                 "temperature_F", 	"temperature",	DATA_FORMAT,    "%.1f F", DATA_DOUBLE,    tempf,
                 "humidity",     NULL,	DATA_FORMAT,    "%d",   DATA_INT,   humidity,
                 NULL);

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -246,6 +246,27 @@ void data_acquired_handler(data_t *data)
                         *pos = 'C';
                     }
             }
+            // Convert any fields ending in _mph to _kph
+            else if ((d->type == DATA_DOUBLE) && (strstr(d->key, "_mph") != NULL)) {
+                   *(double*)d->value = mph2kmph(*(double*)d->value);
+                   char *new_label = str_replace(d->key, "_mph", "_kph");
+                   free(d->key);
+                   d->key = new_label;
+                   char *new_format_label = str_replace(d->format, "mph", "kph");
+                   free(d->format);
+                   d->format = new_format_label;
+            }
+
+            // Convert any fields ending in _mph to _kph
+            else if ((d->type == DATA_DOUBLE) && (strstr(d->key, "_inch") != NULL)) {
+                   *(double*)d->value = inch2mm(*(double*)d->value);
+                   char *new_label = str_replace(d->key, "_inch", "_mm");
+                   free(d->key);
+                   d->key = new_label;
+                   char *new_format_label = str_replace(d->format, "inch", "mm");
+                   free(d->format);
+                   d->format = new_format_label;
+            }
         }
     }
     if (conversion_mode == CONVERT_CUSTOMARY) {
@@ -260,6 +281,27 @@ void data_acquired_handler(data_t *data)
                         (pos = strrchr(d->format, 'C'))) {
                         *pos = 'F';
                     }
+            }
+            // Convert any fields ending in _kph to _mph
+            else if ((d->type == DATA_DOUBLE) && (strstr(d->key, "_kph") != NULL)) {
+                   *(double*)d->value = kmph2mph(*(double*)d->value);
+                   char *new_label = str_replace(d->key, "_kph", "_mph");
+                   free(d->key);
+                   d->key = new_label;
+                   char *new_format_label = str_replace(d->format, "kph", "mph");
+                   free(d->format);
+                   d->format = new_format_label;
+            }
+
+            // Convert any fields ending in _mm to _inch
+            else if ((d->type == DATA_DOUBLE) && (strstr(d->key, "_mm") != NULL)) {
+                   *(double*)d->value = mm2inch(*(double*)d->value);
+                   char *new_label = str_replace(d->key, "_mm", "_inch");
+                   free(d->key);
+                   d->key = new_label;
+                   char *new_format_label = str_replace(d->format, "mm", "inch");
+                   free(d->format);
+                   d->format = new_format_label;
             }
         }
     }

--- a/src/util.c
+++ b/src/util.c
@@ -9,7 +9,9 @@
  */
 
 #include "util.h"
+#include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 
 uint8_t reverse8(uint8_t x) {
     x = (x & 0xF0) >> 4 | (x & 0x0F) << 4;
@@ -167,6 +169,66 @@ float kmph2mph(float kmph)
 float mph2kmph(float mph)
 {
     return mph * 1.609344;
+}
+
+
+float mm2inch(float mm) {
+    return mm * 0.039370;
+}
+
+float inch2mm(float inch) {
+    return inch / 0.039370;
+}
+
+
+// Original string replacement function was found here:
+// https://stackoverflow.com/questions/779875/what-is-the-function-to-replace-string-in-c/779960#779960
+//
+// You must free the result if result is non-NULL.
+char *str_replace(char *orig, char *rep, char *with) {
+    char *result;  // the return string
+    char *ins;     // the next insert point
+    char *tmp;     // varies
+    int len_rep;   // length of rep (the string to remove)
+    int len_with;  // length of with (the string to replace rep with)
+    int len_front; // distance between rep and end of last rep
+    int count;     // number of replacements
+
+    // sanity checks and initialization
+    if (!orig || !rep)
+        return NULL;
+    len_rep = strlen(rep);
+    if (len_rep == 0)
+        return NULL; // empty rep causes infinite loop during count
+    if (!with)
+        with = "";
+    len_with = strlen(with);
+
+    // count the number of replacements needed
+    ins = orig;
+    for (count = 0; (tmp = strstr(ins, rep)); ++count) {
+        ins = tmp + len_rep;
+    }
+
+    tmp = result = malloc(strlen(orig) + (len_with - len_rep) * count + 1);
+
+    if (!result)
+        return NULL;
+
+    // first time through the loop, all the variables are set correctly
+    // from here on,
+    //    tmp points to the end of the result string
+    //    ins points to the next occurrence of rep in orig
+    //    orig points to the remainder of orig after "end of rep"
+    while (count--) {
+        ins = strstr(orig, rep);
+        len_front = ins - orig;
+        tmp = strncpy(tmp, orig, len_front) + len_front;
+        tmp = strcpy(tmp, with) + len_with;
+        orig += len_front + len_rep; // move to next "end of rep"
+    }
+    strcpy(tmp, orig);
+    return result;
 }
 
 


### PR DESCRIPTION
I recently purchased an Acurite 5n1 device and was using rtl_433 to decode the transmitted signal. I wanted units reported in metric (e.g. SI style) units. When I used the ``-C si`` command line argument I observed that only the temperature field was being modifed to metric leaving some other fields reporting in imperial (e.g. the wind speed reading in miles per hour and rain accumulation in inches). This was unexpected and annoying, so I have tried to improve rtl_433 a little to fix this problem.

The fixes in this merge request may partially address the problem decribed in #471.

These changes solve the problem I had with rtl_433.

Change description:

- In ``util.c`` and ``util.h`` add:
  - additional converter functions for inch2mm and mm2inch.
  - A string pattern replacement function (found at StackOverflow) to support field
    name modification. This function is called by the ``data_aquired_handler`` in
    ``rtl_433.c`` when performing unit conversions.
  
- In ``rtl_433.c`` update the ``data_aquired_handler`` function performing unit
  conversion to support additional conversions (mph to kph, kph to mph, inch to
  mm and mm to inch).
  No doubt other conversion routines may be useful here in future but the code as is 
  solves the problem highlighted in this issue. The updates may improve the existing
  conversion support capabilities (if fields are named appropriately) and act as
  an example for others wanting to add more in the future as required.
  
- In ``acurite.c`` modify the 5n1 message parsing function in ``acurite.c`` to adopt
  data field names that can be used within the units conversion function to swap
  fields between customary and metric (i.e. si) units.
  - Use the pretty key data field to retain the existing output labels.