### PR TITLE
[MSVC] fix warning on min/max

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -11,6 +11,7 @@
 #ifndef INCLUDE_UTIL_H_
 #define INCLUDE_UTIL_H_
 
+#include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <time.h>


### PR DESCRIPTION
This is a simple fix for MSVC where I get this warning:
```
stdlib.h(1300): warning C4005: 'max': macro redefinition
RTL_433\include\util.h(20): note: see previous definition of 'max'
stdlib.h(1301): warning C4005: 'min': macro redefinition
RTL_433\include\util.h(23): note: see previous definition of 'min'
```

Hence add `#include <stdlib.h>` first.

PS. I'm pretty amazed this warning is still there after 2 year.
More MSVC patches in progress if there's any interest?.....