### PR TITLE
eusahues' changes to add currentcost counter devices added as per htt…

### DIFF
--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -43,7 +43,7 @@
 
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           101
+#define MAX_PROTOCOLS           102
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -48,6 +48,7 @@
 		DECL(hideki_ts04) \
 		DECL(oil_watchman) \
 		DECL(current_cost) \
+		DECL(current_cost_counter) \
 		DECL(emontx) \
 		DECL(ht680) \
 		DECL(s3318p) \

--- a/src/devices/current_cost.c
+++ b/src/devices/current_cost.c
@@ -3,6 +3,53 @@
 #include "util.h"
 #include "data.h"
 
+static int current_cost_counter_callback(bitbuffer_t *bitbuffer) {
+    bitbuffer_invert(bitbuffer);
+    bitrow_t *bb = bitbuffer->bb;
+    uint8_t *b = bb[0];
+
+    char time_str[LOCAL_TIME_BUFLEN];
+    data_t *data;
+    local_time_str(0, time_str);
+
+    uint8_t init_pattern[] = {
+        0xcc, //8
+        0xcc, //16
+        0xcc, //24
+        0xce, //32
+        0x91, //40
+        0x5d, //45 (! last 3 bits is not init)
+    };
+    unsigned int start_pos = bitbuffer_search(bitbuffer, 0, 0, init_pattern, 45);
+
+    if(start_pos == bitbuffer->bits_per_row[0]){
+        return 0;
+    }
+    start_pos += 45;
+
+    bitbuffer_t packet_bits = {0};
+
+    start_pos = bitbuffer_manchester_decode(bitbuffer, 0, start_pos, &packet_bits, 0);
+
+    uint8_t *packet = packet_bits.bb[0];
+    // Read data
+    if(packet_bits.bits_per_row[0] >= 56 && ((packet[0] & 0xf0) == 64) ){
+        uint16_t device_id = (packet[0] & 0x0f) << 8 | packet[1];
+        uint16_t sensor_type = packet[3]; //Sensor type. Valid values are: 2-Electric, 3-Gas, 4-Water
+        uint32_t c_impulse = packet[4] << 24 | packet[5] <<16 | packet[6] <<8 | packet[7] ;
+
+        data = data_make("time",          "",       DATA_STRING, time_str,
+                "model",         "",              DATA_STRING, "CurrentCost Counter", //TODO: it may have different CC Model ? any ref ?
+                "dev_id",       "Device Id",     DATA_FORMAT, "%d", DATA_INT, device_id,
+                "sensor_type",  "Sensor Id",        DATA_FORMAT, "%d", DATA_INT, sensor_type,
+                "counter",      "Counter",       DATA_FORMAT, "%d", DATA_INT, c_impulse,
+                NULL);
+        data_acquired_handler(data);
+        return 1;
+    }
+    return 0;
+}
+
 static int current_cost_callback(bitbuffer_t *bitbuffer) {
     bitbuffer_invert(bitbuffer);
     bitrow_t *bb = bitbuffer->bb;
@@ -33,12 +80,11 @@ static int current_cost_callback(bitbuffer_t *bitbuffer) {
 
     uint8_t *packet = packet_bits.bb[0];
     // Read data
-    if(packet_bits.bits_per_row[0] >= 56 && ((packet[0] & 0xf0) == 0) ){
-        uint16_t device_id = (packet[0] & 0x0f) << 8 | packet[1];
-
-        uint16_t watt0 = (packet[2] & 0x7F) << 8 | packet[3] ;
-        uint16_t watt1 = (packet[4] & 0x7F) << 8 | packet[5] ;
-        uint16_t watt2 = (packet[6] & 0x7F) << 8 | packet[7] ;
+        if(packet_bits.bits_per_row[0] >= 56 && ((packet[0] & 0xf0) == 0) ){
+            uint16_t device_id = (packet[0] & 0x0f) << 8 | packet[1];
+            uint16_t watt0 = (packet[2] & 0x7F) << 8 | packet[3] ;
+            uint16_t watt1 = (packet[4] & 0x7F) << 8 | packet[5] ;
+            uint16_t watt2 = (packet[6] & 0x7F) << 8 | packet[7] ;
         data = data_make("time",          "",       DATA_STRING, time_str,
                 "model",         "",              DATA_STRING, "CurrentCost TX", //TODO: it may have different CC Model ? any ref ?
                 //"rc",            "Rolling Code",  DATA_INT, rc, //TODO: add rolling code b[1] ? test needed
@@ -64,6 +110,14 @@ static char *output_fields[] = {
     NULL
 };
 
+static char *output_fields_counter[] = {
+    "time",
+    "model",
+    "sensor",
+    "counter",
+    NULL
+};
+
 r_device current_cost = {
     .name           = "CurrentCost Current Sensor",
     .modulation     = FSK_PULSE_PCM,
@@ -73,4 +127,15 @@ r_device current_cost = {
     .json_callback  = &current_cost_callback,
     .disabled       = 0,
     .fields         = output_fields,
+};
+
+r_device current_cost_counter = {
+    .name           = "CurrentCost OptiSmart Impulse Sensor",
+    .modulation     = FSK_PULSE_PCM,
+    .short_limit    = 250,
+    .long_limit     = 250, // NRZ
+    .reset_limit    = 8000,
+    .json_callback  = &current_cost_counter_callback,
+    .disabled       = 0,
+    .fields         = output_fields_counter,
 };


### PR DESCRIPTION
I didn't write this patch, I got it from eusahues (at https://github.com/EusaHues/rtl_433/commit/a4188a36f0a38e8e84ea99117bd51e7c6bc8584b ) and updated it slightly.

It extends the existing currentcost device support, to support "counter" type devices. These are currentcost devices which count pulses from a light, or magnet on a meter, such as the flashing light on an electricity meter or pulse output on a gas meter.

Please would you add it?

