### PR TITLE
Add VCD and SR output

### DIFF
--- a/include/pulse_detect.h
+++ b/include/pulse_detect.h
@@ -41,6 +41,9 @@ void pulse_data_clear(pulse_data_t *data);		// Clear the struct
 /// Print the content of a pulse_data_t structure (for debug)
 void pulse_data_print(const pulse_data_t *data);
 
+/// Dump the content of a pulse_data_t structure as raw binary
+void pulse_data_dump_raw(uint8_t *buf, unsigned len, intmax_t buf_offset, const pulse_data_t *data, uint8_t bits);
+
 /// Print a header for the VCD format
 void pulse_data_print_vcd_header(FILE *file, uint32_t sample_rate);
 

--- a/include/pulse_detect.h
+++ b/include/pulse_detect.h
@@ -12,6 +12,7 @@
 #define INCLUDE_PULSE_DETECT_H_
 
 #include <stdint.h>
+#include <stdio.h>
 
 #define PD_MAX_PULSES 1200			// Maximum number of pulses before forcing End Of Package
 #define PD_MIN_PULSES 16			// Minimum number of pulses before declaring a proper package
@@ -23,6 +24,7 @@
 
 /// Data for a compact representation of generic pulse train
 typedef struct {
+	intmax_t offset;			// Offset to first pulse in number of samples from start of stream
 	unsigned int num_pulses;
 	int pulse[PD_MAX_PULSES];	// Contains width of a pulse	(high)
 	int gap[PD_MAX_PULSES];		// Width of gaps between pulses (low)
@@ -39,6 +41,11 @@ void pulse_data_clear(pulse_data_t *data);		// Clear the struct
 /// Print the content of a pulse_data_t structure (for debug)
 void pulse_data_print(const pulse_data_t *data);
 
+/// Print a header for the VCD format
+void pulse_data_print_vcd_header(FILE *file, uint32_t sample_rate);
+
+/// Print the content of a pulse_data_t structure in VCD format
+void pulse_data_print_vcd(FILE *file, const pulse_data_t *data, int ch_id, uint32_t sample_rate);
 
 /// Demodulate On/Off Keying (OOK) and Frequency Shift Keying (FSK) from an envelope signal
 ///
@@ -52,8 +59,7 @@ void pulse_data_print(const pulse_data_t *data);
 /// @return 0 if all input sample data is processed
 /// @return 1 if OOK package is detected (but all sample data is still not completely processed)
 /// @return 2 if FSK package is detected (but all sample data is still not completely processed)
-int pulse_detect_package(const int16_t *envelope_data, const int16_t *fm_data, int len, int16_t level_limit, uint32_t samp_rate, pulse_data_t *pulses, pulse_data_t *fsk_pulses);
-
+int pulse_detect_package(const int16_t *envelope_data, const int16_t *fm_data, int len, int16_t level_limit, uint32_t samp_rate, intmax_t sample_offset, pulse_data_t *pulses, pulse_data_t *fsk_pulses);
 
 /// Analyze and print result
 void pulse_analyzer(pulse_data_t *data, uint32_t samp_rate);

--- a/tests/sigrok-conv.sh
+++ b/tests/sigrok-conv.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+if [ -z "$1" ] ; then
+  echo input file missing
+  echo "Usage: $0 input.cu8 output.sr [sample rate in kHz]"
+  exit 1
+fi
+if [ ! -r "$1" ] ; then
+  echo input not found
+  echo "Usage: $0 input.cu8 output.sr [sample rate in kHz]"
+  exit 1
+fi
+file=$1
+
+if [ -z "$2" ] ; then
+  echo output file missing
+  echo "Usage: $0 input.cu8 output.sr [sample rate in kHz]"
+  exit 1
+fi
+if [ -e "$2" ] ; then
+  echo output already exists
+  echo "Usage: $0 input.cu8 output.sr [sample rate in kHz]"
+  exit 1
+fi
+out=$2
+
+if [ -z "$3" ] ; then
+  rate=250
+else
+  rate=$3
+fi
+
+if [ ! -z "$4" ] ; then
+  echo too many arguments
+  echo "Usage: $0 input.cu8 output.sr [sample rate in kHz]"
+  exit 1
+fi
+
+# create I-data channel
+rtl_433 -q -r "$file" -m 7 analog-1-4-1 >/dev/null 2>&1
+# create Q-data channel
+rtl_433 -q -r "$file" -m 8 analog-1-5-1 >/dev/null 2>&1
+# create AM-data channel
+rtl_433 -q -r "$file" -m 5 analog-1-6-1 >/dev/null 2>&1
+# create FM-data channel
+rtl_433 -q -r "$file" -m 6 analog-1-7-1 >/dev/null 2>&1
+# create state channels
+rtl_433 -q -r "$file" -m 10 logic-1-1 >/dev/null 2>&1
+# create version tag
+echo -n "2" >version
+# create meta data
+cat >metadata <<EOF
+[device 1]
+capturefile=logic-1
+total probes=3
+samplerate=$rate kHz
+total analog=4
+probe1=FRAME
+probe2=ASK
+probe3=FSK
+analog4=I
+analog5=Q
+analog6=AM
+analog7=FM
+unitsize=1
+EOF
+
+zip "$out" version metadata analog-1-4-1 analog-1-5-1 analog-1-6-1 analog-1-7-1 logic-1-1
+rm version metadata analog-1-4-1 analog-1-5-1 analog-1-6-1 analog-1-7-1 logic-1-1

--- a/tests/sigrok-open.sh
+++ b/tests/sigrok-open.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+if [ -z "$1" ] ; then
+  echo input file missing
+  echo "Usage: $0 input.cu8 output.sr [sample rate in kHz]"
+  exit 1
+fi
+if [ ! -r "$1" ] ; then
+  echo input not found
+  echo "Usage: $0 input.cu8 output.sr [sample rate in kHz]"
+  exit 1
+fi
+file=$1
+
+filename=$(basename "$file")
+tempdir=$(mktemp -d)
+out="$tempdir/$filename.sr"
+trap "rm -f -- '$out'; rmdir -- '$tempdir'" EXIT
+
+if [ -z "$2" ] ; then
+  rate=250
+else
+  rate=$2
+fi
+
+if [ ! -z "$3" ] ; then
+  echo too many arguments
+  echo "Usage: $0 input.cu8 output.sr [sample rate in kHz]"
+  exit 1
+fi
+
+# create I-data channel
+rtl_433 -q -r "$file" -m 7 analog-1-4-1 >/dev/null 2>&1
+# create Q-data channel
+rtl_433 -q -r "$file" -m 8 analog-1-5-1 >/dev/null 2>&1
+# create AM-data channel
+rtl_433 -q -r "$file" -m 5 analog-1-6-1 >/dev/null 2>&1
+# create FM-data channel
+rtl_433 -q -r "$file" -m 6 analog-1-7-1 >/dev/null 2>&1
+# create state channels
+rtl_433 -q -r "$file" -m 10 logic-1-1 >/dev/null 2>&1
+# create version tag
+echo -n "2" >version
+# create meta data
+cat >metadata <<EOF
+[device 1]
+capturefile=logic-1
+total probes=3
+samplerate=$rate kHz
+total analog=4
+probe1=FRAME
+probe2=ASK
+probe3=FSK
+analog4=I
+analog5=Q
+analog6=AM
+analog7=FM
+unitsize=1
+EOF
+
+zip "$out" version metadata analog-1-4-1 analog-1-5-1 analog-1-6-1 analog-1-7-1 logic-1-1
+rm version metadata analog-1-4-1 analog-1-5-1 analog-1-6-1 analog-1-7-1 logic-1-1
+
+case "$OSTYPE" in
+  darwin*)
+    open -b org.sigrok.PulseView --fresh --new --wait-apps --args -i "$out"
+    ;;
+  *)
+    pulseview -i "$out"
+    ;;
+esac
+
+rm -f -- "$out"
+rmdir -- "$tempdir"
+trap - EXIT


### PR DESCRIPTION
While toying with CAN bus the other day and using a mixed signal digital oscilloscope I was very pleased with some visualizations.
I think those visualizations are better suited and easier than telling people to use Audacity.

This branch isn't ready for merge, but the pictures are already exciting!

There is a native [VCD](https://en.wikipedia.org/wiki/Value_change_dump) output (e.g. for [GTKWave](http://gtkwave.sourceforge.net/) and lots of commercial tools if you have them) and a script to compile .sr files for [Sigrok's Pulseview](https://sigrok.org/).

```
rtl_433 -q -r ./rtl_433_tests/tests/lacrosse/tx141th-bv2/tx141th-bv2-0002.cu8 \
-m 5 ~/Desktop/tx141th-bv2-0002.vcd

./tests/sigrok-conv.sh ./rtl_433_tests/tests/lacrosse/tx141th-bv2/tx141th-bv2-0002.cu8 \
 ~/Desktop/tx141th-bv2-0002.sr
```
