### PR TITLE
Add high-level utility functions for decoders

### DIFF
--- a/include/decoder.h
+++ b/include/decoder.h
@@ -6,6 +6,7 @@
 #include "bitbuffer.h"
 #include "data.h"
 #include "util.h"
+#include "decoder_util.h"
 
 /* Supported modulation types */
 #define OOK_PULSE_MANCHESTER_ZEROBIT    3  // Manchester encoding. Hardcoded zerobit. Rising Edge = 0, Falling edge = 1

--- a/include/decoder_util.h
+++ b/include/decoder_util.h
@@ -1,0 +1,61 @@
+/**
+ * High-level utility functions for decoders
+ *
+ * Copyright (C) 2018 Christian Zuckschwerdt
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef INCLUDE_DECODER_UTIL_H_
+#define INCLUDE_DECODER_UTIL_H_
+
+#include <stdarg.h>
+#include "bitbuffer.h"
+
+// be terse, a maximum msg length of 60 characters is supported on the decoder_output_ functions
+// e.g. "FoobarCorp-XY3000: unexpected type code %02x"
+
+/// Output a message
+void decoder_output_message(char const *msg);
+
+/// Output a message and the content of a bitbuffer
+void decoder_output_bitbuffer(bitbuffer_t const *bitbuffer, char const *msg);
+
+/// Output a message and the content of a bitbuffer
+/// Not recommended.
+void decoder_output_bitbuffer_array(bitbuffer_t const *bitbuffer, char const *msg);
+
+/// Output a message and the content of a bit row (byte buffer)
+void decoder_output_bitrow(bitrow_t const bitrow, unsigned bit_len, char const *msg);
+
+// print helpers
+
+/// Output a message with args
+void decoder_output_messagef(char const *restrict format, ...);
+
+/// Output a message with args and the content of a bitbuffer
+void decoder_output_bitbufferf(bitbuffer_t const *bitbuffer, char const *restrict format, ...);
+
+/// Output a message with args and the content of a bitbuffer
+void decoder_output_bitbuffer_arrayf(bitbuffer_t const *bitbuffer, char const *restrict format, ...);
+
+/// Output a message with args and the content of a bit row (byte buffer)
+void decoder_output_bitrowf(bitrow_t const bitrow, unsigned bit_len, char const *restrict format, ...);
+
+
+/// Print the content of the bitbuffer
+void bitbuffer_printf(const bitbuffer_t *bitbuffer, char const *restrict format, ...);
+
+/// Debug the content of the bitbuffer
+void bitbuffer_debugf(const bitbuffer_t *bitbuffer, char const *restrict format, ...);
+
+/// Print the content of a bit row (byte buffer)
+void bitrow_printf(bitrow_t const bitrow, unsigned bit_len, char const *restrict format, ...);
+
+/// Debug the content of a bit row (byte buffer)
+void bitrow_debugf(bitrow_t const bitrow, unsigned bit_len, char const *restrict format, ...);
+
+#endif /* INCLUDE_DECODER_UTIL_H_ */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(rtl_433
 	bitbuffer.c
 	confparse.c
 	data.c
+	decoder_util.c
 	fileformat.c
 	optparse.c
 	pulse_demod.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,6 +8,7 @@ rtl_433_SOURCES      = am_analyze.c \
                        bitbuffer.c \
                        confparse.c \
                        data.c \
+                       decoder_util.c \
                        fileformat.c \
                        optparse.c \
                        pulse_demod.c \

--- a/src/decoder_util.c
+++ b/src/decoder_util.c
@@ -1,0 +1,225 @@
+/**
+ * High-level utility functions for decoders
+ *
+ * Copyright (C) 2018 Christian Zuckschwerdt
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <stdio.h>
+//#include "bitbuffer.h"
+//#include "data.h"
+//#include "util.h"
+#include "decoder.h"
+#include "decoder_util.h"
+
+// variadic print functions
+
+void bitbuffer_printf(const bitbuffer_t *bitbuffer, char const *restrict format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    vfprintf(stderr, format, ap);
+    va_end(ap);
+    bitbuffer_print(bitbuffer);
+}
+
+void bitbuffer_debugf(const bitbuffer_t *bitbuffer, char const *restrict format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    vfprintf(stderr, format, ap);
+    va_end(ap);
+    bitbuffer_debug(bitbuffer);
+}
+
+void bitrow_printf(bitrow_t const bitrow, unsigned bit_len, char const *restrict format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    vfprintf(stderr, format, ap);
+    va_end(ap);
+    bitrow_print(bitrow, bit_len);
+}
+
+void bitrow_debugf(bitrow_t const bitrow, unsigned bit_len, char const *restrict format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    vfprintf(stderr, format, ap);
+    va_end(ap);
+    bitrow_debug(bitrow, bit_len);
+}
+
+// variadic output functions
+
+void decoder_output_messagef(char const *restrict format, ...)
+{
+    char msg[60]; // fixed length limit
+    va_list ap;
+    va_start(ap, format);
+    vsnprintf(msg, 60, format, ap);
+    va_end(ap);
+    decoder_output_message(msg);
+}
+
+void decoder_output_bitbufferf(bitbuffer_t const *bitbuffer, char const *restrict format, ...)
+{
+    char msg[60]; // fixed length limit
+    va_list ap;
+    va_start(ap, format);
+    vsnprintf(msg, 60, format, ap);
+    va_end(ap);
+    decoder_output_bitbuffer(bitbuffer, msg);
+}
+
+void decoder_output_bitbuffer_arrayf(bitbuffer_t const *bitbuffer, char const *restrict format, ...)
+{
+    char msg[60]; // fixed length limit
+    va_list ap;
+    va_start(ap, format);
+    vsnprintf(msg, 60, format, ap);
+    va_end(ap);
+    decoder_output_bitbuffer_array(bitbuffer, msg);
+}
+
+void decoder_output_bitrowf(bitrow_t const bitrow, unsigned bit_len, char const *restrict format, ...)
+{
+    char msg[60]; // fixed length limit
+    va_list ap;
+    va_start(ap, format);
+    vsnprintf(msg, 60, format, ap);
+    va_end(ap);
+    decoder_output_bitrow(bitrow, bit_len, msg);
+}
+
+// output functions
+
+void decoder_output_message(char const *msg)
+{
+    data_t *data;
+    char time_str[LOCAL_TIME_BUFLEN];
+
+    local_time_str(0, time_str);
+    data = data_make(
+            "time", "", DATA_STRING, time_str,
+            "msg", "", DATA_STRING, msg,
+            NULL);
+    data_acquired_handler(data);
+}
+
+void decoder_output_bitbuffer(bitbuffer_t const *bitbuffer, char const *msg)
+{
+    data_t *data;
+    char *row_codes[BITBUF_ROWS];
+    char row_bytes[BITBUF_COLS * 2 + 1];
+    char time_str[LOCAL_TIME_BUFLEN];
+    unsigned i;
+
+    local_time_str(0, time_str);
+
+    for (i = 0; i < bitbuffer->num_rows; i++) {
+        row_bytes[0] = '\0';
+        // print byte-wide
+        for (unsigned col = 0; col < (bitbuffer->bits_per_row[i] + 7) / 8; ++col) {
+            sprintf(&row_bytes[2 * col], "%02x", bitbuffer->bb[i][col]);
+        }
+        // remove last nibble if needed
+        row_bytes[2 * (bitbuffer->bits_per_row[i] + 3) / 8] = '\0';
+
+        // a simpler representation for csv output
+        row_codes[i] = malloc(8 + BITBUF_COLS * 2 + 1); // "{nnn}..\0"
+        sprintf(row_codes[i], "{%d}%s", bitbuffer->bits_per_row[i], row_bytes);
+    }
+
+    data = data_make(
+            "time", "", DATA_STRING, time_str,
+            "msg", "", DATA_STRING, msg,
+            "num_rows", "", DATA_INT, bitbuffer->num_rows,
+            "codes", "", DATA_ARRAY, data_array(bitbuffer->num_rows, DATA_STRING, row_codes),
+            NULL);
+    data_acquired_handler(data);
+
+    for (i = 0; i < bitbuffer->num_rows; i++) {
+        free(row_codes[i]);
+    }
+}
+
+void decoder_output_bitbuffer_array(bitbuffer_t const *bitbuffer, char const *msg)
+{
+    data_t *data;
+    data_t *row_data[BITBUF_ROWS];
+    char *row_codes[BITBUF_ROWS];
+    char row_bytes[BITBUF_COLS * 2 + 1];
+    char time_str[LOCAL_TIME_BUFLEN];
+    unsigned i;
+
+    local_time_str(0, time_str);
+
+    for (i = 0; i < bitbuffer->num_rows; i++) {
+        row_bytes[0] = '\0';
+        // print byte-wide
+        for (unsigned col = 0; col < (bitbuffer->bits_per_row[i] + 7) / 8; ++col) {
+            sprintf(&row_bytes[2 * col], "%02x", bitbuffer->bb[i][col]);
+        }
+        // remove last nibble if needed
+        row_bytes[2 * (bitbuffer->bits_per_row[i] + 3) / 8] = '\0';
+
+        row_data[i] = data_make(
+                "len", "", DATA_INT, bitbuffer->bits_per_row[i],
+                "data", "", DATA_STRING, row_bytes,
+                NULL);
+
+        // a simpler representation for csv output
+        row_codes[i] = malloc(8 + BITBUF_COLS * 2 + 1); // "{nnn}..\0"
+        sprintf(row_codes[i], "{%d}%s", bitbuffer->bits_per_row[i], row_bytes);
+    }
+
+    data = data_make(
+            "time", "", DATA_STRING, time_str,
+            "msg", "", DATA_STRING, msg,
+            "num_rows", "", DATA_INT, bitbuffer->num_rows,
+            "rows", "", DATA_ARRAY, data_array(bitbuffer->num_rows, DATA_DATA, row_data),
+            "codes", "", DATA_ARRAY, data_array(bitbuffer->num_rows, DATA_STRING, row_codes),
+            NULL);
+    data_acquired_handler(data);
+
+    for (i = 0; i < bitbuffer->num_rows; i++) {
+        free(row_codes[i]);
+    }
+}
+
+void decoder_output_bitrow(bitrow_t const bitrow, unsigned bit_len, char const *msg)
+{
+    data_t *data;
+    char *row_code;
+    char row_bytes[BITBUF_COLS * 2 + 1];
+    char time_str[LOCAL_TIME_BUFLEN];
+    unsigned i;
+
+    local_time_str(0, time_str);
+
+    row_bytes[0] = '\0';
+    // print byte-wide
+    for (unsigned col = 0; col < (bit_len + 7) / 8; ++col) {
+        sprintf(&row_bytes[2 * col], "%02x", bitrow[col]);
+    }
+    // remove last nibble if needed
+    row_bytes[2 * (bit_len + 3) / 8] = '\0';
+
+    // a simpler representation for csv output
+    row_code = malloc(8 + BITBUF_COLS * 2 + 1); // "{nnn}..\0"
+    sprintf(row_code, "{%d}%s", bit_len, row_bytes);
+
+    data = data_make(
+            "time", "", DATA_STRING, time_str,
+            "msg", "", DATA_STRING, msg,
+            "codes", "", DATA_STRING, row_code,
+            NULL);
+    data_acquired_handler(data);
+
+    free(row_code);
+}

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1313,15 +1313,17 @@ static void parse_conf_option(struct app_cfg *cfg, int opt, char *arg)
     }
 }
 
-static char const *well_known_tag[]  = {"tag", NULL};
-static char const *well_known_null[] = {NULL};
+// well-known fields "msg" and "codes" are used to output general decoder messages
+// well-known field "tag" is only used when output tagging is requested
+static char const *well_known_with_tag[]  = {"msg", "codes", "tag", NULL};
+static char const *well_known_default[] = {"msg", "codes", NULL};
 static char const **well_known_output_fields(struct app_cfg *cfg)
 {
     if (cfg->output_tag) {
-        return well_known_tag;
+        return well_known_with_tag;
     }
     else {
-        return well_known_null;
+        return well_known_default;
     }
 }
 

--- a/vs15/rtl_433.vcxproj
+++ b/vs15/rtl_433.vcxproj
@@ -91,6 +91,7 @@
     <ClInclude Include="..\include\confparse.h" />
     <ClInclude Include="..\include\data.h" />
     <ClInclude Include="..\include\decoder.h" />
+    <ClInclude Include="..\include\decoder_util.h" />
     <ClInclude Include="..\include\fileformat.h" />
     <ClInclude Include="..\include\optparse.h" />
     <ClInclude Include="..\include\pulse_demod.h" />
@@ -107,6 +108,7 @@
     <ClCompile Include="..\src\bitbuffer.c" />
     <ClCompile Include="..\src\confparse.c" />
     <ClCompile Include="..\src\data.c" />
+    <ClCompile Include="..\src\decoder_util.c" />
     <ClCompile Include="..\src\fileformat.c" />
     <ClCompile Include="..\src\optparse.c" />
     <ClCompile Include="..\src\pulse_demod.c" />

--- a/vs15/rtl_433.vcxproj.filters
+++ b/vs15/rtl_433.vcxproj.filters
@@ -35,6 +35,9 @@
     <ClInclude Include="..\include\decoder.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\decoder_util.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\include\fileformat.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -77,6 +80,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\src\data.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\decoder_util.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\src\fileformat.c">


### PR DESCRIPTION
Adds utility functions for decoders to output exceptional messages using the regular output facilities.

This is not intended for debug messages on unfinished decoders (use common prints there), but rather to put notes about exceptional states from established decoders into long running logs.

E.g. `FoobarCorp-XY3000: unexpected type code %02x` – think multi-sensors weather stations.

These utility functions will likely get some updates later and merge parts of the flex decoder.