### PR TITLE
Modularize dumpers, allow multiple

### DIFF
--- a/include/fileformat.h
+++ b/include/fileformat.h
@@ -13,6 +13,7 @@
 #define INCLUDE_FILEFORMAT_H_
 
 #include <stdint.h>
+#include <stdio.h>
 
 // a single handy number to define the file type.
 // bitmask: RRRR LLLL WWWWWWWW 00CC 00FS
@@ -73,6 +74,7 @@ typedef struct {
     uint32_t sample_rate;
     char const *spec;
     char const *path;
+    FILE *file;
 } file_info_t;
 
 int parse_file_info(const char *filename, file_info_t *info);

--- a/src/fileformat.c
+++ b/src/fileformat.c
@@ -10,7 +10,6 @@
  */
 
 #include <string.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <strings.h>
 //#include "optparse.h"

--- a/tests/sigrok-conv.sh
+++ b/tests/sigrok-conv.sh
@@ -36,16 +36,8 @@ if [ ! -z "$4" ] ; then
   exit 1
 fi
 
-# create I-data channel
-rtl_433 -q -r "$file" F32:I:analog-1-4-1 >/dev/null 2>&1
-# create Q-data channel
-rtl_433 -q -r "$file" F32:Q:analog-1-5-1 >/dev/null 2>&1
-# create AM-data channel
-rtl_433 -q -r "$file" F32:AM:analog-1-6-1 >/dev/null 2>&1
-# create FM-data channel
-rtl_433 -q -r "$file" F32:FM:analog-1-7-1 >/dev/null 2>&1
-# create state channels
-rtl_433 -q -r "$file" U8:LOGIC:logic-1-1 >/dev/null 2>&1
+# create channels
+rtl_433 -q -r "$file" -w F32:I:analog-1-4-1 -w F32:Q:analog-1-5-1 -w F32:AM:analog-1-6-1 -w F32:FM:analog-1-7-1 -w U8:LOGIC:logic-1-1 >/dev/null 2>&1
 # create version tag
 echo -n "2" >version
 # create meta data

--- a/tests/sigrok-open.sh
+++ b/tests/sigrok-open.sh
@@ -29,16 +29,8 @@ if [ ! -z "$3" ] ; then
   exit 1
 fi
 
-# create I-data channel
-rtl_433 -q -r "$file" F32:I:analog-1-4-1 >/dev/null 2>&1
-# create Q-data channel
-rtl_433 -q -r "$file" F32:Q:analog-1-5-1 >/dev/null 2>&1
-# create AM-data channel
-rtl_433 -q -r "$file" F32:AM:analog-1-6-1 >/dev/null 2>&1
-# create FM-data channel
-rtl_433 -q -r "$file" F32:FM:analog-1-7-1 >/dev/null 2>&1
-# create state channels
-rtl_433 -q -r "$file" U8:LOGIC:logic-1-1 >/dev/null 2>&1
+# create channels
+rtl_433 -q -r "$file" -w F32:I:analog-1-4-1 -w F32:Q:analog-1-5-1 -w F32:AM:analog-1-6-1 -w F32:FM:analog-1-7-1 -w U8:LOGIC:logic-1-1 >/dev/null 2>&1
 # create version tag
 echo -n "2" >version
 # create meta data


### PR DESCRIPTION
Allow multiple file dumpers in on go. Switch to `-w FILENAME` (and `-W FILENAME` for overwrite) and deprecate positional filename for output.
Goes on top of #815