### PR TITLE
Add output tag option, multiple input files

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,11 @@ Usage:	= General options =
 	[-r <filename>] Read data from input file instead of a receiver
 	[-w <filename>] Save data stream to output file (a '-' dumps samples to stdout)
 	[-W <filename>] Save data stream to output file, overwrite existing file
+	= Data output options =
 	[-F] kv|json|csv|syslog|null Produce decoded output in given format. Not yet supported by all drivers.
 		 Append output to file with :<filename> (e.g. -F csv:log.csv), defaults to stdout.
 		 Specify host/port for syslog with e.g. -F syslog:127.0.0.1:1514
+	[-K] FILE|PATH|<tag> Add an expanded token or fixed tag to every output line.
 	[-C] native|si|customary Convert units in decoded output.
 	[-T] Specify number of seconds to run
 	[-U] Print timestamps in UTC (this may also be accomplished by invocation with TZ environment variable set).

--- a/include/data.h
+++ b/include/data.h
@@ -118,11 +118,17 @@ typedef struct data {
 */
 data_t *data_make(const char *key, const char *pretty_key, ...);
 
-/** Adds to a structured data object.
+/** Adds to a structured data object, by appending data.
 
     @see data_make()
 */
 data_t *data_append(data_t *first, const char *key, const char *pretty_key, ...);
+
+/** Adds to a structured data object, by prepending data.
+
+    @see data_make()
+*/
+data_t *data_prepend(data_t *first, const char *key, const char *pretty_key, ...);
 
 /** Constructs an array from given data of the given uniform type.
 

--- a/include/fileformat.h
+++ b/include/fileformat.h
@@ -15,6 +15,8 @@
 #include <stdint.h>
 #include <stdio.h>
 
+char const *file_basename(char const *path);
+
 // a single handy number to define the file type.
 // bitmask: RRRR LLLL WWWWWWWW 00CC 00FS
 enum file_type {

--- a/src/data.c
+++ b/src/data.c
@@ -302,6 +302,9 @@ data_t *data_prepend(data_t *first, const char *key, const char *pretty_key, ...
     data_t *result = vdata_make(NULL, key, pretty_key, ap);
     va_end(ap);
 
+    if (!result)
+        return first;
+
     data_t *prev = result;
     while (prev && prev->next)
         prev = prev->next;

--- a/src/data.c
+++ b/src/data.c
@@ -295,6 +295,21 @@ data_t *data_append(data_t *first, const char *key, const char *pretty_key, ...)
     return result;
 }
 
+data_t *data_prepend(data_t *first, const char *key, const char *pretty_key, ...)
+{
+    va_list ap;
+    va_start(ap, pretty_key);
+    data_t *result = vdata_make(NULL, key, pretty_key, ap);
+    va_end(ap);
+
+    data_t *prev = result;
+    while (prev && prev->next)
+        prev = prev->next;
+    prev->next = first;
+
+    return result;
+}
+
 void data_array_free(data_array_t *array)
 {
     array_element_release_fn release = dmt[array->type].array_element_release;

--- a/src/fileformat.c
+++ b/src/fileformat.c
@@ -21,6 +21,21 @@
 //#include "optparse.h"
 #include "fileformat.h"
 
+#ifdef _WIN32
+#define PATH_SEPARATOR '\\'
+#else
+#define PATH_SEPARATOR '/'
+#endif
+
+char const *file_basename(char const *path)
+{
+    char const *p = strrchr(path, PATH_SEPARATOR);
+    if (p)
+        return p + 1;
+    else
+        return path;
+}
+
 void check_read_file_info(file_info_t *info)
 {
     if (info->format != CU8_IQ


### PR DESCRIPTION
Adds an output tag option (-K) to tag structured output lines.
The tokens `FILE` and `PATH` are expanded to the current input file basename or full path, if available.
Also works with CSV output by adding "well_known" fields (CSV columns).

Second commit allows multiple input files (-r) and treats all positional command line arguments as input files.

We can now use `rtl_433 -K FILE *.cu8` to run a batch of files and get the input name in each output line:
```
{"tag" : "g001.cu8", "time" : "@0.524288s", "model" : …}
{"tag" : "g001.cu8", "time" : "@0.524288s", "model" : …}
{"tag" : "g002.cu8", "time" : "@0.524288s", "model" : …}
…
```