### PR TITLE
Refactor out rtlsdr calls

### DIFF
--- a/include/sdr.h
+++ b/include/sdr.h
@@ -1,0 +1,38 @@
+/**
+ * SDR input from RTLSDR or SoapySDR
+ *
+ * Copyright (C) 2018 Christian Zuckschwerdt
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef INCLUDE_SDR_H_
+#define INCLUDE_SDR_H_
+
+#include <stdint.h>
+
+typedef struct sdr_dev sdr_dev_t;
+typedef void (*sdr_read_cb_t)(unsigned char *buf, uint32_t len, void *ctx);
+
+int sdr_open(sdr_dev_t **out_dev, int *sample_size, char const *dev_query, int verbose);
+int sdr_close(sdr_dev_t *dev);
+
+int sdr_set_center_freq(sdr_dev_t *dev, uint32_t freq, int verbose);
+uint32_t sdr_get_center_freq(sdr_dev_t *dev);
+
+int sdr_set_freq_correction(sdr_dev_t *dev, int ppm, int verbose);
+
+int sdr_set_auto_gain(sdr_dev_t *dev, int verbose);
+int sdr_set_tuner_gain(sdr_dev_t *dev, int gain, int verbose);
+
+int sdr_set_sample_rate(sdr_dev_t *dev, uint32_t rate, int verbose);
+uint32_t sdr_get_sample_rate(sdr_dev_t *dev);
+
+int sdr_reset(sdr_dev_t *dev);
+int sdr_start(sdr_dev_t *dev, sdr_read_cb_t cb, void *ctx, uint32_t buf_num, uint32_t buf_len);
+int sdr_stop(sdr_dev_t *dev);
+
+#endif /* INCLUDE_SDR_H_ */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(rtl_433
 	pulse_demod.c
 	pulse_detect.c
 	rtl_433.c
+	sdr.c
 	util.c
 	devices/acurite.c
 	devices/akhan_100F14.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,6 +11,7 @@ rtl_433_SOURCES      = baseband.c \
                        pulse_demod.c \
                        pulse_detect.c \
                        rtl_433.c \
+                       sdr.c \
                        util.c \
                        devices/acurite.c \
                        devices/akhan_100F14.c \

--- a/src/sdr.c
+++ b/src/sdr.c
@@ -1,0 +1,190 @@
+/**
+ * SDR input from RTLSDR or SoapySDR
+ *
+ * Copyright (C) 2018 Christian Zuckschwerdt
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "sdr.h"
+#include "rtl-sdr.h"
+#include "util.h"
+
+struct sdr_dev {
+    rtlsdr_dev_t *rtlsdr_dev;
+    int sample_size;
+    int running;
+};
+
+int sdr_open(sdr_dev_t **out_dev, int *sample_size, char const *dev_query, int verbose)
+{
+    uint32_t device_count = rtlsdr_get_device_count();
+    if (!device_count) {
+        fprintf(stderr, "No supported devices found.\n");
+        return -1;
+    }
+
+    if (verbose)
+        fprintf(stderr, "Found %d device(s)\n\n", device_count);
+
+    int dev_index = 0;
+    // select rtlsdr device by serial (-d :<serial>)
+    if (dev_query && *dev_query == ':') {
+        dev_index = rtlsdr_get_index_by_serial(&dev_query[1]);
+        if (dev_index < 0) {
+            if (verbose)
+                fprintf(stderr, "Could not find device with serial '%s' (err %d)",
+                        &dev_query[1], dev_index);
+            return -1;
+        }
+    }
+
+    // select rtlsdr device by number (-d <n>)
+    else if (dev_query) {
+        dev_index = atoi(dev_query);
+        // check if 0 is a parsing error?
+        if (dev_index < 0) {
+            // select first available rtlsdr device
+            dev_index = 0;
+            dev_query = NULL;
+        }
+    }
+
+    char vendor[256], product[256], serial[256];
+    int r = -1;
+    sdr_dev_t *dev = calloc(1, sizeof(sdr_dev_t));
+
+    for (uint32_t i = dev_query ? dev_index : 0;
+            //cast quiets -Wsign-compare; if dev_index were < 0, would have returned -1 above
+            i < (dev_query ? (unsigned)dev_index + 1 : device_count);
+            i++) {
+        rtlsdr_get_device_usb_strings(i, vendor, product, serial);
+
+        if (verbose)
+            fprintf(stderr, "trying device  %d:  %s, %s, SN: %s\n",
+                    i, vendor, product, serial);
+
+        r = rtlsdr_open(&dev->rtlsdr_dev, i);
+        if (r < 0) {
+            if (verbose)
+                fprintf(stderr, "Failed to open rtlsdr device #%d.\n\n", i);
+        } else {
+            if (verbose)
+                fprintf(stderr, "Using device %d: %s\n",
+                        i, rtlsdr_get_device_name(i));
+            dev->sample_size = sizeof(uint8_t); // CU8
+            *sample_size = sizeof(uint8_t); // CU8
+            break;
+        }
+    }
+    if (r < 0) {
+        free(dev);
+        if (verbose)
+            fprintf(stderr, "Unable to open a device\n");
+    } else {
+        *out_dev = dev;
+    }
+
+    return r;
+}
+
+int sdr_close(sdr_dev_t *dev)
+{
+    return rtlsdr_close(dev->rtlsdr_dev);
+}
+
+int sdr_set_center_freq(sdr_dev_t *dev, uint32_t freq, int verbose)
+{
+    int r = rtlsdr_set_center_freq(dev->rtlsdr_dev, freq);
+    if (verbose) {
+        if (r < 0)
+            fprintf(stderr, "WARNING: Failed to set center freq.\n");
+        else
+            fprintf(stderr, "Tuned to %s.\n", nice_freq(sdr_get_center_freq(dev)));
+    }
+    return r;
+}
+
+uint32_t sdr_get_center_freq(sdr_dev_t *dev)
+{
+    return rtlsdr_get_center_freq(dev->rtlsdr_dev);
+}
+
+int sdr_set_freq_correction(sdr_dev_t *dev, int ppm, int verbose)
+{
+    int r = rtlsdr_set_freq_correction(dev->rtlsdr_dev, ppm);
+    if (verbose) {
+        if (r < 0)
+            fprintf(stderr, "WARNING: Failed to set frequency correction.\n");
+        else
+            fprintf(stderr, "Frequency correction set to %d.\n", ppm);
+    }
+    return r;
+}
+
+int sdr_set_auto_gain(sdr_dev_t *dev, int verbose)
+{
+    int r = rtlsdr_set_tuner_gain_mode(dev->rtlsdr_dev, 0);
+    if (verbose) {
+        if (r < 0)
+            fprintf(stderr, "WARNING: Failed to enable automatic gain.\n");
+        else
+            fprintf(stderr, "Tuner gain set to Auto.\n");
+    }
+    return r;
+}
+
+int sdr_set_tuner_gain(sdr_dev_t *dev, int gain, int verbose)
+{
+    /* Enable manual gain */
+    int r = rtlsdr_set_tuner_gain_mode(dev->rtlsdr_dev, 1);
+    if (verbose)
+        if (r < 0)
+            fprintf(stderr, "WARNING: Failed to enable manual gain.\n");
+
+    /* Set the tuner gain */
+    r = rtlsdr_set_tuner_gain(dev->rtlsdr_dev, gain);
+    if (verbose) {
+        if (r < 0)
+            fprintf(stderr, "WARNING: Failed to set tuner gain.\n");
+        else
+            fprintf(stderr, "Tuner gain set to %f dB.\n", gain / 10.0);
+    }
+    return r;
+}
+
+int sdr_set_sample_rate(sdr_dev_t *dev, uint32_t rate, int verbose)
+{
+    int r = rtlsdr_set_sample_rate(dev->rtlsdr_dev, rate);
+    if (verbose) {
+        if (r < 0)
+            fprintf(stderr, "WARNING: Failed to set sample rate.\n");
+        else
+            fprintf(stderr, "Sample rate set to %d.\n", sdr_get_sample_rate(dev)); // Unfortunately, doesn't return real rate
+    }
+    return r;
+}
+uint32_t sdr_get_sample_rate(sdr_dev_t *dev)
+{
+    return rtlsdr_get_sample_rate(dev->rtlsdr_dev);
+}
+
+int sdr_reset(sdr_dev_t *dev)
+{
+    return rtlsdr_reset_buffer(dev->rtlsdr_dev);
+}
+
+int sdr_start(sdr_dev_t *dev, sdr_read_cb_t cb, void *ctx, uint32_t buf_num, uint32_t buf_len)
+{
+    return rtlsdr_read_async(dev->rtlsdr_dev, cb, ctx, buf_num, buf_len);
+}
+
+int sdr_stop(sdr_dev_t *dev)
+{
+    return rtlsdr_cancel_async(dev->rtlsdr_dev);
+}

