### PR TITLE
Fix typos/misspellings

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Usage:	= Tuner options =
 	[-n <value>] Specify number of samples to take (each sample is 2 bytes: 1 each of I & Q)
 	= Analyze/Debug options =
 	[-a] Analyze mode. Print a textual description of the signal. Disables decoding
-	[-A] Pulse Analyzer. Enable pulse analyzis and decode attempt
+	[-A] Pulse Analyzer. Enable pulse analysis and decode attempt
 	[-I] Include only: 0 = all (default), 1 = unknown devices, 2 = known devices
 	[-D] Print debug info on event (repeat for more info)
 	[-q] Quiet mode, suppress non-data messages
@@ -215,7 +215,7 @@ Examples:
 | `rtl_433 -F json -U \| mosquitto_pub -t home/rtl_433 -l` | Will pipe the output to network as JSON formatted MQTT messages. A test MQTT client can be found in `tests/mqtt_rtl_433_test.py`.
 | `rtl_433 -f 433535000 -f 434019000 -H 15` | Will poll two frequencies with 15 seconds interval.
 
-This software is mostly useable for developers right now.
+This software is mostly usable for developers right now.
 
 
 Supporting Additional Devices and Test Data

--- a/include/data.h
+++ b/include/data.h
@@ -74,7 +74,7 @@ typedef struct data {
     @param pretty_key Pretty name for the key. Use "" if to omit pretty label for this field completely,
                       or NULL if to use key name for it.
     @param type Type of the first value to put in.
-    @param ... The value of the first value to put in, follwed by the rest of the
+    @param ... The value of the first value to put in, followed by the rest of the
                key-type-values. The list is terminated with a NULL.
 
     @return A constructed data_t* object or NULL if there was a memory allocation error.

--- a/src/data.c
+++ b/src/data.c
@@ -53,7 +53,7 @@ typedef struct {
 
     /* function for importing arrays. strings are specially handled (as they
        are copied deeply), whereas other arrays are just copied shallowly
-       (but copied nevertheles) */
+       (but copied nevertheless) */
     array_elementwise_import_fn array_elementwise_import;
 
     /* a function for releasing an element when put in an array; integers

--- a/src/devices/alecto.c
+++ b/src/devices/alecto.c
@@ -86,7 +86,7 @@ static int alectov1_callback(bitbuffer_t *bitbuffer) {
 
         csum = reverse8((csum & 0xf) << 4);
         csum2 = reverse8((csum2 & 0xf) << 4);
-        /* Quit if checksup does not work out */
+        /* Quit if checksum does not work out */
         if (csum != (bb[1][4] >> 4) || csum2 != (bb[5][4] >> 4)) {
             //fprintf(stdout, "\nAlectoV1 CRC error");
             if(debug_output) {

--- a/src/devices/blyss.c
+++ b/src/devices/blyss.c
@@ -19,7 +19,7 @@ static int blyss_dc5_uk_wh(bitbuffer_t *bitbuffer)
 	for (int i = 0; i < bitbuffer->num_rows; i++)
 	{
 		//This needs additional validation, but works on mine. Suspect each DC5-UK-WH uses different codes as the transmitter
-		//is paired to the receivers to avoid being triggerd by the neighbours transmitter ?!?
+		//is paired to the receivers to avoid being triggered by the neighbours transmitter ?!?
 		if (((bb[i][0] == 0xce) && (bb[i][1] == 0x8e) && (bb[i][2] == 0x2a) && (bb[i][3] == 0x6c) && (bb[i][4] == 0x80)) ||
 			((bb[i][0] == 0xe7) && (bb[i][1] == 0x37) && (bb[i][2] == 0x7a) && (bb[i][3] == 0x2c) && (bb[i][4] == 0x80)))
 		{

--- a/src/devices/brennenstuhl_rcs_2044.c
+++ b/src/devices/brennenstuhl_rcs_2044.c
@@ -113,7 +113,7 @@ static int brennenstuhl_rcs_2044_process_row(int row, const bitbuffer_t *bitbuff
                                           be set and is accepted by receiver) */
     };
 
-    /* extrat on/off bits (first or second key column on the remote */
+    /* extract on/off bits (first or second key column on the remote) */
     int on  = b[2]>>2 & 1;
     int off = b[2]    & 1;
 

--- a/src/devices/calibeur.c
+++ b/src/devices/calibeur.c
@@ -18,7 +18,7 @@
  *
  * Channel number is encoded into fractional temperature
  * Temperature is oddly arranged and offset for negative temperatures = <6543210> - 41 C
- * Allways an odd number of 1s (odd parity)
+ * Always an odd number of 1s (odd parity)
  *
  * Encoding legend:
  * f = fractional temperature + <ch no> * 10
@@ -46,7 +46,7 @@ static int calibeur_rf104_callback(bitbuffer_t *bitbuffer) {
 
 	bitbuffer_invert(bitbuffer);
 	// Validate package (row [0] is empty due to sync bit)
-	if ((bitbuffer->bits_per_row[1] == 21)			// Dont waste time on a long/short package
+	if ((bitbuffer->bits_per_row[1] == 21)			// Don't waste time on a long/short package
 		&& (crc8(bb[1], 3, 0x80, 0) != 0)		// It should be odd parity
 		&& (memcmp(bb[1], bb[2], 3) == 0)	// We want at least two messages in a row
 	)

--- a/src/devices/cardin.c
+++ b/src/devices/cardin.c
@@ -4,7 +4,7 @@
 /*
  * Cardin S466-TX2 generic garage door remote control on 27.195 Mhz
  * Remember to set de freq right with -f 27195000
- * May be usefull for other Cardin product too
+ * May be useful for other Cardin product too
  *
  * Copyright (C) 2015 Denis Bodor
  * This program is free software; you can redistribute it and/or modify

--- a/src/devices/danfoss.c
+++ b/src/devices/danfoss.c
@@ -23,9 +23,9 @@
  *  #7      -- Message Count. Rolling counter incremented at each unique message.
  *  #8      -- Switch setting -> 2="day", 4="timer", 8="night"
  *  #9 -#10 -- Temperature decimal <value>/256
- *  #11-#12 -- Temperature integer (in Celcius)
+ *  #11-#12 -- Temperature integer (in Celsius)
  *  #13-#14 -- Set point decimal <value>/256
- *  #15-#16 -- Set point integer (in Celcius)
+ *  #15-#16 -- Set point integer (in Celsius)
  *  #17-#20 -- CRC16, poly 0x1021, includes nibble #1-#16
  *
  * Copyright (C) 2016 Tommy Vestermark

--- a/src/devices/dsc.c
+++ b/src/devices/dsc.c
@@ -13,7 +13,7 @@
  * DSC - Digital Security Controls 433 Mhz Wireless Security Contacts
  *       doors, windows, smoke, CO2, water,
  *
- * Protcol Description available in this FCC Report for FCC ID F5300NB912
+ * Protocol Description available in this FCC Report for FCC ID F5300NB912
  *  https://apps.fcc.gov/eas/GetApplicationAttachment.html?id=100988
  *
  * General Packet Description
@@ -57,7 +57,7 @@
  *
  * The ESN in practice is 24 bits, The type + remaining 5 nybbles,
  *
- * The CRC is 8 bit, "little endian", Polynomial 0xf5, Inital value 0x3d
+ * The CRC is 8 bit, "little endian", Polynomial 0xf5, Initial value 0x3d
  *
  * CRC algorithm found with CRC reveng (reveng.sourceforge.net)
  *

--- a/src/devices/ec3k.c
+++ b/src/devices/ec3k.c
@@ -2,7 +2,7 @@
  *
  * "Voltcraft Energy Count 3000" sensor sold by Conrad
  * aka “Velleman NETBSEM4”
- * aka “La Crosse Techology Remote Cost Control Monitor – RS3620”.
+ * aka “La Crosse Technology Remote Cost Control Monitor – RS3620”.
  * aka "ELV Cost Control"
  *
  * Stub driver

--- a/src/devices/efergy_optical.c
+++ b/src/devices/efergy_optical.c
@@ -105,7 +105,7 @@ static int efergy_optical_callback(bitbuffer_t *bitbuffer) {
 		{
 			energy = ((pulsecount/n_imp) * (3600/30));
 		}
-		//New code for calculating varous energy values for differing pulse-kwh values
+		//New code for calculating various energy values for differing pulse-kwh values
 		const int imp_kwh[] = {3200, 2000, 1000, 500, 0};
 		for (unsigned i=0; imp_kwh[i] !=0; ++i) {
 			if (pulsecount < 3)

--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -26,7 +26,7 @@
  * pre is always 0xFF
  * type is always 0x4 (may be different for different sensor type?)
  * id is a random id that is generated when the sensor starts
- * temp is 12 bit signed magnitude scaled by 10 celcius
+ * temp is 12 bit signed magnitude scaled by 10 celsius
  * humi is 8 bit relative humidity percentage
  *
  * Based on reverse engineering with gnu-radio and the nice article here:

--- a/src/devices/fineoffset_wh1080.c
+++ b/src/devices/fineoffset_wh1080.c
@@ -45,7 +45,7 @@
  * That's why it's NOT possible to get pressure data by wireless communication. If you need pressure data you should try
  * an Arduino/Raspberry solution wired with a BMP180/280 or BMP085 sensor.
  *
- * Data are trasmitted in a 48 seconds cycle (data packet, then wait 48 seconds, then data packet...).
+ * Data are transmitted in a 48 seconds cycle (data packet, then wait 48 seconds, then data packet...).
  *
  * This module is also capable to decode the DCF77/WWVB time signal sent by the time signal decoder
  * (which is enclosed on the sensor tx): around the minute 59 of the even hours the sensor's TX stops sending weather data,

--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -1,4 +1,4 @@
-/* Flexible general purpose deocder.
+/* Flexible general purpose decoder.
  *
  * Copyright (C) 2017 Christian Zuckschwerdt
  *

--- a/src/devices/gt_wt_02.c
+++ b/src/devices/gt_wt_02.c
@@ -27,7 +27,7 @@
  TYP AAAAAAAA BCDDEFFF FFFFFFFF GGGGGGGx xxxxx
  BIT 76543210 76543210 76543210 76543210 76543
 
- TYPDescriptian
+ TYPDescription
  A = Rolling Device Code, Change after battery replacement
  B = Battery 0=OK 1=LOW
  C = Manual Send Button Pressed 0=not pressed 1=pressed

--- a/src/devices/hideki.c
+++ b/src/devices/hideki.c
@@ -40,7 +40,7 @@ static int hideki_ts04_callback(bitbuffer_t *bitbuffer) {
         unsigned int offset = i/8;
         packet[i] = b[i+offset] << (i%8);
         packet[i] |= b[i+offset+1] >> (8 - i%8);
-        // reverse as it is litle endian...
+        // reverse as it is little endian...
         packet[i] = reverse8(packet[i]);
         // toggle each bit
         packet[i] ^= 0xFF;

--- a/src/devices/interlogix.c
+++ b/src/devices/interlogix.c
@@ -17,7 +17,7 @@
  * 
  * Frequency: 319508000
  * 
- * Deocding done per us patent #5761206
+ * Decoding done per us patent #5761206
  * https://www.google.com/patents/US5761206
  *
  * Protocol Bits
@@ -29,7 +29,7 @@
  * 36-39 4 bit device type code (DT bits 0-3)
  * 40-42 3 bit trigger count (TC bit 0-2)
  * 43 low battery bit
- * 44 F1 latch bit NOTE: F1 latch bit and debounce are reversed.  Typo or endianess issue?
+ * 44 F1 latch bit NOTE: F1 latch bit and debounce are reversed.  Typo or endianness issue?
  * 45 F1 debounced level
  * 46 F2 latch bit
  * 47 F2 debounced level
@@ -164,7 +164,7 @@ static int interlogix_callback(bitbuffer_t *bitbuffer)
 
     sprintf(raw_message, "%02x%02x%02x", message[3], message[4], message[5]);
 
-    // keyfob logic. see prootcol description addendum for protocol exceptions
+    // keyfob logic. see protocol description addendum for protocol exceptions
     if ((reverse8(message[2]) >> 4) == 0xf) {
         low_battery    = "OK";
         f1_latch_state = ((message[3] & 0xe) == 0x4) ? "CLOSED" : "OPEN";

--- a/src/devices/kerui.c
+++ b/src/devices/kerui.c
@@ -1,6 +1,6 @@
 /* Kerui PIR sensor
 *
-*	Code derrived from akhan_100F14.c
+*	Code derived from akhan_100F14.c
 *
 * Such as
 * http://www.ebay.co.uk/sch/i.html?_from=R40&_trksid=p2050601.m570.l1313.TR0.TRC0.H0.Xkerui+pir.TRS0&_nkw=kerui+pir&_sacat=0

--- a/src/devices/lacrosse.c
+++ b/src/devices/lacrosse.c
@@ -20,7 +20,7 @@
  * - Zero Pulses are longer (1,400 uS High, 1,000 uS Low) = 2,400 uS
  * - One Pulses are shorter (  550 uS High, 1,000 uS Low) = 1,600 uS
  * - Sensor id changes when the battery is changed
- * - Primay Value are BCD with one decimal place: vvv = 12.3
+ * - Primary Value are BCD with one decimal place: vvv = 12.3
  * - Secondary value is integer only intval = 12, seems to be a repeat of primary
  *   This may actually be an additional data check because the 4 bit checksum
  *   and parity bit is  pretty week at detecting errors.
@@ -39,7 +39,7 @@
  *   the detect and decode could be collapsed into a single reasonably
  *   readable function.
  *
- * - Make the time stamp output a generat utility function.
+ * - Make the time stamp output a general utility function.
  */
 
 #include "rtl_433.h"
@@ -56,7 +56,7 @@
 // for clarity.  The LaCrosse protocol is based
 // on 4 bit nybbles.
 //
-// Domodulation
+// Demodulation
 // Long bits = 0
 // short bits = 1
 //

--- a/src/devices/lacrosse_TX141TH_Bv2.c
+++ b/src/devices/lacrosse_TX141TH_Bv2.c
@@ -60,7 +60,7 @@
  * - LACROSSE_TX141_BITLEN is 37 instead of 40. 
  * - The humidity variable has been removed for TX141.
  * - Battery check bit is inverse of TX141TH.
- * - temp_f removed, temp_c (celcius) is what's provided by the device.
+ * - temp_f removed, temp_c (celsius) is what's provided by the device.
  *
  * The CRC Checksum is not checked. In trying to reverse engineer the
  * CRC, the first nibble can be checked by:

--- a/src/devices/lacrosse_tx35.c
+++ b/src/devices/lacrosse_tx35.c
@@ -22,7 +22,7 @@ Random device id (6 bits)
                                           ~ 3rd bits of byte 5
 new battery indicator
                                            ~ 4th bits of byte 5
-unkown, unused
+unknown, unused
                                              ~~~~ ~~~~ ~~~~ 2nd nibble of byte 5 and byte 6
 temperature, in bcd *10 +40
                                                             ~ 1st bit of byte 7
@@ -51,7 +51,7 @@ How to make a decoder : https://enavarro.me/ajouter-un-decodeur-ask-a-rtl_433.ht
 #include "util.h"
 #include "data.h"
 
-#define LACROSSE_TX29_NOHUMIDSENSOR  0x6a // Sensor do not support humidty
+#define LACROSSE_TX29_NOHUMIDSENSOR  0x6a // Sensor do not support humidity
 #define LACROSSE_TX35_CRC_POLY       0x31
 #define LACROSSE_TX35_CRC_INIT       0x00
 #define LACROSSE_TX29_MODEL          29 // Model number
@@ -75,7 +75,7 @@ static int lacrosse_it(bitbuffer_t *bitbuffer, uint8_t device29or35) {
 
 	static const uint8_t preamble[] = {
 		0xaa, // preamble
-		0x2d, // brand identifer
+		0x2d, // brand identifier
 		0xd4, // brand identifier
 		0x90, // data length (this decoder work only with data length of 9, so we hardcode it on the preamble)
 	};

--- a/src/devices/maverick_et73x.c
+++ b/src/devices/maverick_et73x.c
@@ -19,7 +19,7 @@
  *
  * Assuming MSB first and falling edge = 1.
  *
- * quarternary conversion of message needed:
+ * quaternary conversion of message needed:
  * 0x05 = 0
  * 0x06 = 1
  * 0x09 = 2
@@ -28,8 +28,8 @@
  * Message looks like this:
  * a = Header (0xAA9995)
  * b = device state (2=default; 7=init)
- * c = temp1 (need to substract 532)
- * d = temp2 (need to substract 532)
+ * c = temp1 (need to subtract 532)
+ * d = temp2 (need to subtract 532)
  * e = checksum (the checksum gets renewed on a device reset, and represents a kind of session_id)
  *
  * nibble: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25
@@ -50,7 +50,7 @@
 
 //here we extract bitbuffer values, for easy data handling
 static void convert_bitbuffer(bitbuffer_t *bitbuffer, unsigned int *msg_converted, char *msg_hex_combined) {
-    //quarternary convertion
+    //quaternary conversion
     unsigned int quart_convert[16] ={0,0,0,0,0,0,1,0,0,2,3,0,0,0,0,0};
     int i;
     for(i = 0; i < 13; i++) {
@@ -199,7 +199,7 @@ static int maverick_et73x_callback(bitbuffer_t *bitbuffer) {
     if((bitbuffer->bb[0][0] != 0xAA || bitbuffer->bb[0][0] != 0xaa ) || bitbuffer->bb[0][1] != 0x99 || bitbuffer->bb[0][2] != 0x95)
         return 0;
 
-    //convert hex values into quardinary values
+    //convert hex values into quaternary values
     convert_bitbuffer(bitbuffer, msg_converted, msg_hex_combined);
 
     //checksum is used to represent a session. This means, we get a new session_id if a reset or battery exchange is done.

--- a/src/devices/new_template.c
+++ b/src/devices/new_template.c
@@ -137,7 +137,7 @@ static int template_callback(bitbuffer_t *bitbuffer)
     }
 
     /*
-     * Or (prefered) search for the message preamble:
+     * Or (preferred) search for the message preamble:
      * See bitbuffer_search()
      */
 
@@ -199,7 +199,7 @@ static int template_callback(bitbuffer_t *bitbuffer)
         /*
          * received an unexpected message type
          * could be a bad message or a new message not
-         * previously seen.  Optionally log debug putput.
+         * previously seen.  Optionally log debug output.
          */
         return 0;
     }

--- a/src/devices/newkaku.c
+++ b/src/devices/newkaku.c
@@ -25,9 +25,9 @@ static int newkaku_callback(bitbuffer_t *bitbuffer) {
     char time_str[LOCAL_TIME_BUFLEN];
     local_time_str(0, time_str);
 
-    if (bb[0][0] == 0xac || bb[0][0] == 0xb2) {//allways starts with ac or b2
+    if (bb[0][0] == 0xac || bb[0][0] == 0xb2) {//always starts with ac or b2
         // first bit is from startbit sequence, not part of payload!
-        // check protocol if value is 10 or 01, else stop processing as it is no vallid KAKU packet!
+        // check protocol if value is 10 or 01, else stop processing as it is no valid KAKU packet!
         //get id=24bits, remember 1st 1 bit = startbit, no payload!
         for (packet = 0; packet < 6; packet++) {//get first part kakuid
             tmp = bb[0][packet] << 1;

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -14,7 +14,7 @@
  * and CC is the channel: 0=CH1, 1=CH2, 2=CH3
  * temp is 12 bit signed scaled by 10
  * const is always 1111 (0x0F)
- * humiditiy is 8 bits
+ * humidity is 8 bits
  *
  * The sensor can be bought at Clas Ohlsen
  */
@@ -64,8 +64,8 @@ static int nexus_callback(bitbuffer_t *bitbuffer) {
         battery = bb[r][1]&0x80;
         channel = ((bb[r][1]&0x30) >> 4) + 1;
 
-        /* Nible 3,4,5 contains 12 bits of temperature
-         * The temerature is signed and scaled by 10 */
+        /* Nibble 3,4,5 contains 12 bits of temperature
+         * The temperature is signed and scaled by 10 */
         temp = (int16_t)((uint16_t)(bb[r][1] << 12) | (bb[r][2] << 4));
         temp = temp >> 4;
 

--- a/src/devices/oil_standard.c
+++ b/src/devices/oil_standard.c
@@ -60,9 +60,9 @@ static int oil_standard_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bi
 	// 0x02: High-bit for depth
 	// 0x04: (always zero?)
 	// 0x08: Leak/theft alarm
-	// 0x10: (unkown toggle)
-	// 0x20: (unkown toggle)
-	// 0x40: (unkown toggle)
+	// 0x10: (unknown toggle)
+	// 0x20: (unknown toggle)
+	// 0x40: (unknown toggle)
 	// 0x80: (always zero?)
 	flags = b[2] & ~0x0A;
 	alarm = (b[2] & 0x08) >> 3;

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -308,7 +308,7 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
             "id",         "House Code",     DATA_INT,    get_os_rollingcode(msg, sensor_id),
             "channel",    "Channel",        DATA_INT,    get_os_channel(msg, sensor_id),
             "battery",    "Battery",        DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
-            "temperature_C",  "Celcius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
+            "temperature_C",  "Celsius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
             "humidity",   "Humidity",       DATA_FORMAT, "%u %%",   DATA_INT,    get_os_humidity(msg, sensor_id),
             "pressure_hPa",  "Pressure",    DATA_FORMAT, "%.0f hPa",   DATA_DOUBLE, pressure,
             NULL);
@@ -344,7 +344,7 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
             "id",            "House Code",  DATA_INT,    get_os_rollingcode(msg, sensor_id),
             "channel",       "Channel",     DATA_INT,    get_os_channel(msg, sensor_id),
             "battery",       "Battery",     DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
-            "temperature_C",  "Celcius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
+            "temperature_C",  "Celsius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
             NULL);
         data_acquired_handler(data);
       }
@@ -360,7 +360,7 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
             "id",            "House Code",  DATA_INT,    get_os_rollingcode(msg, sensor_id),
             "channel",       "Channel",     DATA_INT,    get_os_channel(msg, sensor_id),
             "battery",       "Battery",     DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
-            "temperature_C",  "Celcius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
+            "temperature_C",  "Celsius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
             NULL);
         data_acquired_handler(data);
       }
@@ -375,7 +375,7 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
             "id",            "House Code",  DATA_INT,    get_os_rollingcode(msg, sensor_id),
             "channel",       "Channel",     DATA_INT,    get_os_channel(msg, sensor_id), // 1 to 5
             "battery",       "Battery",     DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
-            "temperature_C",  "Celcius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
+            "temperature_C",  "Celsius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
             "humidity",      "Humidity",    DATA_FORMAT, "%u %%",   DATA_INT,    get_os_humidity(msg, sensor_id),
             NULL);
         data_acquired_handler(data);
@@ -391,7 +391,7 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
             "id",            "House Code",  DATA_INT,    get_os_rollingcode(msg, sensor_id),
             "channel",       "Channel",     DATA_INT,    get_os_channel(msg, sensor_id), // 1 to 5
             "battery",       "Battery",     DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
-            "temperature_C",  "Celcius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
+            "temperature_C",  "Celsius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
             "humidity",      "Humidity",    DATA_FORMAT, "%u %%",   DATA_INT,    get_os_humidity(msg, sensor_id),
             NULL);
         data_acquired_handler(data);
@@ -410,7 +410,7 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
             "id",            "House Code",  DATA_INT,    get_os_rollingcode(msg, sensor_id),
             "channel",       "Channel",     DATA_INT,    get_os_channel(msg, sensor_id), // 1 to 5
             "battery",       "Battery",     DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
-            "temperature_C",  "Celcius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
+            "temperature_C",  "Celsius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
             NULL);
         data_acquired_handler(data);
       }
@@ -427,7 +427,7 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
             "id",            "House Code",  DATA_INT,    get_os_rollingcode(msg, sensor_id),
             "channel",       "Channel",     DATA_INT,    get_os_channel(msg, sensor_id), // 1 to 5
             "battery",       "Battery",     DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
-            "temperature_C",  "Celcius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
+            "temperature_C",  "Celsius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
             "humidity",       "Humidity",   DATA_FORMAT, "%u %%", DATA_INT, get_os_humidity(msg, sensor_id),
             "pressure_hPa",  "Pressure",    DATA_FORMAT, "%.02f mPa", DATA_DOUBLE, pressure,
             NULL);
@@ -525,7 +525,7 @@ static int oregon_scientific_v3_parser(bitbuffer_t *bitbuffer) {
           "id",             "House Code", DATA_INT,    get_os_rollingcode(msg, sensor_id),
           "channel",        "Channel",    DATA_INT,    get_os_channel(msg, sensor_id),
           "battery",        "Battery",    DATA_STRING, get_os_battery(msg, sensor_id)?"LOW":"OK",
-          "temperature_C",  "Celcius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
+          "temperature_C",  "Celsius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
           "humidity",       "Humidity",   DATA_FORMAT, "%u %%", DATA_INT, humidity,
           NULL);
         data_acquired_handler(data);
@@ -541,7 +541,7 @@ static int oregon_scientific_v3_parser(bitbuffer_t *bitbuffer) {
             "id",             "House Code", DATA_INT,    get_os_rollingcode(msg, sensor_id),
             "channel",        "Channel",    DATA_INT,    get_os_channel(msg, sensor_id),
             "battery",        "Battery",    DATA_STRING, get_os_battery(msg, sensor_id)?"LOW":"OK",
-            "temperature_C",  "Celcius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
+            "temperature_C",  "Celsius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
             NULL);
           data_acquired_handler(data);
         }

--- a/src/devices/oregon_scientific_sl109h.c
+++ b/src/devices/oregon_scientific_sl109h.c
@@ -126,7 +126,7 @@ static int oregon_scientific_callback_sl109h(bitbuffer_t *bitbuffer)
                          "model",         "Model",                              DATA_STRING,    "Oregon Scientific SL109H",
                          "id",            "Id",                                 DATA_INT,    id,
                          "channel",       "Channel",                            DATA_INT,    channel,
-                         "temperature_C", "Celcius",	DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
+                         "temperature_C", "Celsius",	DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
                          "humidity",      "Humidity",	DATA_FORMAT, "%u %%",   DATA_INT,    humidity,
                          "status",        "Status",                             DATA_INT,    status,
                          "mic",           "Integrity",   DATA_STRING, "CHECKSUM",

--- a/src/devices/proove.c
+++ b/src/devices/proove.c
@@ -7,7 +7,7 @@
  * From http://elektronikforumet.com/wiki/index.php/RF_Protokoll_-_Proove_self_learning
  * Proove packet structure (32 bits):
  * HHHH HHHH HHHH HHHH HHHH HHHH HHGO CCEE
- * H = The first 26 bits are transmitter unique codes, and it is this code that the reciever “learns” to recognize.
+ * H = The first 26 bits are transmitter unique codes, and it is this code that the receiver “learns” to recognize.
  * G = Group code. Set to 0 for on, 1 for off.
  * O = On/Off bit. Set to 0 for on, 1 for off.
  * C = Channel bits.

--- a/src/devices/rftech.c
+++ b/src/devices/rftech.c
@@ -76,7 +76,7 @@ static int rftech_callback(bitbuffer_t *bitbuffer) {
  * List of fields to output when using CSV
  *
  * Used to determine what fields will be output in what
- * order for this devince when using -F csv.
+ * order for this device when using -F csv.
  *
  */
 static char *csv_output_fields[] = {

--- a/src/devices/rubicson.c
+++ b/src/devices/rubicson.c
@@ -4,7 +4,7 @@
 /* Currently this can decode the temperature and id from Rubicson sensors
  *
  * the sensor sends 36 bits 12 times pwm modulated
- * the data is grouped into 9 nibles
+ * the data is grouped into 9 nibbles
  * [id0] [id1], [bat|unk1|chan1|chan2] [temp0], [temp1] [temp2], [F] [crc1], [crc2]
  *
  * The id changes when the battery is changed in the sensor.
@@ -82,8 +82,8 @@ static int rubicson_callback(bitbuffer_t *bitbuffer) {
     if (rubicson_crc_check(bb)) {
         local_time_str(0, time_str);
 
-        /* Nible 3,4,5 contains 12 bits of temperature
-         * The temerature is signed and scaled by 10 */
+        /* Nibble 3,4,5 contains 12 bits of temperature
+         * The temperature is signed and scaled by 10 */
         temp = (int16_t)((uint16_t)(bb[0][1] << 12) | (bb[0][2] << 4));
         temp = temp >> 4;
 

--- a/src/devices/s3318p.c
+++ b/src/devices/s3318p.c
@@ -27,7 +27,7 @@
  *
  * Temperature:
  * Sensor sends data in °F, lowest supported value is 90°F
- * 12 bit uingned and scaled by 10 (Nibbles: 6,5,4)
+ * 12 bit unsigned and scaled by 10 (Nibbles: 6,5,4)
  * in this case "011001100101" =  1637/10 - 90 = 73.7 °F (23.17 °C)
  *
  * Humidity:
@@ -45,7 +45,7 @@
  *
  * Unknown1: (Bits 8,9) changes not so often
  * Unknown2: (Bits 36-39) changes with every packet, probably checksum
- * Unknown3: (Bits 34,35) changes not so often, mayby also part of the checksum
+ * Unknown3: (Bits 34,35) changes not so often, maybe also part of the checksum
  *
  */
 

--- a/src/devices/solight_te44.c
+++ b/src/devices/solight_te44.c
@@ -65,7 +65,7 @@ static int solight_te44_callback(bitbuffer_t *bitbuffer) {
         }
 
         // all lines should have equal content
-        // will work also for the last, shorter line, as the separating bit is allways 0 anyway
+        // will work also for the last, shorter line, as the separating bit is always 0 anyway
         if (i > 0 && 0 != memcmp(bb[i], bb[i - 1], BITBUF_COLS)) {
             return 0;
         }

--- a/src/devices/steelmate.c
+++ b/src/devices/steelmate.c
@@ -9,7 +9,7 @@
  * (at your option) any later version.
  *
  * Packet payload: 9 bytes.
- * Bytes 2 to 9 are inverted Manchester with swaped MSB/LSB:
+ * Bytes 2 to 9 are inverted Manchester with swapped MSB/LSB:
  *
  *                               0  1  2  3  4  5  6  7  8
  *                    [00] {72} 00 00 7f 3c f0 d7 ad 8e fa

--- a/src/devices/tfa_pool_thermometer.c
+++ b/src/devices/tfa_pool_thermometer.c
@@ -34,7 +34,7 @@ AAAABBBB BBBBCCCC CCCCCCCC DDEE
 
 A: ?
 B: device id (changing only after reset)
-C: templerature
+C: temperature
 D: channel number
 E: ?
 */

--- a/src/devices/thermopro_tp12.c
+++ b/src/devices/thermopro_tp12.c
@@ -75,7 +75,7 @@ static int thermopro_tp12_sensor_callback(bitbuffer_t *bitbuffer) {
         // There is a mysterious checksum in bytes[4].  It may be the same as the checksum used by the TP-11,
         // which consisted of a lookup table containing, for each bit in the message, a byte to be xor-ed into
         // the checksum if the message bit was 1.  It should be possible to solve for that table using Gaussian
-        // elimnation, so dump some data so we can try this.
+        // elimination, so dump some data so we can try this.
 
         // This format is easily usable by bruteforce-crc, after piping through | grep raw_data | cut -d':' -f2 
         // bruteforce-crc didn't find anything, though - this may not be a CRC algorithm specifically.

--- a/src/devices/vaillant_vrt340f.c
+++ b/src/devices/vaillant_vrt340f.c
@@ -127,7 +127,7 @@ vaillant_vrt340_parser (bitbuffer_t *bitbuffer)
 
     uint16_t bitcount = bits.bits_per_row[0];
 
-    // Change to least-significant-bit last (protocol uses least-siginificant-bit first) for hex representation:
+    // Change to least-significant-bit last (protocol uses least-significant-bit first) for hex representation:
     for (uint16_t k = 0; k <= (uint16_t)(bitcount-1)/8; k++) {
         bits.bb[0][k] = reverse8(bits.bb[0][k]);
     }

--- a/src/devices/wg_pb12v1.c
+++ b/src/devices/wg_pb12v1.c
@@ -21,14 +21,14 @@
  *
  * Temperature
  * ---
- * Temperature value is "milli-celcius", ie 1000 mC = 1C, offset by -40 C.
+ * Temperature value is "milli-celsius", ie 1000 mC = 1C, offset by -40 C.
  *
  * 0010 01011101 = 605 mC => 60.5 C
  * Remove offset => 60.5 C - 40 C = 20.5 C
  *
  * Unknown
  * ---
- * Possbible uses could be weak battey, or new battery.
+ * Possible uses could be weak battery, or new battery.
  *
  * At the moment it this device cannot distinguish between a Fine Offset
  * device, see fineoffset.c.
@@ -67,7 +67,7 @@ static int wg_pb12v1_callback(bitbuffer_t *bitbuffer) {
     if (bitbuffer->bits_per_row[0] >= 48 &&              // Don't waste time on a short packages
         bb[0][0] == 0xFF &&                              // Preamble
         bb[0][5] == crc8(&bb[0][1], 4, polynomial, 0) && // CRC (excluding preamble)
-        bb[0][4] == 0xFF                                 // Humitidy set to 11111111
+        bb[0][4] == 0xFF                                 // Humidity set to 11111111
         ){
 
         /* Get time now */
@@ -77,7 +77,7 @@ static int wg_pb12v1_callback(bitbuffer_t *bitbuffer) {
         id = ((bb[0][3]&0x1F));
 
         // Nibble 5,6,7 contains 12 bits of temperature
-        // The temperature is "milli-celcius", ie 1000 mC = 1C, offset by -40 C.
+        // The temperature is "milli-celsius", ie 1000 mC = 1C, offset by -40 C.
         temp = ((bb[0][1] & 0x0F) << 8) | bb[0][2];
         temperature = ((float)temp / 10)-40;
 

--- a/src/devices/x10_rf.c
+++ b/src/devices/x10_rf.c
@@ -20,7 +20,7 @@ static int X10_RF_callback(bitbuffer_t *bitbuffer) {
 
 	// Row [0] is sync pulse
 	// Validate package
-	if ((bitbuffer->bits_per_row[1] == 32)		// Dont waste time on a short package
+	if ((bitbuffer->bits_per_row[1] == 32)		// Don't waste time on a short package
 	// && (bb[1][0] == (uint8_t)(~bb[1][1]))		// Check integrity - apparently some chips may use both bytes..
 	 && (bb[1][2] == ((0xff & (~bb[1][3]))))		// Check integrity
 	)

--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -2,7 +2,7 @@
  * X10 Security sensor decoder.
  *
  * Each packet starts with a sync pulse of 9000 us and 4500 us gap.
- * The message is OOK PPM codeded with 567 us pulse and long gap (0 bit)
+ * The message is OOK PPM encoded with 567 us pulse and long gap (0 bit)
  * of 1680 us or short gap (1 bit) of 590 us. There are 41 bits, the
  * message is repeated 5 times with a packet gap of 40000 us.
  *

--- a/src/pulse_demod.c
+++ b/src/pulse_demod.c
@@ -38,7 +38,7 @@ int pulse_demod_pcm(const pulse_data_t *pulses, struct protocol_state *device)
 		}
 		// Add run of zeros
 		periods -= highs;					// Remove 1s from whole period
-		periods = min(periods, MAX_ZEROS); 	// Dont overflow at end of message
+		periods = min(periods, MAX_ZEROS); 	// Don't overflow at end of message
 		for (int i=0; i < periods; ++i) {
 			bitbuffer_add_bit(&bits, 0);
 		}
@@ -58,7 +58,7 @@ int pulse_demod_pcm(const pulse_data_t *pulses, struct protocol_state *device)
 
 		// End of Message?
 		if (((n == pulses->num_pulses-1) 	// No more pulses? (FSK)
-		 || (pulses->gap[n] > device->reset_limit))	// Loong silence (OOK)
+		 || (pulses->gap[n] > device->reset_limit))	// Long silence (OOK)
 		 && (bits.bits_per_row[0] > 0)		// Only if data has been accumulated
 		) {
 			if (device->callback) {
@@ -256,7 +256,7 @@ int pulse_demod_manchester_zerobit(const pulse_data_t *pulses, struct protocol_s
 	int time_since_last = 0;
 	bitbuffer_t bits = {0};
 
-	// First rising edge is allways counted as a zero (Seems to be hardcoded policy for the Oregon Scientific sensors...)
+	// First rising edge is always counted as a zero (Seems to be hardcoded policy for the Oregon Scientific sensors...)
 	bitbuffer_add_bit(&bits, 0);
 
 	for(unsigned n = 0; n < pulses->num_pulses; ++n) {

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -195,7 +195,7 @@ typedef struct {
 	int pulse_length;		// Counter for internal pulse detection
 	int max_pulse;			// Size of biggest pulse detected
 
-	int data_counter;		// Counter for how much of data chunck is processed
+	int data_counter;		// Counter for how much of data chunk is processed
 	int lead_in_counter;	// Counter for allowing initial noise estimate to settle
 
 	int ook_low_estimate;		// Estimate for the OOK low level (base noise level) in the envelope data
@@ -243,7 +243,7 @@ int pulse_detect_package(const int16_t *envelope_data, const int16_t *fm_data, i
 					s->ook_high_estimate = OOK_HIGH_LOW_RATIO * s->ook_low_estimate;	// Default is a ratio of low level
 					s->ook_high_estimate = max(s->ook_high_estimate, OOK_MIN_HIGH_LEVEL);
 					s->ook_high_estimate = min(s->ook_high_estimate, OOK_MAX_HIGH_LEVEL);
-					if (s->lead_in_counter <= OOK_EST_LOW_RATIO) s->lead_in_counter++;		// Allow inital estimate to settle
+					if (s->lead_in_counter <= OOK_EST_LOW_RATIO) s->lead_in_counter++;		// Allow initial estimate to settle
 				}
 				break;
 			case PD_OOK_STATE_PULSE:

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -127,7 +127,7 @@ void usage(r_device *devices) {
             "\t[-n <value>] Specify number of samples to take (each sample is 2 bytes: 1 each of I & Q)\n"
             "\t= Analyze/Debug options =\n"
             "\t[-a] Analyze mode. Print a textual description of the signal. Disables decoding\n"
-            "\t[-A] Pulse Analyzer. Enable pulse analyzis and decode attempt\n"
+            "\t[-A] Pulse Analyzer. Enable pulse analysis and decode attempt\n"
             "\t[-I] Include only: 0 = all (default), 1 = unknown devices, 2 = known devices\n"
             "\t[-D] Print debug info on event (repeat for more info)\n"
             "\t[-q] Quiet mode, suppress non-data messages\n"
@@ -1173,7 +1173,7 @@ int main(int argc, char **argv) {
         r = 0;
         for (i = 0; i < demod->r_dev_num; i++) {
             if (!quiet_mode)
-                fprintf(stderr, "Verifing test data with device %s.\n", demod->r_devs[i]->name);
+                fprintf(stderr, "Verifying test data with device %s.\n", demod->r_devs[i]->name);
             r += pulse_demod_string(test_data, demod->r_devs[i]);
         }
         exit(!r);


### PR DESCRIPTION
Mostly just common typos.  Should be no variable changes.  Just comments and strings.