### PR TITLE
README.md: Add another Debian dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Depending on your system, you may also need to install the following libraries.
 
 Debian:
 
-    sudo apt-get install libtool libusb-1.0.0-dev librtlsdr-dev rtl-sdr build-essential autoconf cmake
+    sudo apt-get install libtool libusb-1.0.0-dev librtlsdr-dev rtl-sdr build-essential autoconf cmake pkg-config
 
 Centos/Fedora/RHEL (for Centos/RHEL with enabled EPEL):
 


### PR DESCRIPTION
`autoreconf --install` will create a broken `configure` if pkg-config is not installed.