--- a/vs15/rtl_433.vcxproj
+++ b/vs15/rtl_433.vcxproj
@@ -94,6 +94,7 @@
     <ClInclude Include="..\include\pulse_detect.h" />
     <ClInclude Include="..\include\rtl_433.h" />
     <ClInclude Include="..\include\rtl_433_devices.h" />
+    <ClInclude Include="..\include\sdr.h" />
     <ClInclude Include="..\include\util.h" />
     <ClInclude Include="..\src\getopt\getopt.h" />
   </ItemGroup>
@@ -106,6 +107,7 @@
     <ClCompile Include="..\src\pulse_demod.c" />
     <ClCompile Include="..\src\pulse_detect.c" />
     <ClCompile Include="..\src\rtl_433.c" />
+    <ClCompile Include="..\src\sdr.c" />
     <ClCompile Include="..\src\util.c" />
     <ClCompile Include="..\src\devices\acurite.c" />
     <ClCompile Include="..\src\devices\akhan_100F14.c" />

--- a/vs15/rtl_433.vcxproj.filters
+++ b/vs15/rtl_433.vcxproj.filters
@@ -44,6 +44,9 @@
     <ClInclude Include="..\include\rtl_433_devices.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\sdr.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\include\util.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -74,6 +77,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\src\rtl_433.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\sdr.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\src\util.c">


### PR DESCRIPTION
Breaks out all actual rtlsdr calls into a separate file.
No functional changes (quiet mode got a little quieter).
Paves the way for a clean SoapySDR integration.