### PR TITLE
add support for TP08 remote thermometer

### DIFF
--- a/src/devices/thermopro_tp12.c
+++ b/src/devices/thermopro_tp12.c
@@ -11,7 +11,7 @@
 #include "rtl_433.h"
 #include "util.h"
 
-#define MODEL "Thermopro TP08/TP12 Thermometer"
+#define MODEL "Thermopro TP12 Thermometer"
 
 /*
 A normal sequence for the TP12:
@@ -56,10 +56,12 @@ static int thermopro_tp12_sensor_callback(bitbuffer_t *bitbuffer) {
 
     // The device transmits 16 rows, let's check for 3 matching.
     // (Really 17 rows, but the last one doesn't match because it's missing a trailing 1.)
-    // Update for TP08: same is true but only 2 rows (plus a third missing the trailing 1) are xmitted.
-    // Rather than create a whole new device I simply lowered min_repeat_count, everything else
-    // works perfectly. is this bad?
-    good = bitbuffer_find_repeated_row(bitbuffer, 2, 40);
+    // Update for TP08: same is true but only 2 rows.
+    good = bitbuffer_find_repeated_row(
+        bitbuffer, 
+        (bitbuffer->num_rows > 5) ? 5 : 2,
+        40
+    );
     if (good < 0) {
         return 0;
     }
@@ -137,7 +139,7 @@ Those gaps are suspiciously close to 500 us and 1500 us.
 */
 
 r_device thermopro_tp12 = {
-    .name          = MODEL,
+    .name          = "Thermopro TP08/TP12 thermometer",
     .modulation    = OOK_PULSE_PPM_RAW,
     // note that these are in microseconds, not samples.
     .short_limit   = 1000,

--- a/src/devices/thermopro_tp12.c
+++ b/src/devices/thermopro_tp12.c
@@ -11,7 +11,7 @@
 #include "rtl_433.h"
 #include "util.h"
 
-#define MODEL "Thermopro TP12 Thermometer"
+#define MODEL "Thermopro TP08/TP12 Thermometer"
 
 /*
 A normal sequence for the TP12:
@@ -56,7 +56,10 @@ static int thermopro_tp12_sensor_callback(bitbuffer_t *bitbuffer) {
 
     // The device transmits 16 rows, let's check for 3 matching.
     // (Really 17 rows, but the last one doesn't match because it's missing a trailing 1.)
-    good = bitbuffer_find_repeated_row(bitbuffer, 5, 40);
+    // Update for TP08: same is true but only 2 rows (plus a third missing the trailing 1) are xmitted.
+    // Rather than create a whole new device I simply lowered min_repeat_count, everything else
+    // works perfectly. is this bad?
+    good = bitbuffer_find_repeated_row(bitbuffer, 2, 40);
     if (good < 0) {
         return 0;
     }


### PR DESCRIPTION
A minor modification allows the existing ThermoPro TP12 device handler to also decode the [TP-08](https://www.amazon.com/ThermoPro-TP-08-Wireless-Thermometer-Grilling/dp/B014DAVHSQ) (and probably the TP07/TP20 as well). I have tested this for several days and it seems to work fine.

It would be interesting to try and figure out the checksum that is also being transmitted...