### PR TITLE
am_analyze.c: Fix compilation under MS VS 2015/2017

### DIFF
--- a/src/am_analyze.c
+++ b/src/am_analyze.c
@@ -12,7 +12,17 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#ifdef _MSC_VER
+#define F_OK 0
+#endif
+#endif
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include "bitbuffer.h"
 


### PR DESCRIPTION
MS environment does not provide <unistd.h>.

I chose an equivalent solution than already present in rtl_433.h