### PR TITLE
Clean up baseband, optimize FM, add baseband-test

### DIFF
--- a/include/baseband.h
+++ b/include/baseband.h
@@ -25,18 +25,25 @@
 /// @param len: number of samples to process
 void envelope_detect(const uint8_t *iq_buf, uint16_t *y_buf, uint32_t len);
 
+// for evaluation
+void envelope_detect_nolut(const uint8_t *iq_buf, uint16_t *y_buf, uint32_t len);
+void magnitude_est_cu8(const uint8_t *iq_buf, uint16_t *y_buf, uint32_t len);
+void magnitude_true_cu8(const uint8_t *iq_buf, uint16_t *y_buf, uint32_t len);
+void magnitude_est_cs16(const int16_t *iq_buf, uint16_t *y_buf, uint32_t len);
+void magnitude_true_cs16(const int16_t *iq_buf, uint16_t *y_buf, uint32_t len);
+
 #define FILTER_ORDER 1
 
 /// Filter state buffer
 typedef struct {
-	int16_t	y[FILTER_ORDER];
-	int16_t	x[FILTER_ORDER];
+    int16_t y[FILTER_ORDER];
+    int16_t x[FILTER_ORDER];
 } FilterState;
 
 /// FM_Demod state buffer
 typedef struct {
-	int16_t	br, bi;		// Last I/Q sample
-	int16_t xlp, ylp;	// Low-pass filter state
+    int32_t br, bi;   // Last I/Q sample
+    int32_t xlp, ylp; // Low-pass filter state
 } DemodFM_State;
 
 /// Lowpass filter
