### PR TITLE
Add stats reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Usage:		= General options =
   [-F kv | json | csv | syslog | null | help] Produce decoded output in given format.
        Append output to file with :<filename> (e.g. -F csv:log.csv), defaults to stdout.
        Specify host/port for syslog with e.g. -F syslog:127.0.0.1:1514
-  [-M time | reltime | notime | hires | utc | protocol | level | bits | help] Add various meta data to each output.
+  [-M time | reltime | notime | hires | utc | protocol | level | stats | bits | help] Add various meta data to each output.
   [-K FILE | PATH | <tag>] Add an expanded token or fixed tag to every output line.
   [-C native | si | customary] Convert units in decoded output.
   [-T <seconds>] Specify number of seconds to run
@@ -284,6 +284,8 @@ Option -M:
 		(this may also be accomplished by invocation with TZ environment variable set).
 	Use "protocol" / "noprotocol" to output the decoder protocol number meta data.
 	Use "level" to add Modulation, Frequency, RSSI, SNR, and Noise meta data.
+	Use "stats[:[<level>][:<interval>]]" to report statistics (default: 600 seconds).
+	  level 0: no report, 1: report successful devices, 2: report active devices, 3: report all
 	Use "bits" to add bit representation to code outputs (for debug).
 
 Option -r:

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -124,8 +124,11 @@ analyze_pulses false
 #   (this may also be accomplished by invocation with TZ environment variable set).
 # Use "protocol" / "noprotocol" to output the decoder protocol number meta data.
 # Use "level" to add Modulation, Frequency, RSSI, SNR, and Noise meta data.
+# Use "stats[:[<level>][:<interval>]]" to report statistics (default: 600 seconds).
+#   level 0: no report, 1: report successful devices, 2: report active devices, 3: report all
 # Use "newmodel" to transition to new model keys. This will become the default someday.
 report_meta level
+report_meta stats
 report_meta hires
 report_meta protocol
 report_meta newmodel

--- a/include/r_device.h
+++ b/include/r_device.h
@@ -21,6 +21,17 @@ enum modulation_types {
     FSK_PULSE_MANCHESTER_ZEROBIT = 18, ///< FSK, Manchester encoding.
 };
 
+/** Decoders should return n>=0 for n packets successfully decoded,
+    an ABORT code if the bitbuffer is no applicable,
+    or a FAIL code if the message is malformed. */
+enum decode_return_codes {
+    DECODE_FAIL_OTHER   = 0, ///< legacy, do not use
+    DECODE_ABORT_LENGTH = -1,
+    DECODE_ABORT_EARLY  = -2,
+    DECODE_FAIL_MIC     = -3,
+    DECODE_FAIL_SANITY  = -4,
+};
+
 struct bitbuffer;
 struct data;
 
@@ -47,6 +58,12 @@ typedef struct r_device {
     int verbose;
     int verbose_bits;
     void (*output_fn)(struct r_device *decoder, struct data *data);
+
+    /* Decoder results / statistics */
+    unsigned decode_events;
+    unsigned decode_ok;
+    unsigned decode_messages;
+    unsigned decode_fails[5];
 
     /* private for flex decoder and output callback */
     void *decode_ctx;

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -76,6 +76,10 @@ typedef struct r_cfg {
     int report_time_hires;
     int report_time_utc;
     int report_description;
+    int report_stats;
+    int stats_interval;
+    int stats_now;
+    time_t stats_time;
     int no_default_devices;
     struct r_device *devices;
     uint16_t num_r_devices;
@@ -83,6 +87,10 @@ typedef struct r_cfg {
     list_t output_handler;
     struct dm_state *demod;
     int new_model_keys;
+    /* stats*/
+    unsigned frames_count; ///< stats counter for interval
+    unsigned frames_fsk; ///< stats counter for interval
+    unsigned frames_events; ///< stats counter for interval
 } r_cfg_t;
 
 #endif /* INCLUDE_RTL_433_H_ */

--- a/src/devices/bresser_3ch.c
+++ b/src/devices/bresser_3ch.c
@@ -33,7 +33,7 @@ static int bresser_3ch_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
     int r = bitbuffer_find_repeated_row(bitbuffer, 3, 40);
     if (r < 0 || bitbuffer->bits_per_row[r] > 42) {
-        return 0;
+        return DECODE_ABORT_LENGTH;
     }
 
     b = bitbuffer->bb[r];
@@ -47,7 +47,7 @@ static int bresser_3ch_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         if (decoder->verbose) {
             fprintf(stderr, "Bresser 3CH checksum error\n");
         }
-        return 0;
+        return DECODE_FAIL_MIC;
     }
 
     id = b[0];
@@ -66,7 +66,7 @@ static int bresser_3ch_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         if (decoder->verbose) {
             fprintf(stderr, "Bresser 3CH data error\n");
         }
-        return 0;
+        return DECODE_FAIL_SANITY;
     }
 
     data = data_make(


### PR DESCRIPTION
early WIP, not for merge. s.a. #727

Adds an experimental undocumented option `-L` for stats reporting:
- 0: do not report (default)
- 1: report successful devices
- 2: report active devices
- 3: report all

Test with e.g. `rtl_433 -q -F json -L 1 -T 60`