### PR TITLE
Add device: Kerui Door Sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Supported device protocols:
     [99]  X10 Security
     [100]  Interlogix GE UTC Security Devices
     [101]* Dish remote 6.3
+    [102]  Kerui Door Sensor
 
 * Disabled by default, use -R n or -G
 

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -43,7 +43,7 @@
 
 #define MINIMAL_BUF_LENGTH      512
 #define MAXIMAL_BUF_LENGTH      (256 * 16384)
-#define MAX_PROTOCOLS           101
+#define MAX_PROTOCOLS           102
 #define SIGNAL_GRABBER_BUFFER   (12 * DEFAULT_BUF_LENGTH)
 
 /* Supported modulation types */

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -104,7 +104,8 @@
 		DECL(ge_coloreffects) \
 		DECL(x10_sec) \
 		DECL(interlogix) \
-		DECL(dish_remote_6_3)
+		DECL(dish_remote_6_3) \
+    DECL(kerui_door)
 
 typedef struct {
 	char name[256];

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -105,7 +105,7 @@
 		DECL(x10_sec) \
 		DECL(interlogix) \
 		DECL(dish_remote_6_3) \
-    DECL(kerui_door)
+		DECL(kerui_door)
 
 typedef struct {
 	char name[256];

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,6 +114,7 @@ add_executable(rtl_433
 	devices/x10_sec.c
 	devices/interlogix.c
 	devices/dish_remote_6_3.c
+	devices/kerui_door.c
 )
 
 add_library(data data.c)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -99,6 +99,7 @@ rtl_433_SOURCES      = baseband.c \
                        devices/thermopro_tp12.c \
                        devices/x10_sec.c \
                        devices/interlogix.c \
-                       devices/dish_remote_6_3.c
+                       devices/dish_remote_6_3.c \
+                       devices/kerui_door.c
 
 rtl_433_LDADD        = $(LIBRTLSDR) $(LIBM)

--- a/src/devices/kerui_door.c
+++ b/src/devices/kerui_door.c
@@ -1,0 +1,52 @@
+/* Kerui Door/Window sensor
+*
+*	Code derived from kerui.c
+*
+*/
+
+#include "rtl_433.h"
+#include "pulse_demod.h"
+#include "util.h"
+#include "data.h"
+
+static int kerui_door_callback(bitbuffer_t *bitbuffer) {
+	bitrow_t *bb = bitbuffer->bb;
+	uint8_t *b = bb[0];
+
+	unsigned bits = bitbuffer->bits_per_row[0];
+
+	if (bits == 25) {
+		char time_str[LOCAL_TIME_BUFLEN];
+		local_time_str(0, time_str);
+		data_t *data;
+		uint32_t ID = (b[3] << 24) + (b[2] << 16) + (b[1] << 8) + b[0];
+	
+		data = data_make(	"time",		"",				DATA_STRING,	time_str,
+							"model",	"",				DATA_STRING,	"Kerui Door Sensor",
+							"id",			"ID",	DATA_FORMAT, 	"0x%x", 	DATA_INT, ID ,
+							NULL);
+
+		data_acquired_handler(data);
+		return 1;
+	}
+	return 0;
+}
+
+static char *output_fields[] = {
+	"time",
+	"model",
+	"id",
+	NULL
+};
+
+r_device kerui_door = {
+	.name          = "Kerui Door Sensor",
+	.modulation    = OOK_PULSE_PWM_PRECISE,
+	.short_limit   = 303,
+	.long_limit    = 888,
+	.reset_limit   = 8000,
+	.json_callback = &kerui_door_callback,
+	.disabled      = 0,
+	.tolerance     = 80,
+	.sync_width = 0
+};


### PR DESCRIPTION
Added support for Kerui Door Sensors such as the ones available here: http://www.keruistore.com/kerui-g18-app-control-wireless-gsm-home-security-burglar-alarm-system-outdoor-siren.php
