### PR TITLE
WIP - Add CRC check to solight_te44

### DIFF
--- a/src/devices/solight_te44.c
+++ b/src/devices/solight_te44.c
@@ -38,6 +38,8 @@
 #include "rtl_433.h"
 #include "util.h"
 
+extern int rubicson_crc_check(bitrow_t *bb);
+
 static int solight_te44_callback(bitbuffer_t *bitbuffer) {
 
     data_t *data;
@@ -70,6 +72,8 @@ static int solight_te44_callback(bitbuffer_t *bitbuffer) {
             return 0;
         }
     }
+
+    if (!rubicson_crc_check(bb)) return 0;
 
     local_time_str(0, time_str);
 


### PR DESCRIPTION
It turns out solight_te44 is using same CRC8 algorithm as rubicson (#833) according to the tests.

However, I would like some guidance on how to refactor solight_te44.c.