### PR TITLE
MQTT: Add Model ID to devices and script to generate proper MQTT topics

### DIFF
--- a/src/devices/calibeur.c
+++ b/src/devices/calibeur.c
@@ -82,6 +82,7 @@ static int calibeur_rf104_callback(bitbuffer_t *bitbuffer) {
 		local_time_str(0, time_str);
 		data = data_make("time",          "",            DATA_STRING, time_str,
 						"model",         "",            DATA_STRING, "Calibeur RF-104",
+						"mid",           "MID",         DATA_STRING, "CALRF104",
 						"id",            "ID",          DATA_INT, ID,
 						"temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
 						"humidity",      "Humidity",    DATA_FORMAT, "%2.0f %%", DATA_DOUBLE, humidity,

--- a/src/devices/chuango.c
+++ b/src/devices/chuango.c
@@ -71,6 +71,7 @@ static int chuango_callback(bitbuffer_t *bitbuffer) {
     data = data_make(
             "time",     "",             DATA_STRING, time_str,
             "model",    "",             DATA_STRING, "Chuango Security Technology",
+            "mid",      "MID",          DATA_STRING, "CHUANGO",
             "id",       "ID",           DATA_INT,    id,
             "cmd",      "CMD",          DATA_STRING, cmd_str,
             "cmd_id",   "CMD_ID",       DATA_INT,    cmd,

--- a/src/devices/danfoss.c
+++ b/src/devices/danfoss.c
@@ -138,6 +138,7 @@ static int danfoss_CFR_callback(bitbuffer_t *bitbuffer) {
 		data = data_make(
 			"time",		"",		DATA_STRING,	time_str,
 			"model",		"",		DATA_STRING,	"Danfoss CFR Thermostat",
+			"mid",		"MID",		DATA_STRING, "DANCFR",
 			"id",		"ID",		DATA_INT,	id,
 			"temperature_C", 	"Temperature",	DATA_FORMAT,	"%.2f C", DATA_DOUBLE, temp_meas,
 			"setpoint_C",	"Setpoint",	DATA_FORMAT,	"%.2f C", DATA_DOUBLE, temp_setp,

--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -41,6 +41,7 @@ static int fineoffset_WH2_callback(bitbuffer_t *bitbuffer) {
     char time_str[LOCAL_TIME_BUFLEN];
 
     char *model;
+    char *mid;
     int type;
     uint8_t id;
     int16_t temp;
@@ -51,22 +52,22 @@ static int fineoffset_WH2_callback(bitbuffer_t *bitbuffer) {
             bb[0][0] == 0xFF) { // WH2
         bitbuffer_extract_bytes(bitbuffer, 0, 8, b, 40);
         model = "Fine Offset Electronics, WH2 Temperature/Humidity sensor";
-
+        mid = "FOWH2";
     } else if (bitbuffer->bits_per_row[0] == 55 &&
             bb[0][0] == 0xFE) { // WH2A
         bitbuffer_extract_bytes(bitbuffer, 0, 7, b, 48);
         model = "Fine Offset WH2A sensor";
-
+        mid = "FOWH2A";
     } else if (bitbuffer->bits_per_row[0] == 47 &&
             bb[0][0] == 0xFE) { // WH5
         bitbuffer_extract_bytes(bitbuffer, 0, 7, b, 40);
         model = "Fine Offset WH5 sensor";
-
+        mid = "FOWH5";
     } else if (bitbuffer->bits_per_row[0] == 49 &&
             bb[0][0] == 0xFF && (bb[0][1]&0x80) == 0x80) { // Telldus
         bitbuffer_extract_bytes(bitbuffer, 0, 9, b, 40);
         model = "Telldus/Proove thermometer";
-
+        mid = "TELLTHER";
     } else
         return 0;
 
@@ -110,6 +111,7 @@ static int fineoffset_WH2_callback(bitbuffer_t *bitbuffer) {
     if (b[3] == 0xFF) {
         data = data_make("time",          "",            DATA_STRING, time_str,
                          "model",         "",            DATA_STRING, model,
+                         "mid",           "MID",         DATA_STRING, mid,
                          "id",            "ID",          DATA_INT, id,
                          "temperature_C", "Temperature", DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
                          "mic",           "Integrity",   DATA_STRING, "CRC",
@@ -120,6 +122,7 @@ static int fineoffset_WH2_callback(bitbuffer_t *bitbuffer) {
     else {
         data = data_make("time",          "",            DATA_STRING, time_str,
                          "model",         "",            DATA_STRING, model,
+                         "mid",           "MID",         DATA_STRING, mid,
                          "id",            "ID",          DATA_INT, id,
                          "temperature_C", "Temperature", DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
                          "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, humidity,
@@ -249,6 +252,7 @@ static int fineoffset_WH24_callback(bitbuffer_t *bitbuffer)
     data = data_make(
             "time",             "",                 DATA_STRING, time_str,
             "model",            "",                 DATA_STRING, "Fine Offset WH24",
+            "mid",              "MID",              DATA_STRING, "FOWH24",
             "id",               "ID",               DATA_INT, id,
             NULL);
     if (temp_raw       != 0x7ff)
@@ -349,6 +353,7 @@ static int fineoffset_WH25_callback(bitbuffer_t *bitbuffer) {
     local_time_str(0, time_str);
     data = data_make("time",          "",            DATA_STRING, time_str,
                      "model",         "",            DATA_STRING, "Fine Offset Electronics, WH25",
+                     "mid",           "MID",         DATA_STRING, "FOWH25",
                      "id",            "ID",          DATA_INT, id,
                      "temperature_C", "Temperature", DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
                      "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, humidity,
@@ -419,6 +424,7 @@ static int fineoffset_WH0530_callback(bitbuffer_t *bitbuffer) {
     local_time_str(0, time_str);
     data = data_make("time",          "",            DATA_STRING, time_str,
                      "model",         "",            DATA_STRING, "Fine Offset Electronics, WH0530 Temperature/Rain sensor",
+                     "mid",           "MID",         DATA_STRING, "FOWH0530",
                      "id",            "ID",          DATA_INT, id,
                      "temperature_C", "Temperature", DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
                      "rain",          "Rain",        DATA_FORMAT, "%.01f mm", DATA_DOUBLE, rainfall,

--- a/tests/rtl_433_mqtt.py
+++ b/tests/rtl_433_mqtt.py
@@ -57,8 +57,8 @@ def main():
             continue
 
         mqtt_topic = MQTT_TOPIC_PREFIX      # Build up topic string
-#        model_id = d.get('mid')
-        model_id = mid.get(d.get('model'))     # Map Model name to Model ID
+        model_id = d.get('mid')
+#        model_id = mid.get(d.get('model'))     # Map Model name to Model ID
         if model_id:
             mqtt_topic += '/' + model_id
             sensor_id = d.get('id')
@@ -68,7 +68,7 @@ def main():
         mqtt_client.publish(mqtt_topic, line)
         log.info(mqtt_topic + "\t" + line)
 
-
+"""
 # Model IDs mapping the loong Model names into a short (max 8 chars) 'mid'
 # Should probably be incorporated into rtl_433 sensor data itself
 mid = {
@@ -79,7 +79,7 @@ mid = {
     "Fine Offset Electronics, WH25" :                               "FOWH25",
     "Fine Offset Electronics, WH0530 Temperature/Rain sensor" :     "FOWH0530",
 }
-
+"""
 
 if __name__ == "__main__":
     main()

--- a/tests/rtl_433_mqtt.py
+++ b/tests/rtl_433_mqtt.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+""" MQTT client for sending rtl_433 JSON data strutured into mqtt topics
+
+Topic string is: <prefix>/<model id>/<sensor id>
+Example: home/rtl_433/CALRF104/3
+
+Recommended way of sending rtl_433 data on network is:
+$ rtl_433 -F json -U | tests/rtl_433_mqtt.py
+
+An MQTT broker e.g. 'mosquitto' must be running on local computer
+"""
+
+import json
+import logging
+import multiprocessing as mp
+import sys
+
+import paho.mqtt.client as mqtt
+
+MQTT_SERVER = "127.0.0.1"
+MQTT_TOPIC_PREFIX = "home/rtl_433"
+
+#log = logging.getLogger()  # Single process logger
+log = mp.log_to_stderr()  # Multiprocessing capable logger
+log.setLevel(logging.INFO)
+
+def on_connect(client, userdata, flags, rc):
+    """ Callback for when the client receives a CONNACK response from the server. """
+    log.info("MQTT Connection: " + mqtt.connack_string(rc))
+    if rc != 0:
+        log.error("Could not connect to MQTT broker. RC: " + str(rc))
+        exit()
+
+
+def on_disconnect(client, userdata, rc):
+    if rc != 0:
+        log.error("Disconnected from MQTT broker. RC: " + str(rc))
+
+
+# Setup MQTT client
+mqtt_client = mqtt.Client("RTL_433_MQTT")
+mqtt_client.on_connect = on_connect
+mqtt_client.on_disconnect = on_disconnect
+mqtt_client.connect(MQTT_SERVER)
+mqtt_client.loop_start()
+
+
+def main():
+    log.info("RTL_433 to MQTT")
+
+    for line in sys.stdin:
+        try:
+            # Decode JSON payload
+            d = json.loads(line)
+        except json.decoder.JSONDecodeError:
+            log.warning("JSON decode error: " + line)
+            continue
+
+        mqtt_topic = MQTT_TOPIC_PREFIX      # Build up topic string
+#        model_id = d.get('mid')
+        model_id = mid.get(d.get('model'))     # Map Model name to Model ID
+        if model_id:
+            mqtt_topic += '/' + model_id
+            sensor_id = d.get('id')
+            if sensor_id:
+                mqtt_topic += '/' + str(sensor_id)
+
+        mqtt_client.publish(mqtt_topic, line)
+        log.info(mqtt_topic + "\t" + line)
+
+
+# Model IDs mapping the loong Model names into a short (max 8 chars) 'mid'
+# Should probably be incorporated into rtl_433 sensor data itself
+mid = {
+    "Calibeur RF-104" :                                             "CALRF104",
+    "Chuango Security Technology" :                                 "CHUANGO",
+    "Danfoss CFR Thermostat" :                                      "DANCFR",
+    "Fine Offset Electronics, WH2 Temperature/Humidity sensor" :    "FOWH2",
+    "Fine Offset Electronics, WH25" :                               "FOWH25",
+    "Fine Offset Electronics, WH0530 Temperature/Rain sensor" :     "FOWH0530",
+}
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
**Request for Comment**
Currently the recommended way to pass rtl_433 output to MQTT is via a simple pipe to a topic common for all models and sensors (`rtl_433 -F json -U | mosquitto_pub -t home/rtl_433 -l`). 

However that means MQTT subscribers will have to filter state updates based on the JSON content. This is not the [recommended](https://www.hivemq.com/blog/mqtt-essentials-part-5-mqtt-topics-best-practices) way to generate MQTT topics, and not supported by e.g. [Home Assistant](https://www.home-assistant.io), which have [rejected](https://github.com/home-assistant/home-assistant/pull/12666) adding such a feature.

Since the Model names in rtl_433 are long and contain spaces and slashes, it is not possible to make a canonical MQTT topic like `home/rtl_433/<model>/<id>`, which would generate a separate topic for each sensor update and make integration with e.g. Home Assistant easy.

I therefore propose adding a `mid` or "Model ID" to each device, consisting of a unique short string (Max ~8 characters). That will make it possible to generate a topic like `home/rtl_433/<mid>/<id>` or example `home/rtl_433/FOWH0530/183` (for the "Fine Offset Electronics, WH0530 Temperature/Rain sensor" with sensor ID 183).

A sample Python script for piping rtl_433 to MQTT topics is included such that the new recommended way to output to MQTT will be `rtl_433 -F json -U | tests/rtl_433_mqtt.py`. Furthermore `mid` is added to a couple of devices. I will add it to the rest (~100), if the proposal is accepted.