@@ -55,7 +62,10 @@ void baseband_low_pass_filter(const uint16_t *x_buf, int16_t *y_buf, uint32_t le
 /// @param *y_buf: output from FM demodulator
 /// @param len: number of samples to process
 /// @param DemodFM_State: State to store between chunk processing
-void baseband_demod_FM(const uint8_t *x_buf, int16_t *y_buf, unsigned num_samples, DemodFM_State *state);
+void baseband_demod_FM(const uint8_t *x_buf, int16_t *y_buf, unsigned long num_samples, DemodFM_State *state);
+
+// for evaluation
+void baseband_demod_FM_cs16(const int16_t *x_buf, int16_t *y_buf, unsigned long num_samples, DemodFM_State *state);
 
 /// Initialize tables and constants
 /// Should be called once at startup

--- a/src/baseband.c
+++ b/src/baseband.c
@@ -23,7 +23,8 @@
 static uint16_t scaled_squares[256];
 
 /* precalculate lookup table for envelope detection */
-static void calc_squares() {
+static void calc_squares()
+{
     int i;
     for (i = 0; i < 256; i++)
         scaled_squares[i] = (127 - i) * (127 - i);
@@ -34,13 +35,84 @@ static void calc_squares() {
  *  The output will be written in the input buffer
  *  @returns   pointer to the input buffer
  */
-void envelope_detect(const uint8_t *iq_buf, uint16_t *y_buf, uint32_t len) {
-    unsigned int i;
+void envelope_detect(const uint8_t *iq_buf, uint16_t *y_buf, uint32_t len)
+{
+    unsigned long i;
     for (i = 0; i < len; i++) {
         y_buf[i] = scaled_squares[iq_buf[2 * i ]] + scaled_squares[iq_buf[2 * i + 1]];
     }
 }
 
+/** This will give a noisy envelope of OOK/ASK signals.
+ *  Subtracts the bias (-128) and calculates the norm (scaled by 16384).
+ *  Using a LUT is slower for O1 and above.
+ */
+void envelope_detect_nolut(const uint8_t *iq_buf, uint16_t *y_buf, uint32_t len)
+{
+    unsigned long i;
+    for (i = 0; i < len; i++) {
+        int16_t x = 127 - iq_buf[2 * i];
+        int16_t y = 127 - iq_buf[2 * i + 1];
+        y_buf[i]  = x * x + y * y; // max 16384
+    }
+}
+
+// note that magnitude emphasizes quiet signals / deemphasizes loud signals
+// 61/64, 13/32 Magnitude Estimator for CU8 (SIMD has min/max)
+void magnitude_est_cu8(const uint8_t *iq_buf, uint16_t *y_buf, uint32_t len)
+{
+    unsigned long i;
+    for (i = 0; i < len; i++) {
+        uint16_t x = abs(iq_buf[2 * i] - 128);
+        uint16_t y = abs(iq_buf[2 * i + 1] - 128);
+        uint16_t mi = x < y ? x : y;
+        uint16_t mx = x > y ? x : y;
+        uint16_t mag_est = 122 * mx + 52 * mi;
+        y_buf[i] = mag_est; // max 22272
+    }
+}
+
+// True Magnitude for CU8 (sqrt can SIMD but float is slow)
+void magnitude_true_cu8(const uint8_t *iq_buf, uint16_t *y_buf, uint32_t len)
+{
+    unsigned long i;
+    for (i = 0; i < len; i++) {
+        int16_t x = iq_buf[2 * i] - 128;
+        int16_t y = iq_buf[2 * i + 1] - 128;
+        y_buf[i]  = sqrt(x * x + y * y) * 128.0; // max 181, scaled 23170
+    }
+}
+
+// 61/64, 13/32 Magnitude Estimator for CS16 (SIMD has min/max)
+void magnitude_est_cs16(const int16_t *iq_buf, uint16_t *y_buf, uint32_t len)
+{
+    unsigned long i;
+    for (i = 0; i < len; i++) {
+        uint32_t x = abs(iq_buf[2 * i]);
+        uint32_t y = abs(iq_buf[2 * i + 1]);
+        uint32_t mi = x < y ? x : y;
+        uint32_t mx = x > y ? x : y;
+        uint32_t mag_est = 122 * mx + 52 * mi;
+        y_buf[i] = mag_est >> 8; // max 5701632, scaled 22272
+    }
+}
+
+// True Magnitude for CS16 (sqrt can SIMD but float is slow)
+void magnitude_true_cs16(const int16_t *iq_buf, uint16_t *y_buf, uint32_t len)
+{
+    unsigned long i;
+    for (i = 0; i < len; i++) {
+        int32_t x = iq_buf[2 * i];
+        int32_t y = iq_buf[2 * i + 1];
+        y_buf[i]  = (int)sqrt(x * x + y * y) >> 1; // max 46341, scaled 23170
+    }
+}
+
+
+// Fixed-point arithmetic on Q0.15
+#define F_SCALE 15
+#define S_CONST (1 << F_SCALE)
+#define FIX(x) ((int)(x * S_CONST))
 
 /** Something that might look like a IIR lowpass filter
  *
@@ -51,20 +123,16 @@ void envelope_detect(const uint8_t *iq_buf, uint16_t *y_buf, uint32_t len) {
  *  but the b coeffs are small so it wont happen
  *  Q15.14>>14 = Q15.0 \o/
  */
-#define F_SCALE 15
-#define S_CONST (1<<F_SCALE)
-#define FIX(x) ((int)(x*S_CONST))
+void baseband_low_pass_filter(const uint16_t *x_buf, int16_t *y_buf, uint32_t len, FilterState *state)
+{
+    ///  [b,a] = butter(1, 0.01) -> 3x tau (95%) ~100 samples
+    //static int a[FILTER_ORDER + 1] = {FIX(1.00000), FIX(0.96907)};
+    //static int b[FILTER_ORDER + 1] = {FIX(0.015466), FIX(0.015466)};
+    ///  [b,a] = butter(1, 0.05) -> 3x tau (95%) ~20 samples
+    static int a[FILTER_ORDER + 1] = {FIX(1.00000), FIX(0.85408)};
+    static int b[FILTER_ORDER + 1] = {FIX(0.07296), FIX(0.07296)};
 
-///  [b,a] = butter(1, 0.01) -> 3x tau (95%) ~100 samples
-//static int a[FILTER_ORDER + 1] = {FIX(1.00000), FIX(0.96907)};
-//static int b[FILTER_ORDER + 1] = {FIX(0.015466), FIX(0.015466)};
-///  [b,a] = butter(1, 0.05) -> 3x tau (95%) ~20 samples
-static int a[FILTER_ORDER + 1] = {FIX(1.00000), FIX(0.85408)};
-static int b[FILTER_ORDER + 1] = {FIX(0.07296), FIX(0.07296)};
-
-
-void baseband_low_pass_filter(const uint16_t *x_buf, int16_t *y_buf, uint32_t len, FilterState *state) {
-    unsigned int i;
+    unsigned long i;
     // Fixme: Will Segmentation Fault if len < FILTERORDER
 
     /* Calculate first sample */
@@ -83,41 +151,41 @@ void baseband_low_pass_filter(const uint16_t *x_buf, int16_t *y_buf, uint32_t le
 /// Integer implementation of atan2() with int16_t normalized output
 ///
 /// Returns arc tangent of y/x across all quadrants in radians
+/// Error max 0.07 radians
 /// Reference: http://dspguru.com/dsp/tricks/fixed-point-atan2-with-self-normalization
 /// @param y: Numerator (imaginary value of complex vector)
 /// @param x: Denominator (real value of complex vector)
 /// @return angle in radians (Pi equals INT16_MAX)
-int16_t atan2_int16(int16_t y, int16_t x) {
+int16_t atan2_int16(int16_t y, int16_t x)
+{
     static const int32_t I_PI_4 = INT16_MAX/4;      // M_PI/4
     static const int32_t I_3_PI_4 = 3*INT16_MAX/4;  // 3*M_PI/4
+
     const int32_t abs_y = abs(y);
-    int32_t r, angle;
+    int32_t angle;
 
     if (x >= 0) {    // Quadrant I and IV
         int32_t denom = (abs_y + x);
         if (denom == 0) denom = 1;  // Prevent divide by zero
-        r = ((x - abs_y) << 16) / denom;
-        angle = I_PI_4;
+        angle = I_PI_4 - I_PI_4 * (x - abs_y) / denom;
     } else {        // Quadrant II and III
         int32_t denom = (abs_y - x);
         if (denom == 0) denom = 1;  // Prevent divide by zero
-        r = ((x + abs_y) << 16) / denom;
-        angle = I_3_PI_4;
+        angle = I_3_PI_4 - I_PI_4 * (x + abs_y) / denom;
     }
-    angle -= (I_PI_4 * r) >> 16;  // Error max 0.07 radians
     if (y < 0) angle = -angle;    // Negate if in III or IV
     return angle;
 }
 
+void baseband_demod_FM(const uint8_t *x_buf, int16_t *y_buf, unsigned long num_samples, DemodFM_State *state)
+{
+    ///  [b,a] = butter(1, 0.1) -> 3x tau (95%) ~10 samples
+    //static int alp[2] = {FIX(1.00000), FIX(0.72654)};
+    //static int blp[2] = {FIX(0.13673), FIX(0.13673)};
+    ///  [b,a] = butter(1, 0.2) -> 3x tau (95%) ~5 samples
+    static int alp[2] = {FIX(1.00000), FIX(0.50953)};
+    static int blp[2] = {FIX(0.24524), FIX(0.24524)};
 
-///  [b,a] = butter(1, 0.1) -> 3x tau (95%) ~10 samples
-//static int alp[2] = {FIX(1.00000), FIX(0.72654)};
-//static int blp[2] = {FIX(0.13673), FIX(0.13673)};
-///  [b,a] = butter(1, 0.2) -> 3x tau (95%) ~5 samples
-static int alp[2] = {FIX(1.00000), FIX(0.50953)};
-static int blp[2] = {FIX(0.24524), FIX(0.24524)};
-
-void baseband_demod_FM(const uint8_t *x_buf, int16_t *y_buf, unsigned num_samples, DemodFM_State *state) {
     int16_t ar, ai;  // New IQ sample: x[n]
     int16_t br, bi;  // Old IQ sample: x[n-1]
     int32_t pr, pi;  // Phase difference vector
@@ -153,14 +221,89 @@ void baseband_demod_FM(const uint8_t *x_buf, int16_t *y_buf, unsigned num_sample
 }
 
 
-void baseband_init(void) {
+// Fixed-point arithmetic on Q0.31 (actually Q0.30 to counter 64 signed trouble)
+#define F_SCALE32 30
+#define S_CONST32 (1 << F_SCALE32)
+#define FIX32(x) ((int)(x * S_CONST32))
+
+// for evaluation
+int32_t atan2_int32(int32_t y, int32_t x)
+{
+    static const int64_t I_PI_4 = INT32_MAX / 4;          // M_PI/4
+    static const int64_t I_3_PI_4 = 3ll * INT32_MAX / 4;  // 3*M_PI/4
+
+    const int64_t abs_y = abs(y);
+    int64_t angle;
+
+    if (x >= 0) { // Quadrant I and IV
+        int64_t denom = (abs_y + x);
+        if (denom == 0) denom = 1; // Prevent divide by zero
+        angle = I_PI_4 - I_PI_4 * (x - abs_y) / denom;
+    } else { // Quadrant II and III
+        int64_t denom = (abs_y - x);
+        if (denom == 0) denom = 1; // Prevent divide by zero
+        angle = I_3_PI_4 - I_PI_4 * (x + abs_y) / denom;
+    }
+    if (y < 0) angle = -angle; // Negate if in III or IV
+    return angle;
+}
+
+// for evaluation
+void baseband_demod_FM_cs16(const int16_t *x_buf, int16_t *y_buf, unsigned long num_samples, DemodFM_State *state)
+{
+    ///  [b,a] = butter(1, 0.1) -> 3x tau (95%) ~10 samples
+    //static int alp[2] = {FIX32(1.00000), FIX32(0.72654)};
+    //static int blp[2] = {FIX32(0.13673), FIX32(0.13673)};
+    ///  [b,a] = butter(1, 0.2) -> 3x tau (95%) ~5 samples
+    static int64_t alp[2] = {FIX32(1.00000), FIX32(0.50953)};
+    static int64_t blp[2] = {FIX32(0.24524), FIX32(0.24524)};
+
+    int32_t ar, ai;  // New IQ sample: x[n]
+    int32_t br, bi;  // Old IQ sample: x[n-1]
+    int64_t pr, pi;  // Phase difference vector
+    int32_t angle;   // Phase difference angle
+    int32_t xlp, ylp, xlp_old, ylp_old;  // Low Pass filter variables
+
+    // Pre-feed old sample
+    ar = state->br; ai = state->bi;
+    xlp_old = state->xlp; ylp_old = state->ylp;
+
+    for (unsigned n = 0; n < num_samples; n++) {
+        // delay old sample
+        br = ar;
+        bi = ai;
+        // get new sample
+        ar = x_buf[2*n];
+        ai = x_buf[2*n+1];
+        // Calculate phase difference vector: x[n] * conj(x[n-1])
+        pr = (int64_t)ar*br+ai*bi;  // May exactly overflow an int32_t (-32768*-32768 + -32768*-32768)
+        pi = (int64_t)ai*br-ar*bi;
+//        xlp = (int32_t)((atan2f(pi, pr) / M_PI) * INT32_MAX);    // Floating point implementation
+        xlp = atan2_int32(pi, pr);  // Integer implementation
+//        xlp = atan2_int16(pi>>16, pr>>16) << 16;  // Integer implementation
+//        xlp = pi;                    // Cheat and use only imaginary part (works OK, but is amplitude sensitive)
+        // Low pass filter
+        ylp = (alp[1] * ylp_old + blp[0] * xlp + blp[1] * xlp_old) >> F_SCALE32;
+        ylp_old = ylp; xlp_old = xlp;
+        y_buf[n] = ylp >> 16; // not really losing info here, maybe optimize earlier
+    }
+
+    // Store newest sample for next run
+    state->br = ar; state->bi = ai;
+    state->xlp = xlp_old; state->ylp = ylp_old;
+}
+
+
+void baseband_init(void)
+{
     calc_squares();
 }
 
 
 static FILE *dumpfile = NULL;
 
-void baseband_dumpfile(const uint8_t *buf, uint32_t len) {
+void baseband_dumpfile(const uint8_t *buf, uint32_t len)
+{
     if (dumpfile == NULL) {
         dumpfile = fopen("dumpfile.dat", "wb");
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,9 @@
 add_executable(data-test data-test.c)
 
 target_link_libraries(data-test data)
+
+add_executable(baseband-test baseband-test.c ../src/baseband.c)
+
+if(UNIX)
+target_link_libraries(baseband-test m)
+endif()

--- a/tests/baseband-test.c
+++ b/tests/baseband-test.c
@@ -1,0 +1,149 @@
+/*
+ * Baseband Evaluation
+ *
+ * Functional and speed test for various baseband functions.
+ *
+ * Copyright (C) 2018 by Christian Zuckschwerdt <zany@triq.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <unistd.h>
+#include <time.h>
+
+#include "baseband.h"
+
+#define MEASURE(label, block)                                              \
+    do {                                                                   \
+        clock_t start = clock();                                           \
+        block;                                                             \
+        clock_t stop   = clock();                                          \
+        double elapsed = (double)(stop - start) * 1000.0 / CLOCKS_PER_SEC; \
+        printf("Time elapsed in ms: %f for: %s\n", elapsed, label);        \
+    } while (0);
+
+int read_buf(const char *filename, void *buf, size_t nbyte)
+{
+    int fd = open(filename, O_RDONLY);
+    if (fd < 0) {
+        fprintf(stderr, "Failed to open %s\n", filename);
+        return -1;
+    }
+    ssize_t ret = read(fd, buf, nbyte);
+    close(fd);
+    return ret;
+}
+
+int write_buf(const char *filename, const void *buf, size_t nbyte)
+{
+    int fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        fprintf(stderr, "Failed to open %s\n", filename);
+        return -1;
+    }
+    ssize_t ret = write(fd, buf, nbyte);
+    close(fd);
+    return ret;
+}
+
+int main(int argc, char *argv[])
+{
+    baseband_init();
+
+    uint8_t *cu8_buf;
+    uint16_t *y16_buf;
+    int16_t *cs16_buf;
+    uint32_t *y32_buf;
+    uint16_t *u16_buf;
+    uint32_t *u32_buf;
+    int16_t *s16_buf;
+    int32_t *s32_buf;
+    int fd;
+    char *filename;
+    long n_read;
+    unsigned long n_samples;
+    int max_block_size = 4096000;
+    FilterState state;
+    DemodFM_State fm_state;
+
+    if (argc <= 1) {
+        return 1;
+    }
+    filename = argv[1];
+
+    cu8_buf  = malloc(sizeof(uint8_t) * 2 * max_block_size);
+    y16_buf  = malloc(sizeof(uint16_t) * max_block_size);
+    cs16_buf = malloc(sizeof(int16_t) * 2 * max_block_size);
+    y32_buf  = malloc(sizeof(uint32_t) * max_block_size);
+    u16_buf  = malloc(sizeof(uint16_t) * max_block_size);
+    u32_buf  = malloc(sizeof(uint32_t) * max_block_size);
+    s16_buf  = malloc(sizeof(int16_t) * max_block_size);
+    s32_buf  = malloc(sizeof(int32_t) * max_block_size);
+
+    n_read = read_buf(filename, cu8_buf, sizeof(uint8_t) * 2 * max_block_size);
+    if (n_read < 1) {
+        return 1;
+    }
+    n_samples = n_read / (sizeof(uint8_t) * 2);
+
+    for (unsigned long i = 0; i < n_samples * 2; i++) {
+        cs16_buf[i] = (int16_t)cu8_buf[i] * 128 - 16320;
+        //cs16_buf[i] = (int16_t)cu8_buf[i] * 256 - 32640;
+    }
+
+    MEASURE("envelope_detect",
+        envelope_detect(cu8_buf, y16_buf, n_samples);
+    );
+    MEASURE("envelope_detect_nolut",
+        envelope_detect_nolut(cu8_buf, y16_buf, n_samples);
+    );
+    MEASURE("magnitude_est_cu8",
+        magnitude_est_cu8(cu8_buf, y16_buf, n_samples);
+    );
+    MEASURE("magnitude_true_cu8",
+        magnitude_true_cu8(cu8_buf, y16_buf, n_samples);
+    );
+    write_buf("bb_am.u16", y16_buf, sizeof(uint16_t) * n_samples);
+    MEASURE("baseband_low_pass_filter",
+        baseband_low_pass_filter(y16_buf, (int16_t *)u16_buf, n_samples, &state);
+    );
+    write_buf("bb_am.lp.u16", u16_buf, sizeof(int16_t) * n_samples);
+    MEASURE("baseband_demod_FM",
+        baseband_demod_FM(cu8_buf, s16_buf, n_samples, &fm_state);
+    );
+    write_buf("bb_fm.s16", s16_buf, sizeof(int16_t) * n_samples);
+
+    write_buf("bb.cs16", cs16_buf, sizeof(int16_t) * 2 * n_samples);
+    //envelope_detect_cs16(cs16_buf, y32_buf, n_samples);
+    //write_buf("bb_am.u32", y32_buf, sizeof(uint32_t) * n_samples);
+    //baseband_low_pass_filter_u32(y32_buf, u32_buf, n_samples, &state);
+    //write_buf("bb_am.lp.u32", u32_buf, sizeof(uint32_t) * n_samples);
+
+    MEASURE("magnitude_est_cs16",
+        magnitude_est_cs16(cs16_buf, y16_buf, n_samples);
+    );
+    MEASURE("magnitude_true_cs16",
+        magnitude_true_cs16(cs16_buf, y16_buf, n_samples);
+    );
+    write_buf("bb_m.u16", y16_buf, sizeof(uint16_t) * n_samples);
+    MEASURE("baseband_low_pass_filter",
+        baseband_low_pass_filter(y16_buf, (int16_t *)u16_buf, n_samples, &state);
+    );
+    write_buf("bb_m.lp.u16", u16_buf, sizeof(int16_t) * n_samples);
+
+    //baseband_demod_FM_cs16(cs16_buf, s32_buf, n_samples, &fm_state);
+    //write_buf("bb_fm.s32", s32_buf, sizeof(int32_t) * n_samples);
+
+    MEASURE("baseband_demod_FM_cs16",
+        baseband_demod_FM_cs16(cs16_buf, s16_buf, n_samples, &fm_state);
+    );
+    write_buf("bb_fm.cs16.s16", s16_buf, sizeof(int16_t) * n_samples);
+}


### PR DESCRIPTION
Adds a baseband-test to evaluate and compare speed and output.
Optimizes FM demod by removing intermediate shifts (no loss of precision).