### PR TITLE
DSC data_make additions.

### DIFF
--- a/src/devices/dsc.c
+++ b/src/devices/dsc.c
@@ -159,12 +159,12 @@ static int dsc_callback(bitbuffer_t *bitbuffer)
         local_time_str(0, time_str);
 
         data = data_make(
-		"time", "", DATA_STRING, time_str,
-		"model", "", DATA_STRING, "DSC Contact",
-		"id", "", DATA_INT, esn,
-		"esn", "", DATA_STRING, esn_str,
-		"status", "", DATA_INT, status,
-		"status_hex", "", DATA_STRING, status_str, // TEMP DELETE once bits are output
+                "time", "", DATA_STRING, time_str,
+                "model", "", DATA_STRING, "DSC Contact",
+                "id", "", DATA_INT, esn,
+                "esn", "", DATA_STRING, esn_str, // to be removed - transitional
+                "status", "", DATA_INT, status,
+                "status_hex", "", DATA_STRING, status_str, // to be removed - once bits are output
                 "mic", "", DATA_STRING, "CRC",
                 NULL);
         data_acquired_handler(data);

--- a/src/devices/intertechno.c
+++ b/src/devices/intertechno.c
@@ -3,8 +3,7 @@
 static int intertechno_callback(bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
 
-      //if (bb[1][1] == 0 && bb[1][0] != 0 && bb[1][3]==bb[2][3]){
-      if(bb[0][0]==0 && bb[0][0] == 0 && bb[1][0] == 0x56){
+      if(bb[0][0]==0 && (bb[1][0] == 0x56 || bb[1][0] == 0x69)){
         fprintf(stdout, "Switch event:\n");
         fprintf(stdout, "protocol       = Intertechno\n");
         fprintf(stdout, "rid            = %x\n",bb[1][0]);
@@ -28,8 +27,8 @@ static int intertechno_callback(bitbuffer_t *bitbuffer) {
 r_device intertechno = {
     .name           = "Intertechno 433",
     .modulation     = OOK_PULSE_PPM_RAW,
-    .short_limit    = 400,
-    .long_limit     = 1400,
+    .short_limit    = 600,
+    .long_limit     = 1700,
     .reset_limit    = 10000,
     .json_callback  = &intertechno_callback,
     .disabled       = 1,


### PR DESCRIPTION
* Merge branch 'master' of https://github.com/merbanan/rtl_433 into feat-dsc (@zuckschwerdt's initial data_make conversion)
* Output ID and Status byte as INTs for easy parsing.
* "transitional" data fields as an aid:
  * Add ESN back as a hex ID for readers/consumers that want to see a hex string.
  * Temporarily outputting status as hex until the bits are broken out.