### PR TITLE
Fix on_connect signature and topic subscriptions in MQTT examples.

### DIFF
--- a/tests/mqtt_rtl_433_test.py
+++ b/tests/mqtt_rtl_433_test.py
@@ -48,14 +48,14 @@ def print_sensor_state():
     sys.stdout.flush()  # Print in real-time
 
 
-def on_connect(client, userdata, rc):
+def on_connect(client, userdata, flags, rc):
     """ Callback for when the client receives a CONNACK response from the server. """
     log.info("MQTT Connection: " + mqtt.connack_string(rc))
     if rc != 0:
         log.error("Could not connect. RC: " + str(rc))
         exit()
     # Subscribing in on_connect() means that if we lose the connection and reconnect then subscriptions will be renewed.
-    client.subscribe(MQTT_TOPIC_PREFIX + "/#")
+    client.subscribe(MQTT_TOPIC_PREFIX)
 
 
 def on_disconnect(client, userdata, rc):


### PR DESCRIPTION
Paho changed the signature of `on_connect` to require 4 arguments as of [v1.3.0](https://github.com/eclipse/paho.mqtt.python/issues/197) (breaking change in Paho, previously it was optional).

Remove the `/#` from the subscription since it wouldn't match the example topic which didn't include anything after rtl_433.