### PR TITLE
Enhance currentcost device with OptiSmart (Counter) support

### DIFF
--- a/src/devices/current_cost.c
+++ b/src/devices/current_cost.c
@@ -33,6 +33,7 @@ static int current_cost_callback(bitbuffer_t *bitbuffer) {
 
     uint8_t *packet = packet_bits.bb[0];
     // Read data
+    // Meter
     if(packet_bits.bits_per_row[0] >= 56 && ((packet[0] & 0xf0) == 0) ){
         uint16_t device_id = (packet[0] & 0x0f) << 8 | packet[1];
 
@@ -51,6 +52,23 @@ static int current_cost_callback(bitbuffer_t *bitbuffer) {
         data_acquired_handler(data);
         return 1;
     }
+    // Counter
+    else if(packet_bits.bits_per_row[0] >= 56 && ((packet[0] & 0xf0) == 64) ){
+       uint16_t device_id = (packet[0] & 0x0f) << 8 | packet[1];
+
+       uint16_t sensor_type = packet[3]; //Sensor type. Valid values are: 2-Electric, 3-Gas, 4-Water
+       uint32_t c_impulse = packet[4] << 24 | packet[5] <<16 | packet[6] <<8 | packet[7] ;
+       data = data_make("time",         "",              DATA_STRING, time_str,
+               "model",        "",              DATA_STRING, "CurrentCost Counter", //TODO: it may have different CC Model ? any ref ?
+               "dev_id",       "Device Id",     DATA_FORMAT, "%d", DATA_INT, device_id,
+               "sensor_type",  "Sensor Id",     DATA_FORMAT, "%d", DATA_INT, sensor_type,
+               //"counter",      "Counter",       DATA_FORMAT, "%d", DATA_INT, c_impulse,
+               "power0",       "Counter",       DATA_FORMAT, "%d", DATA_INT, c_impulse,
+               NULL);
+       data_acquired_handler(data);
+       return 1;
+    }
+
     return 0;
 }
 

--- a/src/devices/current_cost.c
+++ b/src/devices/current_cost.c
@@ -33,13 +33,13 @@ static int current_cost_callback(bitbuffer_t *bitbuffer) {
 
     uint8_t *packet = packet_bits.bb[0];
     // Read data
-    // Meter
+    // Meter (packet[0] = 0000xxxx) bits 5 and 4 are "unknown", but always 0 to date.
     if(packet_bits.bits_per_row[0] >= 56 && ((packet[0] & 0xf0) == 0) ){
         uint16_t device_id = (packet[0] & 0x0f) << 8 | packet[1];
-
-        uint16_t watt0 = (packet[2] & 0x7F) << 8 | packet[3] ;
-        uint16_t watt1 = (packet[4] & 0x7F) << 8 | packet[5] ;
-        uint16_t watt2 = (packet[6] & 0x7F) << 8 | packet[7] ;
+        //Check the "Data valid indicator" bit is 1 before using the sensor values
+        if((packet[2] & 0x80) == 1) { uint16_t watt0 = (packet[2] & 0x7F) << 8 | packet[3] ; }
+        if((packet[4] & 0x80) == 1) { uint16_t watt1 = (packet[4] & 0x7F) << 8 | packet[5] ; }
+        if((packet[6] & 0x80) == 1) { uint16_t watt2 = (packet[6] & 0x7F) << 8 | packet[7] ; }
         data = data_make("time",          "",       DATA_STRING, time_str,
                 "model",         "",              DATA_STRING, "CurrentCost TX", //TODO: it may have different CC Model ? any ref ?
                 //"rc",            "Rolling Code",  DATA_INT, rc, //TODO: add rolling code b[1] ? test needed
@@ -52,16 +52,16 @@ static int current_cost_callback(bitbuffer_t *bitbuffer) {
         data_acquired_handler(data);
         return 1;
     }
-    // Counter
+    // Counter (packet[0] = 0100xxxx) bits 5 and 4 are "unknown", but always 0 to date.
     else if(packet_bits.bits_per_row[0] >= 56 && ((packet[0] & 0xf0) == 64) ){
        uint16_t device_id = (packet[0] & 0x0f) << 8 | packet[1];
-
+       // packet[2] is "Apparently unused"
        uint16_t sensor_type = packet[3]; //Sensor type. Valid values are: 2-Electric, 3-Gas, 4-Water
        uint32_t c_impulse = packet[4] << 24 | packet[5] <<16 | packet[6] <<8 | packet[7] ;
        data = data_make("time",         "",              DATA_STRING, time_str,
                "model",        "",              DATA_STRING, "CurrentCost Counter", //TODO: it may have different CC Model ? any ref ?
                "dev_id",       "Device Id",     DATA_FORMAT, "%d", DATA_INT, device_id,
-               "sensor_type",  "Sensor Id",     DATA_FORMAT, "%d", DATA_INT, sensor_type,
+               "sensor_type",  "Sensor Id",     DATA_FORMAT, "%d", DATA_INT, sensor_type, //Could "friendly name" this?
                //"counter",      "Counter",       DATA_FORMAT, "%d", DATA_INT, c_impulse,
                "power0",       "Counter",       DATA_FORMAT, "%d", DATA_INT, c_impulse,
                NULL);

--- a/src/devices/current_cost.c
+++ b/src/devices/current_cost.c
@@ -57,7 +57,7 @@ static int current_cost_callback(bitbuffer_t *bitbuffer) {
 static char *output_fields[] = {
     "time",
     "model",
-    "rc",
+    "dev_id",
     "power0",
     "power1",
     "power2",

--- a/src/devices/current_cost.c
+++ b/src/devices/current_cost.c
@@ -36,10 +36,13 @@ static int current_cost_callback(bitbuffer_t *bitbuffer) {
     // Meter (packet[0] = 0000xxxx) bits 5 and 4 are "unknown", but always 0 to date.
     if(packet_bits.bits_per_row[0] >= 56 && ((packet[0] & 0xf0) == 0) ){
         uint16_t device_id = (packet[0] & 0x0f) << 8 | packet[1];
+        uint16_t watt0 = 0;
+        uint16_t watt1 = 0;
+        uint16_t watt2 = 0;
         //Check the "Data valid indicator" bit is 1 before using the sensor values
-        if((packet[2] & 0x80) == 1) { uint16_t watt0 = (packet[2] & 0x7F) << 8 | packet[3] ; }
-        if((packet[4] & 0x80) == 1) { uint16_t watt1 = (packet[4] & 0x7F) << 8 | packet[5] ; }
-        if((packet[6] & 0x80) == 1) { uint16_t watt2 = (packet[6] & 0x7F) << 8 | packet[7] ; }
+        if((packet[2] & 0x80) == 128) { watt0 = (packet[2] & 0x7F) << 8 | packet[3] ; }
+        if((packet[4] & 0x80) == 128) { watt1 = (packet[4] & 0x7F) << 8 | packet[5] ; }
+        if((packet[6] & 0x80) == 128) { watt2 = (packet[6] & 0x7F) << 8 | packet[7] ; }
         data = data_make("time",          "",       DATA_STRING, time_str,
                 "model",         "",              DATA_STRING, "CurrentCost TX", //TODO: it may have different CC Model ? any ref ?
                 //"rc",            "Rolling Code",  DATA_INT, rc, //TODO: add rolling code b[1] ? test needed


### PR DESCRIPTION
Hopefully addresses the feedback in https://github.com/merbanan/rtl_433/pull/703

adds to existing  currentcost device (model: "CurrentCost TX") with model: "CurrentCost Counter")

The csv output was already "broken" for multiple devices as device_id was not included
Rather than add fields to the output format I've replaced "rc" (which was never populated) with device_id (144 and 3572 below)

2018-06-27 22:17:29,CurrentCost Counter,144,16409099,,
2018-06-27 22:17:34,CurrentCost TX,3572,589,534,57

The change might still break users of csv/json output format that don't check the "model" string, as I've overloaded the counter into "power0" for the csv (and json) output formats (any preferred solution to this problem gladly accepted!)

{"time" : "2018-06-27 22:17:01", "model" : "CurrentCost Counter", "dev_id" : 144, "sensor_type" : 2, "power0" : 16409095}
{"time" : "2018-06-27 22:17:05", "model" : "CurrentCost TX", "dev_id" : 3572, "power0" : 539, "power1" : 540, "power2" : 16}

For the kv output field I've called it Counter, and added the sensor "type" (Sensor Id).

2018-06-27 22:16:33 :   CurrentCost Counter
        Device Id:       144
        Sensor Id:       2
        Counter:         16409092
2018-06-27 22:16:34 :   CurrentCost TX
        Device Id:       3572
        Power 0:         538 W
        Power 1:         532 W
        Power 2:         16 W

Recordings in https://github.com/merbanan/rtl_433_tests/pull/222

