### PR TITLE
Improved checking of Simplisafe data and default enable decoder

### DIFF
--- a/src/devices/simplisafe.c
+++ b/src/devices/simplisafe.c
@@ -152,7 +152,7 @@ ss_sensor_callback (bitbuffer_t *bitbuffer)
 
 	uint8_t *b = bitbuffer->bb[row];
 
-	if (b[0] != 0x33 && b[1] != 0xa0) // All Messages Must start with 0x33a0
+	if (b[0] != 0x33 || b[1] != 0xa0) // All Messages Must start with 0x33a0
 		return 0;
 
 	if (b[2] == 0x88) {

--- a/src/devices/simplisafe.c
+++ b/src/devices/simplisafe.c
@@ -146,7 +146,7 @@ ss_keypad_commands (bitbuffer_t *bitbuffer, int row)
 static int
 ss_sensor_callback (bitbuffer_t *bitbuffer)
 {
-        // Simplisafe transmits data twice. Treat second copy as a checkum
+        // Simplisafe transmits data twice. Treat second copy as a checksum
         // and reject transmissions that lack it.
         int row = bitbuffer_find_repeated_row(bitbuffer, 2, 90);
         if (row < 0) return 0;

--- a/src/devices/simplisafe.c
+++ b/src/devices/simplisafe.c
@@ -42,13 +42,18 @@ ss_sensor_parser (bitbuffer_t *bitbuffer, int row)
 	if (bitbuffer->bits_per_row[row] != 92)
 		return 0;
 
+        uint8_t seq = reverse8(b[8]);
+        uint8_t state = reverse8(b[9]);
+        uint8_t csum = reverse8(b[10]);
+        if (((seq + state) & 0xff) != csum) return 0;
+
 	ss_get_id(id, b);
 
-	if (b[9] == 64) {
+        if (state == 1) {
+                strcpy(extradata,"Contact Open");
+        } else if (state == 2) {
 		strcpy(extradata,"Contact Closed");
-	} else if (b[9] == 128) {
-		strcpy(extradata,"Contact Open");
-	} else if (b[9] == 192) {
+        } else if (state == 3) {
 		strcpy(extradata,"Alarm Off");
 	}
 
@@ -57,8 +62,8 @@ ss_sensor_parser (bitbuffer_t *bitbuffer, int row)
 		"time",		"",	DATA_STRING, time_str,
 		"model",	"",	DATA_STRING, "SimpliSafe Sensor",
 		"device",	"Device ID",	DATA_STRING, id,
-		"seq",		"Sequence",	DATA_INT, b[8],
-		"state",	"State",	DATA_INT, b[9],
+		"seq",		"Sequence",	DATA_INT, seq,
+		"state",	"State",	DATA_INT, state,
 		"extradata",	"Extra Data",	DATA_STRING, extradata,
 		NULL
 	);

--- a/src/devices/simplisafe.c
+++ b/src/devices/simplisafe.c
@@ -146,16 +146,15 @@ ss_keypad_commands (bitbuffer_t *bitbuffer, int row)
 static int
 ss_sensor_callback (bitbuffer_t *bitbuffer)
 {
-        // Simplisafe transmits data twice. Treat second copy as a checksum
-        // and reject transmissions that lack it.
+        // Require two identical rows.
         int row = bitbuffer_find_repeated_row(bitbuffer, 2, 90);
         if (row < 0) return 0;
-	bitbuffer_invert(bitbuffer); // Invert the Bits
 
-	uint8_t *b = bitbuffer->bb[row];
+        // The row must start with 0xcc5f (0x33a0 inverted).
+        uint8_t *b = bitbuffer->bb[row];
+	if (b[0] != 0xcc || b[1] != 0x5f) return 0;
 
-	if (b[0] != 0x33 || b[1] != 0xa0) // All Messages Must start with 0x33a0
-		return 0;
+	bitbuffer_invert(bitbuffer);
 
 	if (b[2] == 0x88) {
 		return ss_sensor_parser (bitbuffer, row);

--- a/src/devices/simplisafe.c
+++ b/src/devices/simplisafe.c
@@ -146,6 +146,8 @@ ss_keypad_commands (bitbuffer_t *bitbuffer, int row)
 static int
 ss_sensor_callback (bitbuffer_t *bitbuffer)
 {
+        // Simplisafe transmits data twice. Treat second copy as a checkum
+        // and reject transmissions that lack it.
         int row = bitbuffer_find_repeated_row(bitbuffer, 2, 90);
         if (row < 0) return 0;
 	bitbuffer_invert(bitbuffer); // Invert the Bits


### PR DESCRIPTION
Simplisafe devices transmit each packet twice with about 2ms gap between them. This changes the decoder to detect and remove the duplicates.