### PR TITLE
Fix MinGW build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -121,11 +121,18 @@ add_executable(rtl_433
 
 add_library(data data.c)
 
+if(MINGW)
+target_link_libraries(data ws2_32 mswsock)
+endif()
+
 target_link_libraries(rtl_433
 	${SDR_LIBRARIES}
-    ${CMAKE_THREAD_LIBS_INIT}
+	${CMAKE_THREAD_LIBS_INIT}
 )
 
+if(MINGW)
+target_link_libraries(rtl_433 ws2_32 mswsock)
+endif()
 
 set(INSTALL_TARGETS rtl_433)
 if(UNIX)

--- a/tests/baseband-test.c
+++ b/tests/baseband-test.c
@@ -15,7 +15,9 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <sys/types.h>
+#ifndef _WIN32
 #include <sys/uio.h>
+#endif
 #include <unistd.h>
 #include <time.h>
 


### PR DESCRIPTION
src/CMakeLists.txt
With MinGW you need to link against ws2_32 and mswsock

tests/baseband-test.c
sys/uio.h is not available on windows