### PR TITLE
Adds x10_sec device for decoding X10 Security RF signals

### DIFF
--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -43,7 +43,7 @@
 
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           98
+#define MAX_PROTOCOLS           99
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -101,7 +101,8 @@
 		DECL(schrader_EG53MA4) \
 		DECL(nexa) \
 		DECL(thermopro_tp12) \
-		DECL(ge_coloreffects)
+		DECL(ge_coloreffects) \
+		DECL(x10_sec)
 
 typedef struct {
 	char name[256];

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,6 +111,7 @@ add_executable(rtl_433
 	devices/philips.c
 	devices/nexa.c
 	devices/thermopro_tp12.c
+	devices/x10_sec.c
 )
 
 add_library(data data.c)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -95,6 +95,7 @@ rtl_433_SOURCES      = baseband.c \
                        devices/fordremote.c \
                        devices/philips.c \
                        devices/nexa.c \
-                       devices/thermopro_tp12.c
+                       devices/thermopro_tp12.c \
+                       devices/x10_sec.c
 
 rtl_433_LDADD        = $(LIBRTLSDR) $(LIBM)

--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -26,99 +26,99 @@
 #include "util.h"
 
 static int x10_sec_callback(bitbuffer_t *bitbuffer) {
-	bitrow_t *bb = bitbuffer->bb;
-	data_t *data;
-    uint16_t r;							/* a row index				*/
-    uint8_t *b;							/* bits of a row			*/
-	uint8_t test_a;						/* test 1/2 for message		*/
-	uint8_t test_b;						/* test 2/2 for message		*/
-	char *event_str = "UNKNOWN";		/* human-readable event		*/
-	char x10_id_str[5] = "\0";			/* string showing hex value	*/
-	char x10_code_str[5] = "\0";		/* string showing hex value	*/
-	char time_str[LOCAL_TIME_BUFLEN];
+    bitrow_t *bb = bitbuffer->bb;
+    data_t *data;
+    uint16_t r;                            /* a row index                */
+    uint8_t *b;                            /* bits of a row            */
+    uint8_t test_a;                        /* test 1/2 for message        */
+    uint8_t test_b;                        /* test 2/2 for message        */
+    char *event_str = "UNKNOWN";        /* human-readable event        */
+    char x10_id_str[5] = "\0";            /* string showing hex value    */
+    char x10_code_str[5] = "\0";        /* string showing hex value    */
+    char time_str[LOCAL_TIME_BUFLEN];
 
-    for ( r=0; r<bitbuffer->num_rows; ++r) {
+    for (r=0; r < bitbuffer->num_rows; ++r) {
         b = bitbuffer->bb[r];
 
-		/* looking for five bytes */
+        /* looking for five bytes */
         if (bitbuffer->bits_per_row[r] < 40) {
-			continue;
-		}
+            continue;
+        }
 
-		/* validate what we received ...
-		 * used intermediate variables test_a and test_b to suppress
-		 * warnings generated when compiling using:
-		 *
-		 *   if((b[0]^0x0f)==b[1] && (b[2]^0xff)==b[3])
-		 */
-		test_a = b[0]^0x0f;
-		test_b = b[2]^0xff;
-		if (test_a != b[1] || test_b != b[3]) {
-			continue;
-		} else {
-			/* set event_str based on code received */
-	        switch(b[2]) {
-				case 0x04:
-					event_str = "DS10A DOOR/WINDOW OPEN";
-					break;
-				case 0x06:
-					event_str = "KR10A KEY-FOB ARM";
-					break;
-				case 0x0c:
-					event_str = "MS10A MOTION TRIPPED";
-					break;
-				case 0x46:
-					event_str = "KR10A KEY-FOB LIGHTS-ON";
-					break;
-				case 0x82:
-					event_str = "SH624 SEC-REMOTE DISARM";
-					break;
-				case 0x84:
-					event_str = "DS10A DOOR/WINDOW CLOSED";
-					break;
-				case 0x86:
-					event_str = "KR10A KEY-FOB DISARM";
-					break;
-				case 0x88:
-					event_str = "KR15A PANIC";
-					break;
-				case 0x8c:
-					event_str = "MS10A MOTION READY";
-					break;
-				case 0x98:
-					event_str = "KR15A PANIC-3SECOND";
-					break;
-				case 0xc6:
-					event_str = "KR10A KEY-FOB LIGHTS-OFF";
-					break;
-			}
+        /* validate what we received ...
+         * used intermediate variables test_a and test_b to suppress
+         * warnings generated when compiling using:
+         *
+         *   if((b[0]^0x0f)==b[1] && (b[2]^0xff)==b[3])
+         */
+        test_a = b[0] ^ 0x0f;
+        test_b = b[2] ^ 0xff;
+        if (test_a != b[1] || test_b != b[3]) {
+            continue;
+        } else {
+            /* set event_str based on code received */
+            switch(b[2]) {
+                case 0x04:
+                    event_str = "DS10A DOOR/WINDOW OPEN";
+                    break;
+                case 0x06:
+                    event_str = "KR10A KEY-FOB ARM";
+                    break;
+                case 0x0c:
+                    event_str = "MS10A MOTION TRIPPED";
+                    break;
+                case 0x46:
+                    event_str = "KR10A KEY-FOB LIGHTS-ON";
+                    break;
+                case 0x82:
+                    event_str = "SH624 SEC-REMOTE DISARM";
+                    break;
+                case 0x84:
+                    event_str = "DS10A DOOR/WINDOW CLOSED";
+                    break;
+                case 0x86:
+                    event_str = "KR10A KEY-FOB DISARM";
+                    break;
+                case 0x88:
+                    event_str = "KR15A PANIC";
+                    break;
+                case 0x8c:
+                    event_str = "MS10A MOTION READY";
+                    break;
+                case 0x98:
+                    event_str = "KR15A PANIC-3SECOND";
+                    break;
+                case 0xc6:
+                    event_str = "KR10A KEY-FOB LIGHTS-OFF";
+                    break;
+            }
 
-			/* get x10_id_str, x10_code_str, and time_str ready for output */
-			sprintf(x10_id_str,"%02x%02x",b[0],b[4]);
-			sprintf(x10_code_str,"%02x",b[2]);
-			local_time_str(0, time_str);
+            /* get x10_id_str, x10_code_str, and time_str ready for output */
+            sprintf(x10_id_str, "%02x%02x", b[0], b[4]);
+            sprintf(x10_code_str, "%02x", b[2]);
+            local_time_str(0, time_str);
 
-			/* debug output */
-			if (debug_output) {
-				fprintf(stderr, "%20s  X10SEC: id = %02x%02x code=%02x event_str=%s\n", time_str, b[0], b[4], b[2], event_str);
-				bitbuffer_print(bitbuffer);
-			}
+            /* debug output */
+            if (debug_output) {
+                fprintf(stderr, "%20s  X10SEC: id = %02x%02x code=%02x event_str=%s\n", time_str, b[0], b[4], b[2], event_str);
+                bitbuffer_print(bitbuffer);
+            }
 
-			/* build and handle data set for normal output */
-			data = data_make(
-				 "time",	"",				DATA_STRING, time_str,
-				 "model",	"",				DATA_STRING, "X10 Security",
-				 "id",		"Device ID",	DATA_STRING, x10_id_str,
-				 "code",	"Code",			DATA_STRING, x10_code_str,
-				 "event",	"Event",		DATA_STRING, event_str,
-				 NULL
-			);
-			data_acquired_handler(data);
+            /* build and handle data set for normal output */
+            data = data_make(
+                    "time",     "",             DATA_STRING, time_str,
+                    "model",    "",             DATA_STRING, "X10 Security",
+                    "id",       "Device ID",    DATA_STRING, x10_id_str,
+                    "code",     "Code",         DATA_STRING, x10_code_str,
+                    "event",    "Event",        DATA_STRING, event_str,
+                    NULL
+                    );
+            data_acquired_handler(data);
 
-			return 1;
-		}
+            return 1;
+        }
     }
-	return 0;
+    return 0;
 }
 
 static char *output_fields[] = {
@@ -132,13 +132,15 @@ static char *output_fields[] = {
 
 /* r_device definition */
 r_device x10_sec = {
-	.name			= "X10 Security",
-	.modulation		= OOK_PULSE_PPM_RAW,	/* new equivalent to OOK_PWM_D */
-	.short_limit	= 1100,
-	.long_limit		= 2200,
-	.reset_limit	= 10000,
-	.json_callback	= &x10_sec_callback,
-	.disabled		= 1,
-	.demod_arg		= 0,
+    .name           = "X10 Security",
+    .modulation     = OOK_PULSE_PPM_RAW,    /* new equivalent to OOK_PWM_D */
+    .short_limit    = 1100,
+    .long_limit     = 2200,
+    .reset_limit    = 10000,
+    .json_callback  = &x10_sec_callback,
+    .disabled       = 1,
+    .demod_arg      = 0,
     .fields         = output_fields
 };
+
+// vim: ts=4 sts=4 sw=4 et

--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -45,15 +45,8 @@ static int x10_sec_callback(bitbuffer_t *bitbuffer) {
             continue;
         }
 
-        /* validate what we received ...
-         * used intermediate variables test_a and test_b to suppress
-         * warnings generated when compiling using:
-         *
-         *   if((b[0]^0x0f)==b[1] && (b[2]^0xff)==b[3])
-         */
-        test_a = b[0] ^ 0x0f;
-        test_b = b[2] ^ 0xff;
-        if (test_a != b[1] || test_b != b[3]) continue;
+        /* validate what we received */
+        if ((b[0] ^ b[1]) != 0x0f || (b[2] ^ b[3]) != 0xff) continue;
 
         /* set event_str based on code received */
         switch(b[2]) {

--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -30,8 +30,6 @@ static int x10_sec_callback(bitbuffer_t *bitbuffer) {
     data_t *data;
     uint16_t r;                          /* a row index              */
     uint8_t *b;                          /* bits of a row            */
-    uint8_t test_a;                      /* test 1/2 for message     */
-    uint8_t test_b;                      /* test 2/2 for message     */
     char *event_str = "UNKNOWN";         /* human-readable event     */
     char x10_id_str[5] = "\0";           /* string showing hex value */
     char x10_code_str[5] = "\0";         /* string showing hex value */

--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -26,7 +26,6 @@
 #include "util.h"
 
 static int x10_sec_callback(bitbuffer_t *bitbuffer) {
-    bitrow_t *bb = bitbuffer->bb;
     data_t *data;
     uint16_t r;                          /* a row index              */
     uint8_t *b;                          /* bits of a row            */

--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -53,70 +53,67 @@ static int x10_sec_callback(bitbuffer_t *bitbuffer) {
          */
         test_a = b[0] ^ 0x0f;
         test_b = b[2] ^ 0xff;
-        if (test_a != b[1] || test_b != b[3]) {
-            continue;
-        } else {
-            /* set event_str based on code received */
-            switch(b[2]) {
-                case 0x04:
-                    event_str = "DS10A DOOR/WINDOW OPEN";
-                    break;
-                case 0x06:
-                    event_str = "KR10A KEY-FOB ARM";
-                    break;
-                case 0x0c:
-                    event_str = "MS10A MOTION TRIPPED";
-                    break;
-                case 0x46:
-                    event_str = "KR10A KEY-FOB LIGHTS-ON";
-                    break;
-                case 0x82:
-                    event_str = "SH624 SEC-REMOTE DISARM";
-                    break;
-                case 0x84:
-                    event_str = "DS10A DOOR/WINDOW CLOSED";
-                    break;
-                case 0x86:
-                    event_str = "KR10A KEY-FOB DISARM";
-                    break;
-                case 0x88:
-                    event_str = "KR15A PANIC";
-                    break;
-                case 0x8c:
-                    event_str = "MS10A MOTION READY";
-                    break;
-                case 0x98:
-                    event_str = "KR15A PANIC-3SECOND";
-                    break;
-                case 0xc6:
-                    event_str = "KR10A KEY-FOB LIGHTS-OFF";
-                    break;
-            }
+        if (test_a != b[1] || test_b != b[3]) continue;
 
-            /* get x10_id_str, x10_code_str, and time_str ready for output */
-            sprintf(x10_id_str, "%02x%02x", b[0], b[4]);
-            sprintf(x10_code_str, "%02x", b[2]);
-            local_time_str(0, time_str);
-
-            /* debug output */
-            if (debug_output) {
-                fprintf(stderr, "%20s  X10SEC: id = %02x%02x code=%02x event_str=%s\n", time_str, b[0], b[4], b[2], event_str);
-                bitbuffer_print(bitbuffer);
-            }
-
-            /* build and handle data set for normal output */
-            data = data_make(
-                    "time",     "",             DATA_STRING, time_str,
-                    "model",    "",             DATA_STRING, "X10 Security",
-                    "id",       "Device ID",    DATA_STRING, x10_id_str,
-                    "code",     "Code",         DATA_STRING, x10_code_str,
-                    "event",    "Event",        DATA_STRING, event_str,
-                    NULL
-                    );
-            data_acquired_handler(data);
-
-            return 1;
+        /* set event_str based on code received */
+        switch(b[2]) {
+            case 0x04:
+                event_str = "DS10A DOOR/WINDOW OPEN";
+                break;
+            case 0x06:
+                event_str = "KR10A KEY-FOB ARM";
+                break;
+            case 0x0c:
+                event_str = "MS10A MOTION TRIPPED";
+                break;
+            case 0x46:
+                event_str = "KR10A KEY-FOB LIGHTS-ON";
+                break;
+            case 0x82:
+                event_str = "SH624 SEC-REMOTE DISARM";
+                break;
+            case 0x84:
+                event_str = "DS10A DOOR/WINDOW CLOSED";
+                break;
+            case 0x86:
+                event_str = "KR10A KEY-FOB DISARM";
+                break;
+            case 0x88:
+                event_str = "KR15A PANIC";
+                break;
+            case 0x8c:
+                event_str = "MS10A MOTION READY";
+                break;
+            case 0x98:
+                event_str = "KR15A PANIC-3SECOND";
+                break;
+            case 0xc6:
+                event_str = "KR10A KEY-FOB LIGHTS-OFF";
+                break;
         }
+
+        /* get x10_id_str, x10_code_str, and time_str ready for output */
+        sprintf(x10_id_str, "%02x%02x", b[0], b[4]);
+        sprintf(x10_code_str, "%02x", b[2]);
+        local_time_str(0, time_str);
+
+        /* debug output */
+        if (debug_output) {
+            fprintf(stderr, "%20s  X10SEC: id = %02x%02x code=%02x event_str=%s\n", time_str, b[0], b[4], b[2], event_str);
+            bitbuffer_print(bitbuffer);
+        }
+
+        /* build and handle data set for normal output */
+        data = data_make(
+                "time",     "",             DATA_STRING, time_str,
+                "model",    "",             DATA_STRING, "X10 Security",
+                "id",       "Device ID",    DATA_STRING, x10_id_str,
+                "code",     "Code",         DATA_STRING, x10_code_str,
+                "event",    "Event",        DATA_STRING, event_str,
+                NULL
+                );
+        data_acquired_handler(data);
+        return 1;
     }
     return 0;
 }

--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -28,13 +28,13 @@
 static int x10_sec_callback(bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
     data_t *data;
-    uint16_t r;                            /* a row index                */
-    uint8_t *b;                            /* bits of a row            */
-    uint8_t test_a;                        /* test 1/2 for message        */
-    uint8_t test_b;                        /* test 2/2 for message        */
-    char *event_str = "UNKNOWN";        /* human-readable event        */
-    char x10_id_str[5] = "\0";            /* string showing hex value    */
-    char x10_code_str[5] = "\0";        /* string showing hex value    */
+    uint16_t r;                          /* a row index              */
+    uint8_t *b;                          /* bits of a row            */
+    uint8_t test_a;                      /* test 1/2 for message     */
+    uint8_t test_b;                      /* test 2/2 for message     */
+    char *event_str = "UNKNOWN";         /* human-readable event     */
+    char x10_id_str[5] = "\0";           /* string showing hex value */
+    char x10_code_str[5] = "\0";         /* string showing hex value */
     char time_str[LOCAL_TIME_BUFLEN];
 
     for (r=0; r < bitbuffer->num_rows; ++r) {

--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -1,0 +1,137 @@
+/*
+ * X10 Security sensor decoding for rtl_433
+ *
+ * Based on code provided by Willi 'wherzig' in issue #30 (2014-04-21)
+ * https://github.com/merbanan/rtl_433/issues/30
+ * Danke, Willi
+ *
+ * Tested with American sensors operating at 310 MHz
+ * e.g., rtl_433 -f 310.558M
+ *
+ * This is pretty rudimentary, and I bet the byte value decoding, based
+ * on limited observations, doesn't take into account bits that might
+ * be set to indicate something like a low battery condition.
+ *
+ * Copyright (C) 2018 Anthony Kava
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ */
+
+#include "rtl_433.h"
+#include "data.h"
+#include "util.h"
+
+static int x10_sec_callback(bitbuffer_t *bitbuffer)
+{
+	bitrow_t *bb = bitbuffer->bb;		
+	data_t *data;
+
+	char *remarks_str="UNKNOWN";		/* human-readable remarks */
+	char time_str[LOCAL_TIME_BUFLEN];
+	char x10_id_str[5]="\0";			/* string showing hex value */
+	char x10_code_str[5]="\0";			/* string showing hex value */
+
+	/* validate what we received ...
+	 * used intermediate variables test_a and test_b to suppress
+	 * warnings generated when compiling using:
+	 *
+	 *   if((bb[1][0]^0x0f)==bb[1][1] && (bb[1][2]^0xff)==bb[1][3])
+	 */
+	uint8_t test_a=bb[1][0]^0x0f;
+	uint8_t test_b=bb[1][2]^0xff;
+	if(test_a==bb[1][1] && test_b==bb[1][3])
+	{
+		/* set remarks based on code received */
+        switch(bb[1][2])
+		{
+			case 0x04:
+				remarks_str="DS10A DOOR/WINDOW OPEN";
+                break;
+			case 0x06:
+				remarks_str="KR10A KEY-FOB ARM";
+                break;
+			case 0x0c:
+				remarks_str="MS10A MOTION TRIPPED";
+                break;
+			case 0x46:
+				remarks_str="KR10A KEY-FOB LIGHTS-ON";
+                break;
+			case 0x82:
+				remarks_str="SH624 SEC-REMOTE DISARM";
+                break;
+            case 0x84:
+                remarks_str="DS10A DOOR/WINDOW CLOSED";
+                break;
+			case 0x86:
+				remarks_str="KR10A KEY-FOB DISARM";
+                break;
+			case 0x88:
+				remarks_str="KR15A PANIC";
+                break;
+			case 0x8c:
+				remarks_str="MS10A MOTION READY";
+                break;
+			case 0x98:
+				remarks_str="KR15A PANIC-3SECOND";
+                break;
+			case 0xc6:
+				remarks_str="KR10A KEY-FOB LIGHTS-OFF";
+                break;
+		}
+
+		/* get x10_id_str, x10_code_str, and time_str ready for output */
+		sprintf(x10_id_str,"%02x%02x",bb[1][0],bb[1][4]);
+		sprintf(x10_code_str,"%02x",bb[1][2]);
+		local_time_str(0, time_str);
+
+		/* debug output */
+		if(debug_output)
+		{
+			fprintf(stderr, "%20s  X10SEC: id = %02x%02x code=%02x remarks_str=%s\n",time_str,bb[1][0],bb[1][4],bb[1][2],remarks_str);
+			bitbuffer_print(bitbuffer);
+		}
+
+		/* build and handle data set for normal output */
+		data=data_make
+		(
+			"time",		"",				DATA_STRING, time_str,
+			"model",	"",				DATA_STRING, "X10 Security",
+			"id",		"Device ID",	DATA_STRING, x10_id_str,
+			"code",		"Code",			DATA_STRING, x10_code_str,
+			"remarks",	"Remarks",		DATA_STRING, remarks_str,
+			NULL
+		);
+    	data_acquired_handler(data);
+
+		return 1;
+	}
+	return 0;
+}
+
+static char *output_fields[] =
+{
+    "time",
+    "model",
+    "id",
+    "code",
+    "remarks",
+    NULL
+};
+
+/* r_device definition */
+r_device x10_sec =
+{
+	.name			= "X10 Security",
+	.modulation		= OOK_PULSE_PPM_RAW,	/* new equivalent to OOK_PWM_D */
+	.short_limit	= 1100,
+	.long_limit		= 2200,
+	.reset_limit	= 10000,
+	.json_callback	= &x10_sec_callback,
+	.disabled		= 1,
+	.demod_arg		= 0,
+    .fields         = output_fields
+};

--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -41,9 +41,7 @@ static int x10_sec_callback(bitbuffer_t *bitbuffer) {
         b = bitbuffer->bb[r];
 
         /* looking for five bytes */
-        if (bitbuffer->bits_per_row[r] < 40) {
-            continue;
-        }
+        if (bitbuffer->bits_per_row[r] < 40) continue;
 
         /* validate what we received */
         if ((b[0] ^ b[1]) != 0x0f || (b[2] ^ b[3]) != 0xff) continue;

--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -99,7 +99,7 @@ static int x10_sec_callback(bitbuffer_t *bitbuffer) {
 
         /* debug output */
         if (debug_output) {
-            fprintf(stderr, "%20s  X10SEC: id = %02x%02x code=%02x event_str=%s\n", time_str, b[0], b[4], b[2], event_str);
+            fprintf(stderr, "%20s  X10SEC: id=%02x%02x code=%02x event_str=%s\n", time_str, b[0], b[4], b[2], event_str);
             bitbuffer_print(bitbuffer);
         }
 


### PR DESCRIPTION
Please be kind.  This addresses issue #30 and adapts code provided by the OP.  Adds an x10_sec device that decodes X10 Security signals.  I'm also providing a test to rtl_433_tests.