### PR TITLE
Make intertechno decoder work with ITT-1500 remote

### DIFF
--- a/src/devices/intertechno.c
+++ b/src/devices/intertechno.c
@@ -3,8 +3,7 @@
 static int intertechno_callback(bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
 
-      //if (bb[1][1] == 0 && bb[1][0] != 0 && bb[1][3]==bb[2][3]){
-      if(bb[0][0]==0 && bb[0][0] == 0 && bb[1][0] == 0x56){
+      if(bb[0][0]==0 && (bb[1][0] == 0x56 || bb[1][0] == 0x69)){
         fprintf(stdout, "Switch event:\n");
         fprintf(stdout, "protocol       = Intertechno\n");
         fprintf(stdout, "rid            = %x\n",bb[1][0]);
@@ -28,8 +27,8 @@ static int intertechno_callback(bitbuffer_t *bitbuffer) {
 r_device intertechno = {
     .name           = "Intertechno 433",
     .modulation     = OOK_PULSE_PPM_RAW,
-    .short_limit    = 400,
-    .long_limit     = 1400,
+    .short_limit    = 600,
+    .long_limit     = 1700,
     .reset_limit    = 10000,
     .json_callback  = &intertechno_callback,
     .disabled       = 1,


### PR DESCRIPTION
Extended short_limit and long_limit by 200 and 300 µs. Added 0x69 as a possible 0th message byte. Removed extraneous check bb[0][0] == 0

I've got an intertechno remote labeled ITT-1500 that came with 3x ITR-1500 remote outlets. The set is labeled IT-1500. The remote seems to use the same protocol that the existing callback is expecting, but it is not recognized because of timings and the first byte in each message. The PPM consists of a 220µs high followed by 340µs or 1400µs of gap. This did not fit into the long_limit that was previously 1400, so the message was split at each high bit. My remote id is 69 69 55 59 a9.

```
rtl_433 -p75 -R0 -a
Disabling all device decoders.
Registered 0 out of 100 device decoding protocols
Found 1 device(s)

trying device  0:  Realtek, RTL2838UHIDIR, SN: 00000013
Found Rafael Micro R820T tuner
Using device 0: Generic RTL2832U OEM
Exact sample rate is: 250000.000414 Hz
Sample rate set to 250000.
Bit detection level set to 0 (Auto).
Tuner gain set to Auto.
Reading samples in async mode...
Tuned to 433920000 Hz.
*** signal_start = 224300, signal_end = 347426
signal_len = 123126,  pulses = 330
Iteration 1. t: 57    min: 56 (25)    max: 58 (305)    delta 9
Iteration 2. t: 57    min: 56 (7)    max: 58 (323)    delta 0
Distance coding: Pulse length 57

Short distance: 83, long distance: 361, packet distance: 2693

p_limit: 57
bitbuffer:: Number of rows: 5 
[00] {65} b4 b4 aa ac d4 d5 4b 2a 80 
[01] {65} b4 b4 aa ac d4 d5 4b 2a 80 
[02] {65} b4 b4 aa ac d4 d5 4b 2a 80 
[03] {65} b4 b4 aa ac d4 d5 4b 2a 80 
[04] {65} b4 b4 aa ac d4 d5 4b 2a 80 
*** signal_start = 1051203, signal_end = 1174329
signal_len = 123126,  pulses = 330
Iteration 1. t: 57    min: 56 (36)    max: 58 (294)    delta 10
Iteration 2. t: 56    min: 55 (9)    max: 58 (321)    delta 1
Iteration 3. t: 56    min: 55 (4)    max: 58 (326)    delta 0
Distance coding: Pulse length 56

Short distance: 83, long distance: 361, packet distance: 2693

p_limit: 56
bitbuffer:: Number of rows: 5 
[00] {65} b4 b4 aa ac d4 d5 4a ab 00 
[01] {65} b4 b4 aa ac d4 d5 4a ab 00 
[02] {65} b4 b4 aa ac d4 d5 4a ab 00 
[03] {65} b4 b4 aa ac d4 d5 4a ab 00 
[04] {65} b4 b4 aa ac d4 d5 4a ab 00
```

This is channel 0 on and channel 1 off packets with the most restrictive timings that still work with my remote (220+340 and 220+1410µs):
```
rtl_433 -p75 -R0 -X "intertechno:OOK_PPM_RAW:560:1630:10000"
Disabling all device decoders.
Registering protocol [1] "General purpose decoder 'intertechno'"
Registered 1 out of 100 device decoding protocols
Found 1 device(s)

trying device  0:  Realtek, RTL2838UHIDIR, SN: 00000013
Found Rafael Micro R820T tuner
Using device 0: Generic RTL2832U OEM
Exact sample rate is: 250000.000414 Hz
Sample rate set to 250000.
Bit detection level set to 0 (Auto).
Tuner gain set to Auto.
Reading samples in async mode...
Tuned to 433920000 Hz.
2018-03-04 12:25:54 :   intertechno     :       2       :       2       :       [       :       0       :       ,       :       64      :       69695559a9aa9655]       :       [{0}, {64}69695559a9aa9655]
2018-03-04 12:25:54 :   intertechno     :       2       :       2       :       [       :       0       :       ,       :       64      :       69695559a9aa9655]       :       [{0}, {64}69695559a9aa9655]
2018-03-04 12:25:54 :   intertechno     :       2       :       2       :       [       :       0       :       ,       :       64      :       69695559a9aa9655]       :       [{0}, {64}69695559a9aa9655]
2018-03-04 12:25:55 :   intertechno     :       2       :       2       :       [       :       0       :       ,       :       64      :       69695559a9aa9655]       :       [{0}, {64}69695559a9aa9655]
2018-03-04 12:25:55 :   intertechno     :       2       :       2       :       [       :       0       :       ,       :       64      :       69695559a9aa9655]       :       [{0}, {64}69695559a9aa9655]
2018-03-04 12:25:56 :   intertechno     :       2       :       2       :       [       :       0       :       ,       :       64      :       69695559a9aa9556]       :       [{0}, {64}69695559a9aa9556]
2018-03-04 12:25:56 :   intertechno     :       2       :       2       :       [       :       0       :       ,       :       64      :       69695559a9aa9556]       :       [{0}, {64}69695559a9aa9556]
2018-03-04 12:25:57 :   intertechno     :       2       :       2       :       [       :       0       :       ,       :       64      :       69695559a9aa9556]       :       [{0}, {64}69695559a9aa9556]
2018-03-04 12:25:57 :   intertechno     :       2       :       2       :       [       :       0       :       ,       :       64      :       69695559a9aa9556]       :       [{0}, {64}69695559a9aa9556]
2018-03-04 12:25:57 :   intertechno     :       2       :       2       :       [       :       0       :       ,       :       64      :       69695559a9aa9556]       :       [{0}, {64}69695559a9aa9556]
```

I can provide rtl_433 raw dumps or oscilloscope screencaptures if needed.