### PR TITLE
Decouple decoders

### DIFF
--- a/include/decoder.h
+++ b/include/decoder.h
@@ -26,7 +26,4 @@
 extern int debug_output;
 extern float sample_file_pos;
 
-/** Pass the data structure to all output handlers. Frees data afterwards. */
-void data_acquired_handler(data_t *data);
-
 #endif /* INCLUDE_DECODER_H_ */

--- a/include/decoder.h
+++ b/include/decoder.h
@@ -23,7 +23,4 @@
 #define FSK_PULSE_PWM                   17 // FSK, Pulse Width Modulation. Short pulses = 1, Long = 0
 #define FSK_PULSE_MANCHESTER_ZEROBIT    18 // FSK, Manchester encoding
 
-extern int debug_output;
-extern float sample_file_pos;
-
 #endif /* INCLUDE_DECODER_H_ */

--- a/include/decoder_util.h
+++ b/include/decoder_util.h
@@ -14,36 +14,40 @@
 
 #include <stdarg.h>
 #include "bitbuffer.h"
+#include "rtl_433_devices.h"
+
+/// Output data
+void decoder_output_data(r_device *decoder, data_t *data);
 
 // be terse, a maximum msg length of 60 characters is supported on the decoder_output_ functions
 // e.g. "FoobarCorp-XY3000: unexpected type code %02x"
 
 /// Output a message
-void decoder_output_message(char const *msg);
+void decoder_output_message(r_device *decoder, char const *msg);
 
 /// Output a message and the content of a bitbuffer
-void decoder_output_bitbuffer(bitbuffer_t const *bitbuffer, char const *msg);
+void decoder_output_bitbuffer(r_device *decoder, bitbuffer_t const *bitbuffer, char const *msg);
 
 /// Output a message and the content of a bitbuffer
 /// Not recommended.
-void decoder_output_bitbuffer_array(bitbuffer_t const *bitbuffer, char const *msg);
+void decoder_output_bitbuffer_array(r_device *decoder, bitbuffer_t const *bitbuffer, char const *msg);
 
 /// Output a message and the content of a bit row (byte buffer)
-void decoder_output_bitrow(bitrow_t const bitrow, unsigned bit_len, char const *msg);
+void decoder_output_bitrow(r_device *decoder, bitrow_t const bitrow, unsigned bit_len, char const *msg);
 
 // print helpers
 
 /// Output a message with args
-void decoder_output_messagef(char const *restrict format, ...);
+void decoder_output_messagef(r_device *decoder, char const *restrict format, ...);
 
 /// Output a message with args and the content of a bitbuffer
-void decoder_output_bitbufferf(bitbuffer_t const *bitbuffer, char const *restrict format, ...);
+void decoder_output_bitbufferf(r_device *decoder, bitbuffer_t const *bitbuffer, char const *restrict format, ...);
 
 /// Output a message with args and the content of a bitbuffer
-void decoder_output_bitbuffer_arrayf(bitbuffer_t const *bitbuffer, char const *restrict format, ...);
+void decoder_output_bitbuffer_arrayf(r_device *decoder, bitbuffer_t const *bitbuffer, char const *restrict format, ...);
 
 /// Output a message with args and the content of a bit row (byte buffer)
-void decoder_output_bitrowf(bitrow_t const bitrow, unsigned bit_len, char const *restrict format, ...);
+void decoder_output_bitrowf(r_device *decoder, bitrow_t const bitrow, unsigned bit_len, char const *restrict format, ...);
 
 
 /// Print the content of the bitbuffer

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -131,7 +131,7 @@ typedef struct r_device {
     float gap_limit;
     float sync_width;
     float tolerance;
-    int (*json_callback)(struct bitbuffer *bitbuffer);
+    int (*json_callback)(struct r_device *decoder, struct bitbuffer *bitbuffer);
     unsigned disabled;
     char **fields; // List of fields this decoder produces; required for CSV output. NULL-terminated.
 

--- a/include/util.h
+++ b/include/util.h
@@ -121,9 +121,16 @@ int byteParity(uint8_t inByte);
 /// Printable timestamp in local time
 ///
 /// @param time_secs: 0 for now, or seconds since the epoch
-/// @param buf: output buffer, long enough for YYYY-MM-DD HH:MM:SS
+/// @param buf: output buffer, long enough for "YYYY-MM-DD HH:MM:SS"
 /// @return buf pointer (for short hand use as operator)
 char* local_time_str(time_t time_secs, char *buf);
+
+/// Printable sample position
+///
+/// @param sample_pos sample position
+/// @param buf: output buffer, long enough for "@0.000000s"
+/// @return buf pointer (for short hand use as operator)
+char *sample_pos_str(float sample_file_pos, char *buf);
 
 /// Convert Celsius to Fahrenheit
 ///

--- a/src/decoder_util.c
+++ b/src/decoder_util.c
@@ -103,12 +103,7 @@ void decoder_output_data(r_device *decoder, data_t *data)
 
 void decoder_output_message(r_device *decoder, char const *msg)
 {
-    data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
-
-    local_time_str(0, time_str);
-    data = data_make(
-            "time", "", DATA_STRING, time_str,
+    data_t *data = data_make(
             "msg", "", DATA_STRING, msg,
             NULL);
     decoder_output_data(decoder, data);
@@ -119,10 +114,7 @@ void decoder_output_bitbuffer(r_device *decoder, bitbuffer_t const *bitbuffer, c
     data_t *data;
     char *row_codes[BITBUF_ROWS];
     char row_bytes[BITBUF_COLS * 2 + 1];
-    char time_str[LOCAL_TIME_BUFLEN];
     unsigned i;
-
-    local_time_str(0, time_str);
 
     for (i = 0; i < bitbuffer->num_rows; i++) {
         row_bytes[0] = '\0';
@@ -139,7 +131,6 @@ void decoder_output_bitbuffer(r_device *decoder, bitbuffer_t const *bitbuffer, c
     }
 
     data = data_make(
-            "time", "", DATA_STRING, time_str,
             "msg", "", DATA_STRING, msg,
             "num_rows", "", DATA_INT, bitbuffer->num_rows,
             "codes", "", DATA_ARRAY, data_array(bitbuffer->num_rows, DATA_STRING, row_codes),
@@ -157,10 +148,7 @@ void decoder_output_bitbuffer_array(r_device *decoder, bitbuffer_t const *bitbuf
     data_t *row_data[BITBUF_ROWS];
     char *row_codes[BITBUF_ROWS];
     char row_bytes[BITBUF_COLS * 2 + 1];
-    char time_str[LOCAL_TIME_BUFLEN];
     unsigned i;
-
-    local_time_str(0, time_str);
 
     for (i = 0; i < bitbuffer->num_rows; i++) {
         row_bytes[0] = '\0';
@@ -182,7 +170,6 @@ void decoder_output_bitbuffer_array(r_device *decoder, bitbuffer_t const *bitbuf
     }
 
     data = data_make(
-            "time", "", DATA_STRING, time_str,
             "msg", "", DATA_STRING, msg,
             "num_rows", "", DATA_INT, bitbuffer->num_rows,
             "rows", "", DATA_ARRAY, data_array(bitbuffer->num_rows, DATA_DATA, row_data),
@@ -200,10 +187,7 @@ void decoder_output_bitrow(r_device *decoder, bitrow_t const bitrow, unsigned bi
     data_t *data;
     char *row_code;
     char row_bytes[BITBUF_COLS * 2 + 1];
-    char time_str[LOCAL_TIME_BUFLEN];
     unsigned i;
-
-    local_time_str(0, time_str);
 
     row_bytes[0] = '\0';
     // print byte-wide
@@ -218,7 +202,6 @@ void decoder_output_bitrow(r_device *decoder, bitrow_t const bitrow, unsigned bi
     sprintf(row_code, "{%d}%s", bit_len, row_bytes);
 
     data = data_make(
-            "time", "", DATA_STRING, time_str,
             "msg", "", DATA_STRING, msg,
             "codes", "", DATA_STRING, row_code,
             NULL);

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -245,7 +245,7 @@ static int acurite_rain_gauge_callback(r_device *decoder, bitbuffer_t *bitbuffer
             "rain",     "Total Rain",    DATA_FORMAT,    "%.1f mm", DATA_DOUBLE, total_rain,
             NULL);
 
-        data_acquired_handler(data);
+		decoder_output_data(decoder, data);
 
         return 1;
     }
@@ -315,7 +315,7 @@ static int acurite_th_callback(r_device *decoder, bitbuffer_t *bitbuf)
              "humidity",        "Humidity",    DATA_INT,    humidity,
              NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     valid++;
     }
 
@@ -472,7 +472,7 @@ static float acurite_6045_getTemp(uint8_t highbyte, uint8_t lowbyte)
  * @todo - figure out remaining status bits and how to report
  */
 
-static int acurite_6045_decode(bitrow_t bb, int browlen)
+static int acurite_6045_decode(r_device *decoder, bitrow_t bb, int browlen)
 {
     int valid = 0;
     float tempf;
@@ -552,7 +552,7 @@ static int acurite_6045_decode(bitrow_t bb, int browlen)
        "raw_msg",        "raw_message",        DATA_STRING,    raw_str,
      NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     valid++;
 
     return(valid);
@@ -664,7 +664,7 @@ static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuf)
 
                     NULL);
 
-            data_acquired_handler(data);
+            decoder_output_data(decoder, data);
             valid++;
         }
 
@@ -719,7 +719,7 @@ static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuf)
                     "raincounter_raw",  NULL,   DATA_INT,   raincounter,
                     NULL);
 
-                data_acquired_handler(data);
+                decoder_output_data(decoder, data);
 
             } else if (message_type == ACURITE_MSGTYPE_5N1_WINDSPEED_TEMP_HUMIDITY) {
                 // Wind speed, temperature and humidity
@@ -741,7 +741,7 @@ static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuf)
                     "temperature_F",     "temperature",    DATA_FORMAT,    "%.1f F", DATA_DOUBLE,    tempf,
                     "humidity",     NULL,    DATA_FORMAT,    "%d",   DATA_INT,   humidity,
                     NULL);
-                data_acquired_handler(data);
+                decoder_output_data(decoder, data);
 
             } else if (message_type == ACURITE_MSGTYPE_WINDSPEED_TEMP_HUMIDITY_3N1) {
                 // Wind speed, temperature and humidity for 3-n-1
@@ -762,7 +762,7 @@ static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuf)
                     "temperature_F",     "temperature",    DATA_FORMAT,    "%.1f F", DATA_DOUBLE,    tempf,
                     "humidity",     NULL,    DATA_FORMAT,    "%d",   DATA_INT,   humidity,
                     NULL);
-                data_acquired_handler(data);
+                decoder_output_data(decoder, data);
 
             } else {
                 fprintf(stderr, "%s Acurite 5n1 sensor 0x%04X Ch %c, Status %02X, Unknown message type 0x%02x\n",
@@ -772,7 +772,7 @@ static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuf)
 
         if (browlen == ACURITE_6045_BITLEN / 8) {
             // @todo check parity and reject if invalid
-            valid += acurite_6045_decode(bb, browlen);
+            valid += acurite_6045_decode(decoder, bb, browlen);
         }
 
     }
@@ -926,7 +926,7 @@ static int acurite_986_callback(r_device *decoder, bitbuffer_t *bitbuf)
                 "status",        "status",    DATA_INT,    status,
                 NULL);
 
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
 
         valid_cnt++;
 
@@ -1019,7 +1019,7 @@ static int acurite_606_callback(r_device *decoder, bitbuffer_t *bitbuf)
                     "battery",          "Battery",     DATA_STRING, battery ? "OK" : "LOW",
                     "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
                     NULL);
-            data_acquired_handler(data);
+            decoder_output_data(decoder, data);
             return 1;
         }
     }
@@ -1144,7 +1144,7 @@ static int acurite_00275rm_callback(r_device *decoder, bitbuffer_t *bitbuf)
             } else { // suppress compiler warning
                 return 0;
             }
-            data_acquired_handler(data);
+            decoder_output_data(decoder, data);
             valid=1;
         }
     }

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -220,7 +220,7 @@ static int acurite_5n1_getBatteryLevel(uint8_t byte)
 }
 
 
-static int acurite_rain_gauge_callback(bitbuffer_t *bitbuffer)
+static int acurite_rain_gauge_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     bitrow_t *bb = bitbuffer->bb;
     // This needs more validation to positively identify correct sensor type, but it basically works if message is really from acurite raingauge and it doesn't have any errors
@@ -276,7 +276,7 @@ static float acurite_th_temperature(uint8_t *s)
 //
 // @todo - see if the 3rd nybble is battery/status
 //
-static int acurite_th_callback(bitbuffer_t *bitbuf)
+static int acurite_th_callback(r_device *decoder, bitbuffer_t *bitbuf)
 {
     uint8_t *bb = NULL;
     int cksum, battery_low, valid = 0;
@@ -571,7 +571,7 @@ static int acurite_6045_decode(bitrow_t bb, int browlen)
  * @todo - TBD Are parity and checksum the same across these devices?
  *         (opportunity to DRY-up and simplify?)
  */
-static int acurite_txr_callback(bitbuffer_t *bitbuf)
+static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuf)
 {
     int browlen, valid = 0;
     uint8_t *bb;
@@ -823,7 +823,7 @@ static int acurite_txr_callback(bitbuffer_t *bitbuf)
  *
  */
 
-static int acurite_986_callback(bitbuffer_t *bitbuf)
+static int acurite_986_callback(r_device *decoder, bitbuffer_t *bitbuf)
 {
     int const browlen = 5;
     uint8_t *bb, sensor_num, status, crc, crcc;
@@ -976,7 +976,7 @@ uint8_t acurite_606_checksum(int length, uint8_t *buff)
     return checksum;
 }
 
-static int acurite_606_callback(bitbuffer_t *bitbuf)
+static int acurite_606_callback(r_device *decoder, bitbuffer_t *bitbuf)
 {
     data_t *data;
     bitrow_t *bb = bitbuf->bb;
@@ -1027,7 +1027,8 @@ static int acurite_606_callback(bitbuffer_t *bitbuf)
     return 0;
 }
 
-static int acurite_00275rm_callback(bitbuffer_t *bitbuf) {
+static int acurite_00275rm_callback(r_device *decoder, bitbuffer_t *bitbuf)
+{
     int crc, battery_low, id, model, valid = 0;
     data_t *data;
     char *model1 = "00275rm", *model2 = "00276rm";

--- a/src/devices/akhan_100F14.c
+++ b/src/devices/akhan_100F14.c
@@ -9,7 +9,7 @@
  */
 #include "decoder.h"
 
-static int akhan_rke_callback(bitbuffer_t *bitbuffer) {
+static int akhan_rke_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t *b;

--- a/src/devices/akhan_100F14.c
+++ b/src/devices/akhan_100F14.c
@@ -10,7 +10,6 @@
 #include "decoder.h"
 
 static int akhan_rke_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t *b;
     int id;
@@ -39,9 +38,7 @@ static int akhan_rke_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     if (!cmd_str)
         return 0;
 
-    local_time_str(0, time_str);
     data = data_make(
-            "time",     "",             DATA_STRING, time_str,
             "model",    "",             DATA_STRING, "Akhan 100F14 remote keyless entry",
             "id",       "ID (20bit)",   DATA_FORMAT, "0x%x", DATA_INT, id,
             "data",     "Data (4bit)",  DATA_STRING, cmd_str,
@@ -52,7 +49,6 @@ static int akhan_rke_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "data",

--- a/src/devices/akhan_100F14.c
+++ b/src/devices/akhan_100F14.c
@@ -47,7 +47,7 @@ static int akhan_rke_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
             "data",     "Data (4bit)",  DATA_STRING, cmd_str,
             NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     return 1;
 }
 

--- a/src/devices/alecto.c
+++ b/src/devices/alecto.c
@@ -131,7 +131,7 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                                     "wind_direction", "Direction",  DATA_INT,    direction,
                                     "mic",           "Integrity",   DATA_STRING,    "CHECKSUM",
                                     NULL);
-                    data_acquired_handler(data);
+                    decoder_output_data(decoder, data);
                 }
             } else {
                 // Rain sensor
@@ -145,7 +145,7 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                                 "rain_total",    "Total Rain", DATA_FORMAT, "%.02f mm", DATA_DOUBLE, rain_mm,
                                 "mic",           "Integrity",  DATA_STRING,    "CHECKSUM",
                                 NULL);
-                data_acquired_handler(data);
+                decoder_output_data(decoder, data);
             }
         } else if (bb[2][0] == bb[3][0] && bb[3][0] == bb[4][0] && bb[4][0] == bb[5][0] &&
                 bb[5][0] == bb[6][0] && (bb[3][4] & 0xf) == 0 && (bb[5][4] & 0xf) == 0) {
@@ -166,7 +166,7 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                             "humidity",      "Humidity",    DATA_FORMAT, "%u %%",   DATA_INT, humidity,
                             "mic",           "",            DATA_STRING,    "CHECKSUM",
                             NULL);
-            data_acquired_handler(data);
+            decoder_output_data(decoder, data);
         }
         if (debug_output){
             fprintf(stdout, "Checksum      = %01x (calculated %01x)\n", bb[1][4] >> 4, csum);

--- a/src/devices/alecto.c
+++ b/src/devices/alecto.c
@@ -85,7 +85,7 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         /* Quit if checksum does not work out */
         if (csum != (bb[1][4] >> 4) || csum2 != (bb[5][4] >> 4)) {
             //fprintf(stdout, "\nAlectoV1 CRC error");
-            if(debug_output) {
+            if(decoder->verbose) {
                 fprintf(stderr,
                 "%s AlectoV1 Checksum/Parity error\n",
                 time_str);
@@ -168,7 +168,7 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                             NULL);
             decoder_output_data(decoder, data);
         }
-        if (debug_output){
+        if (decoder->verbose){
             fprintf(stdout, "Checksum      = %01x (calculated %01x)\n", bb[1][4] >> 4, csum);
             fprintf(stdout, "Received Data = ");
             bitrow_print(bb[1], 40);

--- a/src/devices/alecto.c
+++ b/src/devices/alecto.c
@@ -51,7 +51,7 @@ uint8_t bcd_decode8(uint8_t x) {
     return ((x & 0xF0) >> 4) * 10 + (x & 0x0F);
 }
 
-static int alectov1_callback(bitbuffer_t *bitbuffer) {
+static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
     int16_t temp;
     uint8_t humidity, csum = 0, csum2 = 0;

--- a/src/devices/alecto.c
+++ b/src/devices/alecto.c
@@ -58,13 +58,11 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     int i;
 
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
     unsigned bits = bitbuffer->bits_per_row[1];
 
     if (bits != 36)
         return 0;
 
-    local_time_str(0, time_str);
 
     if (bb[1][0] == bb[5][0] && bb[2][0] == bb[6][0] && (bb[1][4] & 0xf) == 0 && (bb[5][4] & 0xf) == 0
         && (bb[5][0] != 0 && bb[5][1] != 0)) {
@@ -86,9 +84,7 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         if (csum != (bb[1][4] >> 4) || csum2 != (bb[5][4] >> 4)) {
             //fprintf(stdout, "\nAlectoV1 CRC error");
             if(decoder->verbose) {
-                fprintf(stderr,
-                "%s AlectoV1 Checksum/Parity error\n",
-                time_str);
+                fprintf(stderr, "AlectoV1 Checksum/Parity error\n");
             }
             return 0;
         } //Invalid checksum
@@ -121,7 +117,7 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                     double gust = reverse8(bb[5 + skip][3]);
                     int direction = (reverse8(bb[5 + skip][2]) << 1) | (bb[5 + skip][1] & 0x1);
 
-                    data = data_make("time",          "",           DATA_STRING, time_str,
+                    data = data_make(
                                     "model",          "",           DATA_STRING, "AlectoV1 Wind Sensor",
                                     "id",             "House Code", DATA_INT,    sensor_id,
                                     "channel",        "Channel",    DATA_INT,    channel,
@@ -137,7 +133,7 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                 // Rain sensor
                 double rain_mm = ((reverse8(bb[1][3]) << 8)+reverse8(bb[1][2])) * 0.25F;
 
-                data = data_make("time",         "",           DATA_STRING, time_str,
+                data = data_make(
                                 "model",         "",           DATA_STRING, "AlectoV1 Rain Sensor",
                                 "id",            "House Code", DATA_INT,    sensor_id,
                                 "channel",       "Channel",    DATA_INT,    channel,
@@ -157,7 +153,7 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
             humidity = bcd_decode8(reverse8(bb[1][3]));
             if (humidity>100) return 0;//extra detection false positive!! prologue is also 36bits and sometimes detected as alecto
 
-            data = data_make("time",         "",            DATA_STRING, time_str,
+            data = data_make(
                             "model",         "",            DATA_STRING, "AlectoV1 Temperature Sensor",
                             "id",            "House Code",  DATA_INT,    sensor_id,
                             "channel",       "Channel",     DATA_INT,    channel,
@@ -186,7 +182,6 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "channel",

--- a/src/devices/ambient_weather.c
+++ b/src/devices/ambient_weather.c
@@ -22,7 +22,6 @@ ambient_weather_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, 
     int channel;
     float temperature;
     int humidity;
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
 
     bitbuffer_extract_bytes(bitbuffer, row, bitpos, b, 6*8);
@@ -46,9 +45,7 @@ ambient_weather_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, 
     temperature = (temp_f - 400) / 10.0f;
     humidity = b[4];
 
-    local_time_str(0, time_str);
     data = data_make(
-            "time",           "",             DATA_STRING, time_str,
             "model",          "",             DATA_STRING, "Ambient Weather F007TH Thermo-Hygrometer",
             "device",         "House Code",   DATA_INT,    deviceID,
             "channel",        "Channel",      DATA_INT,    channel,
@@ -93,7 +90,6 @@ ambient_weather_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "device",
     "channel",

--- a/src/devices/ambient_weather.c
+++ b/src/devices/ambient_weather.c
@@ -14,7 +14,7 @@ static const uint8_t preamble_pattern[2] = {0x01, 0x45}; // 12 bits
 static const uint8_t preamble_inverted[2] = {0xfd, 0x45}; // 12 bits
 
 static int
-ambient_weather_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
+ambient_weather_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     uint8_t b[6];
     int deviceID;
@@ -57,7 +57,7 @@ ambient_weather_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
             "humidity",       "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, humidity,
             "mic",            "Integrity",    DATA_STRING, "CRC",
             NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }
@@ -75,7 +75,7 @@ ambient_weather_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         while ((bitpos = bitbuffer_search(bitbuffer, row, bitpos,
                 (const uint8_t *)&preamble_pattern, 12)) + 8+6*8 <=
                 bitbuffer->bits_per_row[row]) {
-            events += ambient_weather_decode(bitbuffer, row, bitpos + 8);
+            events += ambient_weather_decode(decoder, bitbuffer, row, bitpos + 8);
             if (events) return events; // for now, break after first successful message
             bitpos += 16;
         }
@@ -83,7 +83,7 @@ ambient_weather_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         while ((bitpos = bitbuffer_search(bitbuffer, row, bitpos,
                 (const uint8_t *)&preamble_inverted, 12)) + 8+6*8 <=
                 bitbuffer->bits_per_row[row]) {
-            events += ambient_weather_decode(bitbuffer, row, bitpos + 8);
+            events += ambient_weather_decode(decoder, bitbuffer, row, bitpos + 8);
             if (events) return events; // for now, break after first successful message
             bitpos += 15;
         }

--- a/src/devices/ambient_weather.c
+++ b/src/devices/ambient_weather.c
@@ -31,7 +31,7 @@ ambient_weather_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, 
     uint8_t calculated = lfsr_digest8(b, 5, 0x98, 0x3e) ^ 0x64;
 
     if (expected != calculated) {
-        if (debug_output) {
+        if (decoder->verbose) {
             fprintf(stderr, "Checksum error in Ambient Weather message.    Expected: %02x    Calculated: %02x\n", expected, calculated);
             fprintf(stderr, "Message: ");
             bitrow_print(b, 48);

--- a/src/devices/ambient_weather.c
+++ b/src/devices/ambient_weather.c
@@ -63,7 +63,7 @@ ambient_weather_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 }
 
 static int
-ambient_weather_callback(bitbuffer_t *bitbuffer)
+ambient_weather_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     int row;
     unsigned bitpos;

--- a/src/devices/ambientweather_tx8300.c
+++ b/src/devices/ambientweather_tx8300.c
@@ -84,11 +84,8 @@ static int ambientweather_tx8300_callback(r_device *decoder, bitbuffer_t *bitbuf
     if (((b[0] & 0xf0) >> 4) > 9 || (b[0] & 0x0f) > 9) // invalid humidity
         humidity = -1;
 
-    char time_str[LOCAL_TIME_BUFLEN];
-    local_time_str(0, time_str);
 
     data = data_make(
-            "time",          "",            DATA_STRING, time_str,
             "model",         "",            DATA_STRING, "AmbientWeather-TX8300",
             "id",            "",            DATA_INT, sensor_id,
             "channel",       "",            DATA_INT, channel,
@@ -110,7 +107,6 @@ static int ambientweather_tx8300_callback(r_device *decoder, bitbuffer_t *bitbuf
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "channel",

--- a/src/devices/ambientweather_tx8300.c
+++ b/src/devices/ambientweather_tx8300.c
@@ -51,7 +51,7 @@ static int ambientweather_tx8300_callback(r_device *decoder, bitbuffer_t *bitbuf
 
     /* length check */
     if (74 != bitbuffer->bits_per_row[0]) {
-        if( debug_output > 1)
+        if( decoder->verbose > 1)
             fprintf(stderr, "AmbientWeather-TX8300: wrong size (%i bits)\n", bitbuffer->bits_per_row[0]);
         return 0;
     }

--- a/src/devices/ambientweather_tx8300.c
+++ b/src/devices/ambientweather_tx8300.c
@@ -44,7 +44,7 @@
 
 #include "decoder.h"
 
-static int ambientweather_tx8300_callback(bitbuffer_t *bitbuffer)
+static int ambientweather_tx8300_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
     uint8_t b[9] = {0};

--- a/src/devices/ambientweather_tx8300.c
+++ b/src/devices/ambientweather_tx8300.c
@@ -104,7 +104,7 @@ static int ambientweather_tx8300_callback(r_device *decoder, bitbuffer_t *bitbuf
     data = data_append(data,
             "mic",           "MIC",         DATA_STRING, "CHECKSUM", // actually a per-bit parity, chksum unknown
             NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }

--- a/src/devices/ambientweather_wh31e.c
+++ b/src/devices/ambientweather_wh31e.c
@@ -35,7 +35,6 @@
 
 static int ambientweather_wh31e_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     int events = 0;
     uint8_t b[11]; // actually only 6 bytes, no indication what the other 5 might be
@@ -53,7 +52,6 @@ static int ambientweather_wh31e_callback(r_device *decoder, bitbuffer_t *bitbuff
             0x30, // type code (presumed)
     };
 
-    local_time_str(0, time_str);
     for (row = 0; row < bitbuffer->num_rows; ++row) {
         // Validate message and reject it as fast as possible : check for preamble
         unsigned start_pos = bitbuffer_search(bitbuffer, row, 0, preamble, 28);
@@ -88,7 +86,6 @@ static int ambientweather_wh31e_callback(r_device *decoder, bitbuffer_t *bitbuff
 
         /* clang-format off */
         data = data_make(
-                "time",             "",             DATA_STRING, time_str,
                 "model",            "",             DATA_STRING, "AmbientWeather-WH31E",
                 "id" ,              "",             DATA_INT, id,
                 "channel",          "Channel",      DATA_INT, channel,
@@ -107,7 +104,6 @@ static int ambientweather_wh31e_callback(r_device *decoder, bitbuffer_t *bitbuff
 
 /* clang-format off */
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "channel",

--- a/src/devices/ambientweather_wh31e.c
+++ b/src/devices/ambientweather_wh31e.c
@@ -33,7 +33,7 @@
 
 #include "decoder.h"
 
-static int ambientweather_wh31e_callback(bitbuffer_t *bitbuffer)
+static int ambientweather_wh31e_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
@@ -99,7 +99,7 @@ static int ambientweather_wh31e_callback(bitbuffer_t *bitbuffer)
                 "mic",              "Integrity",    DATA_STRING, "CRC",
                 NULL);
         /* clang-format on */
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
         events++;
     }
     return events;

--- a/src/devices/ambientweather_wh31e.c
+++ b/src/devices/ambientweather_wh31e.c
@@ -59,20 +59,20 @@ static int ambientweather_wh31e_callback(r_device *decoder, bitbuffer_t *bitbuff
         unsigned start_pos = bitbuffer_search(bitbuffer, row, 0, preamble, 28);
         if (start_pos == bitbuffer->bits_per_row[row])
             continue; // no preamble detected, move to the next row
-        if (debug_output)
+        if (decoder->verbose)
             fprintf(stderr, "Ambient Weather WH31E detected, buffer is %d bits length\n", bitbuffer->bits_per_row[row]);
         // remove preamble and keep only 64 bits
         bitbuffer_extract_bytes(bitbuffer, row, start_pos + 24, b, 11 * 8);
 
         if (b[0] != 0x30) {
-            if (debug_output)
+            if (decoder->verbose)
                 fprintf(stderr, "Ambient Weather WH31E unknown message type %02x (expected 0x30)\n", b[0]);
             continue;
         }
 
         c_crc = crc8(b, 5, 0x31, 0x00);
         if (c_crc != b[5]) {
-            if (debug_output)
+            if (decoder->verbose)
                 fprintf(stderr, "Ambient Weather WH31E bad CRC: calculated %02x, received %02x\n", c_crc, b[5]);
             continue;
         }

--- a/src/devices/blyss.c
+++ b/src/devices/blyss.c
@@ -43,7 +43,7 @@ static int blyss_callback(r_device *decoder,bitbuffer_t *bitbuffer) {
                 "model",	"", DATA_STRING, "Blyss-DC5ukwh",
                 "id",	 	"", DATA_STRING, id_str,
                 NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
 
         return 1;
     }

--- a/src/devices/blyss.c
+++ b/src/devices/blyss.c
@@ -17,7 +17,7 @@
 
 #include "decoder.h"
 
-static int blyss_callback(bitbuffer_t *bitbuffer) {
+static int blyss_callback(r_device *decoder,bitbuffer_t *bitbuffer) {
     data_t *data;
     char time_str[LOCAL_TIME_BUFLEN];
     uint8_t *b;

--- a/src/devices/blyss.c
+++ b/src/devices/blyss.c
@@ -19,7 +19,6 @@
 
 static int blyss_callback(r_device *decoder,bitbuffer_t *bitbuffer) {
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
     uint8_t *b;
 	char id_str[9];
 
@@ -37,9 +36,7 @@ static int blyss_callback(r_device *decoder,bitbuffer_t *bitbuffer) {
 
         sprintf(id_str, "%02x%02x%02x%02x", b[0], b[1], b[2], b[3]);
 
-        local_time_str(0, time_str);
         data = data_make(
-				"time", 	"", DATA_STRING, time_str,
                 "model",	"", DATA_STRING, "Blyss-DC5ukwh",
                 "id",	 	"", DATA_STRING, id_str,
                 NULL);
@@ -52,7 +49,6 @@ static int blyss_callback(r_device *decoder,bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     NULL

--- a/src/devices/brennenstuhl_rcs_2044.c
+++ b/src/devices/brennenstuhl_rcs_2044.c
@@ -85,10 +85,7 @@ static int brennenstuhl_rcs_2044_process_row(r_device *decoder, bitbuffer_t cons
     if (on_off != 0x02 && on_off != 0x01)
         return 0; /* Pressing simultaneously ON and OFF key is not useful either */
 
-    char time_str[LOCAL_TIME_BUFLEN];
-    local_time_str(0, time_str);
     data = data_make(
-            "time",     "Time",     DATA_STRING, time_str,
             "model",    "Model",    DATA_STRING, "Brennenstuhl RCS 2044",
             "id",       "id",       DATA_INT, system_code,
             "key",      "key",      DATA_STRING, key,
@@ -107,7 +104,6 @@ static int brennenstuhl_rcs_2044_callback(r_device *decoder, bitbuffer_t *bitbuf
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "type",
     "state",

--- a/src/devices/brennenstuhl_rcs_2044.c
+++ b/src/devices/brennenstuhl_rcs_2044.c
@@ -98,7 +98,7 @@ static int brennenstuhl_rcs_2044_process_row(bitbuffer_t const *bitbuffer, int r
     return 1;
 }
 
-static int brennenstuhl_rcs_2044_callback(bitbuffer_t *bitbuffer)
+static int brennenstuhl_rcs_2044_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     int counter = 0;
     for (int row = 0; row < bitbuffer->num_rows; row++)

--- a/src/devices/brennenstuhl_rcs_2044.c
+++ b/src/devices/brennenstuhl_rcs_2044.c
@@ -17,7 +17,7 @@
 
 #include "decoder.h"
 
-static int brennenstuhl_rcs_2044_process_row(bitbuffer_t const *bitbuffer, int row)
+static int brennenstuhl_rcs_2044_process_row(r_device *decoder, bitbuffer_t const *bitbuffer, int row)
 {
     uint8_t const *b = bitbuffer->bb[row];
     int const length = bitbuffer->bits_per_row[row];
@@ -94,7 +94,7 @@ static int brennenstuhl_rcs_2044_process_row(bitbuffer_t const *bitbuffer, int r
             "key",      "key",      DATA_STRING, key,
             "state",    "state",    DATA_STRING, (on_off == 0x02 ? "ON" : "OFF"),
             NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     return 1;
 }
 
@@ -102,7 +102,7 @@ static int brennenstuhl_rcs_2044_callback(r_device *decoder, bitbuffer_t *bitbuf
 {
     int counter = 0;
     for (int row = 0; row < bitbuffer->num_rows; row++)
-        counter += brennenstuhl_rcs_2044_process_row(bitbuffer, row);
+        counter += brennenstuhl_rcs_2044_process_row(decoder, bitbuffer, row);
     return counter;
 }
 

--- a/src/devices/bresser_3ch.c
+++ b/src/devices/bresser_3ch.c
@@ -24,7 +24,7 @@
  */
 #include "decoder.h"
 
-static int bresser_3ch_callback(bitbuffer_t *bitbuffer) {
+static int bresser_3ch_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t *b;

--- a/src/devices/bresser_3ch.c
+++ b/src/devices/bresser_3ch.c
@@ -45,7 +45,7 @@ static int bresser_3ch_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     b[4] = ~b[4];
 
     if (((b[0] + b[1] + b[2] + b[3] - b[4]) & 0xFF) != 0) {
-        if (debug_output) {
+        if (decoder->verbose) {
             fprintf(stderr, "Bresser 3CH checksum error\n");
         }
         return 0;
@@ -64,7 +64,7 @@ static int bresser_3ch_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     humidity = b[3];
 
     if ((channel == 0) || (humidity > 100) || (temp_f < -20.0) || (temp_f > 160.0)) {
-        if (debug_output) {
+        if (decoder->verbose) {
             fprintf(stderr, "Bresser 3CH data error\n");
         }
         return 0;

--- a/src/devices/bresser_3ch.c
+++ b/src/devices/bresser_3ch.c
@@ -25,7 +25,6 @@
 #include "decoder.h"
 
 static int bresser_3ch_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t *b;
 
@@ -70,9 +69,7 @@ static int bresser_3ch_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         return 0;
     }
 
-    local_time_str(0, time_str);
     data = data_make(
-            "time",          "",            DATA_STRING, time_str,
             "model",         "",            DATA_STRING, "Bresser 3CH sensor",
             "id",            "Id",          DATA_INT,    id,
             "channel",       "Channel",     DATA_INT,    channel,
@@ -87,7 +84,6 @@ static int bresser_3ch_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "channel",

--- a/src/devices/bresser_3ch.c
+++ b/src/devices/bresser_3ch.c
@@ -81,7 +81,7 @@ static int bresser_3ch_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
             "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, humidity,
             "mic",           "Integrity",   DATA_STRING, "CHECKSUM",
             NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }

--- a/src/devices/calibeur.c
+++ b/src/devices/calibeur.c
@@ -34,7 +34,6 @@
 
 static int calibeur_rf104_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	data_t *data;
-	char time_str[LOCAL_TIME_BUFLEN];
 
 	uint8_t ID;
 	float temperature;
@@ -77,8 +76,7 @@ static int calibeur_rf104_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 		bits |= ((bb[1][2] & 0x08) << 1);	// [4]
 		humidity = bits;
 
-		local_time_str(0, time_str);
-		data = data_make("time",          "",            DATA_STRING, time_str,
+		data = data_make(
 						"model",         "",            DATA_STRING, "Calibeur RF-104",
 						"id",            "ID",          DATA_INT, ID,
 						"temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
@@ -92,7 +90,6 @@ static int calibeur_rf104_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-	"time",
 	"model",
 	"id",
 	"temperature_C",

--- a/src/devices/calibeur.c
+++ b/src/devices/calibeur.c
@@ -85,7 +85,7 @@ static int calibeur_rf104_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 						"humidity",      "Humidity",    DATA_FORMAT, "%2.0f %%", DATA_DOUBLE, humidity,
 						"mic",           "Integrity",   DATA_STRING,    "CRC",
 						NULL);
-		data_acquired_handler(data);
+		decoder_output_data(decoder, data);
 		return 1;
 	}
 	return 0;

--- a/src/devices/calibeur.c
+++ b/src/devices/calibeur.c
@@ -32,7 +32,7 @@
 */
 #include "decoder.h"
 
-static int calibeur_rf104_callback(bitbuffer_t *bitbuffer) {
+static int calibeur_rf104_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	data_t *data;
 	char time_str[LOCAL_TIME_BUFLEN];
 

--- a/src/devices/cardin.c
+++ b/src/devices/cardin.c
@@ -23,7 +23,6 @@ static int cardin_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	 */
 	char *rbutton[4] = { "11R", "10R", "01R", "00L?" };
 	data_t *data;
-	char time_str[LOCAL_TIME_BUFLEN];
 
 	// validate message as we can
 	if((bb[0][2] & 48) == 0 && bitbuffer->bits_per_row[0] == 24 && (
@@ -103,9 +102,7 @@ static int cardin_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 				dip[8]='+';
 		}
 
-		local_time_str(0, time_str);
 		data = data_make(
-			"time",       "",                       DATA_STRING, time_str,
 			"model",      "",                       DATA_STRING, "Cardin S466",
 			"dipswitch",  "dipswitch",              DATA_STRING, dip,
 			"rbutton",    "right button switches",  DATA_STRING, rbutton[((bb[0][2] & 15) / 3)-1],
@@ -119,7 +116,6 @@ static int cardin_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-	"time",
 	"model",
 	"dipswitch",
 	"rbutton",

--- a/src/devices/cardin.c
+++ b/src/devices/cardin.c
@@ -111,7 +111,7 @@ static int cardin_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 			"rbutton",    "right button switches",  DATA_STRING, rbutton[((bb[0][2] & 15) / 3)-1],
 			NULL);
 
-		data_acquired_handler(data);
+		decoder_output_data(decoder, data);
 
 		return 1;
 	}

--- a/src/devices/cardin.c
+++ b/src/devices/cardin.c
@@ -11,7 +11,7 @@
  * published by the Free Software Foundation.
  */
 
-static int cardin_callback(bitbuffer_t *bitbuffer) {
+static int cardin_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	bitrow_t *bb = bitbuffer->bb;
 	unsigned char dip[10] = {'-','-','-','-','-','-','-','-','-', '\0'};
 

--- a/src/devices/chuango.c
+++ b/src/devices/chuango.c
@@ -73,7 +73,7 @@ static int chuango_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
             "cmd_id",   "CMD_ID",       DATA_INT,    cmd,
             NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     return 1;
 }
 

--- a/src/devices/chuango.c
+++ b/src/devices/chuango.c
@@ -20,7 +20,7 @@
  */
 #include "decoder.h"
 
-static int chuango_callback(bitbuffer_t *bitbuffer) {
+static int chuango_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t *b;

--- a/src/devices/chuango.c
+++ b/src/devices/chuango.c
@@ -21,7 +21,6 @@
 #include "decoder.h"
 
 static int chuango_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t *b;
     int id;
@@ -64,9 +63,7 @@ static int chuango_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         default:  cmd_str = ""; break;
     }
 
-    local_time_str(0, time_str);
     data = data_make(
-            "time",     "",             DATA_STRING, time_str,
             "model",    "",             DATA_STRING, "Chuango Security Technology",
             "id",       "ID",           DATA_INT,    id,
             "cmd",      "CMD",          DATA_STRING, cmd_str,
@@ -78,7 +75,6 @@ static int chuango_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "cmd",

--- a/src/devices/current_cost.c
+++ b/src/devices/current_cost.c
@@ -5,9 +5,7 @@ static int current_cost_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
     uint8_t *b = bb[0];
 
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
-    local_time_str(0, time_str);
 
     uint8_t init_pattern[] = {
         0xcc, //8
@@ -40,7 +38,7 @@ static int current_cost_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         if((packet[2] & 0x80) == 128) { watt0 = (packet[2] & 0x7F) << 8 | packet[3] ; }
         if((packet[4] & 0x80) == 128) { watt1 = (packet[4] & 0x7F) << 8 | packet[5] ; }
         if((packet[6] & 0x80) == 128) { watt2 = (packet[6] & 0x7F) << 8 | packet[7] ; }
-        data = data_make("time",          "",       DATA_STRING, time_str,
+        data = data_make(
                 "model",         "",              DATA_STRING, "CurrentCost TX", //TODO: it may have different CC Model ? any ref ?
                 //"rc",            "Rolling Code",  DATA_INT, rc, //TODO: add rolling code b[1] ? test needed
                 "dev_id",       "Device Id",     DATA_FORMAT, "%d", DATA_INT, device_id,
@@ -58,7 +56,7 @@ static int current_cost_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
        // packet[2] is "Apparently unused"
        uint16_t sensor_type = packet[3]; //Sensor type. Valid values are: 2-Electric, 3-Gas, 4-Water
        uint32_t c_impulse = packet[4] << 24 | packet[5] <<16 | packet[6] <<8 | packet[7] ;
-       data = data_make("time",         "",              DATA_STRING, time_str,
+       data = data_make(
                "model",        "",              DATA_STRING, "CurrentCost Counter", //TODO: it may have different CC Model ? any ref ?
                "dev_id",       "Device Id",     DATA_FORMAT, "%d", DATA_INT, device_id,
                "sensor_type",  "Sensor Id",     DATA_FORMAT, "%d", DATA_INT, sensor_type, //Could "friendly name" this?
@@ -73,7 +71,6 @@ static int current_cost_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "dev_id",
     "power0",

--- a/src/devices/current_cost.c
+++ b/src/devices/current_cost.c
@@ -49,7 +49,7 @@ static int current_cost_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                 "power2",       "Power 2",       DATA_FORMAT, "%d W", DATA_INT, watt2,
                 //"battery",       "Battery",       DATA_STRING, battery_low ? "LOW" : "OK", //TODO is there some low battery indicator ?
                 NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
         return 1;
     }
     // Counter (packet[0] = 0100xxxx) bits 5 and 4 are "unknown", but always 0 to date.
@@ -65,7 +65,7 @@ static int current_cost_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                //"counter",      "Counter",       DATA_FORMAT, "%d", DATA_INT, c_impulse,
                "power0",       "Counter",       DATA_FORMAT, "%d", DATA_INT, c_impulse,
                NULL);
-       data_acquired_handler(data);
+       decoder_output_data(decoder, data);
        return 1;
     }
 

--- a/src/devices/current_cost.c
+++ b/src/devices/current_cost.c
@@ -1,6 +1,6 @@
 #include "decoder.h"
 
-static int current_cost_callback(bitbuffer_t *bitbuffer) {
+static int current_cost_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     bitbuffer_invert(bitbuffer);
     bitrow_t *bb = bitbuffer->bb;
     uint8_t *b = bb[0];

--- a/src/devices/danfoss.c
+++ b/src/devices/danfoss.c
@@ -66,7 +66,8 @@ static uint8_t danfoss_decode_nibble(uint8_t byte) {
 }
 
 
-static int danfoss_cfr_callback(bitbuffer_t *bitbuffer) {
+static int danfoss_cfr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
+{
 	uint8_t bytes[NUM_BYTES];	// Decoded bytes with two 4 bit nibbles in each
 	data_t *data;
 	char time_str[LOCAL_TIME_BUFLEN];

--- a/src/devices/danfoss.c
+++ b/src/devices/danfoss.c
@@ -70,9 +70,7 @@ static int danfoss_cfr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
 	uint8_t bytes[NUM_BYTES];	// Decoded bytes with two 4 bit nibbles in each
 	data_t *data;
-	char time_str[LOCAL_TIME_BUFLEN];
 
-	local_time_str(0, time_str);
 
 	// Validate package
 	unsigned bits = bitbuffer->bits_per_row[0];
@@ -136,7 +134,6 @@ static int danfoss_cfr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
 		// Output data
 		data = data_make(
-			"time",		"",		DATA_STRING,	time_str,
 			"model",		"",		DATA_STRING,	"Danfoss CFR Thermostat",
 			"id",		"ID",		DATA_INT,	id,
 			"temperature_C", 	"Temperature",	DATA_FORMAT,	"%.2f C", DATA_DOUBLE, temp_meas,
@@ -153,7 +150,6 @@ static int danfoss_cfr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
 
 static char *output_fields[] = {
-	"time",
 	"brand"
 	"model"
 	"id"

--- a/src/devices/danfoss.c
+++ b/src/devices/danfoss.c
@@ -80,7 +80,7 @@ static int danfoss_cfr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 		// Find a package
 		unsigned bit_offset = bitbuffer_search(bitbuffer, 0, 112, HEADER, sizeof(HEADER)*8);	// Normal index is 128, skip first 14 bytes to find faster
 		if (bits-bit_offset < 126) {	// Package should be at least 126 bits
-			if (debug_output) {
+			if (decoder->verbose) {
 				fprintf(stderr, "Danfoss: short package. Header index: %u\n", bit_offset);
 				bitbuffer_print(bitbuffer);
 			}
@@ -93,7 +93,7 @@ static int danfoss_cfr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 			uint8_t nibble_h = danfoss_decode_nibble(bitrow_get_byte(bitbuffer->bb[0], n*12+bit_offset) >> 2);
 			uint8_t nibble_l = danfoss_decode_nibble(bitrow_get_byte(bitbuffer->bb[0], n*12+bit_offset+6) >> 2);
 			if (nibble_h > 0xF || nibble_l > 0xF) {
-				if (debug_output) {
+				if (decoder->verbose) {
 					fprintf(stderr, "Danfoss: 6b/4b decoding error\n");
 					bitbuffer_print(bitbuffer);
 				}
@@ -103,7 +103,7 @@ static int danfoss_cfr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 		}
 
 		// Output raw decoded data for debug
-		if (debug_output) {
+		if (decoder->verbose) {
 			char str_raw[NUM_BYTES*2+4];	// Add some extra space for line end
 			for (unsigned n=0; n<NUM_BYTES; ++n) {
 				sprintf(str_raw+n*2, "%02X", bytes[n]);
@@ -116,7 +116,7 @@ static int danfoss_cfr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 		if (bytes[0] != 0x02		// Somewhat redundant to header search, but checks last bits
 		 || crc_calc != (((uint16_t)bytes[8] << 8) | bytes[9])
 		) {
-			if (debug_output) fprintf(stderr, "Danfoss: Prefix or CRC error.\n");
+			if (decoder->verbose) fprintf(stderr, "Danfoss: Prefix or CRC error.\n");
 			return 0;
 		}
 

--- a/src/devices/danfoss.c
+++ b/src/devices/danfoss.c
@@ -144,7 +144,7 @@ static int danfoss_cfr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 			"switch",		"Switch",	DATA_STRING,	str_sw,
 			"mic",           "Integrity",            DATA_STRING,    "CRC",
 			NULL);
-		data_acquired_handler(data);
+		decoder_output_data(decoder, data);
 
 		return 1;
 	}

--- a/src/devices/dish_remote_6_3.c
+++ b/src/devices/dish_remote_6_3.c
@@ -93,7 +93,6 @@ char *button_map[] = {
 
 static int dish_remote_6_3_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     int r; // a row index
     uint8_t *b; // bits of a row
@@ -120,10 +119,8 @@ static int dish_remote_6_3_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     button = b[0] >> 2;
     button_string = button_map[button];
 	
-    local_time_str(0, time_str);
 
     data = data_make(
-            "time",  "", DATA_STRING, time_str,
             "model", "", DATA_STRING, "Dish remote 6.3",
             "button", "", DATA_STRING, button_string,
             NULL);
@@ -134,7 +131,6 @@ static int dish_remote_6_3_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "button",
     NULL

--- a/src/devices/dish_remote_6_3.c
+++ b/src/devices/dish_remote_6_3.c
@@ -91,7 +91,7 @@ char *button_map[] = {
 /* 63 */ "Info"
 };
 
-static int dish_remote_6_3_callback(bitbuffer_t *bitbuffer)
+static int dish_remote_6_3_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;

--- a/src/devices/dish_remote_6_3.c
+++ b/src/devices/dish_remote_6_3.c
@@ -128,7 +128,7 @@ static int dish_remote_6_3_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             "button", "", DATA_STRING, button_string,
             NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }

--- a/src/devices/dish_remote_6_3.c
+++ b/src/devices/dish_remote_6_3.c
@@ -100,7 +100,7 @@ static int dish_remote_6_3_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     uint8_t button;
     char *button_string;
 
-    if (debug_output > 1) {
+    if (decoder->verbose > 1) {
         fprintf(stderr,"dish_remote_6_3_callback callback:\n");
         bitbuffer_print(bitbuffer);
     }

--- a/src/devices/dsc.c
+++ b/src/devices/dsc.c
@@ -74,7 +74,6 @@
 
 static int dsc_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t *b;
     int valid_cnt = 0;
@@ -180,10 +179,8 @@ static int dsc_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         sprintf(status_str, "%02x", status);
         sprintf(esn_str, "%06x", esn);
 
-        local_time_str(0, time_str);
 
         data = data_make(
-                "time", "", DATA_STRING, time_str,
                 "model", "", DATA_STRING, "DSC Contact",
                 "id", "", DATA_INT, esn,
                 "closed", "", DATA_INT, s_closed, // @todo make bool
@@ -214,7 +211,6 @@ static int dsc_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "status",

--- a/src/devices/dsc.c
+++ b/src/devices/dsc.c
@@ -201,7 +201,7 @@ static int dsc_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                 "status_hex", "", DATA_STRING, status_str, // to be removed - once bits are output
                 "mic", "", DATA_STRING, "CRC",
                 NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
 
         valid_cnt++; // Have a valid packet.
     }

--- a/src/devices/dsc.c
+++ b/src/devices/dsc.c
@@ -72,7 +72,7 @@
 #define DSC_CT_CRC_POLY        0xf5
 #define DSC_CT_CRC_INIT        0x3d
 
-static int dsc_callback(bitbuffer_t *bitbuffer)
+static int dsc_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;

--- a/src/devices/dsc.c
+++ b/src/devices/dsc.c
@@ -86,13 +86,13 @@ static int dsc_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     int s_closed, s_event, s_tamper, s_battery_low;
     int s_xactivity, s_xtamper1, s_xtamper2, s_exception;
 
-    if (debug_output > 1) {
+    if (decoder->verbose > 1) {
         fprintf(stderr,"Possible DSC Contact: ");
         bitbuffer_print(bitbuffer);
     }
 
     for (int row = 0; row < bitbuffer->num_rows; row++) {
-        if (debug_output > 1 && bitbuffer->bits_per_row[row] > 0 ) {
+        if (decoder->verbose > 1 && bitbuffer->bits_per_row[row] > 0 ) {
             fprintf(stderr,"row %d bit count %d\n", row,
                 bitbuffer->bits_per_row[row]);
         }
@@ -106,7 +106,7 @@ static int dsc_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         // will need to be changed as there may be more zero bit padding
         if (bitbuffer->bits_per_row[row] < 48 ||
             bitbuffer->bits_per_row[row] > 70) {  // should be 48 at most
-            if (debug_output > 1 && bitbuffer->bits_per_row[row] > 0) {
+            if (decoder->verbose > 1 && bitbuffer->bits_per_row[row] > 0) {
             fprintf(stderr,"DSC row %d invalid bit count %d\n",
                 row, bitbuffer->bits_per_row[row]);
             }
@@ -120,7 +120,7 @@ static int dsc_callback(r_device *decoder, bitbuffer_t *bitbuffer)
               (b[2] & 0x04) &&    // every 8 data bits
               (b[3] & 0x02) &&
               (b[4] & 0x01))) {
-            if (debug_output > 1) {
+            if (decoder->verbose > 1) {
                 fprintf(stderr, "DSC Invalid start/sync bits ");
                 bitrow_print(b, 40);
             }
@@ -133,8 +133,8 @@ static int dsc_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         bytes[3] = ((b[3] & 0x01) << 7) | ((b[4] & 0xFE) >> 1);
         bytes[4] = ((b[5]));
 
-        // XXX change to debug_output
-        if (debug_output) {
+        // XXX change to decoder->verbose
+        if (decoder->verbose) {
             fprintf(stdout, "DSC Contact Raw Data: ");
             bitrow_print(bytes, 40);
         }
@@ -144,7 +144,7 @@ static int dsc_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         crc = bytes[4];
 
         if (crc8le(bytes, DSC_CT_MSGLEN, DSC_CT_CRC_POLY, DSC_CT_CRC_INIT) != 0) {
-            if (debug_output)
+            if (decoder->verbose)
                 fprintf(stderr,"DSC Contact bad CRC: %06X, Status: %02X, CRC: %02X\n",
                         esn, status, crc);
             continue;

--- a/src/devices/ec3k.c
+++ b/src/devices/ec3k.c
@@ -15,7 +15,7 @@
  */
 #include "decoder.h"
 
-static int ec3k_callback(bitbuffer_t *bitbuffer) {
+static int ec3k_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	bitrow_t *bb = bitbuffer->bb;
 
 	// Validate package

--- a/src/devices/efergy_e2_classic.c
+++ b/src/devices/efergy_e2_classic.c
@@ -90,7 +90,7 @@ static int efergy_e2_classic_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                      "mic",      "Integrity",      DATA_STRING, "CHECKSUM",
                      NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }

--- a/src/devices/efergy_e2_classic.c
+++ b/src/devices/efergy_e2_classic.c
@@ -24,7 +24,7 @@
 
 #include "decoder.h"
 
-static int efergy_e2_classic_callback(bitbuffer_t *bitbuffer) {
+static int efergy_e2_classic_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     unsigned num_bits = bitbuffer->bits_per_row[0];
     uint8_t *bytes = bitbuffer->bb[0];
     data_t *data;

--- a/src/devices/efergy_e2_classic.c
+++ b/src/devices/efergy_e2_classic.c
@@ -28,7 +28,6 @@ static int efergy_e2_classic_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     unsigned num_bits = bitbuffer->bits_per_row[0];
     uint8_t *bytes = bitbuffer->bb[0];
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
 
     if (num_bits < 64 || num_bits > 80) {
         return 0;
@@ -77,10 +76,9 @@ static int efergy_e2_classic_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     uint8_t fact = (-(int8_t)bytes[6] + 15);
     float current_adc = (float)((bytes[4] << 8 | bytes[5])) / (1 << fact);
 
-    local_time_str(0, time_str);
 
     // Output data
-    data = data_make("time",     "",               DATA_STRING, time_str,
+    data = data_make(
                      "model",    "",               DATA_STRING, "Efergy e2 CT",
                      "id",       "Transmitter ID", DATA_INT, address,
                      "current",  "Current",        DATA_FORMAT, "%.2f A", DATA_DOUBLE, current_adc,
@@ -96,7 +94,6 @@ static int efergy_e2_classic_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "current",

--- a/src/devices/efergy_optical.c
+++ b/src/devices/efergy_optical.c
@@ -63,7 +63,7 @@ static int efergy_optical_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 		}
 	}
 
-	if (debug_output) {
+	if (decoder->verbose) {
 		fprintf(stdout,"Possible Efergy Optical: ");
 		bitbuffer_print(bitbuffer);
 	}
@@ -83,7 +83,7 @@ static int efergy_optical_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
 	if (crc == csum1)
 	{
-		if (debug_output) {
+		if (decoder->verbose) {
 			fprintf(stdout, "Checksum OK :) :)\n");
 			fprintf(stdout, "Calculated crc is 0x%02X\n", crc);
 			fprintf(stdout, "Received csum1 is 0x%02X\n", csum1);
@@ -128,7 +128,7 @@ static int efergy_optical_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
 	else
 	{
-		if (debug_output)
+		if (decoder->verbose)
 		{
 			fprintf(stdout, "Checksum not OK !!!\n");
 			fprintf(stdout, "Calculated crc is 0x%02X\n", crc);

--- a/src/devices/efergy_optical.c
+++ b/src/devices/efergy_optical.c
@@ -121,7 +121,7 @@ static int efergy_optical_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 				"pulses",	"Pulse-rate",	DATA_FORMAT,"%i", DATA_INT, imp_kwh[i],
 				"energy",       "Energy",     DATA_FORMAT,"%.03f KWh", DATA_DOUBLE, energy,
 				NULL);
-			data_acquired_handler(data);
+			decoder_output_data(decoder, data);
 		}
 		return 1;
 	}

--- a/src/devices/efergy_optical.c
+++ b/src/devices/efergy_optical.c
@@ -20,7 +20,7 @@
 
 #include "decoder.h"
 
-static int efergy_optical_callback(bitbuffer_t *bitbuffer) {
+static int efergy_optical_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	unsigned num_bits = bitbuffer->bits_per_row[0];
 	uint8_t *bytes = bitbuffer->bb[0];
 	double energy, n_imp;

--- a/src/devices/efergy_optical.c
+++ b/src/devices/efergy_optical.c
@@ -27,7 +27,6 @@ static int efergy_optical_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	double pulsecount;
 	double seconds;
 	data_t *data;
-	char time_str[LOCAL_TIME_BUFLEN];
  	uint16_t crc;
 	uint16_t csum1;
 
@@ -114,9 +113,7 @@ static int efergy_optical_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 			{
 				energy = ((pulsecount/imp_kwh[i]) * (3600/30));
 			}
-			local_time_str(0, time_str);
 			data = data_make(
-				"time",          "Time",            DATA_STRING, time_str,
 				"model",         "Model",            DATA_STRING, "Efergy Optical",
 				"pulses",	"Pulse-rate",	DATA_FORMAT,"%i", DATA_INT, imp_kwh[i],
 				"energy",       "Energy",     DATA_FORMAT,"%.03f KWh", DATA_DOUBLE, energy,
@@ -139,7 +136,6 @@ static int efergy_optical_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-	"time",
 	"model",
 	"pulses",
 	"energy",

--- a/src/devices/elro_db286a.c
+++ b/src/devices/elro_db286a.c
@@ -21,7 +21,6 @@
 
 static int elro_db286a_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t *b;
     char id_str[4*2+1];
@@ -37,9 +36,7 @@ static int elro_db286a_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     // 32 bits, trailing bit is dropped
     sprintf(id_str, "%02x%02x%02x%02x", b[0], b[1], b[2], b[3]);
 
-    local_time_str(0, time_str);
     data = data_make(
-            "time",     "",        DATA_STRING, time_str,
             "model",    "",        DATA_STRING, "Elro-DB286A",
             "id",       "ID",      DATA_STRING, id_str,
             NULL);
@@ -51,7 +48,6 @@ static int elro_db286a_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     NULL

--- a/src/devices/elro_db286a.c
+++ b/src/devices/elro_db286a.c
@@ -19,7 +19,7 @@
 
 #include "decoder.h"
 
-static int elro_db286a_callback(bitbuffer_t *bitbuffer)
+static int elro_db286a_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;

--- a/src/devices/elro_db286a.c
+++ b/src/devices/elro_db286a.c
@@ -44,7 +44,7 @@ static int elro_db286a_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             "id",       "ID",      DATA_STRING, id_str,
             NULL);
 
-    data_acquired_handler(data);
+	decoder_output_data(decoder, data);
 
     return 1;
 

--- a/src/devices/elv.c
+++ b/src/devices/elv.c
@@ -11,7 +11,7 @@ uint16_t AD_POP(uint8_t *bb, uint8_t bits, uint8_t bit) {
     return val;
 }
 
-static int em1000_callback(bitbuffer_t *bitbuffer) {
+static int em1000_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     // based on fs20.c
     bitrow_t *bb = bitbuffer->bb;
     uint8_t dec[10];
@@ -65,7 +65,7 @@ static int em1000_callback(bitbuffer_t *bitbuffer) {
     return 1;
 }
 
-static int ws2000_callback(bitbuffer_t *bitbuffer) {
+static int ws2000_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     // based on http://www.dc3yc.privat.t-online.de/protocol.htm
     bitrow_t *bb = bitbuffer->bb;
     uint8_t dec[13];

--- a/src/devices/elv.c
+++ b/src/devices/elv.c
@@ -81,7 +81,7 @@ static int ws2000_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     dec[0] = AD_POP (bb[0], 4, bit); bit+=4;
     stopbit= AD_POP (bb[0], 1, bit); bit+=1;
     if (!stopbit) {
-        if(debug_output) fprintf(stdout, "!stopbit\n");
+        if(decoder->verbose) fprintf(stdout, "!stopbit\n");
         return 0;
     }
     check_calculated ^= dec[0];
@@ -92,17 +92,17 @@ static int ws2000_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         dec[i] = AD_POP (bb[0], 4, bit); bit+=4;
         stopbit= AD_POP (bb[0], 1, bit); bit+=1;
         if (!stopbit) {
-            if(debug_output) fprintf(stdout, "!stopbit %i\n", bit);
+            if(decoder->verbose) fprintf(stdout, "!stopbit %i\n", bit);
             return 0;
         }
         check_calculated ^= dec[i];
         sum_calculated   += dec[i];
         nibbles++;
     }
-    if(debug_output) { for (i = 0; i < nibbles; i++) fprintf(stdout, "%02X ", dec[i]); fprintf(stdout, "\n"); }
+    if(decoder->verbose) { for (i = 0; i < nibbles; i++) fprintf(stdout, "%02X ", dec[i]); fprintf(stdout, "\n"); }
 
     if (check_calculated) {
-        if(debug_output) fprintf(stdout, "check_calculated (%d) != 0\n", check_calculated);
+        if(decoder->verbose) fprintf(stdout, "check_calculated (%d) != 0\n", check_calculated);
         return 0;
     }
 
@@ -111,7 +111,7 @@ static int ws2000_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     sum_calculated+=5;
     sum_calculated&=0xF;
     if (sum_received != sum_calculated) {
-        if(debug_output) fprintf(stdout, "sum_received (%d) != sum_calculated (%d) ", sum_received, sum_calculated);
+        if(decoder->verbose) fprintf(stdout, "sum_received (%d) != sum_calculated (%d) ", sum_received, sum_calculated);
         return 0;
     }
 

--- a/src/devices/emontx.c
+++ b/src/devices/emontx.c
@@ -126,7 +126,7 @@ static int emontx_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 				 words[9] == 3000 ? NULL : "temp5_C", "", DATA_FORMAT, "%.1f", DATA_DOUBLE, (double)words[9] / 10.0,
 				 words[10] == 3000 ? NULL : "temp6_C", "", DATA_FORMAT, "%.1f", DATA_DOUBLE, (double)words[10] / 10.0,
 				 NULL);
-		data_acquired_handler(data);
+		decoder_output_data(decoder, data);
 		events++;
 	}
 	return events;

--- a/src/devices/emontx.c
+++ b/src/devices/emontx.c
@@ -36,7 +36,7 @@ static unsigned char preamble[3] = { 0xaa, 0xaa, 0xaa };
 static unsigned char pkt_hdr_inverted[3] = { 0xd2, 0x2d, 0xc0 };
 static unsigned char pkt_hdr[3] = { 0x2d, 0xd2, 0x00 };
 
-static int emontx_callback(bitbuffer_t *bitbuffer) {
+static int emontx_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	bitrow_t *bb = bitbuffer->bb;
 	unsigned bitpos = 0;
 	unsigned bits = bitbuffer->bits_per_row[0];

--- a/src/devices/emontx.c
+++ b/src/devices/emontx.c
@@ -50,7 +50,6 @@ static int emontx_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 		unsigned pkt_pos;
 		uint16_t crc;
 		data_t *data;
-		char time_str[LOCAL_TIME_BUFLEN];
 		union {
 			struct emontx p;
 			uint8_t b[sizeof(struct emontx)];
@@ -108,8 +107,7 @@ static int emontx_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
 		vrms = (double)words[4] / 100.0;
 
-		local_time_str(0, time_str);
-		data = data_make("time", "", DATA_STRING, time_str,
+		data = data_make(
 				 "model", "", DATA_STRING, "emonTx",
 				 "node", "", DATA_FORMAT, "%02x", DATA_INT, pkt.p.node & 0x1f,
 				 "ct1", "", DATA_FORMAT, "%d", DATA_INT, (int16_t)words[0],
@@ -133,9 +131,21 @@ static int emontx_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-	"time", "model", "node", "ct1", "ct2", "ct3", "ct4", "Vrms/batt",
-	"temp1_C", "temp2_C", "temp3_C", "temp4_C", "temp5_C", "temp6_C",
-	"pulse", NULL
+	"model",
+	"node",
+	"ct1",
+	"ct2",
+	"ct3",
+	"ct4",
+	"Vrms/batt",
+	"temp1_C",
+	"temp2_C",
+	"temp3_C",
+	"temp4_C",
+	"temp5_C",
+	"temp6_C",
+	"pulse",
+	NULL
 };
 
 r_device emontx = {

--- a/src/devices/esperanza_ews.c
+++ b/src/devices/esperanza_ews.c
@@ -53,7 +53,7 @@
 */
 #include "decoder.h"
 
-static int esperanza_ews_process_row(const bitbuffer_t *bitbuffer, int row)
+static int esperanza_ews_process_row(r_device *decoder, bitbuffer_t *bitbuffer, int row)
 {
     const uint8_t *b = bitbuffer->bb[row];
     uint8_t humidity;
@@ -80,7 +80,7 @@ static int esperanza_ews_process_row(const bitbuffer_t *bitbuffer, int row)
                      "temperature_F", "Temperature", DATA_FORMAT, "%.02f F", DATA_DOUBLE, temperature_f,
                      "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, humidity,
                       NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }
@@ -106,7 +106,7 @@ static int esperanza_ews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             if (memcmp(bitbuffer->bb[row], bitbuffer->bb[row+2], sizeof(bitbuffer->bb[row])) != 0 || bitbuffer->bits_per_row[row] != 42)
                 return 0;
         }
-        esperanza_ews_process_row(bitbuffer, 2);
+        esperanza_ews_process_row(decoder, bitbuffer, 2);
         return 1;
     }
     return 0;

--- a/src/devices/esperanza_ews.c
+++ b/src/devices/esperanza_ews.c
@@ -64,7 +64,6 @@ static int esperanza_ews_process_row(r_device *decoder, bitbuffer_t *bitbuffer, 
 
     data_t *data;
 
-    char time_str[LOCAL_TIME_BUFLEN];
 
     humidity = (uint8_t)((b[3] << 6) | ((b[4] >> 2) & 0x0F) | ((b[3] >>2) & 0xF));
     temperature_with_offset = (uint16_t)(((b[2] << 10) | ((b[3] << 2) & 0x300) | ((b[3] << 2) & 0xF0) | ((b[1] << 2) & 0x0C) |  b[2] >> 6) & 0x0FFF);
@@ -72,8 +71,7 @@ static int esperanza_ews_process_row(r_device *decoder, bitbuffer_t *bitbuffer, 
     channel = (uint8_t)((b[1] & 0x0C)+1);
     temperature_f = (float)((temperature_with_offset-900)/10.0);
 
-    local_time_str(0, time_str);
-    data = data_make("time",          "",            DATA_STRING, time_str,
+    data = data_make(
                      "model",         "",            DATA_STRING, "Esperanza EWS",
                      "id",            "",            DATA_INT, device_id,
                      "channel",       "Channel",     DATA_INT, channel,
@@ -86,7 +84,6 @@ static int esperanza_ews_process_row(r_device *decoder, bitbuffer_t *bitbuffer, 
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "channel",

--- a/src/devices/esperanza_ews.c
+++ b/src/devices/esperanza_ews.c
@@ -95,7 +95,7 @@ static char *output_fields[] = {
     NULL
 };
 
-static int esperanza_ews_callback(bitbuffer_t *bitbuffer)
+static int esperanza_ews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     // require two leading sync pulses
     if (bitbuffer->bits_per_row[0] != 0 || bitbuffer->bits_per_row[1] != 0)

--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -35,7 +35,6 @@ static int fineoffset_WH2_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
     uint8_t b[6] = {0};
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
 
     char *model;
     int type;
@@ -101,11 +100,10 @@ static int fineoffset_WH2_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     humidity = b[3];
 
     /* Get time now */
-    local_time_str(0, time_str);
 
     // Thermo
     if (b[3] == 0xFF) {
-        data = data_make("time",          "",            DATA_STRING, time_str,
+        data = data_make(
                          "model",         "",            DATA_STRING, model,
                          "id",            "ID",          DATA_INT, id,
                          "temperature_C", "Temperature", DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
@@ -115,7 +113,7 @@ static int fineoffset_WH2_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     }
     // Thermo/Hygro
     else {
-        data = data_make("time",          "",            DATA_STRING, time_str,
+        data = data_make(
                          "model",         "",            DATA_STRING, model,
                          "id",            "ID",          DATA_INT, id,
                          "temperature_C", "Temperature", DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
@@ -165,7 +163,6 @@ static int fineoffset_WH2_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 static int fineoffset_WH24_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
     static uint8_t const preamble[] = {0xAA, 0x2D, 0xD4}; // part of preamble and sync word
     uint8_t b[17]; // aligned packet data
     unsigned bit_offset;
@@ -265,9 +262,7 @@ static int fineoffset_WH24_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     while (uv_index < 13 && uvi_upper[uv_index] < uv_raw) ++uv_index;
 
     // Output data
-    local_time_str(0, time_str);
     data = data_make(
-            "time",             "",                 DATA_STRING, time_str,
             "model",            "",                 DATA_STRING, model == MODEL_WH24 ? "Fine Offset WH24" : "Fine Offset WH65B",
             "id",               "ID",               DATA_INT, id,
             NULL);
@@ -316,7 +311,6 @@ static int fineoffset_WH24_callback(r_device *decoder, bitbuffer_t *bitbuffer)
  */
 static int fineoffset_WH25_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
     static uint8_t const preamble[] = {0xAA, 0x2D, 0xD4};
     uint8_t b[8];
     unsigned bit_offset;
@@ -366,8 +360,7 @@ static int fineoffset_WH25_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     float pressure    = (b[4] << 8 | b[5]) * 0.1;
 
     // Output data
-    local_time_str(0, time_str);
-    data = data_make("time",          "",            DATA_STRING, time_str,
+    data = data_make(
                      "model",         "",            DATA_STRING, "Fine Offset Electronics, WH25",
                      "id",            "ID",          DATA_INT, id,
                      "temperature_C", "Temperature", DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
@@ -402,7 +395,6 @@ static int fineoffset_WH25_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
  */
 static int fineoffset_WH0530_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
     bitrow_t *bb = bitbuffer->bb;
 
     // Validate package
@@ -436,8 +428,7 @@ static int fineoffset_WH0530_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     int rainfall_raw = buffer[4] << 8 | buffer[3]; // rain tip counter
     float rainfall = rainfall_raw * 0.3; // each tip is 0.3mm
 
-    local_time_str(0, time_str);
-    data = data_make("time",          "",            DATA_STRING, time_str,
+    data = data_make(
                      "model",         "",            DATA_STRING, "Fine Offset Electronics, WH0530 Temperature/Rain sensor",
                      "id",            "ID",          DATA_INT, id,
                      "temperature_C", "Temperature", DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
@@ -451,7 +442,6 @@ static int fineoffset_WH0530_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "temperature_C",
@@ -461,7 +451,6 @@ static char *output_fields[] = {
 };
 
 static char *output_fields_WH25[] = {
-    "time",
     "model",
     "id",
     "temperature_C",
@@ -481,7 +470,6 @@ static char *output_fields_WH25[] = {
 };
 
 static char *output_fields_WH0530[] = {
-    "time",
     "model",
     "id",
     "temperature_C",

--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -111,7 +111,7 @@ static int fineoffset_WH2_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                          "temperature_C", "Temperature", DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
                          "mic",           "Integrity",   DATA_STRING, "CRC",
                           NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
     }
     // Thermo/Hygro
     else {
@@ -122,7 +122,7 @@ static int fineoffset_WH2_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                          "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, humidity,
                          "mic",           "Integrity",   DATA_STRING, "CRC",
                           NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
     }
     return 1;
 }
@@ -289,7 +289,7 @@ static int fineoffset_WH24_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         data_append(data,   "light_lux",        "Light",            DATA_FORMAT, "%.1f lux", DATA_DOUBLE, light_lux, NULL);
     data_append(data,       "battery",          "Battery",          DATA_STRING, low_battery ? "LOW" : "OK",
                             "mic",              "Integrity",        DATA_STRING, "CRC", NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }
@@ -376,7 +376,7 @@ static int fineoffset_WH25_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                      "battery",       "Battery",     DATA_STRING, low_battery ? "LOW" : "OK",
                      "mic",           "Integrity",   DATA_STRING, "CHECKSUM",
                       NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }
@@ -445,7 +445,7 @@ static int fineoffset_WH0530_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                      "battery",       "Battery",     DATA_STRING, battery_low ? "LOW" : "OK",
                      "mic",           "Integrity",   DATA_STRING, "CRC",
                      NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }

--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -74,7 +74,7 @@ static int fineoffset_WH2_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     // Nibble 2 contains type, must be 0x04 -- or is this a (battery) flag maybe? please report.
     type = b[0] >> 4;
     if (type != 4) {
-        if (debug_output) {
+        if (decoder->verbose) {
             fprintf(stderr, "%s: Unknown type: %d\n", model, type);
         }
         return 0;
@@ -179,7 +179,7 @@ static int fineoffset_WH24_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     // Find a data package and extract data buffer
     bit_offset = bitbuffer_search(bitbuffer, 0, 0, preamble, sizeof(preamble) * 8) + sizeof(preamble) * 8;
     if (bit_offset + sizeof(b) * 8 > bitbuffer->bits_per_row[0]) { // Did not find a big enough package
-        if (debug_output) {
+        if (decoder->verbose) {
             fprintf(stderr, "Fineoffset_WH24: short package. Header index: %u\n", bit_offset);
             bitbuffer_print(bitbuffer);
         }
@@ -191,7 +191,7 @@ static int fineoffset_WH24_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         model = MODEL_WH65B; // nominal 12 bits postamble
     bitbuffer_extract_bytes(bitbuffer, 0, bit_offset, b, sizeof(b) * 8);
 
-    if (debug_output) {
+    if (decoder->verbose) {
         char raw_str[17 * 3 + 1];
         for (unsigned n = 0; n < sizeof(b); n++) {
             sprintf(raw_str + n * 3, "%02x ", b[n]);
@@ -209,7 +209,7 @@ static int fineoffset_WH24_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         checksum += b[n];
     }
     if (crc != b[15] || checksum != b[16]) {
-        if (debug_output) {
+        if (decoder->verbose) {
             fprintf(stderr, "Fineoffset_WH24: Checksum error: %02x %02x\n", crc, checksum);
         }
         return 0;
@@ -329,7 +329,7 @@ static int fineoffset_WH25_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     // Find a data package and extract data payload
     bit_offset = bitbuffer_search(bitbuffer, 0, 320, preamble, sizeof(preamble) * 8) + sizeof(preamble) * 8; // Normal index is 367, skip some bytes to find faster
     if (bit_offset + sizeof(b) * 8 > bitbuffer->bits_per_row[0]) {  // Did not find a big enough package
-        if (debug_output) {
+        if (decoder->verbose) {
             fprintf(stderr, "Fineoffset_WH25: short package. Header index: %u\n", bit_offset);
             bitbuffer_print(bitbuffer);
         }
@@ -337,7 +337,7 @@ static int fineoffset_WH25_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     }
     bitbuffer_extract_bytes(bitbuffer, 0, bit_offset, b, sizeof(b) * 8);
 
-    if (debug_output) {
+    if (decoder->verbose) {
         char raw_str[8 * 3 + 1];
         for (unsigned n=0; n<sizeof(b); n++) { sprintf(raw_str+n*3, "%02x ", b[n]); }
         fprintf(stderr, "Fineoffset_WH25: Raw: %s @ bit_offset [%u]\n", raw_str, bit_offset);
@@ -351,7 +351,7 @@ static int fineoffset_WH25_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     }
     bitsum = (bitsum << 4) | (bitsum >> 4);     // Swap nibbles
     if (checksum != b[6] || bitsum != b[7]) {
-        if (debug_output) {
+        if (decoder->verbose) {
             fprintf(stderr, "Fineoffset_WH25: Checksum error: %02x %02x\n", checksum, bitsum);
         }
         return 0;
@@ -414,7 +414,7 @@ static int fineoffset_WH0530_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     uint8_t buffer[8];
     bitbuffer_extract_bytes(bitbuffer, 0, 7, buffer, sizeof(buffer) * 8);     // Skip first 7 bits
 
-    if (debug_output) {
+    if (decoder->verbose) {
         char raw_str[8 * 3 + 1];
         for (unsigned n=0; n<sizeof(buffer); n++) { sprintf(raw_str + n * 3, "%02x ", buffer[n]); }
         fprintf(stderr, "Fineoffset_WH0530: Raw %s\n", raw_str);
@@ -424,7 +424,7 @@ static int fineoffset_WH0530_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     uint8_t crc = crc8(buffer, 6, 0x31, 0);
     uint8_t checksum = buffer[0] + buffer[1] + buffer[2] + buffer[3] + buffer[4] + buffer[5] + buffer[6];
     if (crc != buffer[6] || checksum != buffer[7]) {
-        if (debug_output) {
+        if (decoder->verbose) {
             fprintf(stderr, "Fineoffset_WH0530: Checksum error: %02x %02x\n", crc, checksum);
         }
         return 0;

--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -31,7 +31,7 @@
  * Based on reverse engineering with gnu-radio and the nice article here:
  *  http://lucsmall.com/2012/04/29/weather-station-hacking-part-2/
  */
-static int fineoffset_WH2_callback(bitbuffer_t *bitbuffer) {
+static int fineoffset_WH2_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
     uint8_t b[6] = {0};
     data_t *data;
@@ -162,7 +162,7 @@ static int fineoffset_WH2_callback(bitbuffer_t *bitbuffer) {
  */
 #define MODEL_WH24 24 /* internal identifier for model WH24, family code is always 0x24 */
 #define MODEL_WH65B 65 /* internal identifier for model WH65B, family code is always 0x24 */
-static int fineoffset_WH24_callback(bitbuffer_t *bitbuffer)
+static int fineoffset_WH24_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
     char time_str[LOCAL_TIME_BUFLEN];
@@ -314,7 +314,7 @@ static int fineoffset_WH24_callback(bitbuffer_t *bitbuffer)
  * BB = Bitsum (XOR) of the 6 data bytes (high and low nibble exchanged)
  *
  */
-static int fineoffset_WH25_callback(bitbuffer_t *bitbuffer) {
+static int fineoffset_WH25_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     data_t *data;
     char time_str[LOCAL_TIME_BUFLEN];
     static uint8_t const preamble[] = {0xAA, 0x2D, 0xD4};
@@ -323,7 +323,7 @@ static int fineoffset_WH25_callback(bitbuffer_t *bitbuffer) {
 
     // Validate package
     if (bitbuffer->bits_per_row[0] < 440 || bitbuffer->bits_per_row[0] > 510) {  // Nominal size is 488 bit periods
-        return fineoffset_WH24_callback(bitbuffer); // abort and try WH24, WH65B, HP1000
+        return fineoffset_WH24_callback(decoder, bitbuffer); // abort and try WH24, WH65B, HP1000
     }
 
     // Find a data package and extract data payload
@@ -400,7 +400,7 @@ static int fineoffset_WH25_callback(bitbuffer_t *bitbuffer) {
  * CC = CRC8 with polynomium 0x31
  * CC = Checksum of previous 7 bytes (binary sum truncated to 8 bit)
  */
-static int fineoffset_WH0530_callback(bitbuffer_t *bitbuffer) {
+static int fineoffset_WH0530_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     data_t *data;
     char time_str[LOCAL_TIME_BUFLEN];
     bitrow_t *bb = bitbuffer->bb;

--- a/src/devices/fineoffset_wh1050.c
+++ b/src/devices/fineoffset_wh1050.c
@@ -172,7 +172,7 @@ static int fineoffset_wh1050_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             "rain",          "Total rainfall",    DATA_FORMAT, "%.01f",    DATA_DOUBLE, rain,
             "battery",       "Battery",    DATA_STRING, battery, // Unsure about Battery byte...
             NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     return 1;
 }
 

--- a/src/devices/fineoffset_wh1050.c
+++ b/src/devices/fineoffset_wh1050.c
@@ -108,7 +108,7 @@ static float get_rainfall(const uint8_t* br) {
 //-------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------
 
-static int fineoffset_wh1050_callback(bitbuffer_t *bitbuffer) {
+static int fineoffset_wh1050_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     data_t *data;
     char time_str[LOCAL_TIME_BUFLEN];
     local_time_str(0, time_str);

--- a/src/devices/fineoffset_wh1050.c
+++ b/src/devices/fineoffset_wh1050.c
@@ -110,8 +110,6 @@ static float get_rainfall(const uint8_t* br) {
 
 static int fineoffset_wh1050_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
-    local_time_str(0, time_str);
 
     if (bitbuffer->num_rows != 1) {
         return 0;
@@ -162,7 +160,7 @@ static int fineoffset_wh1050_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 //---------------------------------------------------------------------------------------
 //--------- PRESENTING DATA --------------------------------------------------------------
 
-    data = data_make("time",         "",         DATA_STRING, time_str,
+    data = data_make(
             "model",         "",         DATA_STRING, "Fine Offset WH1050 weather station",
             "id",            "StationID",    DATA_FORMAT, "%04X",    DATA_INT,    device_id,
             "temperature_C", "Temperature",    DATA_FORMAT, "%.01f C",    DATA_DOUBLE, temperature,
@@ -177,7 +175,6 @@ static int fineoffset_wh1050_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "temperature_C",

--- a/src/devices/fineoffset_wh1080.c
+++ b/src/devices/fineoffset_wh1080.c
@@ -245,14 +245,12 @@ static int get_day(const uint8_t* br) {
 
 static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
     const uint8_t *br;
     int msg_type; // 0=Weather 1=Datetime 2=UV/Light
     int sens_msg = 12; // 12=Weather/Time sensor  8=UV/Light sensor
     int i;
     uint8_t bbuf[11]; // max 8 / 11 bytes needed
 
-    local_time_str(0, time_str);
 
     if (bitbuffer->num_rows != 1) {
         return 0;
@@ -374,7 +372,6 @@ static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (msg_type == 0) {
 
         data = data_make(
-                "time",     "",         DATA_STRING,                    time_str,
                 "model",     "",         DATA_STRING,    "Fine Offset Electronics WH1080/WH3080 Weather Station",
                 "msg_type",    "Msg type",    DATA_INT,                    msg_type,
                 "id",        "Station ID",    DATA_FORMAT,    "%d",        DATA_INT,    device_id,
@@ -393,7 +390,6 @@ static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     } else if (msg_type == 1) {
 
         data = data_make(
-                "time",        "",        DATA_STRING,        time_str,
                 "model",    "",        DATA_STRING,    "Fine Offset Electronics WH1080/WH3080 Weather Station",
                 "msg_type",    "Msg type",    DATA_INT,                msg_type,
                 "id",        "Station ID",    DATA_FORMAT,    "%d",    DATA_INT,    device_id,
@@ -411,7 +407,6 @@ static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     } else {
 
         data = data_make(
-                "time",        "",        DATA_STRING,                time_str,
                 "model",    "",        DATA_STRING,    "Fine Offset Electronics WH3080 Weather Station",
                 "msg_type",    "Msg type",    DATA_INT,                msg_type,
                 "uv_sensor_id",    "UV Sensor ID",    DATA_FORMAT,    "%d",    DATA_INT,    uv_sensor_id,
@@ -427,7 +422,6 @@ static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "temperature_C",

--- a/src/devices/fineoffset_wh1080.c
+++ b/src/devices/fineoffset_wh1080.c
@@ -243,7 +243,7 @@ static int get_day(const uint8_t* br) {
 //-------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------
 
-static int fineoffset_wh1080_callback(bitbuffer_t *bitbuffer) {
+static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     data_t *data;
     char time_str[LOCAL_TIME_BUFLEN];
     const uint8_t *br;

--- a/src/devices/fineoffset_wh1080.c
+++ b/src/devices/fineoffset_wh1080.c
@@ -387,7 +387,7 @@ static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                 "rain",        "Total rainfall",DATA_FORMAT,    "%3.1f",    DATA_DOUBLE,     rain,
                 "battery",    "Battery",    DATA_STRING,                    battery,
                 NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
         return 1;
 
     } else if (msg_type == 1) {
@@ -405,7 +405,7 @@ static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                 "month",    "Month\t",    DATA_FORMAT,    "%02d",    DATA_INT,    month,
                 "day",        "Day\t",    DATA_FORMAT,    "%02d",    DATA_INT,    day,
                 NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
         return 1;
 
     } else {
@@ -421,7 +421,7 @@ static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                 "wm",        "Watts/m\t",    DATA_FORMAT,    "%.2f",    DATA_DOUBLE,    wm,
                 "fc",        "Foot-candles",    DATA_FORMAT,    "%.2f",    DATA_DOUBLE,    fc,
                 NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
         return 1;
     }
 }

--- a/src/devices/fineoffset_wh1080.c
+++ b/src/devices/fineoffset_wh1080.c
@@ -283,7 +283,7 @@ static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         return 0;
     }
 
-    if (debug_output) {
+    if (decoder->verbose) {
         bitrow_print(bbuf, (sens_msg - 1) * 8);
     }
 

--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -74,7 +74,6 @@ static int flex_callback(r_device *decoder, bitbuffer_t *bitbuffer, struct flex_
     data_t *row_data[BITBUF_ROWS];
     char *row_codes[BITBUF_ROWS];
     char row_bytes[BITBUF_COLS * 2 + 1];
-    char time_str[LOCAL_TIME_BUFLEN];
     bitrow_t tmp;
 
     // discard short / unwanted bitbuffers
@@ -136,10 +135,8 @@ static int flex_callback(r_device *decoder, bitbuffer_t *bitbuffer, struct flex_
         bitbuffer_print(bitbuffer);
     }
 
-    local_time_str(0, time_str);
     if (params->count_only) {
         data = data_make(
-                "time", "", DATA_STRING, time_str,
                 "model", "", DATA_STRING, params->name,
                 "count", "", DATA_INT, match_count,
                 NULL);
@@ -187,7 +184,6 @@ static int flex_callback(r_device *decoder, bitbuffer_t *bitbuffer, struct flex_
         sprintf(row_codes[i], "{%d}%s", bitbuffer->bits_per_row[i], row_bytes);
     }
     data = data_make(
-            "time", "", DATA_STRING, time_str,
             "model", "", DATA_STRING, params->name,
             "count", "", DATA_INT, match_count,
             "num_rows", "", DATA_INT, bitbuffer->num_rows,
@@ -203,7 +199,6 @@ static int flex_callback(r_device *decoder, bitbuffer_t *bitbuffer, struct flex_
 }
 
 static char *output_fields[] = {
-        "time",
         "model",
         "count",
         "num_rows",

--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -131,7 +131,7 @@ static int flex_callback(r_device *decoder, bitbuffer_t *bitbuffer, struct flex_
             return 0;
     }
 
-    if (debug_output >= 1) {
+    if (decoder->verbose) {
         fprintf(stderr, "%s: ", params->name);
         bitbuffer_print(bitbuffer);
     }
@@ -352,9 +352,11 @@ static void parse_getter(const char *arg, struct flex_get *getter)
         fprintf(stderr, "Bad flex spec, \"get\" missing name!\n");
         usage();
     }
-    if (debug_output)
+    /*
+    if (decoder->verbose)
         fprintf(stderr, "parse_getter() bit_offset: %d bit_count: %d mask: %lx name: %s\n",
                 getter->bit_offset, getter->bit_count, getter->mask, getter->name);
+    */
 }
 
 r_device *flex_create_device(char *spec)
@@ -534,13 +536,15 @@ r_device *flex_create_device(char *spec)
     if (params->min_bits > 0 && params->min_repeats < 1)
         params->min_repeats = 1;
 
-    if (debug_output >= 1) {
+    /*
+    if (decoder->verbose) {
         fprintf(stderr, "Adding flex decoder \"%s\"\n", params->name);
         fprintf(stderr, "\tmodulation=%u, short_limit=%.0f, long_limit=%.0f, reset_limit=%.0f\n",
                 dev->modulation, dev->short_limit, dev->long_limit, dev->reset_limit);
         fprintf(stderr, "\tmin_rows=%u, min_bits=%u, min_repeats=%u, invert=%u, match_len=%u, preamble_len=%u\n",
                 params->min_rows, params->min_bits, params->min_repeats, params->invert, params->match_len, params->preamble_len);
     }
+    */
 
     free(spec);
     next_slot++;

--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -66,7 +66,7 @@ struct flex_params {
     struct flex_get getter[GETTER_SLOTS];
 };
 
-static int flex_callback(bitbuffer_t *bitbuffer, struct flex_params *params)
+static int flex_callback(r_device *decoder, bitbuffer_t *bitbuffer, struct flex_params *params)
 {
     int i;
     int match_count = 0;
@@ -266,16 +266,16 @@ static void help()
 
 #define FLEX_SLOTS 8
 static struct flex_params *params_slot[FLEX_SLOTS];
-static int cb_slot0(bitbuffer_t *bitbuffer) { return flex_callback(bitbuffer, params_slot[0]); }
-static int cb_slot1(bitbuffer_t *bitbuffer) { return flex_callback(bitbuffer, params_slot[1]); }
-static int cb_slot2(bitbuffer_t *bitbuffer) { return flex_callback(bitbuffer, params_slot[2]); }
-static int cb_slot3(bitbuffer_t *bitbuffer) { return flex_callback(bitbuffer, params_slot[3]); }
-static int cb_slot4(bitbuffer_t *bitbuffer) { return flex_callback(bitbuffer, params_slot[4]); }
-static int cb_slot5(bitbuffer_t *bitbuffer) { return flex_callback(bitbuffer, params_slot[5]); }
-static int cb_slot6(bitbuffer_t *bitbuffer) { return flex_callback(bitbuffer, params_slot[6]); }
-static int cb_slot7(bitbuffer_t *bitbuffer) { return flex_callback(bitbuffer, params_slot[7]); }
+static int cb_slot0(r_device *decoder, bitbuffer_t *bitbuffer) { return flex_callback(decoder, bitbuffer, params_slot[0]); }
+static int cb_slot1(r_device *decoder, bitbuffer_t *bitbuffer) { return flex_callback(decoder, bitbuffer, params_slot[1]); }
+static int cb_slot2(r_device *decoder, bitbuffer_t *bitbuffer) { return flex_callback(decoder, bitbuffer, params_slot[2]); }
+static int cb_slot3(r_device *decoder, bitbuffer_t *bitbuffer) { return flex_callback(decoder, bitbuffer, params_slot[3]); }
+static int cb_slot4(r_device *decoder, bitbuffer_t *bitbuffer) { return flex_callback(decoder, bitbuffer, params_slot[4]); }
+static int cb_slot5(r_device *decoder, bitbuffer_t *bitbuffer) { return flex_callback(decoder, bitbuffer, params_slot[5]); }
+static int cb_slot6(r_device *decoder, bitbuffer_t *bitbuffer) { return flex_callback(decoder, bitbuffer, params_slot[6]); }
+static int cb_slot7(r_device *decoder, bitbuffer_t *bitbuffer) { return flex_callback(decoder, bitbuffer, params_slot[7]); }
 static unsigned next_slot = 0;
-int (*callback_slot[])(bitbuffer_t *bitbuffer) = {cb_slot0, cb_slot1, cb_slot2, cb_slot3, cb_slot4, cb_slot5, cb_slot6, cb_slot7};
+int (*callback_slot[])(r_device *decoder, bitbuffer_t *bitbuffer) = {cb_slot0, cb_slot1, cb_slot2, cb_slot3, cb_slot4, cb_slot5, cb_slot6, cb_slot7};
 
 static unsigned parse_bits(const char *code, bitrow_t bitrow)
 {

--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -143,7 +143,7 @@ static int flex_callback(r_device *decoder, bitbuffer_t *bitbuffer, struct flex_
                 "model", "", DATA_STRING, params->name,
                 "count", "", DATA_INT, match_count,
                 NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
 
         return 0;
     }
@@ -194,7 +194,7 @@ static int flex_callback(r_device *decoder, bitbuffer_t *bitbuffer, struct flex_
             "rows", "", DATA_ARRAY, data_array(bitbuffer->num_rows, DATA_DATA, row_data),
             "codes", "", DATA_ARRAY, data_array(bitbuffer->num_rows, DATA_STRING, row_codes),
             NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     for (i = 0; i < bitbuffer->num_rows; i++) {
         free(row_codes[i]);
     }

--- a/src/devices/fordremote.c
+++ b/src/devices/fordremote.c
@@ -54,7 +54,7 @@ static int fordremote_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 				"id",		"device-id",	DATA_INT, device_id,
 				"code", 	"data",		DATA_INT, code,
 				NULL);
-		data_acquired_handler(data);
+		decoder_output_data(decoder, data);
 
 		found++;
 	}

--- a/src/devices/fordremote.c
+++ b/src/devices/fordremote.c
@@ -38,7 +38,7 @@ static int fordremote_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 			continue; // no valid preamble
 		}
 
-		if (debug_output) {
+		if (decoder->verbose) {
 			bitbuffer_print(bitbuffer);
 		}
 

--- a/src/devices/fordremote.c
+++ b/src/devices/fordremote.c
@@ -21,7 +21,6 @@
 
 static int fordremote_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	data_t *data;
-	char time_str[LOCAL_TIME_BUFLEN];
 	uint8_t *bytes;
 	int found = 0;
 	int device_id, code;
@@ -47,9 +46,7 @@ static int fordremote_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 		code = bytes[7];
 
 		/* Get time now */
-		local_time_str(0, time_str);
 		data = data_make(
-	   			"time",		"time",		DATA_STRING, time_str,
 				"model",	"model",	DATA_STRING, "Ford Car Remote",
 				"id",		"device-id",	DATA_INT, device_id,
 				"code", 	"data",		DATA_INT, code,
@@ -62,7 +59,6 @@ static int fordremote_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-	"time",
 	"model",
 	"id",
 	"code",

--- a/src/devices/fordremote.c
+++ b/src/devices/fordremote.c
@@ -19,7 +19,7 @@
 
 #include "decoder.h"
 
-static int fordremote_callback(bitbuffer_t *bitbuffer) {
+static int fordremote_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	data_t *data;
 	char time_str[LOCAL_TIME_BUFLEN];
 	uint8_t *bytes;

--- a/src/devices/ft004b.c
+++ b/src/devices/ft004b.c
@@ -36,7 +36,6 @@ ft004b_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     uint8_t* msg;
     float temperature;
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
 
     if (bitbuffer->bits_per_row[0] != 137 && bitbuffer->bits_per_row[0] != 138) {
@@ -55,9 +54,7 @@ ft004b_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (msg[0] == 0xf4) {
         temperature = get_temperature(msg);
 
-        local_time_str(0, time_str);
         data = data_make(
-                "time", "", DATA_STRING, time_str,
                 "model", "", DATA_STRING, "FT-004-B Temperature Sensor",
                 "temperature_C", "Temperature", DATA_FORMAT, "%.1f", DATA_DOUBLE, temperature,
                 NULL);
@@ -70,7 +67,6 @@ ft004b_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "temperature_C",
     NULL

--- a/src/devices/ft004b.c
+++ b/src/devices/ft004b.c
@@ -32,7 +32,7 @@ get_temperature(uint8_t * msg)
 }
 
 static int
-ft004b_callback(bitbuffer_t *bitbuffer)
+ft004b_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     uint8_t* msg;
     float temperature;

--- a/src/devices/ft004b.c
+++ b/src/devices/ft004b.c
@@ -61,7 +61,7 @@ ft004b_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                 "model", "", DATA_STRING, "FT-004-B Temperature Sensor",
                 "temperature_C", "Temperature", DATA_FORMAT, "%.1f", DATA_DOUBLE, temperature,
                 NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
 
         return 1;
     }

--- a/src/devices/ge_coloreffects.c
+++ b/src/devices/ge_coloreffects.c
@@ -30,7 +30,7 @@ static inline int bit(const uint8_t *bytes, unsigned bit)
  * 10 = 0
  *  1100 = 1
  */
-unsigned ge_decode(bitbuffer_t *inbuf, unsigned row, unsigned start, bitbuffer_t *outbuf)
+unsigned ge_decode(r_device *decoder, bitbuffer_t *inbuf, unsigned row, unsigned start, bitbuffer_t *outbuf)
 {
     uint8_t *bits = inbuf->bb[row];
     unsigned int len = inbuf->bits_per_row[row];
@@ -75,14 +75,15 @@ char *ge_command_name(uint8_t command) {
     }
 }
 
-static int ge_coloreffects_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned start_pos) {
+static int ge_coloreffects_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned start_pos)
+{
     data_t *data;
     bitbuffer_t packet_bits = {0};
     uint8_t device_id;
     uint8_t command;
     char time_str[LOCAL_TIME_BUFLEN];
 
-    ge_decode(bitbuffer, row, start_pos, &packet_bits);
+    ge_decode(decoder, bitbuffer, row, start_pos, &packet_bits);
     //bitbuffer_print(&packet_bits);
 
     /* From http://www.deepdarc.com/2010/11/27/hacking-christmas-lights/
@@ -122,7 +123,7 @@ static int ge_coloreffects_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned
         "command",       "",     DATA_STRING, ge_command_name(command),
         NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     return 1;
 
 }
@@ -135,7 +136,7 @@ static int ge_coloreffects_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     // (if the device id and command were all zeros)
     while ((bitpos = bitbuffer_search(bitbuffer, 0, bitpos, (uint8_t *)&preamble_pattern, 24)) + 57 <=
             bitbuffer->bits_per_row[0]) {
-        events += ge_coloreffects_decode(bitbuffer, 0, bitpos + 24);
+        events += ge_coloreffects_decode(decoder, bitbuffer, 0, bitpos + 24);
         bitpos++;
     }
 

--- a/src/devices/ge_coloreffects.c
+++ b/src/devices/ge_coloreffects.c
@@ -81,7 +81,6 @@ static int ge_coloreffects_decode(r_device *decoder, bitbuffer_t *bitbuffer, uns
     bitbuffer_t packet_bits = {0};
     uint8_t device_id;
     uint8_t command;
-    char time_str[LOCAL_TIME_BUFLEN];
 
     ge_decode(decoder, bitbuffer, row, start_pos, &packet_bits);
     //bitbuffer_print(&packet_bits);
@@ -115,9 +114,7 @@ static int ge_coloreffects_decode(r_device *decoder, bitbuffer_t *bitbuffer, uns
     bitbuffer_extract_bytes(&packet_bits, 0, 8, &command, 8);
     
     // Format data
-    local_time_str(0, time_str);
     data = data_make(
-        "time",          "",     DATA_STRING, time_str,
         "model",         "",     DATA_STRING, "GE Color Effects Remote",
         "id",            "",     DATA_FORMAT, "0x%x", DATA_INT, device_id,
         "command",       "",     DATA_STRING, ge_command_name(command),
@@ -144,7 +141,6 @@ static int ge_coloreffects_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "command",

--- a/src/devices/ge_coloreffects.c
+++ b/src/devices/ge_coloreffects.c
@@ -127,7 +127,7 @@ static int ge_coloreffects_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned
 
 }
 
-static int ge_coloreffects_callback(bitbuffer_t *bitbuffer) {
+static int ge_coloreffects_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     unsigned bitpos = 0;
     int events = 0;
 

--- a/src/devices/generic_motion.c
+++ b/src/devices/generic_motion.c
@@ -51,7 +51,7 @@ static int generic_motion_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                 "code",     "",  DATA_STRING, code_str,
                 NULL);
 
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
         return 1;
     }
     return 0;

--- a/src/devices/generic_motion.c
+++ b/src/devices/generic_motion.c
@@ -26,7 +26,7 @@
 
 #include "decoder.h"
 
-static int generic_motion_callback(bitbuffer_t *bitbuffer) {
+static int generic_motion_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t *b;

--- a/src/devices/generic_motion.c
+++ b/src/devices/generic_motion.c
@@ -27,7 +27,6 @@
 #include "decoder.h"
 
 static int generic_motion_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t *b;
     int code;
@@ -44,9 +43,7 @@ static int generic_motion_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         code = (b[0] << 12) | (b[1] << 4) | (b[2] >> 4);
         sprintf(code_str, "%05x", code);
 
-        local_time_str(0, time_str);
         data = data_make(
-                "time",     "",  DATA_STRING, time_str,
                 "model",    "",  DATA_STRING, "Generic motion sensor",
                 "code",     "",  DATA_STRING, code_str,
                 NULL);
@@ -58,7 +55,6 @@ static int generic_motion_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "code",
     NULL

--- a/src/devices/generic_remote.c
+++ b/src/devices/generic_remote.c
@@ -13,7 +13,8 @@
  */
 #include "decoder.h"
 
-static int generic_remote_callback(bitbuffer_t *bitbuffer) {
+static int generic_remote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
+{
     data_t *data;
     char time_str[LOCAL_TIME_BUFLEN];
     bitrow_t *bb = bitbuffer->bb;

--- a/src/devices/generic_remote.c
+++ b/src/devices/generic_remote.c
@@ -16,7 +16,6 @@
 static int generic_remote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
     bitrow_t *bb = bitbuffer->bb;
     uint8_t *b = bb[0];
     char tristate[23];
@@ -53,9 +52,7 @@ static int generic_remote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     }
     *p = '\0';
 
-    local_time_str(0, time_str);
     data = data_make(
-            "time",         "",             DATA_STRING, time_str,
             "model",        "",             DATA_STRING, "Generic Remote",
             "id",           "House Code",   DATA_INT, id_16b,
             "cmd",          "Command",      DATA_INT, cmd_8b,
@@ -68,7 +65,6 @@ static int generic_remote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model"
     "id"
     "cmd",

--- a/src/devices/generic_remote.c
+++ b/src/devices/generic_remote.c
@@ -62,7 +62,7 @@ static int generic_remote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             "tristate",     "Tri-State",    DATA_STRING, tristate,
             NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }

--- a/src/devices/generic_temperature_sensor.c
+++ b/src/devices/generic_temperature_sensor.c
@@ -46,7 +46,7 @@ static int generic_temperature_sensor_callback(r_device *decoder, bitbuffer_t *b
 		"temperature_C",	"Temperature",		DATA_FORMAT, 	"%.02f C",	DATA_DOUBLE,	fTemp,
 		"battery",      	"Battery?",		DATA_INT,					battery,
 		NULL);
-	data_acquired_handler(data);
+	decoder_output_data(decoder, data);
 
 	return 1;
 

--- a/src/devices/generic_temperature_sensor.c
+++ b/src/devices/generic_temperature_sensor.c
@@ -12,7 +12,6 @@
 
 static int generic_temperature_sensor_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	data_t *data;
-	char time_str[LOCAL_TIME_BUFLEN];
 	uint8_t *b = bitbuffer->bb[1];
 	int i,device,battery;
 	float fTemp;
@@ -39,8 +38,7 @@ static int generic_temperature_sensor_callback(r_device *decoder, bitbuffer_t *b
 	battery=(b[1]&0xF0)>>4;
 	fTemp=(float)((signed short)(((b[1]&0x3f)*256+b[2])<<2))/160.0;
 
-	local_time_str(0, time_str);
-	data = data_make("time", 	"", 			DATA_STRING, 					time_str,
+	data = data_make(
 		"model",		"", 			DATA_STRING, 	"Generic temperature sensor 1",
 		"id",         	"Id",			DATA_FORMAT,	"\t %d",	DATA_INT,	device,
 		"temperature_C",	"Temperature",		DATA_FORMAT, 	"%.02f C",	DATA_DOUBLE,	fTemp,
@@ -53,7 +51,6 @@ static int generic_temperature_sensor_callback(r_device *decoder, bitbuffer_t *b
 }
 
 static char *output_fields[] = {
-	"time",
 	"model",
 	"id",
 	"temperature_C",

--- a/src/devices/generic_temperature_sensor.c
+++ b/src/devices/generic_temperature_sensor.c
@@ -10,7 +10,7 @@
 #include "decoder.h"
 
 
-static int generic_temperature_sensor_callback(bitbuffer_t *bitbuffer) {
+static int generic_temperature_sensor_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	data_t *data;
 	char time_str[LOCAL_TIME_BUFLEN];
 	uint8_t *b = bitbuffer->bb[1];

--- a/src/devices/gt_wt_02.c
+++ b/src/devices/gt_wt_02.c
@@ -128,7 +128,7 @@ static int gt_wt_02_process_row(int row, const bitbuffer_t *bitbuffer)
 //return 1; */
 }
 
-static int gt_wt_02_callback(bitbuffer_t *bitbuffer)
+static int gt_wt_02_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     int counter = 0;
     // iterate through all rows, return on first successful

--- a/src/devices/gt_wt_02.c
+++ b/src/devices/gt_wt_02.c
@@ -49,8 +49,7 @@
   checksum = sum modulo 64
 */
 
-
-static int gt_wt_02_process_row(int row, const bitbuffer_t *bitbuffer)
+static int gt_wt_02_process_row(r_device *decoder, int row, const bitbuffer_t *bitbuffer)
 {
     data_t *data;  /*JF*/
     const uint8_t *b = bitbuffer->bb[row];
@@ -114,7 +113,7 @@ static int gt_wt_02_process_row(int row, const bitbuffer_t *bitbuffer)
         "temperature_C",	"Temperature",	DATA_FORMAT,	"%.01f C",DATA_DOUBLE,tempC,
         "humidity",		"Humidity",	DATA_STRING,	humidity_str,
         NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     return 1;
 //# {
 //    /* @todo: remove timestamp printing as soon as the controller takes this task */
@@ -133,7 +132,7 @@ static int gt_wt_02_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     int counter = 0;
     // iterate through all rows, return on first successful
     for(int row=0; row<bitbuffer->num_rows && !counter; row++)
-        counter += gt_wt_02_process_row(row, bitbuffer);
+        counter += gt_wt_02_process_row(decoder, row, bitbuffer);
     return counter;
 }
 

--- a/src/devices/gt_wt_02.c
+++ b/src/devices/gt_wt_02.c
@@ -100,11 +100,8 @@ static int gt_wt_02_process_row(r_device *decoder, int row, const bitbuffer_t *b
 
     float tempC = (negative_sign ? ( temp - (1<<12) ) : temp ) * 0.1F;
 
-    char time_str[LOCAL_TIME_BUFLEN];
-    local_time_str(0, time_str);
 
     data = data_make(
-        "time",		"",		DATA_STRING,	time_str,
         "model",		"",		DATA_STRING,	"GT_WT_02 sensor",
         "rc",		"Rolling Code",		DATA_INT,	sensor_id,
         "channel",		"Channel",	DATA_INT,	channel+1,
@@ -116,13 +113,9 @@ static int gt_wt_02_process_row(r_device *decoder, int row, const bitbuffer_t *b
     decoder_output_data(decoder, data);
     return 1;
 //# {
-//    /* @todo: remove timestamp printing as soon as the controller takes this task */
-//  char time_str[LOCAL_TIME_BUFLEN];
-//   local_time_str(0, time_str);
-//
 //   /* @todo make temperature unit configurable, not printing both */
-//  fprintf(stdout, "%s, GT-WT-02 Sensor %02x, battery %s, channel %d, button %d, temperature %3.1f C, humidity %s%%\n"
-//      , time_str, sensor_id, battery_low ? "LOW" : "OK", channel+1, button_pressed, tempC, humidity_str);
+//  fprintf(stdout, "GT-WT-02 Sensor %02x, battery %s, channel %d, button %d, temperature %3.1f C, humidity %s%%\n"
+//      , sensor_id, battery_low ? "LOW" : "OK", channel+1, button_pressed, tempC, humidity_str);
 //}
 //return 1; */
 }
@@ -137,7 +130,6 @@ static int gt_wt_02_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "rc",
     "channel",

--- a/src/devices/hideki.c
+++ b/src/devices/hideki.c
@@ -16,7 +16,6 @@
 enum sensortypes { HIDEKI_UNKNOWN, HIDEKI_TEMP, HIDEKI_TS04, HIDEKI_WIND, HIDEKI_RAIN };
 
 static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t *b = bitbuffer->bb[0]; // TODO: handle the 3 row, need change in PULSE_CLOCK decoding
     uint8_t packet[HIDEKI_MAX_BYTES_PER_ROW];
@@ -67,10 +66,9 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     }
     battery_ok = (packet[5]>>6) & 0x01;
 
-    local_time_str(0, time_str);
     if (sensortype == HIDEKI_TS04) {
         humidity = ((packet[6] & 0xF0) >> 4) * 10 + (packet[6] & 0x0F);
-        data = data_make("time",          "",              DATA_STRING, time_str,
+        data = data_make(
                          "model",         "",              DATA_STRING, "HIDEKI TS04 sensor",
                          "rc",            "Rolling Code",  DATA_INT, rc,
                          "channel",       "Channel",       DATA_INT, channel,
@@ -85,7 +83,7 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         const uint8_t wd[] = { 0, 15, 13, 14, 9, 10, 12, 11, 1, 2, 4, 3, 8, 7, 5, 6 };
         wind_direction = wd[((packet[11] & 0xF0) >> 4)] * 225;
         wind_strength = (packet[9] & 0x0F) * 100 + ((packet[8] & 0xF0) >> 4) * 10 + (packet[8] & 0x0F);
-        data = data_make("time",          "",              DATA_STRING, time_str,
+        data = data_make(
                          "model",         "",              DATA_STRING, "HIDEKI Wind sensor",
                          "rc",            "Rolling Code",  DATA_INT, rc,
                          "channel",       "Channel",       DATA_INT, channel,
@@ -98,7 +96,7 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         return 1;
     }
     if (sensortype == HIDEKI_TEMP) {
-        data = data_make("time",          "",              DATA_STRING, time_str,
+        data = data_make(
                          "model",         "",              DATA_STRING, "HIDEKI Temperature sensor",
                          "rc",            "Rolling Code",  DATA_INT, rc,
                          "channel",       "Channel",       DATA_INT, channel,
@@ -111,7 +109,7 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     if (sensortype == HIDEKI_RAIN) {
         rain_units = (packet[5] << 8) + packet[4];
         battery_ok = (packet[2]>>6) & 0x01;
-        data = data_make("time",          "",              DATA_STRING, time_str,
+        data = data_make(
                          "model",         "",              DATA_STRING, "HIDEKI Rain sensor",
                          "rc",            "Rolling Code",  DATA_INT, rc,
                          "channel",       "Channel",       DATA_INT, channel,
@@ -125,7 +123,6 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "rc",
     "channel",

--- a/src/devices/hideki.c
+++ b/src/devices/hideki.c
@@ -15,7 +15,7 @@
 
 enum sensortypes { HIDEKI_UNKNOWN, HIDEKI_TEMP, HIDEKI_TS04, HIDEKI_WIND, HIDEKI_RAIN };
 
-static int hideki_ts04_callback(bitbuffer_t *bitbuffer) {
+static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t *b = bitbuffer->bb[0]; // TODO: handle the 3 row, need change in PULSE_CLOCK decoding

--- a/src/devices/hideki.c
+++ b/src/devices/hideki.c
@@ -78,7 +78,7 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                          "temperature_C", "Temperature",   DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp/10.f,
                          "humidity",      "Humidity",      DATA_FORMAT, "%u %%", DATA_INT, humidity,
                          NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
         return 1;
     }
     if (sensortype == HIDEKI_WIND) {
@@ -94,7 +94,7 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                          "windstrength",  "Wind Strength", DATA_FORMAT, "%.02f km/h", DATA_DOUBLE, wind_strength*0.160934f,
                          "winddirection", "Direction",     DATA_FORMAT, "%.01f °", DATA_DOUBLE, wind_direction/10.f,
                          NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
         return 1;
     }
     if (sensortype == HIDEKI_TEMP) {
@@ -105,7 +105,7 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                          "battery",       "Battery",       DATA_STRING, battery_ok ? "OK": "LOW",
                          "temperature_C", "Temperature",   DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp/10.f,
                          NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
         return 1;
     }
     if (sensortype == HIDEKI_RAIN) {
@@ -118,7 +118,7 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                          "battery",       "Battery",       DATA_STRING, battery_ok ? "OK": "LOW",
                          "rain",          "Rain",          DATA_FORMAT, "%.01f mm", DATA_DOUBLE, rain_units*0.7f,
                          NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
         return 1;
     }
     return 0;

--- a/src/devices/hondaremote.c
+++ b/src/devices/hondaremote.c
@@ -51,7 +51,7 @@ static int hondaremote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                 "code",         "",    DATA_STRING, code,
                 NULL);
 
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
         return 1;
     }
     return 0;

--- a/src/devices/hondaremote.c
+++ b/src/devices/hondaremote.c
@@ -25,7 +25,7 @@ static char const *get_command_codes(const uint8_t *bytes)
     }
 }
 
-static int hondaremote_callback(bitbuffer_t *bitbuffer)
+static int hondaremote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;

--- a/src/devices/hondaremote.c
+++ b/src/devices/hondaremote.c
@@ -27,7 +27,6 @@ static char const *get_command_codes(const uint8_t *bytes)
 
 static int hondaremote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t *b;
 	char const *code;
@@ -43,9 +42,7 @@ static int hondaremote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         code = get_command_codes(b);
         device_id = b[44]<<8 | b[45];
 
-        local_time_str(0, time_str);
         data = data_make(
-                "time",         "",     DATA_STRING, time_str,
                 "model",        "",     DATA_STRING, "Honda Remote",
                 "device id",    "",    DATA_INT, device_id,
                 "code",         "",    DATA_STRING, code,
@@ -58,7 +55,6 @@ static int hondaremote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "device id",
     "code",

--- a/src/devices/honeywell.c
+++ b/src/devices/honeywell.c
@@ -18,7 +18,7 @@
 
 #include "decoder.h"
 
-static int honeywell_callback(bitbuffer_t *bitbuffer) {
+static int honeywell_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     char time_str[LOCAL_TIME_BUFLEN];
     const uint8_t *bb;
     int channel;

--- a/src/devices/honeywell.c
+++ b/src/devices/honeywell.c
@@ -19,7 +19,6 @@
 #include "decoder.h"
 
 static int honeywell_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
-    char time_str[LOCAL_TIME_BUFLEN];
     const uint8_t *bb;
     int channel;
     int device_id;
@@ -48,10 +47,8 @@ static int honeywell_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     state = (event & 0x80) >> 7;
     heartbeat = (event & 0x04) >> 2;
 
-    local_time_str(0, time_str);
 
     data_t *data = data_make(
-          "time",     "", DATA_STRING, time_str,
           "model", "", DATA_STRING, "Honeywell Door/Window Sensor",
           "id",       "", DATA_FORMAT, "%05x", DATA_INT, device_id,
           "channel","", DATA_INT, channel,
@@ -65,7 +62,6 @@ static int honeywell_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "channel",

--- a/src/devices/honeywell.c
+++ b/src/devices/honeywell.c
@@ -60,7 +60,7 @@ static int honeywell_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
           "heartbeat" , "", DATA_STRING, heartbeat ? "yes" : "no",
           NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     return 1;
 }
 

--- a/src/devices/ht680.c
+++ b/src/devices/ht680.c
@@ -68,7 +68,7 @@ static int ht680_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                 "button3",  "Button 3",        	DATA_STRING, button3 == 3 ? "PRESSED" : "",
                 "button4",  "Button 4",        	DATA_STRING, button4 == 3 ? "PRESSED" : "",
                 NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
 
         return 1;
     }

--- a/src/devices/ht680.c
+++ b/src/devices/ht680.c
@@ -13,7 +13,7 @@
 
 #include "decoder.h"
 
-static int ht680_callback(bitbuffer_t *bitbuffer)
+static int ht680_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
     char time_str[LOCAL_TIME_BUFLEN];

--- a/src/devices/ht680.c
+++ b/src/devices/ht680.c
@@ -16,7 +16,6 @@
 static int ht680_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
     uint8_t b[5]; // 36 bits
 
     for (uint8_t row = 0;row < bitbuffer->num_rows;row++){
@@ -57,9 +56,7 @@ static int ht680_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         int button3 = (b[3]>>6) & 0x03;
         int button4 = (b[2]>>0) & 0x03;
 
-        local_time_str(0, time_str);
         data = data_make(
-                "time",     "",     			DATA_STRING, time_str,
                 "model",   	"",					DATA_STRING, "HT680 Remote control",
                 "tristate",	"Tristate code",	DATA_STRING, tristate,
                 "address",  "Address",    		DATA_FORMAT, "0x%06X", DATA_INT, address,
@@ -76,7 +73,6 @@ static int ht680_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "tristate",
     "address",

--- a/src/devices/ibis_beacon.c
+++ b/src/devices/ibis_beacon.c
@@ -71,7 +71,7 @@ static int ibis_beacon_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 		"mic",		"Integrity",	DATA_STRING,	"CRC",
 		NULL);
 
-	data_acquired_handler(data);
+	decoder_output_data(decoder, data);
 	return 1;
 }
 

--- a/src/devices/ibis_beacon.c
+++ b/src/devices/ibis_beacon.c
@@ -14,7 +14,7 @@
 
 #include "decoder.h"
 
-static int ibis_beacon_callback(bitbuffer_t *bitbuffer) {
+static int ibis_beacon_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	char time_str[LOCAL_TIME_BUFLEN];
 	data_t *data;
 	uint8_t search = 0xAB; // preamble is 0xAAB

--- a/src/devices/ibis_beacon.c
+++ b/src/devices/ibis_beacon.c
@@ -15,7 +15,6 @@
 #include "decoder.h"
 
 static int ibis_beacon_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
-	char time_str[LOCAL_TIME_BUFLEN];
 	data_t *data;
 	uint8_t search = 0xAB; // preamble is 0xAAB
 	uint8_t msg[32];
@@ -61,9 +60,7 @@ static int ibis_beacon_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	}
 
 	/* Get time now */
-	local_time_str(0, time_str);
 	data = data_make(
-		"time",		"",				DATA_STRING,	time_str,
 		"model",	"",				DATA_STRING,	"IBIS beacon",
 		"id",		"Vehicle No.",	DATA_INT,		id,
 		"counter",	"Counter",		DATA_INT,		counter,
@@ -76,7 +73,6 @@ static int ibis_beacon_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-	"time",
 	"model",
 	"id",
 	"counter",

--- a/src/devices/infactory.c
+++ b/src/devices/infactory.c
@@ -34,7 +34,6 @@ static int infactory_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     uint8_t *b = bb[0];
     data_t *data;
 
-    char time_str[LOCAL_TIME_BUFLEN];
     int id;
     int humidity;
     int temp;
@@ -49,9 +48,8 @@ static int infactory_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     temp = (b[2] << 4) | (b[3] >> 4);
     temp_f = (float)temp / 10 - 90;
 
-    local_time_str(0, time_str);
 
-    data = data_make( "time",		"",				DATA_STRING,	time_str,
+    data = data_make(
         "model",         "",	   DATA_STRING, "inFactory sensor",
         "id",      "ID",   DATA_FORMAT, "%u", DATA_INT, id,
         "temperature_F", "Temperature",DATA_FORMAT, "%.02f °F", DATA_DOUBLE, temp_f,
@@ -64,7 +62,6 @@ static int infactory_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
 
 static char *output_fields[] = {
-    "time",
     "model"
     "id",
     "temperature_F",

--- a/src/devices/infactory.c
+++ b/src/devices/infactory.c
@@ -57,7 +57,7 @@ static int infactory_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         "temperature_F", "Temperature",DATA_FORMAT, "%.02f °F", DATA_DOUBLE, temp_f,
         "humidity",      "Humidity",   DATA_FORMAT, "%u %%", DATA_INT, humidity,
         NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }

--- a/src/devices/infactory.c
+++ b/src/devices/infactory.c
@@ -28,7 +28,7 @@
 
 #include "decoder.h"
 
-static int infactory_callback(bitbuffer_t *bitbuffer) {
+static int infactory_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
     bitrow_t *bb = bitbuffer->bb;
     uint8_t *b = bb[0];

--- a/src/devices/inovalley-kw9015b.c
+++ b/src/devices/inovalley-kw9015b.c
@@ -13,7 +13,6 @@ extern uint8_t reverse8(uint8_t x);
 static int kw9015b_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	bitrow_t *bb = bitbuffer->bb;
 
-        char time_str[LOCAL_TIME_BUFLEN];
         data_t *data;
 	int i,iRain,device;
 	unsigned char chksum;
@@ -54,9 +53,8 @@ static int kw9015b_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 			if( (chksum&0x0F) == ( reverse8(bb[i][4]) &0x0F)){
 
 				/* Get time now */
-				local_time_str(0, time_str);
 
-				data = data_make("time", "", DATA_STRING, time_str,
+				data = data_make(
 					"model", "", DATA_STRING, "Inovalley kw9015b",
 					"id", "", DATA_INT, device,
 					"temperature_C", "Temperature", DATA_FORMAT, "%.01f C", DATA_DOUBLE, fTemp,
@@ -78,7 +76,6 @@ static int kw9015b_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
 
 static char *kw9015b_csv_output_fields[] = {
-    "time",
     "model",
     "id",
     "temperature_C",

--- a/src/devices/inovalley-kw9015b.c
+++ b/src/devices/inovalley-kw9015b.c
@@ -10,7 +10,7 @@
 
 extern uint8_t reverse8(uint8_t x);
 
-static int kw9015b_callback(bitbuffer_t *bitbuffer) {
+static int kw9015b_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	bitrow_t *bb = bitbuffer->bb;
 
         char time_str[LOCAL_TIME_BUFLEN];

--- a/src/devices/inovalley-kw9015b.c
+++ b/src/devices/inovalley-kw9015b.c
@@ -63,7 +63,7 @@ static int kw9015b_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 					"rain","Rain Count", DATA_INT, iRain,
 					NULL);
 
-				data_acquired_handler(data);
+				decoder_output_data(decoder, data);
 
 
 				return 1;

--- a/src/devices/inovalley-kw9015b.c
+++ b/src/devices/inovalley-kw9015b.c
@@ -37,7 +37,7 @@ static int kw9015b_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 				(reverse8(bb[i][3])>>4)+(reverse8(bb[i][3])&0x0F));
 
 
-                        if (debug_output >= 1) {
+                        if (decoder->verbose) {
 					fprintf(stdout, "\nSensor        = Inovalley kw9015b, TFA Dostmann 30.3161 (Rain and temperature sensor)\n");
 					fprintf(stdout, "Device        = %d\n", device);
 					fprintf(stdout, "Temp          = %f\n",fTemp);

--- a/src/devices/interlogix.c
+++ b/src/devices/interlogix.c
@@ -210,7 +210,7 @@ static int interlogix_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             "switch5",     "Switch5 State", DATA_STRING, f5_latch_state,
             NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }

--- a/src/devices/interlogix.c
+++ b/src/devices/interlogix.c
@@ -114,7 +114,7 @@ static int interlogix_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     // search for preamble and exit if not found
     unsigned int bit_offset = bitbuffer_search(bitbuffer, row, 0, preamble, (sizeof preamble) * 8);
     if (bit_offset == bitbuffer->bits_per_row[row] || bitbuffer->num_rows != 1) {
-        if (debug_output > 1)
+        if (decoder->verbose > 1)
             fprintf(stderr, "Interlogix: Preamble not found, bit_offset: %d\n", bit_offset);
         return 0;
     }
@@ -123,13 +123,13 @@ static int interlogix_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     bit_offset += (sizeof preamble) * 8;
 
     if (bitbuffer->bits_per_row[row] - bit_offset < INTERLOGIX_MSG_BIT_LEN - 1) {
-        if (debug_output > 1)
+        if (decoder->verbose > 1)
             fprintf(stderr, "Interlogix: Found valid preamble but message size (%d) too small\n", bitbuffer->bits_per_row[row] - bit_offset);
         return 0;
     }
 
     if (bitbuffer->bits_per_row[row] - bit_offset > INTERLOGIX_MSG_BIT_LEN + 7) {
-        if (debug_output > 1)
+        if (decoder->verbose > 1)
             fprintf(stderr, "Interlogix: Found valid preamble but message size (%d) too long\n", bitbuffer->bits_per_row[row] - bit_offset);
         return 0;
     }
@@ -157,7 +157,7 @@ static int interlogix_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     int parity_error = parity ^ 0x3; // both parities are odd, i.e. 1 on success
 
     if (parity_error) {
-        if (debug_output)
+        if (decoder->verbose)
             fprintf(stderr, "Interlogix: Parity check failed (%d %d)\n", parity >> 1, parity & 1);
         return 0;
     }

--- a/src/devices/interlogix.c
+++ b/src/devices/interlogix.c
@@ -95,7 +95,7 @@
 // preamble message.  only searching for 0000 0001 (bottom 8 bits of the 13 bits preamble)
 static unsigned char preamble[1] = {0x01};
 
-static int interlogix_callback(bitbuffer_t *bitbuffer)
+static int interlogix_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;

--- a/src/devices/interlogix.c
+++ b/src/devices/interlogix.c
@@ -97,7 +97,6 @@ static unsigned char preamble[1] = {0x01};
 
 static int interlogix_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     unsigned int row = 0;
     char device_type_id[2];
@@ -194,10 +193,8 @@ static int interlogix_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         f5_latch_state = (message[4] & 0x04) ? "OPEN" : "CLOSED";
     }
 
-    local_time_str(0, time_str);
 
     data = data_make(
-            "time",        "Receiver Time", DATA_STRING, time_str,
             "model",       "Model",         DATA_STRING, "Interlogix",
             "id",          "ID",            DATA_STRING, device_serial,
             "device_type", "Device Type",   DATA_STRING, device_type,
@@ -216,7 +213,6 @@ static int interlogix_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "device_type",

--- a/src/devices/intertechno.c
+++ b/src/devices/intertechno.c
@@ -22,7 +22,7 @@ static int intertechno_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (bb[0][0] != 0 || (bb[1][0] != 0x56 && bb[1][0] != 0x69))
         return 0;
 
-    if (debug_output > 1) {
+    if (decoder->verbose > 1) {
         fprintf(stdout, "Switch event:\n");
         fprintf(stdout, "protocol       = Intertechno\n");
         fprintf(stdout, "rid            = %x\n", b[0]);

--- a/src/devices/intertechno.c
+++ b/src/devices/intertechno.c
@@ -53,7 +53,7 @@ static int intertechno_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         "command",          "",     DATA_INT,       command,
         NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     return 1;
 }
 

--- a/src/devices/intertechno.c
+++ b/src/devices/intertechno.c
@@ -8,7 +8,7 @@
 
 #include "decoder.h"
 
-static int intertechno_callback(bitbuffer_t *bitbuffer)
+static int intertechno_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;

--- a/src/devices/intertechno.c
+++ b/src/devices/intertechno.c
@@ -10,7 +10,6 @@
 
 static int intertechno_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     bitrow_t *bb = bitbuffer->bb;
     uint8_t *b = bitbuffer->bb[1];
@@ -43,9 +42,7 @@ static int intertechno_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     master = (b[7] & 0xf0) >> 4;
     command = b[6] & 0x07;
 
-    local_time_str(0, time_str);
     data = data_make(
-        "time",             "",     DATA_STRING,    time_str,
         "model",            "",     DATA_STRING,    "Intertechno",
         "id",               "",     DATA_STRING,    id_str,
         "slave",            "",     DATA_INT,       slave,
@@ -58,7 +55,6 @@ static int intertechno_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "type",
     "id",

--- a/src/devices/kedsum.c
+++ b/src/devices/kedsum.c
@@ -61,7 +61,7 @@ static int kedsum_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     temperature_with_offset =  (tnH<<8) | (tnM<<4) | tnL;
     temperature_f = (temperature_with_offset - 900) / 10.0;
 
-    if (debug_output) {
+    if (decoder->verbose) {
       fprintf(stdout, "Bitstream HEX        = ");
       bitrow_print(b, 48);
       fprintf(stdout, "Humidity HEX         = %02x\n", b[3]);

--- a/src/devices/kedsum.c
+++ b/src/devices/kedsum.c
@@ -25,7 +25,6 @@
 static int kedsum_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
 
     // the signal should start with 15 sync pulses (empty rows)
     // require at least 5 received syncs
@@ -73,8 +72,7 @@ static int kedsum_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
       fprintf(stdout, "TemperatureF         = %.1f\n", temperature_f);
     }
 
-    local_time_str(0, time_str);
-    data = data_make("time",          "",            DATA_STRING, time_str,
+    data = data_make(
                      "model",         "",            DATA_STRING, "Kedsum Temperature & Humidity Sensor",
                      "channel",       "Channel",     DATA_INT, channel,
                      "temperature_F", "Temperature", DATA_FORMAT, "%.02f F", DATA_DOUBLE, temperature_f,
@@ -86,7 +84,6 @@ static int kedsum_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "channel",
     "temperature_F",

--- a/src/devices/kedsum.c
+++ b/src/devices/kedsum.c
@@ -81,7 +81,7 @@ static int kedsum_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                      "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, humidity,
                       NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     return 1;
 }
 

--- a/src/devices/kedsum.c
+++ b/src/devices/kedsum.c
@@ -22,7 +22,7 @@
 */
 #include "decoder.h"
 
-static int kedsum_callback(bitbuffer_t *bitbuffer) {
+static int kedsum_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
     data_t *data;
     char time_str[LOCAL_TIME_BUFLEN];

--- a/src/devices/kerui.c
+++ b/src/devices/kerui.c
@@ -12,7 +12,7 @@
 
 #include "decoder.h"
 
-static int kerui_callback(bitbuffer_t *bitbuffer) {
+static int kerui_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t *b;

--- a/src/devices/kerui.c
+++ b/src/devices/kerui.c
@@ -52,7 +52,7 @@ static int kerui_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
             "state",    "State",          DATA_STRING, cmd_str,
             NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     return 1;
 }
 

--- a/src/devices/kerui.c
+++ b/src/devices/kerui.c
@@ -13,7 +13,6 @@
 #include "decoder.h"
 
 static int kerui_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t *b;
     int id;
@@ -43,9 +42,7 @@ static int kerui_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     if (!cmd_str)
         return 0;
 
-    local_time_str(0, time_str);
     data = data_make(
-            "time",     "",               DATA_STRING, time_str,
             "model",    "",               DATA_STRING, "Kerui Security",
             "id",       "ID (20bit)",     DATA_FORMAT, "0x%x", DATA_INT, id,
             "cmd",      "Command (4bit)", DATA_FORMAT, "0x%x", DATA_INT, cmd,
@@ -57,7 +54,6 @@ static int kerui_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "cmd",

--- a/src/devices/lacrosse.c
+++ b/src/devices/lacrosse.c
@@ -131,7 +131,6 @@ static int lacrossetx_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     int msg_value_int;
     float msg_value = 0, temp_c = 0;
     time_t time_now;
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
 
     for (m = 0; m < BITBUF_ROWS; m++) {
@@ -149,7 +148,6 @@ static int lacrossetx_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
             msg_checksum = msg_nybbles[10];
 
             time(&time_now);
-            local_time_str(0, time_str);
 
             // Check Repeated data values as another way of verifying
             // message integrity.
@@ -166,7 +164,7 @@ static int lacrossetx_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
             switch (msg_type) {
             case 0x00:
                 temp_c = msg_value - 50.0;
-                data = data_make("time",          "",            DATA_STRING, time_str,
+                data = data_make(
                                  "model",         "",            DATA_STRING, "LaCrosse TX Sensor",
                                  "id",            "",            DATA_INT, sensor_id,
                                  "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
@@ -176,7 +174,7 @@ static int lacrossetx_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                 break;
 
             case 0x0E:
-                data = data_make("time",          "",            DATA_STRING, time_str,
+                data = data_make(
                                  "model",         "",            DATA_STRING, "LaCrosse TX Sensor",
                                  "id",            "",            DATA_INT, sensor_id,
                                  "humidity",      "Humidity", DATA_FORMAT, "%.1f %%", DATA_DOUBLE, msg_value,
@@ -189,8 +187,8 @@ static int lacrossetx_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                 // @todo this should be reported/counted as exception, not considered debug
                 if (decoder->verbose) {
                     fprintf(stderr,
-                            "%s LaCrosse Sensor %02x: Unknown Reading type %d, % 3.1f (%d)\n",
-                            time_str, sensor_id, msg_type, msg_value, msg_value_int);
+                            "LaCrosse Sensor %02x: Unknown Reading type %d, % 3.1f (%d)\n",
+                            sensor_id, msg_type, msg_value, msg_value_int);
                 }
             }
         }
@@ -200,7 +198,6 @@ static int lacrossetx_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "temperature_C",

--- a/src/devices/lacrosse.c
+++ b/src/devices/lacrosse.c
@@ -58,7 +58,7 @@
 // Long bits = 0
 // short bits = 1
 //
-static int lacrossetx_detect(uint8_t *pRow, uint8_t *msg_nybbles, int16_t rowlen) {
+static int lacrossetx_detect(r_device *decoder, uint8_t *pRow, uint8_t *msg_nybbles, int16_t rowlen) {
     int i;
     uint8_t rbyte_no, rbit_no, mnybble_no, mbit_no;
     uint8_t bit, checksum, parity_bit, parity = 0;
@@ -107,7 +107,7 @@ static int lacrossetx_detect(uint8_t *pRow, uint8_t *msg_nybbles, int16_t rowlen
         if (checksum == msg_nybbles[10] && (parity % 2 == 0)) {
             return 1;
         } else {
-            if (debug_output > 1) {
+            if (decoder->verbose > 1) {
                 fprintf(stdout,
                         "LaCrosse TX Checksum/Parity error: Comp. %d != Recv. %d, Parity %d\n",
                         checksum, msg_nybbles[10], parity);
@@ -137,7 +137,7 @@ static int lacrossetx_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     for (m = 0; m < BITBUF_ROWS; m++) {
         valid = 0;
         // break out the message nybbles into separate bytes
-        if (lacrossetx_detect(bb[m], msg_nybbles, bitbuffer->bits_per_row[m])) {
+        if (lacrossetx_detect(decoder, bb[m], msg_nybbles, bitbuffer->bits_per_row[m])) {
 
             msg_len = msg_nybbles[1];
             msg_type = msg_nybbles[2];
@@ -155,7 +155,7 @@ static int lacrossetx_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
             // message integrity.
             if (msg_nybbles[5] != msg_nybbles[8] ||
                 msg_nybbles[6] != msg_nybbles[9]) {
-                if (debug_output) {
+                if (decoder->verbose) {
                     fprintf(stderr,
                             "LaCrosse TX Sensor %02x, type: %d: message value mismatch int(%3.1f) != %d?\n",
                             sensor_id, msg_type, msg_value, msg_value_int);
@@ -187,7 +187,7 @@ static int lacrossetx_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
             default:
                 // @todo this should be reported/counted as exception, not considered debug
-                if (debug_output) {
+                if (decoder->verbose) {
                     fprintf(stderr,
                             "%s LaCrosse Sensor %02x: Unknown Reading type %d, % 3.1f (%d)\n",
                             time_str, sensor_id, msg_type, msg_value, msg_value_int);

--- a/src/devices/lacrosse.c
+++ b/src/devices/lacrosse.c
@@ -171,7 +171,7 @@ static int lacrossetx_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                                  "id",            "",            DATA_INT, sensor_id,
                                  "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
                                  NULL);
-                data_acquired_handler(data);
+                decoder_output_data(decoder, data);
                 events++;
                 break;
 
@@ -181,7 +181,7 @@ static int lacrossetx_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                                  "id",            "",            DATA_INT, sensor_id,
                                  "humidity",      "Humidity", DATA_FORMAT, "%.1f %%", DATA_DOUBLE, msg_value,
                                  NULL);
-                data_acquired_handler(data);
+                decoder_output_data(decoder, data);
                 events++;
                 break;
 

--- a/src/devices/lacrosse.c
+++ b/src/devices/lacrosse.c
@@ -121,7 +121,7 @@ static int lacrossetx_detect(uint8_t *pRow, uint8_t *msg_nybbles, int16_t rowlen
 
 // LaCrosse TX-6u, TX-7u,  Temperature and Humidity Sensors
 // Temperature and Humidity are sent in different messages bursts.
-static int lacrossetx_callback(bitbuffer_t *bitbuffer) {
+static int lacrossetx_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
 
     int m, valid = 0;

--- a/src/devices/lacrosse_TX141TH_Bv2.c
+++ b/src/devices/lacrosse_TX141TH_Bv2.c
@@ -161,7 +161,7 @@ static int lacrosse_tx141th_bv2_callback(r_device *decoder, bitbuffer_t *bitbuff
                 "test",          "Test?",         DATA_STRING, test ? "Yes" : "No",
                 NULL);
     }
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }

--- a/src/devices/lacrosse_TX141TH_Bv2.c
+++ b/src/devices/lacrosse_TX141TH_Bv2.c
@@ -94,7 +94,6 @@
 static int lacrosse_tx141th_bv2_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
     int r;
     int device;
     uint8_t *bytes;
@@ -140,10 +139,8 @@ static int lacrosse_tx141th_bv2_callback(r_device *decoder, bitbuffer_t *bitbuff
         return 0;
     }
 
-    local_time_str(0, time_str);
     if (device == LACROSSE_TX141) {
         data = data_make(
-                "time",          "Date and time", DATA_STRING, time_str,
                 "model",         "",              DATA_STRING, "LaCrosse TX141-Bv2 sensor",
                 "id",            "Sensor ID",     DATA_FORMAT, "%02x", DATA_INT, id,
                 "temperature_C", "Temperature",   DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
@@ -152,7 +149,6 @@ static int lacrosse_tx141th_bv2_callback(r_device *decoder, bitbuffer_t *bitbuff
                 NULL);
     } else {
         data = data_make(
-                "time",          "Date and time", DATA_STRING, time_str,
                 "model",         "",              DATA_STRING, "LaCrosse TX141TH-Bv2 sensor",
                 "id",            "Sensor ID",     DATA_FORMAT, "%02x", DATA_INT, id,
                 "temperature_C", "Temperature",   DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
@@ -167,7 +163,6 @@ static int lacrosse_tx141th_bv2_callback(r_device *decoder, bitbuffer_t *bitbuff
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "temperature_C",

--- a/src/devices/lacrosse_TX141TH_Bv2.c
+++ b/src/devices/lacrosse_TX141TH_Bv2.c
@@ -91,7 +91,7 @@
 #define LACROSSE_TX141_BITLEN 37
 #define LACROSSE_TX141TH_BITLEN 40
 
-static int lacrosse_tx141th_bv2_callback(bitbuffer_t *bitbuffer)
+static int lacrosse_tx141th_bv2_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
     char time_str[LOCAL_TIME_BUFLEN];

--- a/src/devices/lacrosse_TX141TH_Bv2.c
+++ b/src/devices/lacrosse_TX141TH_Bv2.c
@@ -133,7 +133,7 @@ static int lacrosse_tx141th_bv2_callback(r_device *decoder, bitbuffer_t *bitbuff
     }
 
     if (0 == id || (device == LACROSSE_TX141TH && (0 == humidity || humidity > 100)) || temp_c < -40.0 || temp_c > 140.0) {
-        if (debug_output) {
+        if (decoder->verbose) {
             fprintf(stderr, "LaCrosse TX141-Bv2/TX141TH-Bv2 data error\n");
             fprintf(stderr, "id: %i, humidity:%i, temp:%f\n", id, humidity, temp_c);
         }

--- a/src/devices/lacrosse_tx35.c
+++ b/src/devices/lacrosse_tx35.c
@@ -85,7 +85,7 @@ static int lacrosse_it(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t device
         unsigned int start_pos = bitbuffer_search(bitbuffer, brow, 0, preamble, 28);
         if (start_pos == bitbuffer->bits_per_row[brow])
             continue; // no preamble detected, move to the next row
-        if (debug_output)
+        if (decoder->verbose)
             fprintf(stderr, "LaCrosse TX29/35 detected, buffer is %d bits length, device is TX%d\n", bitbuffer->bits_per_row[brow], device29or35);
         // remove preamble and keep only 64 bits
         bitbuffer_extract_bytes(bitbuffer, brow, start_pos, out, 64);
@@ -99,7 +99,7 @@ static int lacrosse_it(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t device
         r_crc = out[7];
         c_crc = crc8(&out[3], 4, LACROSSE_TX35_CRC_POLY, LACROSSE_TX35_CRC_INIT);
         if (r_crc != c_crc) {
-            if (debug_output)
+            if (decoder->verbose)
                 fprintf(stderr, "%s LaCrosse TX29/35 bad CRC: calculated %02x, received %02x\n",
                         time_str, c_crc, r_crc);
             // reject row

--- a/src/devices/lacrosse_tx35.c
+++ b/src/devices/lacrosse_tx35.c
@@ -62,7 +62,6 @@ How to make a decoder : https://enavarro.me/ajouter-un-decodeur-ask-a-rtl_433.ht
  **/
 static int lacrosse_it(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t device29or35)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     int brow;
     uint8_t out[8];
@@ -79,7 +78,6 @@ static int lacrosse_it(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t device
             0x90, // data length (this decoder work only with data length of 9, so we hardcode it on the preamble)
     };
 
-    local_time_str(0, time_str);
     for (brow = 0; brow < bitbuffer->num_rows; ++brow) {
         // Validate message and reject it as fast as possible : check for preamble
         unsigned int start_pos = bitbuffer_search(bitbuffer, brow, 0, preamble, 28);
@@ -100,8 +98,7 @@ static int lacrosse_it(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t device
         c_crc = crc8(&out[3], 4, LACROSSE_TX35_CRC_POLY, LACROSSE_TX35_CRC_INIT);
         if (r_crc != c_crc) {
             if (decoder->verbose)
-                fprintf(stderr, "%s LaCrosse TX29/35 bad CRC: calculated %02x, received %02x\n",
-                        time_str, c_crc, r_crc);
+                fprintf(stderr, "LaCrosse TX29/35 bad CRC: calculated %02x, received %02x\n", c_crc, r_crc);
             // reject row
             continue;
         }
@@ -117,7 +114,6 @@ static int lacrosse_it(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t device
         humidity    = out[6] & 0x7f;
         if (humidity == LACROSSE_TX29_NOHUMIDSENSOR) {
             data = data_make(
-                    "time", "", DATA_STRING, time_str,
                     "brand", "", DATA_STRING, "LaCrosse",
                     "model", "", DATA_STRING, (device29or35 == 29 ? "TX29-IT" : "TX35DTH-IT"),
                     "id", "", DATA_INT, sensor_id,
@@ -128,7 +124,6 @@ static int lacrosse_it(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t device
                     NULL);
         } else {
             data = data_make(
-                    "time", "", DATA_STRING, time_str,
                     "brand", "", DATA_STRING, "LaCrosse",
                     "model", "", DATA_STRING, (device29or35 == 29 ? "TX29-IT" : "TX35DTH-IT"),
                     "id", "", DATA_INT, sensor_id,
@@ -162,7 +157,6 @@ static int lacrossetx35_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-	"time",
 	"brand",
 	"model",
 	"id",

--- a/src/devices/lacrosse_tx35.c
+++ b/src/devices/lacrosse_tx35.c
@@ -60,105 +60,105 @@ How to make a decoder : https://enavarro.me/ajouter-un-decodeur-ask-a-rtl_433.ht
  ** Generic decoder for LaCrosse "IT+" (instant transmission) protocol
  ** Param device29or35 contain "29" or "35" depending of the device.
  **/
-static int lacrosse_it(bitbuffer_t *bitbuffer, uint8_t device29or35) {
-	char time_str[LOCAL_TIME_BUFLEN];
-	data_t *data;
-	int brow;
-	uint8_t out[8];
-	int r_crc, c_crc;
-	int sensor_id, newbatt, battery_low;
-	int humidity;
-	float temp_c;
-	int events = 0;
+static int lacrosse_it(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t device29or35)
+{
+    char time_str[LOCAL_TIME_BUFLEN];
+    data_t *data;
+    int brow;
+    uint8_t out[8];
+    int r_crc, c_crc;
+    int sensor_id, newbatt, battery_low;
+    int humidity;
+    float temp_c;
+    int events = 0;
 
-	static const uint8_t preamble[] = {
-		0xaa, // preamble
-		0x2d, // brand identifier
-		0xd4, // brand identifier
-		0x90, // data length (this decoder work only with data length of 9, so we hardcode it on the preamble)
-	};
+    static const uint8_t preamble[] = {
+            0xaa, // preamble
+            0x2d, // brand identifier
+            0xd4, // brand identifier
+            0x90, // data length (this decoder work only with data length of 9, so we hardcode it on the preamble)
+    };
 
-	local_time_str(0, time_str);
-	for (brow = 0; brow < bitbuffer->num_rows; ++brow) {
-		// Validate message and reject it as fast as possible : check for preamble
-		unsigned int start_pos = bitbuffer_search(bitbuffer, brow, 0, preamble, 28);
-		if(start_pos == bitbuffer->bits_per_row[brow])
-			continue; // no preamble detected, move to the next row
-		if (debug_output)
-			fprintf(stderr, "LaCrosse TX29/35 detected, buffer is %d bits length, device is TX%d\n", bitbuffer->bits_per_row[brow], device29or35);
-		// remove preamble and keep only 64 bits
-		bitbuffer_extract_bytes(bitbuffer, brow, start_pos, out, 64);
+    local_time_str(0, time_str);
+    for (brow = 0; brow < bitbuffer->num_rows; ++brow) {
+        // Validate message and reject it as fast as possible : check for preamble
+        unsigned int start_pos = bitbuffer_search(bitbuffer, brow, 0, preamble, 28);
+        if (start_pos == bitbuffer->bits_per_row[brow])
+            continue; // no preamble detected, move to the next row
+        if (debug_output)
+            fprintf(stderr, "LaCrosse TX29/35 detected, buffer is %d bits length, device is TX%d\n", bitbuffer->bits_per_row[brow], device29or35);
+        // remove preamble and keep only 64 bits
+        bitbuffer_extract_bytes(bitbuffer, brow, start_pos, out, 64);
 
-		/*
+        /*
 		 * Check message integrity (CRC/Checksum/parity)
 		 * Normally, it is computed on the whole message, from byte 0 (preamble) to byte 6,
 		 * but preamble is always the same, so we can speed the process by doing a crc check
 		 * only on byte 3,4,5,6
 		 */
-		r_crc = out[7];
-		c_crc = crc8(&out[3], 4, LACROSSE_TX35_CRC_POLY, LACROSSE_TX35_CRC_INIT);
-		if (r_crc != c_crc) {
-			if (debug_output)
-				fprintf(stderr, "%s LaCrosse TX29/35 bad CRC: calculated %02x, received %02x\n",
-					time_str, c_crc, r_crc);
-			// reject row
-			continue;
-		}
+        r_crc = out[7];
+        c_crc = crc8(&out[3], 4, LACROSSE_TX35_CRC_POLY, LACROSSE_TX35_CRC_INIT);
+        if (r_crc != c_crc) {
+            if (debug_output)
+                fprintf(stderr, "%s LaCrosse TX29/35 bad CRC: calculated %02x, received %02x\n",
+                        time_str, c_crc, r_crc);
+            // reject row
+            continue;
+        }
 
-		/*
+        /*
 		 * Now that message "envelope" has been validated,
 		 * start parsing data.
 		 */
-		sensor_id = ((out[3] & 0x0f) << 2) | (out[4]>>6);
-		temp_c = 10.0 * (out[4] & 0x0f) + 1.0 * ((out[5]>>4) & 0x0f) + 0.1 * (out[5] & 0x0f) - 40.0;
-		newbatt = (out[4] >> 5) & 1;
-		battery_low = out[6] >> 7;
-		humidity = out[6] & 0x7f;
-		if (humidity == LACROSSE_TX29_NOHUMIDSENSOR) {
-			data = data_make(
-					"time",				"",				DATA_STRING, time_str,
-					"brand",			"",				DATA_STRING, "LaCrosse",
-					"model",			"",				DATA_STRING, (device29or35 == 29 ? "TX29-IT" : "TX35DTH-IT"),
-					"id",				"",				DATA_INT, sensor_id,
-					"battery",			"Battery",		DATA_STRING, battery_low ? "LOW" : "OK",
-					"newbattery",		"NewBattery",	DATA_INT, newbatt,
-					"temperature_C",	"Temperature",	DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-					"mic",				"Integrity",	DATA_STRING, "CRC",
-					NULL);
-		}
-		else {
-			data = data_make(
-					"time",				"",				DATA_STRING, time_str,
-					"brand",			"",				DATA_STRING, "LaCrosse",
-					"model",			"",				DATA_STRING, (device29or35 == 29 ? "TX29-IT" : "TX35DTH-IT"),
-					"id",				"",				DATA_INT, sensor_id,
-					"battery",			"Battery",		DATA_STRING, battery_low ? "LOW" : "OK",
-					"newbattery",		"NewBattery",	DATA_INT, newbatt,
-					"temperature_C",	"Temperature",	DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-					"humidity",			"Humidity",		DATA_FORMAT, "%u %%", DATA_INT, humidity,
-					"mic",				"Integrity",	DATA_STRING, "CRC",
-					NULL);
-		}
-		// humidity = -1; // The TX29-IT sensor do not have humidity. It is replaced by a special value
+        sensor_id   = ((out[3] & 0x0f) << 2) | (out[4] >> 6);
+        temp_c      = 10.0 * (out[4] & 0x0f) + 1.0 * ((out[5] >> 4) & 0x0f) + 0.1 * (out[5] & 0x0f) - 40.0;
+        newbatt     = (out[4] >> 5) & 1;
+        battery_low = out[6] >> 7;
+        humidity    = out[6] & 0x7f;
+        if (humidity == LACROSSE_TX29_NOHUMIDSENSOR) {
+            data = data_make(
+                    "time", "", DATA_STRING, time_str,
+                    "brand", "", DATA_STRING, "LaCrosse",
+                    "model", "", DATA_STRING, (device29or35 == 29 ? "TX29-IT" : "TX35DTH-IT"),
+                    "id", "", DATA_INT, sensor_id,
+                    "battery", "Battery", DATA_STRING, battery_low ? "LOW" : "OK",
+                    "newbattery", "NewBattery", DATA_INT, newbatt,
+                    "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
+                    "mic", "Integrity", DATA_STRING, "CRC",
+                    NULL);
+        } else {
+            data = data_make(
+                    "time", "", DATA_STRING, time_str,
+                    "brand", "", DATA_STRING, "LaCrosse",
+                    "model", "", DATA_STRING, (device29or35 == 29 ? "TX29-IT" : "TX35DTH-IT"),
+                    "id", "", DATA_INT, sensor_id,
+                    "battery", "Battery", DATA_STRING, battery_low ? "LOW" : "OK",
+                    "newbattery", "NewBattery", DATA_INT, newbatt,
+                    "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
+                    "humidity", "Humidity", DATA_FORMAT, "%u %%", DATA_INT, humidity,
+                    "mic", "Integrity", DATA_STRING, "CRC",
+                    NULL);
+        }
+        // humidity = -1; // The TX29-IT sensor do not have humidity. It is replaced by a special value
 
-		data_acquired_handler(data);
-		events++;
-	}
-	return events;
+        decoder_output_data(decoder, data);
+        events++;
+    }
+    return events;
 }
 
 /**
  ** Wrapper for the TX29 device
  **/
 static int lacrossetx29_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
-	return lacrosse_it(bitbuffer, LACROSSE_TX29_MODEL);
+	return lacrosse_it(decoder, bitbuffer, LACROSSE_TX29_MODEL);
 }
 
 /**
  ** Wrapper for the TX35 device
  **/
 static int lacrossetx35_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
-	return lacrosse_it(bitbuffer, LACROSSE_TX35_MODEL);
+	return lacrosse_it(decoder, bitbuffer, LACROSSE_TX35_MODEL);
 }
 
 static char *output_fields[] = {

--- a/src/devices/lacrosse_tx35.c
+++ b/src/devices/lacrosse_tx35.c
@@ -150,14 +150,14 @@ static int lacrosse_it(bitbuffer_t *bitbuffer, uint8_t device29or35) {
 /**
  ** Wrapper for the TX29 device
  **/
-static int lacrossetx29_callback(bitbuffer_t *bitbuffer) {
+static int lacrossetx29_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	return lacrosse_it(bitbuffer, LACROSSE_TX29_MODEL);
 }
 
 /**
  ** Wrapper for the TX35 device
  **/
-static int lacrossetx35_callback(bitbuffer_t *bitbuffer) {
+static int lacrossetx35_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	return lacrosse_it(bitbuffer, LACROSSE_TX35_MODEL);
 }
 

--- a/src/devices/lacrossews.c
+++ b/src/devices/lacrossews.c
@@ -26,7 +26,7 @@
 
 #define LACROSSE_WS_BITLEN	52
 
-static int lacrossews_detect(uint8_t *pRow, uint8_t *msg_nybbles, int16_t rowlen) {
+static int lacrossews_detect(r_device *decoder, uint8_t *pRow, uint8_t *msg_nybbles, int16_t rowlen) {
 	int i;
 	uint8_t rbyte_no, rbit_no, mnybble_no, mbit_no;
 	uint8_t bit, checksum = 0, parity = 0;
@@ -65,7 +65,7 @@ static int lacrossews_detect(uint8_t *pRow, uint8_t *msg_nybbles, int16_t rowlen
 			return 1;
 		else {
 			local_time_str(0, time_str);
-            if (debug_output) {
+            if (decoder->verbose) {
 			fprintf(stdout,
 				"%s LaCrosse Packet Validation Failed error: Checksum Comp. %d != Recv. %d, Parity %d\n",
 				time_str, checksum, msg_nybbles[12], parity);
@@ -95,7 +95,7 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
 	for (m = 0; m < BITBUF_ROWS; m++) {
 		// break out the message nybbles into separate bytes
-		if (lacrossews_detect(bb[m], msg_nybbles, bitbuffer->bits_per_row[m])) {
+		if (lacrossews_detect(decoder, bb[m], msg_nybbles, bitbuffer->bits_per_row[m])) {
 
 			ws_id = (msg_nybbles[0] << 4) + msg_nybbles[1];
 			msg_type = ((msg_nybbles[2] >> 1) & 0x4) + (msg_nybbles[2] & 0x3);
@@ -109,7 +109,7 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
 			local_time_str(0, time_str);
 
-			if (debug_output)
+			if (decoder->verbose)
 				fprintf(stderr, "%1X%1X%1X%1X%1X%1X%1X%1X%1X%1X%1X%1X%1X   ",
 									msg_nybbles[0], msg_nybbles[1], msg_nybbles[2], msg_nybbles[3],
 									msg_nybbles[4], msg_nybbles[5], msg_nybbles[6], msg_nybbles[7],
@@ -164,7 +164,7 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 				wind_dir = msg_nybbles[9] * 22.5;
 				wind_spd = (msg_nybbles[7] * 16 + msg_nybbles[8])/ 10.0;
 				if(msg_nybbles[7] == 0xF && msg_nybbles[8] == 0xE) {
-					if (debug_output) {
+					if (decoder->verbose) {
 					fprintf(stderr, "%s LaCrosse WS %02X-%02X: %s Not Connected\n",
 						time_str, ws_id, sensor_id, msg_type == 3 ? "Wind":"Gust");
 					}
@@ -182,7 +182,7 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 				}
 				break;
 			default:
-			if (debug_output) {
+			if (decoder->verbose) {
 				fprintf(stderr,
 					"%s LaCrosse WS %02X-%02X: Unknown data type %d, bcd %d bin %d\n",
 					time_str, ws_id, sensor_id, msg_type, msg_value_bcd, msg_value_bin);

--- a/src/devices/lacrossews.c
+++ b/src/devices/lacrossews.c
@@ -30,7 +30,6 @@ static int lacrossews_detect(r_device *decoder, uint8_t *pRow, uint8_t *msg_nybb
 	int i;
 	uint8_t rbyte_no, rbit_no, mnybble_no, mbit_no;
 	uint8_t bit, checksum = 0, parity = 0;
-	char time_str[LOCAL_TIME_BUFLEN];
 
 	// Weather Station 2310 Packets
 	if (rowlen == LACROSSE_WS_BITLEN && pRow[0] == 0x09) {
@@ -64,11 +63,10 @@ static int lacrossews_detect(r_device *decoder, uint8_t *pRow, uint8_t *msg_nybb
 			checksum == msg_nybbles[12])
 			return 1;
 		else {
-			local_time_str(0, time_str);
             if (decoder->verbose) {
 			fprintf(stdout,
-				"%s LaCrosse Packet Validation Failed error: Checksum Comp. %d != Recv. %d, Parity %d\n",
-				time_str, checksum, msg_nybbles[12], parity);
+				"LaCrosse Packet Validation Failed error: Checksum Comp. %d != Recv. %d, Parity %d\n",
+				checksum, msg_nybbles[12], parity);
 			for (i = 0; i < (LACROSSE_WS_BITLEN / 4); i++) {
 				fprintf(stderr, "%X", msg_nybbles[i]);
 			}
@@ -90,7 +88,7 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	uint8_t ws_id, msg_type, sensor_id, msg_data, msg_unknown, msg_checksum;
 	int msg_value_bcd, msg_value_bcd2, msg_value_bin;
 	float temp_c, wind_dir, wind_spd, rain_mm;
-	char time_str[LOCAL_TIME_BUFLEN], *wind_key, *wind_label;
+	char *wind_key, *wind_label;
 	data_t *data;
 
 	for (m = 0; m < BITBUF_ROWS; m++) {
@@ -107,7 +105,6 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 			msg_value_bin = (msg_nybbles[7] * 256 + msg_nybbles[8] * 16 + msg_nybbles[9]);
 			msg_checksum = msg_nybbles[12];
 
-			local_time_str(0, time_str);
 
 			if (decoder->verbose)
 				fprintf(stderr, "%1X%1X%1X%1X%1X%1X%1X%1X%1X%1X%1X%1X%1X   ",
@@ -120,7 +117,7 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 			// Temperature
 			case 0:
 				temp_c = (msg_value_bcd - 300.0) / 10.0;
-				data = data_make("time",          "",             DATA_STRING, time_str,
+				data = data_make(
 													"model",         "",            DATA_STRING, "LaCrosse WS",
 													"ws_id",         "",            DATA_INT, ws_id,
 													"id",            "",            DATA_INT, sensor_id,
@@ -133,10 +130,10 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 			// Humidity
 			case 1:
 				if(msg_nybbles[7] == 0xA && msg_nybbles[8] == 0xA)
-					fprintf(stderr, "%s LaCrosse WS %02X-%02X: Humidity Error\n",
-						time_str, ws_id, sensor_id);
+					fprintf(stderr, "LaCrosse WS %02X-%02X: Humidity Error\n",
+						ws_id, sensor_id);
 				else {
-					data = data_make("time",          "",            DATA_STRING, time_str,
+					data = data_make(
 														"model",         "",            DATA_STRING, "LaCrosse WS",
 														"ws_id",         "",            DATA_INT, ws_id,
 														"id",            "",            DATA_INT, sensor_id,
@@ -149,7 +146,7 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 			// Rain
 			case 2:
 				rain_mm = 0.5180 * msg_value_bin;
-				data = data_make("time",          "",           DATA_STRING, time_str,
+				data = data_make(
 													"model",          "",           DATA_STRING, "LaCrosse WS",
 													"ws_id",          "",           DATA_INT, ws_id,
 													"id",             "",           DATA_INT, sensor_id,
@@ -165,13 +162,13 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 				wind_spd = (msg_nybbles[7] * 16 + msg_nybbles[8])/ 10.0;
 				if(msg_nybbles[7] == 0xF && msg_nybbles[8] == 0xE) {
 					if (decoder->verbose) {
-					fprintf(stderr, "%s LaCrosse WS %02X-%02X: %s Not Connected\n",
-						time_str, ws_id, sensor_id, msg_type == 3 ? "Wind":"Gust");
+					fprintf(stderr, "LaCrosse WS %02X-%02X: %s Not Connected\n",
+						ws_id, sensor_id, msg_type == 3 ? "Wind":"Gust");
 					}
 				} else {
 					wind_key = msg_type == 3 ? "wind_speed_ms":"gust_speed_ms";
 					wind_label = msg_type == 3 ? "Wind speed":"Gust speed";
-					data = data_make("time",          "",           DATA_STRING, time_str,
+					data = data_make(
 														"model",          "",           DATA_STRING, "LaCrosse WS",
 														"ws_id",          "",           DATA_INT, ws_id,
 														"id",             "",           DATA_INT, sensor_id,
@@ -184,8 +181,8 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 			default:
 			if (decoder->verbose) {
 				fprintf(stderr,
-					"%s LaCrosse WS %02X-%02X: Unknown data type %d, bcd %d bin %d\n",
-					time_str, ws_id, sensor_id, msg_type, msg_value_bcd, msg_value_bin);
+					"LaCrosse WS %02X-%02X: Unknown data type %d, bcd %d bin %d\n",
+					ws_id, sensor_id, msg_type, msg_value_bcd, msg_value_bin);
 				}
 				events++;
 			}
@@ -196,7 +193,6 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-	"time",
 	"model",
 	"ws_id",
 	"id",

--- a/src/devices/lacrossews.c
+++ b/src/devices/lacrossews.c
@@ -81,7 +81,7 @@ static int lacrossews_detect(uint8_t *pRow, uint8_t *msg_nybbles, int16_t rowlen
 	return 0;
 }
 
-static int lacrossews_callback(bitbuffer_t *bitbuffer) {
+static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	bitrow_t *bb = bitbuffer->bb;
 
 	int m;

--- a/src/devices/lacrossews.c
+++ b/src/devices/lacrossews.c
@@ -126,7 +126,7 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 													"id",            "",            DATA_INT, sensor_id,
 													"temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
 													NULL);
-				data_acquired_handler(data);
+				decoder_output_data(decoder, data);
 				events++;
 
 				break;
@@ -142,7 +142,7 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 														"id",            "",            DATA_INT, sensor_id,
 														"humidity",      "Humidity",    DATA_INT, msg_value_bcd2,
 														NULL);
-					data_acquired_handler(data);
+					decoder_output_data(decoder, data);
 					events++;
 				}
 				break;
@@ -154,7 +154,7 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 													"ws_id",          "",           DATA_INT, ws_id,
 													"id",             "",           DATA_INT, sensor_id,
 													"rainfall_mm",    "Rainfall",   DATA_FORMAT, "%3.2f mm", DATA_DOUBLE, rain_mm, NULL);
-				data_acquired_handler(data);
+				decoder_output_data(decoder, data);
 				events++;
 				break;
 			// Wind
@@ -177,7 +177,7 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 														"id",             "",           DATA_INT, sensor_id,
 														wind_key,         wind_label,   DATA_FORMAT, "%3.1f m/s", DATA_DOUBLE, wind_spd,
 														"wind_direction", "Direction",  DATA_DOUBLE, wind_dir, NULL);
-					data_acquired_handler(data);
+					decoder_output_data(decoder, data);
 					events++;
 				}
 				break;

--- a/src/devices/lightwave_rf.c
+++ b/src/devices/lightwave_rf.c
@@ -40,7 +40,7 @@ int lightwave_rf_nibble_from_byte(uint8_t in) {
 }
 
 
-static int lightwave_rf_callback(bitbuffer_t *bitbuffer) {
+static int lightwave_rf_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	bitrow_t *bb = bitbuffer->bb;
 
 	// Validate package

--- a/src/devices/lightwave_rf.c
+++ b/src/devices/lightwave_rf.c
@@ -92,7 +92,7 @@ static int lightwave_rf_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 		for(unsigned n=0; n<10; ++n) {		// We have 10 bytes/nibbles
 			int nibble = lightwave_rf_nibble_from_byte(bb[2][n]);
 			if (nibble < 0) {
-				if (debug_output) {
+				if (decoder->verbose) {
 					fprintf(stderr, "LightwaveRF. Nibble decode error %X, idx: %u\n", bb[2][n], n);
 					bitbuffer_print(bitbuffer);
 				}
@@ -111,7 +111,7 @@ static int lightwave_rf_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 		fprintf(stdout, "Command = %u\n", bb[3][1] & 0x0F);
 		fprintf(stdout, "Parameter = %u\n", bb[3][0]);
 
-		if (debug_output) {
+		if (decoder->verbose) {
 			bitbuffer_print(bitbuffer);
 			fprintf(stderr, "  Row 0 = Input, Row 1 = Zero bit stuffing, Row 2 = Stripped delimiters, Row 3 = Decoded nibbles\n");
 		}

--- a/src/devices/m_bus.c
+++ b/src/devices/m_bus.c
@@ -213,8 +213,8 @@ static int m_bus_decode_format_b(const m_bus_data_t *in, m_bus_data_t *out, m_bu
     return 1;
 }
 
-
-static void m_bus_output_data(const m_bus_data_t *out, const m_bus_block1_t *block1) {
+static void m_bus_output_data(r_device *decoder, const m_bus_data_t *out, const m_bus_block1_t *block1)
+{
     data_t  *data;
     char    time_str[LOCAL_TIME_BUFLEN];
     char    str_buf[1024];
@@ -241,7 +241,7 @@ static void m_bus_output_data(const m_bus_data_t *out, const m_bus_block1_t *blo
         "data",     "Data",         DATA_STRING,    str_buf,
         "mic",      "Integrity",    DATA_STRING,    "CRC",
         NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 }
 
 
@@ -313,7 +313,7 @@ static int m_bus_mode_c_t_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         if(!m_bus_decode_format_a(&data_in, &data_out, &block1))    return 0;
     }   // Mode T
 
-    m_bus_output_data(&data_out, &block1);
+    m_bus_output_data(decoder, &data_out, &block1);
     return 1;
 }
 
@@ -345,7 +345,7 @@ static int m_bus_mode_r_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     // Decode
     if(!m_bus_decode_format_a(&data_in, &data_out, &block1))    return 0;
 
-    m_bus_output_data(&data_out, &block1);
+    m_bus_output_data(decoder, &data_out, &block1);
     return 1;
 }
 
@@ -394,7 +394,7 @@ static int m_bus_mode_f_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         return 0;
     }
 
-    m_bus_output_data(&data_out, &block1);
+    m_bus_output_data(decoder, &data_out, &block1);
     return 1;
 }
 

--- a/src/devices/m_bus.c
+++ b/src/devices/m_bus.c
@@ -217,11 +217,9 @@ static int m_bus_decode_format_b(r_device *decoder, const m_bus_data_t *in, m_bu
 static void m_bus_output_data(r_device *decoder, const m_bus_data_t *out, const m_bus_block1_t *block1)
 {
     data_t  *data;
-    char    time_str[LOCAL_TIME_BUFLEN];
     char    str_buf[1024];
 
     // Get time now
-    local_time_str(0, time_str);
 
     // Make data string
     str_buf[0] = 0;
@@ -229,7 +227,6 @@ static void m_bus_output_data(r_device *decoder, const m_bus_data_t *out, const 
 
     // Output data
     data = data_make(
-        "time",     "",             DATA_STRING,    time_str,
         "model",    "",             DATA_STRING,    "Wireless M-Bus",
         "M",        "Manufacturer", DATA_STRING,    block1->M_str,
         "id",       "ID",           DATA_INT,       block1->A_ID,

--- a/src/devices/m_bus.c
+++ b/src/devices/m_bus.c
@@ -245,7 +245,7 @@ static void m_bus_output_data(const m_bus_data_t *out, const m_bus_block1_t *blo
 }
 
 
-static int m_bus_mode_c_t_callback(bitbuffer_t *bitbuffer) {
+static int m_bus_mode_c_t_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     static const uint8_t PREAMBLE_T[]  = {0x55, 0x54, 0x3D};      // Mode T Preamble (always format A - 3of6 encoded)
 //  static const uint8_t PREAMBLE_CA[] = {0x55, 0x54, 0x3D, 0x54, 0xCD};  // Mode C, format A Preamble
 //  static const uint8_t PREAMBLE_CB[] = {0x55, 0x54, 0x3D, 0x54, 0x3D};  // Mode C, format B Preamble
@@ -318,7 +318,7 @@ static int m_bus_mode_c_t_callback(bitbuffer_t *bitbuffer) {
 }
 
 
-static int m_bus_mode_r_callback(bitbuffer_t *bitbuffer) {
+static int m_bus_mode_r_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     static const uint8_t PREAMBLE_RA[]  = {0x55, 0x54, 0x76, 0x96};      // Mode R, format A (B not supported)
 
     m_bus_data_t    data_in     = {0};  // Data from Physical layer decoded to bytes
@@ -350,7 +350,7 @@ static int m_bus_mode_r_callback(bitbuffer_t *bitbuffer) {
 }
 
 
-static int m_bus_mode_f_callback(bitbuffer_t *bitbuffer) {
+static int m_bus_mode_f_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     static const uint8_t PREAMBLE_F[]  = {0x55, 0xF6};      // Mode F Preamble
 //  static const uint8_t PREAMBLE_FA[] = {0x55, 0xF6, 0x8D};  // Mode F, format A Preamble
 //  static const uint8_t PREAMBLE_FB[] = {0x55, 0xF6, 0x72};  // Mode F, format B Preamble

--- a/src/devices/maverick_et73x.c
+++ b/src/devices/maverick_et73x.c
@@ -75,7 +75,7 @@ static int maverick_et73x_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     //digest is used to represent a session. This means, we get a new id if a reset or battery exchange is done.
     int id = lfsr_digest16(chk_data, 24, 0x8810, 0xdd38) ^ digest;
 
-    if (debug_output)
+    if (decoder->verbose)
         fprintf(stderr, "%s: pre %03x, flags %0x, t1 %d, t2 %d, digest %04x, chk_data %06x, digest xor'ed: %04x\n",
                 __FUNCTION__, pre, flags, temp1, temp2, digest, chk_data, id);
 

--- a/src/devices/maverick_et73x.c
+++ b/src/devices/maverick_et73x.c
@@ -88,7 +88,7 @@ static int maverick_et73x_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             "temperature1_C",   "TemperatureSensor1",   DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp1_c,
             "temperature2_C",   "TemperatureSensor2",   DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp2_c,
             NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }

--- a/src/devices/maverick_et73x.c
+++ b/src/devices/maverick_et73x.c
@@ -33,7 +33,8 @@
 
 #include "decoder.h"
 
-static int maverick_et73x_callback(bitbuffer_t *bitbuffer) {
+static int maverick_et73x_callback(r_device *decoder, bitbuffer_t *bitbuffer)
+{
     data_t *data;
     char time_str[LOCAL_TIME_BUFLEN];
     bitbuffer_t mc = {0};

--- a/src/devices/maverick_et73x.c
+++ b/src/devices/maverick_et73x.c
@@ -36,7 +36,6 @@
 static int maverick_et73x_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
     bitbuffer_t mc = {0};
 
     if(bitbuffer->num_rows != 1)
@@ -79,9 +78,7 @@ static int maverick_et73x_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         fprintf(stderr, "%s: pre %03x, flags %0x, t1 %d, t2 %d, digest %04x, chk_data %06x, digest xor'ed: %04x\n",
                 __FUNCTION__, pre, flags, temp1, temp2, digest, chk_data, id);
 
-    local_time_str(0, time_str);
     data = data_make(
-            "time",             "",                     DATA_STRING, time_str,
             "model",            "",                     DATA_STRING, "Maverick-ET73x",
             "id",               "Session_ID",           DATA_INT, id,
             "status",           "Status",               DATA_STRING, status,
@@ -94,7 +91,6 @@ static int maverick_et73x_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "brand"
     "model"
     "id"

--- a/src/devices/mebus.c
+++ b/src/devices/mebus.c
@@ -43,7 +43,7 @@ static int mebus433_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                          "temperature_C", "Temperature", DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp / 10.0,
                          "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, hum,
                          NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
 
 
         return 1;

--- a/src/devices/mebus.c
+++ b/src/devices/mebus.c
@@ -2,7 +2,6 @@
 
 static int mebus433_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
-    char    time_str[LOCAL_TIME_BUFLEN];
     int16_t temp;
     int8_t  hum;
     uint8_t address;
@@ -13,7 +12,6 @@ static int mebus433_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     data_t *data;
 
     if (bb[0][0] == 0 && bb[1][4] !=0 && (bb[1][0] & 0x60) && bb[1][3]==bb[5][3] && bb[1][4] == bb[12][4]){
-        local_time_str(0, time_str);
 
         address = bb[1][0] & 0x1f;
 
@@ -33,7 +31,7 @@ static int mebus433_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         // Always 0b1111?
         unknown2 = (bb[1][3] & 0xf0) >> 4;
 
-        data = data_make("time",          "",            DATA_STRING, time_str,
+        data = data_make(
                          "model",         "",            DATA_STRING, "Mebus/433",
                          "id",            "Address",     DATA_INT, address,
                          "battery",       "Battery",     DATA_STRING, battery ? "OK" : "LOW",

--- a/src/devices/mebus.c
+++ b/src/devices/mebus.c
@@ -1,6 +1,6 @@
 #include "decoder.h"
 
-static int mebus433_callback(bitbuffer_t *bitbuffer) {
+static int mebus433_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
     char    time_str[LOCAL_TIME_BUFLEN];
     int16_t temp;

--- a/src/devices/new_template.c
+++ b/src/devices/new_template.c
@@ -65,7 +65,7 @@ static int template_callback(r_device *decoder, bitbuffer_t *bitbuffer)
      * 1. Enable with -D -D (debug level of 2)
      * 2. Delete this block when your decoder is working
      */
-    //    if (debug_output > 1) {
+    //    if (decoder->verbose > 1) {
     //        fprintf(stderr,"new_tmplate callback:\n");
     //        bitbuffer_print(bitbuffer);
     //    }
@@ -151,7 +151,7 @@ static int template_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     parity = (parity >> 1) ^ (parity & 0x1); // fold to 1 bit
 
     if (!parity) {
-        if (debug_output) {
+        if (decoder->verbose) {
             fprintf(stderr, "new_template parity check failed\n");
         }
         return 0;
@@ -161,7 +161,7 @@ static int template_callback(r_device *decoder, bitbuffer_t *bitbuffer)
      * Check message integrity (Checksum example)
      */
     if (((b[0] + b[1] + b[2] + b[3] - b[4]) & 0xFF) != 0) {
-        if (debug_output) {
+        if (decoder->verbose) {
             fprintf(stderr, "new_template checksum error\n");
         }
         return 0;
@@ -176,7 +176,7 @@ static int template_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     c_crc = crc8(b, MYDEVICE_BITLEN / 8, MYDEVICE_CRC_POLY, MYDEVICE_CRC_INIT);
     if (r_crc != c_crc) {
         // example debugging output
-        if (debug_output) {
+        if (decoder->verbose) {
             fprintf(stderr, "new_template bad CRC: calculated %02x, received %02x\n",
                     c_crc, r_crc);
         }

--- a/src/devices/new_template.c
+++ b/src/devices/new_template.c
@@ -47,7 +47,6 @@
 
 static int template_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     int r; // a row index
     uint8_t *b; // bits of a row
@@ -202,10 +201,8 @@ static int template_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         return 0;
     }
 
-    local_time_str(0, time_str);
 
     data = data_make(
-            "time",  "", DATA_STRING, time_str,
             "model", "", DATA_STRING, "New Template",
             "id",    "", DATA_INT,    sensor_id,
             "data",  "", DATA_INT,    value,
@@ -226,7 +223,6 @@ static int template_callback(r_device *decoder, bitbuffer_t *bitbuffer)
  *
  */
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "data",

--- a/src/devices/new_template.c
+++ b/src/devices/new_template.c
@@ -212,7 +212,7 @@ static int template_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             "mic",   "", DATA_STRING, "CHECKSUM", // CRC, CHECKSUM, or PARITY
             NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     // Return 1 if message successfully decoded
     return 1;

--- a/src/devices/new_template.c
+++ b/src/devices/new_template.c
@@ -45,7 +45,7 @@
 #define MYDEVICE_CRC_POLY    0x07
 #define MYDEVICE_CRC_INIT    0x00
 
-static int template_callback(bitbuffer_t *bitbuffer)
+static int template_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;

--- a/src/devices/newkaku.c
+++ b/src/devices/newkaku.c
@@ -19,8 +19,6 @@ static int newkaku_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     uint32_t kakuid = 0;
     uint8_t dv = 0;
     char *group_call, *command, *dim;
-    char time_str[LOCAL_TIME_BUFLEN];
-    local_time_str(0, time_str);
 
     if (bb[0][0] == 0xac || bb[0][0] == 0xb2) {//always starts with ac or b2
         // first bit is from startbit sequence, not part of payload!
@@ -106,7 +104,7 @@ static int newkaku_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
             dim = "No";
         }
 
-        data = data_make("time",          "",            DATA_STRING, time_str,
+        data = data_make(
                          "model",         "",            DATA_STRING, "KlikAanKlikUit Wireless Switch",
                          "id",            "",            DATA_INT, kakuid,
                          "unit",          "Unit",        DATA_INT, unit,
@@ -123,7 +121,6 @@ static int newkaku_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "unit",

--- a/src/devices/newkaku.c
+++ b/src/devices/newkaku.c
@@ -115,7 +115,7 @@ static int newkaku_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                          "dim",           "Dim",         DATA_STRING, dim,
                          "dim_value",     "Dim Value",   DATA_INT, dv,
                          NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
 
         return 1;
     }

--- a/src/devices/newkaku.c
+++ b/src/devices/newkaku.c
@@ -1,6 +1,6 @@
 #include "decoder.h"
 
-static int newkaku_callback(bitbuffer_t *bitbuffer) {
+static int newkaku_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     /* Two bits map to 2 states, 0 1 -> 0 and 1 1 -> 1 */
     /* Status bit can be 1 1 -> 1 which indicates DIM value. 4 extra bits are present with value */
     /*start pulse: 1T high, 10.44T low */

--- a/src/devices/nexa.c
+++ b/src/devices/nexa.c
@@ -16,7 +16,7 @@
  */
 #include "decoder.h"
 
-static int nexa_callback(bitbuffer_t *bitbuffer) {
+static int nexa_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     data_t *data;
     char time_str[LOCAL_TIME_BUFLEN];
 

--- a/src/devices/nexa.c
+++ b/src/devices/nexa.c
@@ -54,7 +54,7 @@ static int nexa_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                      "unit",          "Unit",        DATA_INT, unit_bit,
                       NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 0;
 }

--- a/src/devices/nexa.c
+++ b/src/devices/nexa.c
@@ -18,7 +18,6 @@
 
 static int nexa_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
 
     /* Reject codes of wrong length */
     if (bitbuffer->bits_per_row[1] != 64 && bitbuffer->bits_per_row[1] != 72)
@@ -43,9 +42,8 @@ static int nexa_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     uint32_t unit_bit = (b[3] & 0x03);
 
     /* Get time now */
-    local_time_str(0, time_str);
 
-    data = data_make("time",          "",            DATA_STRING, time_str,
+    data = data_make(
                      "model",         "",            DATA_STRING, "Nexa",
                      "id",            "House Code",  DATA_INT, sensor_id,
                      "group",         "Group",       DATA_INT, group_code,
@@ -60,7 +58,6 @@ static int nexa_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "channel",

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -29,7 +29,7 @@ static int nexus_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
     char time_str[LOCAL_TIME_BUFLEN];
 
-    if (debug_output > 1) {
+    if (decoder->verbose > 1) {
         fprintf(stderr,"Possible Nexus: ");
         bitbuffer_print(bitbuffer);
     }

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -27,7 +27,6 @@ static int nexus_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
     data_t *data;
 
-    char time_str[LOCAL_TIME_BUFLEN];
 
     if (decoder->verbose > 1) {
         fprintf(stderr,"Possible Nexus: ");
@@ -57,7 +56,6 @@ static int nexus_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
             return 0;
 
         /* Get time now */
-        local_time_str(0, time_str);
 
         /* Nibble 0,1 contains id */
         id = bb[r][0];
@@ -76,7 +74,7 @@ static int nexus_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
         // Thermo
         if (bb[r][3] == 0xF0) {
-        data = data_make("time",          "",            DATA_STRING, time_str,
+        data = data_make(
                          "model",         "",            DATA_STRING, "Nexus Temperature",
                          "id",            "House Code",  DATA_INT, id,
                          "battery",       "Battery",     DATA_STRING, battery ? "OK" : "LOW",
@@ -87,7 +85,7 @@ static int nexus_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         }
         // Thermo/Hygro
         else {
-        data = data_make("time",          "",            DATA_STRING, time_str,
+        data = data_make(
                          "model",         "",            DATA_STRING, "Nexus Temperature/Humidity",
                          "id",            "House Code",  DATA_INT, id,
                          "battery",       "Battery",     DATA_STRING, battery ? "OK" : "LOW",
@@ -103,7 +101,6 @@ static int nexus_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "battery",

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -83,7 +83,7 @@ static int nexus_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                          "channel",       "Channel",     DATA_INT, channel,
                          "temperature_C", "Temperature", DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp/10.0,
                          NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
         }
         // Thermo/Hygro
         else {
@@ -95,7 +95,7 @@ static int nexus_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                          "temperature_C", "Temperature", DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp/10.0,
                          "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, humidity,
                          NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
         }
         return 1;
     }

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -23,7 +23,7 @@
 
 extern int rubicson_crc_check(bitrow_t *bb);
 
-static int nexus_callback(bitbuffer_t *bitbuffer) {
+static int nexus_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
     data_t *data;
 

--- a/src/devices/oil_standard.c
+++ b/src/devices/oil_standard.c
@@ -37,7 +37,6 @@ static const unsigned char preamble_pattern1[2] = { 0x55, 0x62 };
 
 static int oil_standard_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t *b;
     uint16_t unit_id;
@@ -80,9 +79,7 @@ static int oil_standard_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
         // A depth reading of zero indicates no reading.
         depth = ((b[2] & 0x02) << 7) | b[3];
 
-    local_time_str(0, time_str);
     data = data_make(
-            "time", "", DATA_STRING, time_str,
             "model", "", DATA_STRING, "Oil Ultrasonic STANDARD",
             "id", "", DATA_FORMAT, "%04x", DATA_INT, unit_id,
             "flags", "", DATA_FORMAT, "%02x", DATA_INT, flags,
@@ -116,7 +113,6 @@ static int oil_standard_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-	"time",
 	"model",
 	"id",
 	"flags",

--- a/src/devices/oil_standard.c
+++ b/src/devices/oil_standard.c
@@ -95,7 +95,7 @@ static int oil_standard_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bi
 	return 1;
 }
 
-static int oil_standard_callback(bitbuffer_t *bitbuffer) {
+static int oil_standard_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	unsigned bitpos = 0;
 	int events = 0;
 

--- a/src/devices/oil_watchman.c
+++ b/src/devices/oil_watchman.c
@@ -27,13 +27,11 @@ static int oil_watchman_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	uint8_t flags;
 	uint8_t maybetemp;
 	double temperature;
-	char time_str[LOCAL_TIME_BUFLEN];
 	data_t *data;
 	unsigned bitpos = 0;
 	bitbuffer_t databits = {0};
 	int events = 0;
 
-	local_time_str(0, time_str);
 
 	// Find a preamble with enough bits after it that it could be a complete packet
 	while ((bitpos = bitbuffer_search(bitbuffer, 0, bitpos, &preamble_pattern, 6)) + 136 <=
@@ -80,7 +78,7 @@ static int oil_watchman_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 			// the sensor flat down on a table, it still reads about 13.
 			depth = ((b[5] & 3) << 8) | b[6];
 
-		data = data_make("time", "", DATA_STRING, time_str,
+		data = data_make(
 			"model", "", DATA_STRING, "Oil Watchman",
 			"id", "", DATA_FORMAT, "%06x", DATA_INT, unit_id,
 			"flags", "", DATA_FORMAT, "%02x", DATA_INT, flags,
@@ -96,7 +94,6 @@ static int oil_watchman_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-	"time",
 	"model",
 	"id",
 	"flags",

--- a/src/devices/oil_watchman.c
+++ b/src/devices/oil_watchman.c
@@ -19,7 +19,7 @@ static const unsigned char preamble_pattern = 0xe0;
 // End of frame is 00xxxxxx or 11xxxxxx depending on final data bit
 static const unsigned char postamble_pattern[2] = { 0x00, 0xc0 };
 
-static int oil_watchman_callback(bitbuffer_t *bitbuffer) {
+static int oil_watchman_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	uint8_t *b;
 	uint32_t unit_id;
 	uint16_t depth = 0;

--- a/src/devices/oil_watchman.c
+++ b/src/devices/oil_watchman.c
@@ -89,7 +89,7 @@ static int oil_watchman_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 			"binding_countdown", "", DATA_INT, binding_countdown,
 			"depth", "", DATA_INT, depth,
 			NULL);
-		data_acquired_handler(data);
+		decoder_output_data(decoder, data);
 		events++;
 	}
 	return events;

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -169,7 +169,7 @@ static int validate_os_v2_message(unsigned char * msg, int bits_expected, int va
   return 1;
 }
 
-static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
+static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuffer) {
   bitrow_t *bb = bitbuffer->bb;
   // Check 2nd and 3rd bytes of stream for possible Oregon Scientific v2.1 sensor data (skip first byte to get past sync/startup bit errors)
   if( ((bb[0][1] == 0x55) && (bb[0][2] == 0x55)) ||
@@ -258,7 +258,7 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
             "temperature_C", "Temperature", DATA_FORMAT, "%.02f C", DATA_DOUBLE, get_os_temperature(msg, sensor_id),
             "humidity",      "Humidity",    DATA_FORMAT, "%u %%",   DATA_INT,    get_os_humidity(msg, sensor_id),
             NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
       }
       return 1;
     } else if (sensor_id == ID_WGR968) {
@@ -277,7 +277,7 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
             "average",    "Average",    DATA_FORMAT, "%2.1f m/s",DATA_DOUBLE, avgWindspeed,
             "direction",  "Direction",  DATA_FORMAT, "%3.1f degrees",DATA_DOUBLE, quadrant,
             NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
       }
       return 1;
     } else if (sensor_id == ID_BHTR968) {
@@ -307,7 +307,7 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
             "humidity",   "Humidity",       DATA_FORMAT, "%u %%",   DATA_INT,    get_os_humidity(msg, sensor_id),
             "pressure_hPa",  "Pressure",    DATA_FORMAT, "%.0f hPa",   DATA_DOUBLE, pressure,
             NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
       }
       return 1;
     } else if (sensor_id == ID_RGR968) {
@@ -325,7 +325,7 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
             "rain_rate",  "Rain Rate",  DATA_FORMAT, "%.02f mm/hr", DATA_DOUBLE, rain_rate,
             "total_rain", "Total Rain", DATA_FORMAT, "%.02f mm", DATA_DOUBLE, total_rain,
             NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
       }
       return 1;
     } else if (sensor_id == ID_THR228N && num_valid_v2_bits==153) {
@@ -341,7 +341,7 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
             "battery",       "Battery",     DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
             "temperature_C",  "Celsius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
             NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
       }
       return 1;
     } else if (sensor_id == ID_THN132N && num_valid_v2_bits==129) {
@@ -357,7 +357,7 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
             "battery",       "Battery",     DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
             "temperature_C",  "Celsius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
             NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
       }
       return 1;
     } else if ((sensor_id & 0x0fff) == ID_RTGN129 && num_valid_v2_bits==161) {
@@ -373,7 +373,7 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
             "temperature_C",  "Celsius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
             "humidity",      "Humidity",    DATA_FORMAT, "%u %%",   DATA_INT,    get_os_humidity(msg, sensor_id),
             NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
       }
       return 1;
     } else if ((sensor_id & 0x0fff) == ID_RTGN318) {
@@ -389,7 +389,7 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
             "temperature_C",  "Celsius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
             "humidity",      "Humidity",    DATA_FORMAT, "%u %%",   DATA_INT,    get_os_humidity(msg, sensor_id),
             NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
       } else if (num_valid_v2_bits==201 && (validate_os_v2_message(msg, 201, num_valid_v2_bits, 21) == 0)) {
 
         // RF Clock message ??
@@ -407,7 +407,7 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
             "battery",       "Battery",     DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
             "temperature_C",  "Celsius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
             NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
       }
 
       return 1;
@@ -426,7 +426,7 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
             "humidity",       "Humidity",   DATA_FORMAT, "%u %%", DATA_INT, get_os_humidity(msg, sensor_id),
             "pressure_hPa",  "Pressure",    DATA_FORMAT, "%.02f hPa", DATA_DOUBLE, pressure,
             NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
       //}
 
       return 1;
@@ -441,7 +441,7 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
 		  "battery",        "Battery",    DATA_STRING, get_os_battery(msg, sensor_id)?"LOW":"OK",
 		  //"channel",        "Channel",    DATA_INT,    get_os_channel(msg, sensor_id),
 		  NULL);
-		data_acquired_handler(data);
+		decoder_output_data(decoder, data);
 		}
 	 return 1;
     }else if (num_valid_v2_bits > 16) {
@@ -469,7 +469,7 @@ static int oregon_scientific_v2_1_parser(bitbuffer_t *bitbuffer) {
 return 0;
 }
 
-static int oregon_scientific_v3_parser(bitbuffer_t *bitbuffer) {
+static int oregon_scientific_v3_parser(r_device *decoder, bitbuffer_t *bitbuffer) {
   bitrow_t *bb = bitbuffer->bb;
   data_t *data;
   char time_str[LOCAL_TIME_BUFLEN];
@@ -538,7 +538,7 @@ static int oregon_scientific_v3_parser(bitbuffer_t *bitbuffer) {
           "temperature_C",  "Celsius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
           "humidity",       "Humidity",   DATA_FORMAT, "%u %%", DATA_INT, humidity,
           NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
       }
       return 1;                  //msg[k] = ((msg[k] & 0x0F) << 4) + ((msg[k] & 0xF0) >> 4);
     } else if (sensor_id == ID_THN802)    {
@@ -553,7 +553,7 @@ static int oregon_scientific_v3_parser(bitbuffer_t *bitbuffer) {
             "battery",        "Battery",    DATA_STRING, get_os_battery(msg, sensor_id)?"LOW":"OK",
             "temperature_C",  "Celsius",    DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
             NULL);
-          data_acquired_handler(data);
+          decoder_output_data(decoder, data);
         }
         return 1;
     } else if (sensor_id == ID_UV800) {
@@ -568,7 +568,7 @@ static int oregon_scientific_v3_parser(bitbuffer_t *bitbuffer) {
           "battery",        "Battery",    DATA_STRING, get_os_battery(msg, sensor_id)?"LOW":"OK",
           "uv",             "UV Index",   DATA_FORMAT, "%u", DATA_INT, uvidx,
           NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
       }
     } else if (sensor_id == ID_PCR800) {
       if (validate_os_checksum(msg, 18) == 0) {
@@ -584,7 +584,7 @@ static int oregon_scientific_v3_parser(bitbuffer_t *bitbuffer) {
           "rain_rate",  "Rain Rate",  DATA_FORMAT, "%3.1f in/hr", DATA_DOUBLE, rain_rate,
           "rain_total", "Total Rain", DATA_FORMAT, "%3.1f in", DATA_DOUBLE, total_rain,
           NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
         }
 	return 1;
 } else if (sensor_id == ID_PCR800a) {
@@ -601,7 +601,7 @@ static int oregon_scientific_v3_parser(bitbuffer_t *bitbuffer) {
       "rain_rate",  "Rain Rate",  DATA_FORMAT, "%3.1f in/hr", DATA_DOUBLE, rain_rate,
       "rain_total", "Total Rain", DATA_FORMAT, "%3.1f in", DATA_DOUBLE, total_rain,
       NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     }
 return 1;
     } else if (sensor_id == ID_WGR800) {
@@ -620,7 +620,7 @@ return 1;
           "average",    "Average",    DATA_FORMAT,  "%2.1f m/s",DATA_DOUBLE, avgWindspeed,
           "direction",  "Direction",  DATA_FORMAT,  "%3.1f degrees",DATA_DOUBLE, quadrant,
           NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
       }
       return 1;
     } else if ((msg[0] == 0x20) || (msg[0] == 0x21) || (msg[0] == 0x22) || (msg[0] == 0x23) || (msg[0] == 0x24)) { //  Owl CM160 Readings
@@ -635,7 +635,7 @@ return 1;
             "id",     "House Code", DATA_INT, msg[1]&0x0F,
             "power_W", "Power",     DATA_FORMAT,  "%d W", DATA_INT, ipower,
             NULL);
-          data_acquired_handler(data);
+          decoder_output_data(decoder, data);
       }
     } else if (msg[0] == 0x26) { //  Owl CM180 readings
         msg[0]=msg[0] & 0x0f;
@@ -656,7 +656,7 @@ return 1;
               "power_W",    "Power",      DATA_FORMAT,  "%d W",DATA_INT, ipower,
               "energy_kWh", "Energy",     DATA_FORMAT,  "%2.1f kWh",DATA_DOUBLE, total_energy,
               NULL);
-            data_acquired_handler(data);
+            decoder_output_data(decoder, data);
         } else if (!itotal) {
             data = data_make(
               "time",   "",           DATA_STRING,  time_str,
@@ -665,7 +665,7 @@ return 1;
               "id",     "House Code", DATA_INT, msg[1]&0x0F,
               "power_W", "Power",     DATA_FORMAT,  "%d W",DATA_INT, ipower,
               NULL);
-            data_acquired_handler(data);
+            decoder_output_data(decoder, data);
         }
     } else if ((msg[0] != 0) && (msg[1]!= 0)) { //  sync nibble was found  and some data is present...
       if(debug_output) {
@@ -695,9 +695,9 @@ return 1;
 }
 
 static int oregon_scientific_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
-  int ret = oregon_scientific_v2_1_parser(bitbuffer);
+  int ret = oregon_scientific_v2_1_parser(decoder, bitbuffer);
   if (ret == 0)
-    ret = oregon_scientific_v3_parser(bitbuffer);
+    ret = oregon_scientific_v3_parser(decoder, bitbuffer);
   return ret;
 }
 

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -694,7 +694,7 @@ return 1;
   return 0;
 }
 
-static int oregon_scientific_callback(bitbuffer_t *bitbuffer) {
+static int oregon_scientific_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
   int ret = oregon_scientific_v2_1_parser(bitbuffer);
   if (ret == 0)
     ret = oregon_scientific_v3_parser(bitbuffer);

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -242,14 +242,11 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
     } // for (pattern...
 
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
-    local_time_str(0, time_str);
 
     int sensor_id = (msg[0] << 8) | msg[1];
     if ((sensor_id == ID_THGR122N) || (sensor_id == ID_THGR968)){
       if (validate_os_v2_message(decoder, msg, 153, num_valid_v2_bits, 15) == 0) {
         data = data_make(
-            "time",          "",            DATA_STRING, time_str,
             "brand",         "",            DATA_STRING, "OS",
             "model",         "",            DATA_STRING, (sensor_id == ID_THGR122N) ? "THGR122N": "THGR968",
             "id",            "House Code",  DATA_INT,    get_os_rollingcode(msg, sensor_id),
@@ -267,7 +264,6 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
         float avgWindspeed = ((msg[7]>>4)&0x0f) / 10.0F + (msg[7]&0x0f) *1.0F + ((msg[8]>>4)&0x0f) / 10.0F;
         float gustWindspeed = (msg[5]&0x0f) /10.0F + ((msg[6]>>4)&0x0f) *1.0F + (msg[6]&0x0f) / 10.0F;
         data = data_make(
-            "time",       "",           DATA_STRING, time_str,
             "brand",      "",           DATA_STRING, "OS",
             "model",      "",           DATA_STRING, "WGR968",
             "id",         "House Code", DATA_INT,    get_os_rollingcode(msg, sensor_id),
@@ -297,7 +293,6 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
         // fprintf(stdout,"Weather Sensor BHTR968  Indoor    Temp: %3.1fC  %3.1fF   Humidity: %d%%", temp_c, ((temp_c*9)/5)+32, get_os_humidity(msg, sensor_id));
         // fprintf(stdout, " (%s) Pressure: %dmbar (%s)\n", comfort_str, ((msg[7] & 0x0f) | (msg[8] & 0xf0))+856, forecast_str);
         data = data_make(
-            "time",       "",               DATA_STRING, time_str,
             "brand",      "",               DATA_STRING, "OS",
             "model",      "",               DATA_STRING, "BHTR968",
             "id",         "House Code",     DATA_INT,    get_os_rollingcode(msg, sensor_id),
@@ -316,7 +311,6 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
         float total_rain = (((msg[7]&0xf)*10000)+((msg[7]>>4)*1000) + ((msg[6]&0xf)*100)+((msg[6]>>4)*10) + (msg[5]&0xf))/10.0F;
 
         data = data_make(
-            "time",       "",           DATA_STRING, time_str,
             "brand",      "",           DATA_STRING, "OS",
             "model",      "",           DATA_STRING, "RGR968",
             "id",         "House Code", DATA_INT,    get_os_rollingcode(msg, sensor_id),
@@ -333,7 +327,6 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
 
         float temp_c = get_os_temperature(msg, sensor_id);
         data = data_make(
-            "time",          "",            DATA_STRING, time_str,
             "brand",         "",            DATA_STRING, "OS",
             "model",         "",            DATA_STRING, "THR228N",
             "id",            "House Code",  DATA_INT,    get_os_rollingcode(msg, sensor_id),
@@ -349,7 +342,6 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
 
         float temp_c = get_os_temperature(msg, sensor_id);
         data = data_make(
-            "time",          "",            DATA_STRING, time_str,
             "brand",         "",            DATA_STRING, "OS",
             "model",         "",            DATA_STRING, "THN132N",
             "id",            "House Code",  DATA_INT,    get_os_rollingcode(msg, sensor_id),
@@ -364,7 +356,6 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
       if (validate_os_v2_message(decoder, msg, 161, num_valid_v2_bits, 15) == 0) {
         float temp_c = get_os_temperature(msg, sensor_id);
         data = data_make(
-            "time",          "",            DATA_STRING, time_str,
             "brand",         "",            DATA_STRING, "OS",
             "model",         "",            DATA_STRING, "RTGN129",
             "id",            "House Code",  DATA_INT,    get_os_rollingcode(msg, sensor_id),
@@ -380,7 +371,6 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
       if (num_valid_v2_bits==153 && (validate_os_v2_message(decoder, msg, 153, num_valid_v2_bits, 15) == 0)) {
         float temp_c = get_os_temperature(msg, sensor_id);
         data = data_make(
-            "time",          "",            DATA_STRING, time_str,
             "brand",         "",            DATA_STRING, "OS",
             "model",         "",            DATA_STRING, "RTGN318",
             "id",            "House Code",  DATA_INT,    get_os_rollingcode(msg, sensor_id),
@@ -399,7 +389,6 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
       if ((validate_os_v2_message(decoder, msg, 137, num_valid_v2_bits, 12) == 0)) {
         float temp_c = get_os_temperature(msg, sensor_id);
         data = data_make(
-            "time",          "",            DATA_STRING, time_str,
             "brand",         "",            DATA_STRING, "OS",
             "model",         "",            DATA_STRING, "THN129",
             "id",            "House Code",  DATA_INT,    get_os_rollingcode(msg, sensor_id),
@@ -416,7 +405,6 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
         float temp_c = get_os_temperature(msg, sensor_id);
         float pressure = get_os_pressure(decoder, msg, sensor_id);
         data = data_make(
-            "time",          "",            DATA_STRING, time_str,
             "brand",         "",            DATA_STRING, "OS",
             "model",         "",            DATA_STRING, "BTHGN129",
             "id",            "House Code",  DATA_INT,    get_os_rollingcode(msg, sensor_id),
@@ -434,7 +422,6 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
 		if ((validate_os_v2_message(decoder, msg, 297, num_valid_v2_bits, 12) == 0)) {
 		int uvidx = get_os_uv(msg, sensor_id);
 		data = data_make(
-		  "time",           "",           DATA_STRING, time_str,
 		  "model",          "",     	  DATA_STRING, "Oregon Scientific UVR128",
 		  "id",             "House Code", DATA_INT,    get_os_rollingcode(msg, sensor_id),
 		  "uv",             "UV Index",   DATA_FORMAT, "%u", DATA_INT, uvidx,
@@ -472,8 +459,6 @@ return 0;
 static int oregon_scientific_v3_parser(r_device *decoder, bitbuffer_t *bitbuffer) {
   bitrow_t *bb = bitbuffer->bb;
   data_t *data;
-  char time_str[LOCAL_TIME_BUFLEN];
-  local_time_str(0, time_str);
 
   // Check stream for possible Oregon Scientific v3 protocol data (skip part of first and last bytes to get past sync/startup bit errors)
   if ((((bb[0][0]&0xf) == 0x0f) && (bb[0][1] == 0xff) && ((bb[0][2]&0xc0) == 0xc0)) ||
@@ -529,7 +514,6 @@ static int oregon_scientific_v3_parser(r_device *decoder, bitbuffer_t *bitbuffer
         float temp_c = get_os_temperature(msg, sensor_id);
         int humidity = get_os_humidity(msg, sensor_id);
         data = data_make(
-          "time",           "",           DATA_STRING, time_str,
           "brand",          "",           DATA_STRING, "OS",
           "model",          "",           DATA_STRING, "THGR810",
           "id",             "House Code", DATA_INT,    get_os_rollingcode(msg, sensor_id),
@@ -545,7 +529,6 @@ static int oregon_scientific_v3_parser(r_device *decoder, bitbuffer_t *bitbuffer
         if (validate_os_checksum(decoder, msg, 12) == 0) {
           float temp_c = get_os_temperature(msg, sensor_id);
           data = data_make(
-            "time",           "",           DATA_STRING, time_str,
             "brand",          "",           DATA_STRING, "OS",
             "model",          "",           DATA_STRING, "THN802",
             "id",             "House Code", DATA_INT,    get_os_rollingcode(msg, sensor_id),
@@ -560,7 +543,6 @@ static int oregon_scientific_v3_parser(r_device *decoder, bitbuffer_t *bitbuffer
       if (validate_os_checksum(decoder, msg, 13) == 0) {   // ok
         int uvidx = get_os_uv(msg, sensor_id);
         data = data_make(
-          "time",           "",           DATA_STRING, time_str,
           "brand",          "",           DATA_STRING, "OS",
           "model",          "",           DATA_STRING, "UV800",
           "id",             "House Code", DATA_INT,    get_os_rollingcode(msg, sensor_id),
@@ -575,7 +557,6 @@ static int oregon_scientific_v3_parser(r_device *decoder, bitbuffer_t *bitbuffer
         float rain_rate=get_os_rain_rate(msg, sensor_id);
         float total_rain=get_os_total_rain(msg, sensor_id);
         data = data_make(
-          "time",       "",           DATA_STRING, time_str,
           "brand",      "",           DATA_STRING, "OS",
           "model",      "",           DATA_STRING, "PCR800",
           "id",         "House Code", DATA_INT,    get_os_rollingcode(msg, sensor_id),
@@ -592,7 +573,6 @@ static int oregon_scientific_v3_parser(r_device *decoder, bitbuffer_t *bitbuffer
     float rain_rate=get_os_rain_rate(msg, sensor_id);
     float total_rain=get_os_total_rain(msg, sensor_id);
     data = data_make(
-      "time",       "",           DATA_STRING, time_str,
       "brand",      "",           DATA_STRING, "OS",
       "model",      "",           DATA_STRING, "PCR800a",
       "id",         "House Code", DATA_INT,    get_os_rollingcode(msg, sensor_id),
@@ -610,7 +590,6 @@ return 1;
         float avgWindspeed = ((msg[7]>>4)&0x0f) / 10.0F + (msg[7]&0x0f) *1.0F + ((msg[8]>>4)&0x0f) * 10.0F;
         float quadrant = (0x0f&(msg[4]>>4))*22.5F;
         data = data_make(
-          "time",       "",           DATA_STRING,  time_str,
           "brand",      "",           DATA_STRING,  "OS",
           "model",      "",           DATA_STRING,  "WGR800",
           "id",         "House Code", DATA_INT,     get_os_rollingcode(msg, sensor_id),
@@ -629,7 +608,6 @@ return 1;
         float rawAmp = (msg[4] >> 4 << 8 | (msg[3] & 0x0f )<< 4 | msg[3] >> 4);
         unsigned short int ipower = (rawAmp /(0.27*230)*1000);
         data = data_make(
-            "time",   "",           DATA_STRING,  time_str,
             "brand",  "",           DATA_STRING, "OS",
             "model",  "",           DATA_STRING,  "CM160",
             "id",     "House Code", DATA_INT, msg[1]&0x0F,
@@ -649,7 +627,6 @@ return 1;
         float total_energy = itotal/3600/1000.0;
         if (itotal && valid == 0) {
             data = data_make(
-              "time",       "",           DATA_STRING,  time_str,
               "brand",      "",           DATA_STRING, "OS",
               "model",      "",           DATA_STRING,  "CM180",
               "id",         "House Code", DATA_INT, msg[1]&0x0F,
@@ -659,7 +636,6 @@ return 1;
             decoder_output_data(decoder, data);
         } else if (!itotal) {
             data = data_make(
-              "time",   "",           DATA_STRING,  time_str,
               "brand",  "",           DATA_STRING, "OS",
               "model",  "",           DATA_STRING,  "CM180",
               "id",     "House Code", DATA_INT, msg[1]&0x0F,
@@ -702,7 +678,6 @@ static int oregon_scientific_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-  "time",
   "brand",
   "model",
   "id",

--- a/src/devices/oregon_scientific_sl109h.c
+++ b/src/devices/oregon_scientific_sl109h.c
@@ -63,7 +63,7 @@ static int get_status(uint8_t fourth_byte)
     return (fourth_byte & 0x3C) >> 2;
 }
 
-static int calculate_checksum(bitbuffer_t *bitbuffer, unsigned row_index, int channel)
+static int calculate_checksum(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row_index, int channel)
 {
     uint8_t calculated_checksum, actual_checksum;
     uint8_t sum = 0;
@@ -78,7 +78,7 @@ static int calculate_checksum(bitbuffer_t *bitbuffer, unsigned row_index, int ch
     actual_checksum     = bitbuffer->bb[row_index][0] >> 4;
     actual_expected_comparison = (calculated_checksum == actual_checksum);
 
-    if(debug_output & !actual_expected_comparison) {
+    if(decoder->verbose & !actual_expected_comparison) {
         fprintf(stderr, "Checksum error in Oregon Scientific SL109H message.  Expected: %01x  Calculated: %01x\n", actual_checksum, calculated_checksum);
         fprintf(stderr, "Message: ");
         bitbuffer_print(bitbuffer);
@@ -107,7 +107,7 @@ static int oregon_scientific_sl109h_callback(r_device *decoder, bitbuffer_t *bit
         channel_bits = get_channel_bits(msg[0]);
 
         if( !((bitbuffer->bits_per_row[row_index] == SL109H_MESSAGE_LENGTH)
-              && calculate_checksum(bitbuffer, row_index, channel_bits)) ) continue;
+              && calculate_checksum(decoder, bitbuffer, row_index, channel_bits)) ) continue;
 
         local_time_str(0, time_str);
 

--- a/src/devices/oregon_scientific_sl109h.c
+++ b/src/devices/oregon_scientific_sl109h.c
@@ -88,7 +88,7 @@ static int calculate_checksum(bitbuffer_t *bitbuffer, unsigned row_index, int ch
 }
 
 
-static int oregon_scientific_sl109h_callback(bitbuffer_t *bitbuffer)
+static int oregon_scientific_sl109h_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
     uint8_t *msg;

--- a/src/devices/oregon_scientific_sl109h.c
+++ b/src/devices/oregon_scientific_sl109h.c
@@ -130,7 +130,7 @@ static int oregon_scientific_sl109h_callback(r_device *decoder, bitbuffer_t *bit
                          "status",        "Status",                             DATA_INT,    status,
                          "mic",           "Integrity",   DATA_STRING, "CHECKSUM",
                          NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
         return 1;
     }
 

--- a/src/devices/oregon_scientific_sl109h.c
+++ b/src/devices/oregon_scientific_sl109h.c
@@ -99,7 +99,6 @@ static int oregon_scientific_sl109h_callback(r_device *decoder, bitbuffer_t *bit
     int channel;
     uint8_t id;
     int status;
-    char time_str[LOCAL_TIME_BUFLEN];
 
     for(int row_index = 0; row_index < bitbuffer->num_rows; row_index++) {
         msg = bitbuffer->bb[row_index];
@@ -109,7 +108,6 @@ static int oregon_scientific_sl109h_callback(r_device *decoder, bitbuffer_t *bit
         if( !((bitbuffer->bits_per_row[row_index] == SL109H_MESSAGE_LENGTH)
               && calculate_checksum(decoder, bitbuffer, row_index, channel_bits)) ) continue;
 
-        local_time_str(0, time_str);
 
         temp_c = calculate_centigrade_decidegrees(bitbuffer, row_index) / 10.0;
 
@@ -121,7 +119,7 @@ static int oregon_scientific_sl109h_callback(r_device *decoder, bitbuffer_t *bit
 
         status = get_status(msg[3]);
 
-        data = data_make("time",          "",           DATA_STRING,                         time_str,
+        data = data_make(
                          "model",         "Model",                              DATA_STRING,    "Oregon Scientific SL109H",
                          "id",            "Id",                                 DATA_INT,    id,
                          "channel",       "Channel",                            DATA_INT,    channel,
@@ -138,7 +136,6 @@ static int oregon_scientific_sl109h_callback(r_device *decoder, bitbuffer_t *bit
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "channel",

--- a/src/devices/oregon_scientific_v1.c
+++ b/src/devices/oregon_scientific_v1.c
@@ -14,7 +14,7 @@ static int rev_nibble(int nib)
 	return(revnib);
 }
 
-static int oregon_scientific_v1_callback(bitbuffer_t *bitbuffer) {
+static int oregon_scientific_v1_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	int ret = 0;
 	char time_str[LOCAL_TIME_BUFLEN];
 	int row;

--- a/src/devices/oregon_scientific_v1.c
+++ b/src/devices/oregon_scientific_v1.c
@@ -60,7 +60,7 @@ static int oregon_scientific_v1_callback(r_device *decoder, bitbuffer_t *bitbuff
 					"battery",		"Battery",		DATA_STRING,	battery ? "LOW" : "OK",
 					"temperature_C","Temperature",	DATA_FORMAT,	"%.01f C",				DATA_DOUBLE,	tempC,
 					NULL);
-				data_acquired_handler(data);
+				decoder_output_data(decoder, data);
 				ret++;
 			}
 		}

--- a/src/devices/oregon_scientific_v1.c
+++ b/src/devices/oregon_scientific_v1.c
@@ -16,7 +16,6 @@ static int rev_nibble(int nib)
 
 static int oregon_scientific_v1_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	int ret = 0;
-	char time_str[LOCAL_TIME_BUFLEN];
 	int row;
 	int cs;
 	int i;
@@ -26,7 +25,6 @@ static int oregon_scientific_v1_callback(r_device *decoder, bitbuffer_t *bitbuff
 	int battery, uk2, sign, uk3, checksum;
 	data_t *data;
 
-	local_time_str(0, time_str);
 
 	for(row = 0; row < bitbuffer->num_rows; row++) {
 		if(bitbuffer->bits_per_row[row] == OSV1_BITS) {
@@ -52,7 +50,6 @@ static int oregon_scientific_v1_callback(r_device *decoder, bitbuffer_t *bitbuff
 				if(sign) tempC = -tempC;
 
 				data = data_make(
-					"time",			"",				DATA_STRING,	time_str,
 					"brand",		"",				DATA_STRING,	"OS",
 					"model",		"",				DATA_STRING,	"OSv1 Temperature Sensor",
 					"sid",			"SID",			DATA_INT,		sid,
@@ -69,7 +66,6 @@ static int oregon_scientific_v1_callback(r_device *decoder, bitbuffer_t *bitbuff
 }
 
 static char *output_fields[] = {
-	"time",
 	"brand",
 	"model",
 	"id",

--- a/src/devices/philips.c
+++ b/src/devices/philips.c
@@ -48,7 +48,7 @@
 /* Map channel values to their real-world counterparts */
 static const uint8_t channel_map[] = { 2, 0, 1, 0, 3 };
 
-static int philips_callback(bitbuffer_t *bitbuffer) 
+static int philips_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     char time_str[LOCAL_TIME_BUFLEN];
     uint8_t *bb;

--- a/src/devices/philips.c
+++ b/src/devices/philips.c
@@ -50,7 +50,6 @@ static const uint8_t channel_map[] = { 2, 0, 1, 0, 3 };
 
 static int philips_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     uint8_t *bb;
     unsigned int i;
     uint8_t a, b, c;
@@ -62,14 +61,13 @@ static int philips_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     data_t *data;
 
     /* Get the time */
-    local_time_str(0, time_str);
     bitbuffer_invert(bitbuffer);
 
     /* Correct number of rows? */
     if (bitbuffer->num_rows != 1) {
         if (decoder->verbose > 1) {
-            fprintf(stderr, "%s %s: wrong number of rows (%d)\n", 
-                    time_str, __func__, bitbuffer->num_rows);
+            fprintf(stderr, "%s: wrong number of rows (%d)\n", 
+                    __func__, bitbuffer->num_rows);
         }
         return 0;
     }
@@ -77,8 +75,8 @@ static int philips_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     /* Correct bit length? */
     if (bitbuffer->bits_per_row[0] != PHILIPS_BITLEN) {
         if (decoder->verbose > 1) {
-            fprintf(stderr, "%s %s: wrong number of bits (%d)\n", 
-                    time_str, __func__, bitbuffer->bits_per_row[0]);
+            fprintf(stderr, "%s: wrong number of bits (%d)\n", 
+                    __func__, bitbuffer->bits_per_row[0]);
         }
         return 0;
     }
@@ -88,7 +86,7 @@ static int philips_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     /* Correct start sequence? */
     if ((bb[0] >> 4) != PHILIPS_STARTNIBBLE) {
         if (decoder->verbose > 1) {
-            fprintf(stderr, "%s %s: wrong start nibble\n", time_str, __func__);
+            fprintf(stderr, "%s: wrong start nibble\n", __func__);
         }
         return 0;
     }
@@ -104,7 +102,7 @@ static int philips_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* If debug enabled, print the combined majority-wins packet */
     if (decoder->verbose > 1) {
-        fprintf(stderr, "%s %s: combined packet = ", time_str, __func__);
+        fprintf(stderr, "%s: combined packet = ", __func__);
         bitrow_print(packet, PHILIPS_PACKETLEN * 8);
     }
 
@@ -112,8 +110,8 @@ static int philips_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     c_crc = crc4(packet, PHILIPS_PACKETLEN, 0x9, 1); /* Including the CRC nibble */
     if (0 != c_crc) {
         if (decoder->verbose) {
-            fprintf(stderr, "%s %s: CRC failed, calculated %x\n",
-                    time_str, __func__, c_crc);
+            fprintf(stderr, "%s: CRC failed, calculated %x\n",
+                    __func__, c_crc);
         }
         return 0;
     }
@@ -137,7 +135,7 @@ static int philips_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     /* Battery status */
     battery_status = packet[PHILIPS_PACKETLEN - 1] & 0x40;
 
-    data = data_make("time",          "",            DATA_STRING, time_str,
+    data = data_make(
                      "model",         "",            DATA_STRING, "Philips outdoor temperature sensor",
                      "channel",       "Channel",     DATA_INT,    channel,
                      "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
@@ -150,7 +148,6 @@ static int philips_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *philips_output_fields[] = {
-    "time",
     "model",
     "channel",
     "temperature_C",

--- a/src/devices/philips.c
+++ b/src/devices/philips.c
@@ -67,7 +67,7 @@ static int philips_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* Correct number of rows? */
     if (bitbuffer->num_rows != 1) {
-        if (debug_output > 1) {
+        if (decoder->verbose > 1) {
             fprintf(stderr, "%s %s: wrong number of rows (%d)\n", 
                     time_str, __func__, bitbuffer->num_rows);
         }
@@ -76,7 +76,7 @@ static int philips_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* Correct bit length? */
     if (bitbuffer->bits_per_row[0] != PHILIPS_BITLEN) {
-        if (debug_output > 1) {
+        if (decoder->verbose > 1) {
             fprintf(stderr, "%s %s: wrong number of bits (%d)\n", 
                     time_str, __func__, bitbuffer->bits_per_row[0]);
         }
@@ -87,7 +87,7 @@ static int philips_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* Correct start sequence? */
     if ((bb[0] >> 4) != PHILIPS_STARTNIBBLE) {
-        if (debug_output > 1) {
+        if (decoder->verbose > 1) {
             fprintf(stderr, "%s %s: wrong start nibble\n", time_str, __func__);
         }
         return 0;
@@ -103,7 +103,7 @@ static int philips_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* If debug enabled, print the combined majority-wins packet */
-    if (debug_output > 1) {
+    if (decoder->verbose > 1) {
         fprintf(stderr, "%s %s: combined packet = ", time_str, __func__);
         bitrow_print(packet, PHILIPS_PACKETLEN * 8);
     }
@@ -111,7 +111,7 @@ static int philips_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     /* Correct CRC? */
     c_crc = crc4(packet, PHILIPS_PACKETLEN, 0x9, 1); /* Including the CRC nibble */
     if (0 != c_crc) {
-        if (debug_output) {
+        if (decoder->verbose) {
             fprintf(stderr, "%s %s: CRC failed, calculated %x\n",
                     time_str, __func__, c_crc);
         }

--- a/src/devices/philips.c
+++ b/src/devices/philips.c
@@ -144,7 +144,7 @@ static int philips_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                      "battery",       "Battery",     DATA_STRING, battery_status ? "LOW" : "OK",
                      NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }

--- a/src/devices/prologue.c
+++ b/src/devices/prologue.c
@@ -28,7 +28,6 @@ static int prologue_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
     data_t *data;
 
-    char time_str[LOCAL_TIME_BUFLEN];
 
     uint8_t model;
     uint8_t id;
@@ -48,7 +47,6 @@ static int prologue_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
          (bb[r][0]&0xF0) == 0x50)) {
 
         /* Get time now */
-        local_time_str(0, time_str);
 
         /* Prologue sensor */
         model = bb[r][0] >> 4;
@@ -60,7 +58,7 @@ static int prologue_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         temp = temp >> 4;
         humidity = ((bb[r][3]&0x0F) << 4) | (bb[r][4] >> 4);
 
-        data = data_make("time",          "",            DATA_STRING, time_str,
+        data = data_make(
                          "model",         "",            DATA_STRING, "Prologue sensor",
                          "id",            "",            DATA_INT, model, // this should be named "type"
                          "rid",           "",            DATA_INT, id, // this should be named "id"
@@ -78,7 +76,6 @@ static int prologue_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "rid",

--- a/src/devices/prologue.c
+++ b/src/devices/prologue.c
@@ -24,7 +24,7 @@
 
 #include "decoder.h"
 
-static int prologue_callback(bitbuffer_t *bitbuffer) {
+static int prologue_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
     data_t *data;
 

--- a/src/devices/prologue.c
+++ b/src/devices/prologue.c
@@ -70,7 +70,7 @@ static int prologue_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                          "temperature_C", "Temperature", DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp/10.0,
                          "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, humidity,
                           NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
 
         return 1;
     }

--- a/src/devices/proove.c
+++ b/src/devices/proove.c
@@ -65,7 +65,7 @@ static int proove_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                      "unit",          "Unit",        DATA_INT, unit_bit,
                       NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 0;
 }

--- a/src/devices/proove.c
+++ b/src/devices/proove.c
@@ -28,7 +28,7 @@
  */
 #include "decoder.h"
 
-static int proove_callback(bitbuffer_t *bitbuffer) {
+static int proove_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     data_t *data;
     char time_str[LOCAL_TIME_BUFLEN];
 

--- a/src/devices/proove.c
+++ b/src/devices/proove.c
@@ -30,7 +30,6 @@
 
 static int proove_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
 
     /* Reject codes of wrong length */
     if (bitbuffer->bits_per_row[1] != 64)
@@ -55,9 +54,8 @@ static int proove_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     uint32_t unit_bit = (b[3] & 0x03);
 
     /* Get time now */
-    local_time_str(0, time_str);
 
-    data = data_make("time",          "",            DATA_STRING, time_str,
+    data = data_make(
                      "model",         "",            DATA_STRING, "Proove",
                      "id",            "House Code",  DATA_INT, sensor_id,
                      "channel",       "Channel",     DATA_INT, channel_code,
@@ -71,7 +69,6 @@ static int proove_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "channel",

--- a/src/devices/quhwa.c
+++ b/src/devices/quhwa.c
@@ -40,7 +40,7 @@ static int quhwa_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             "id", "ID", DATA_INT, id,
             NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }

--- a/src/devices/quhwa.c
+++ b/src/devices/quhwa.c
@@ -31,11 +31,8 @@ static int quhwa_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     uint32_t id = (b[0] << 8) | b[1];
 
-    char time_str[LOCAL_TIME_BUFLEN];
-    local_time_str(0, time_str);
 
     data_t *data = data_make(
-            "time", "", DATA_STRING, time_str,
             "model", "", DATA_STRING, "Quhwa doorbell",
             "id", "ID", DATA_INT, id,
             NULL);
@@ -46,7 +43,6 @@ static int quhwa_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     NULL

--- a/src/devices/quhwa.c
+++ b/src/devices/quhwa.c
@@ -12,7 +12,7 @@
  */
 #include "decoder.h"
 
-static int quhwa_callback(bitbuffer_t *bitbuffer)
+static int quhwa_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     int r = bitbuffer_find_repeated_row(bitbuffer, 5, 18);
     if (r < 0)

--- a/src/devices/radiohead_ask.c
+++ b/src/devices/radiohead_ask.c
@@ -153,7 +153,7 @@ static int radiohead_ask_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             "payload",      "Payload",      DATA_ARRAY, data_array(data_len, DATA_INT, rh_data_payload),
             "mic",          "Integrity",    DATA_STRING, "CRC",
             NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }
@@ -192,7 +192,7 @@ static int sensible_living_callback(r_device *decoder, bitbuffer_t *bitbuffer)
              "battery_voltage",  "Battery Voltage",  DATA_INT,     battery_voltage,
              "mic",              "Integrity",        DATA_STRING,  "CRC",
              NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }

--- a/src/devices/radiohead_ask.c
+++ b/src/devices/radiohead_ask.c
@@ -121,7 +121,6 @@ static int radiohead_ask_extract(r_device *decoder, bitbuffer_t *bitbuffer, uint
 
 static int radiohead_ask_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t row = 0; // we are considering only first row
     int msg_len, data_len, header_to, header_from, header_id, header_flags;
@@ -141,9 +140,7 @@ static int radiohead_ask_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     for (int j = 0; j < msg_len; j++) {
         rh_data_payload[j] = (int)rh_payload[5 + j];
     }
-    local_time_str(0, time_str);
     data = data_make(
-            "time",         "",             DATA_STRING, time_str,
             "model",        "",             DATA_STRING, "RadioHead ASK",
             "len",          "Data len",     DATA_INT, data_len,
             "to",           "To",           DATA_INT, header_to,
@@ -160,7 +157,6 @@ static int radiohead_ask_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
 static int sensible_living_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t row = 0; // we are considering only first row
     int msg_len, house_id, sensor_type, sensor_count, alarms;
@@ -179,9 +175,7 @@ static int sensible_living_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     sensor_value = (rh_payload[7] << 8) | rh_payload[8];
     battery_voltage = (rh_payload[9] << 8) | rh_payload[10];
 
-    local_time_str(0, time_str);
     data = data_make(
-             "time",             "",                 DATA_STRING,  time_str,
              "model",            "",                 DATA_STRING,  "Sensible Living Plant Moisture",
              "house_id",         "House ID",         DATA_INT,     house_id,
              "module_id",        "Module ID",        DATA_INT,     module_id,
@@ -198,7 +192,6 @@ static int sensible_living_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *radiohead_ask_output_fields[] = {
-    "time",
     "model",
     "len",
     "to",
@@ -211,7 +204,6 @@ static char *radiohead_ask_output_fields[] = {
 };
 
 static char *sensible_living_output_fields[] = {
-    "time",
     "model",
     "house_id",
     "module_id",

--- a/src/devices/radiohead_ask.c
+++ b/src/devices/radiohead_ask.c
@@ -119,7 +119,7 @@ static int radiohead_ask_extract(bitbuffer_t *bitbuffer, uint8_t row, /*OUT*/ ui
     return msg_len;
 }
 
-static int radiohead_ask_callback(bitbuffer_t *bitbuffer)
+static int radiohead_ask_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
@@ -158,7 +158,7 @@ static int radiohead_ask_callback(bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static int sensible_living_callback(bitbuffer_t *bitbuffer)
+static int sensible_living_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;

--- a/src/devices/rftech.c
+++ b/src/devices/rftech.c
@@ -13,7 +13,7 @@
 
 #include "decoder.h"
 
-static int rftech_callback(bitbuffer_t *bitbuffer) {
+static int rftech_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	char time_str[LOCAL_TIME_BUFLEN];
 	bitrow_t *bb = bitbuffer->bb;
 	uint16_t sensor_id = 0;

--- a/src/devices/rftech.c
+++ b/src/devices/rftech.c
@@ -62,7 +62,7 @@ static int rftech_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 			 "temperature", "Temperature", DATA_FORMAT, "%.01f C", DATA_DOUBLE, value,
 			 NULL);
 
-	data_acquired_handler(data);
+	decoder_output_data(decoder, data);
 
 	return 1;
 	}

--- a/src/devices/rftech.c
+++ b/src/devices/rftech.c
@@ -14,7 +14,6 @@
 #include "decoder.h"
 
 static int rftech_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
-	char time_str[LOCAL_TIME_BUFLEN];
 	bitrow_t *bb = bitbuffer->bb;
 	uint16_t sensor_id = 0;
 	uint8_t button;
@@ -23,7 +22,6 @@ static int rftech_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	data_t *data;
 	int r;
 
-	local_time_str(0, time_str);
 
 	r = bitbuffer_find_repeated_row(bitbuffer, 3, 24);
 
@@ -54,7 +52,7 @@ static int rftech_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	battery = (bb[r][2] & 0x80) == 0x80;
 	button = (bb[r][2] & 0x60) != 0;
 
-	data = data_make("time", "", DATA_STRING, time_str,
+	data = data_make(
 			 "model", "", DATA_STRING, "RF-tech",
 			 "id", "Id", DATA_INT, sensor_id,
 			 "battery", "Battery", DATA_STRING, battery ? "OK" : "LOW",
@@ -78,7 +76,6 @@ static int rftech_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
  *
  */
 static char *csv_output_fields[] = {
-	"time",
 	"model",
 	"id",
 	"battery",

--- a/src/devices/rubicson.c
+++ b/src/devices/rubicson.c
@@ -64,7 +64,7 @@ static int rubicson_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                         "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
                         "mic",           "Integrity",   DATA_STRING, "CRC",
                         NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
 
         return 1;
     }

--- a/src/devices/rubicson.c
+++ b/src/devices/rubicson.c
@@ -28,7 +28,7 @@ int rubicson_crc_check(bitrow_t *bb) {
     return crc8(tmp, 5, 0x31, 0x6c) == 0;
 }
 
-static int rubicson_callback(bitbuffer_t *bitbuffer) {
+static int rubicson_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
     unsigned bits = bitbuffer->bits_per_row[0];
     data_t *data;

--- a/src/devices/rubicson.c
+++ b/src/devices/rubicson.c
@@ -33,7 +33,6 @@ static int rubicson_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     unsigned bits = bitbuffer->bits_per_row[0];
     data_t *data;
 
-    char time_str[LOCAL_TIME_BUFLEN];
     uint8_t channel;
     uint8_t sensor_id;
     uint8_t battery;
@@ -44,7 +43,6 @@ static int rubicson_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         return 0;
 
     if (rubicson_crc_check(bb)) {
-        local_time_str(0, time_str);
 
         /* Nibble 3,4,5 contains 12 bits of temperature
          * The temperature is signed and scaled by 10 */
@@ -56,7 +54,7 @@ static int rubicson_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         sensor_id = bb[0][0];
         temp_c = (float) temp / 10.0;
 
-        data = data_make("time",         "",            DATA_STRING, time_str,
+        data = data_make(
                         "model",         "",            DATA_STRING, "Rubicson Temperature Sensor",
                         "id",            "House Code",  DATA_INT,    sensor_id,
                         "channel",       "Channel",     DATA_INT,    channel,
@@ -72,7 +70,6 @@ static int rubicson_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "channel",

--- a/src/devices/s3318p.c
+++ b/src/devices/s3318p.c
@@ -120,7 +120,7 @@ static int s3318p_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                      "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, humidity,
                       NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 0;
 }

--- a/src/devices/s3318p.c
+++ b/src/devices/s3318p.c
@@ -51,7 +51,6 @@ static int s3318p_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     uint8_t *b;
     int browlen;
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
 
     // ignore if two leading sync pulses (Esperanza EWS)
     if (bitbuffer->bits_per_row[0] == 0 && bitbuffer->bits_per_row[1] == 0)
@@ -109,8 +108,7 @@ static int s3318p_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
       fprintf(stdout, "TemperatureF         = %.1f\n", temperature_f);
     }
 
-    local_time_str(0, time_str);
-    data = data_make("time",          "",            DATA_STRING, time_str,
+    data = data_make(
                      "model",         "",            DATA_STRING, "S3318P Temperature & Humidity Sensor",
                      "id",            "House Code",  DATA_INT, sensor_id,
                      "channel",       "Channel",     DATA_INT, channel,
@@ -126,7 +124,6 @@ static int s3318p_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "channel",

--- a/src/devices/s3318p.c
+++ b/src/devices/s3318p.c
@@ -93,7 +93,7 @@ static int s3318p_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     temperature_with_offset = ((b[2] & 0x0F) << 8) | (b[2] & 0xF0) | (b[1] & 0x0F);
     temperature_f = (temperature_with_offset - 900) / 10.0;
 
-    if (debug_output) {
+    if (decoder->verbose) {
       bitbuffer_print(bitbuffer);
       fprintf(stderr, "Sensor ID            = %2x\n",  sensor_id);
       fprintf(stdout, "Bitstream HEX        = ");

--- a/src/devices/s3318p.c
+++ b/src/devices/s3318p.c
@@ -47,7 +47,7 @@
 
 #include "decoder.h"
 
-static int s3318p_callback(bitbuffer_t *bitbuffer) {
+static int s3318p_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     uint8_t *b;
     int browlen;
     data_t *data;

--- a/src/devices/schraeder.c
+++ b/src/devices/schraeder.c
@@ -27,7 +27,7 @@
 
 #include "decoder.h"
 
-static int schraeder_callback(bitbuffer_t *bitbuffer) {
+static int schraeder_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	char time_str[LOCAL_TIME_BUFLEN];
 	data_t *data;
 	uint8_t b[8];
@@ -98,7 +98,7 @@ static int schraeder_callback(bitbuffer_t *bitbuffer) {
   *
   */
   
-static int schrader_EG53MA4_callback(bitbuffer_t *bitbuffer) {
+static int schrader_EG53MA4_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	char time_str[LOCAL_TIME_BUFLEN];
 	data_t *data;
 	uint8_t b[10];

--- a/src/devices/schraeder.c
+++ b/src/devices/schraeder.c
@@ -61,7 +61,7 @@ static int schraeder_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	pressure = b[5] * 25;
 	temperature = b[6] - 50;
 
-	if (debug_output >= 1) {
+	if (decoder->verbose) {
 		fprintf(stderr, "Schrader TPMS decoder\n");
 		bitbuffer_print(bitbuffer);
 		fprintf(stderr, "id = 0x%X\n", serial_id);
@@ -138,7 +138,7 @@ static int schrader_EG53MA4_callback(r_device *decoder, bitbuffer_t *bitbuffer) 
 	/* Get temperature value */
 	temperature = b[8];
 
-	if (debug_output >= 1) {
+	if (decoder->verbose) {
 		fprintf(stderr, "Schrader EG53MA4 TPMS decoder\n");
 		bitbuffer_print(bitbuffer);
 		fprintf(stderr, "id = 0x%X\n", serial_id);

--- a/src/devices/schraeder.c
+++ b/src/devices/schraeder.c
@@ -78,7 +78,7 @@ static int schraeder_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 					"mic", "Integrity", DATA_STRING, "CRC",
 					NULL);
 
-	data_acquired_handler(data);
+	decoder_output_data(decoder, data);
 	return 0;
 }
 
@@ -155,7 +155,7 @@ static int schrader_EG53MA4_callback(r_device *decoder, bitbuffer_t *bitbuffer) 
 					"mic", "Integrity", DATA_STRING, "CHECKSUM",
 					NULL);
 
-	data_acquired_handler(data);
+	decoder_output_data(decoder, data);
 	return 0;
 }
 

--- a/src/devices/schraeder.c
+++ b/src/devices/schraeder.c
@@ -28,7 +28,6 @@
 #include "decoder.h"
 
 static int schraeder_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
-	char time_str[LOCAL_TIME_BUFLEN];
 	data_t *data;
 	uint8_t b[8];
 	int serial_id;
@@ -50,7 +49,6 @@ static int schraeder_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 		return 0;
 	}
 
-	local_time_str(0, time_str);
 
 	/* Get serial number id */
 	serial_id = (b[1]&0x0F) << 24 | b[2] << 16 | b[3] << 8 | b[4];
@@ -68,7 +66,7 @@ static int schraeder_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 		fprintf(stderr, "CRC = %x\n", crc8(b, 7, 0x07, 0xf0));
 	}
 
-	data = data_make("time", "", DATA_STRING, time_str,
+	data = data_make(
 					"model", "", DATA_STRING, "Schrader",
 					"type", "", DATA_STRING, "TPMS",
 					"flags", "", DATA_STRING, flags_str,
@@ -99,7 +97,6 @@ static int schraeder_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
   */
   
 static int schrader_EG53MA4_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
-	char time_str[LOCAL_TIME_BUFLEN];
 	data_t *data;
 	uint8_t b[10];
 	int serial_id;
@@ -123,7 +120,6 @@ static int schrader_EG53MA4_callback(r_device *decoder, bitbuffer_t *bitbuffer) 
         return 0;
     }
 
-	local_time_str(0, time_str);
 
 	/* Get sensor id */
 	serial_id = (b[4] << 16) | (b[5] << 8) | b[6];
@@ -145,7 +141,7 @@ static int schrader_EG53MA4_callback(r_device *decoder, bitbuffer_t *bitbuffer) 
 		fprintf(stderr, "CHECKSUM = %x\n", checksum);
 	}
 
-	data = data_make("time", "", DATA_STRING, time_str,
+	data = data_make(
 					"model", "", DATA_STRING, "Schrader Electronics EG53MA4",
 					"type", "", DATA_STRING, "TPMS",
 					"flags", "", DATA_STRING, flags_str,
@@ -160,7 +156,6 @@ static int schrader_EG53MA4_callback(r_device *decoder, bitbuffer_t *bitbuffer) 
 }
 
 static char *output_fields[] = {
-	"time",
 	"model",
 	"type",
 	"id",
@@ -172,7 +167,6 @@ static char *output_fields[] = {
 };
 
 static char *output_fields_EG53MA4[] = {
-	"time",
 	"model",
 	"type",
 	"id",

--- a/src/devices/silvercrest.c
+++ b/src/devices/silvercrest.c
@@ -13,7 +13,7 @@
 
 uint8_t cmd_lu_tab[16] = {2,3,0,1,4,5,7,6,0xC,0xD,0xF,0xE,8,9,0xB,0xA};
 
-static int silvercrest_callback(bitbuffer_t *bitbuffer) {
+static int silvercrest_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     char time_str[LOCAL_TIME_BUFLEN];
     uint8_t *b; // bits of a row
     uint8_t cmd;

--- a/src/devices/silvercrest.c
+++ b/src/devices/silvercrest.c
@@ -14,7 +14,6 @@
 uint8_t cmd_lu_tab[16] = {2,3,0,1,4,5,7,6,0xC,0xD,0xF,0xE,8,9,0xB,0xA};
 
 static int silvercrest_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
-    char time_str[LOCAL_TIME_BUFLEN];
     uint8_t *b; // bits of a row
     uint8_t cmd;
     data_t *data;
@@ -30,10 +29,8 @@ static int silvercrest_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         if ((b[3]&0xF) != cmd_lu_tab[cmd])
             return 0;
 
-        local_time_str(0, time_str);
 
         data = data_make(
-            "time",  "", DATA_STRING, time_str,
             "model", "", DATA_STRING, "Silvercrest Remote Control",
             "button", "", DATA_INT, cmd,
             NULL);
@@ -46,7 +43,6 @@ static int silvercrest_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "button",
     NULL

--- a/src/devices/silvercrest.c
+++ b/src/devices/silvercrest.c
@@ -38,7 +38,7 @@ static int silvercrest_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
             "button", "", DATA_INT, cmd,
             NULL);
 
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
 
         return 1;
     }

--- a/src/devices/simplisafe.c
+++ b/src/devices/simplisafe.c
@@ -29,7 +29,6 @@ ss_get_id(char *id, uint8_t *b)
 static int
 ss_sensor_parser(r_device *decoder, bitbuffer_t *bitbuffer, int row)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t *b = bitbuffer->bb[row];
     char id[6];
@@ -54,9 +53,7 @@ ss_sensor_parser(r_device *decoder, bitbuffer_t *bitbuffer, int row)
     	strcpy(extradata,"Alarm Off");
     }
 
-    local_time_str(0, time_str);
     data = data_make(
-        	"time",        "",    DATA_STRING, time_str,
         	"model",    "",    DATA_STRING, "SimpliSafe Sensor",
         	"device",    "Device ID",    DATA_STRING, id,
         	"seq",        "Sequence",    DATA_INT, seq,
@@ -72,7 +69,6 @@ ss_sensor_parser(r_device *decoder, bitbuffer_t *bitbuffer, int row)
 static int
 ss_pinentry_parser(r_device *decoder, bitbuffer_t *bitbuffer, int row)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t *b = bitbuffer->bb[row];
     char id[6];
@@ -92,9 +88,7 @@ ss_pinentry_parser(r_device *decoder, bitbuffer_t *bitbuffer, int row)
 
     sprintf(extradata, "Disarm Pin: %x%x%x%x", digits[0], digits[1], digits[2], digits[3]);
 
-    local_time_str(0, time_str);
     data = data_make(
-        	"time",        "",    DATA_STRING, time_str,
         	"model",    "",    DATA_STRING, "SimpliSafe Keypad",
         	"device",    "Device ID",    DATA_STRING, id,
         	"seq",        "Sequence",    DATA_INT, b[9],
@@ -109,7 +103,6 @@ ss_pinentry_parser(r_device *decoder, bitbuffer_t *bitbuffer, int row)
 static int
 ss_keypad_commands(r_device *decoder, bitbuffer_t *bitbuffer, int row)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t *b = bitbuffer->bb[row];
     char id[6];
@@ -131,9 +124,7 @@ ss_keypad_commands(r_device *decoder, bitbuffer_t *bitbuffer, int row)
 
     ss_get_id(id, b);
 
-    local_time_str(0, time_str);
     data = data_make(
-        	"time",        "",    DATA_STRING, time_str,
         	"model",    "",    DATA_STRING, "SimpliSafe Keypad",
         	"device",    "",    DATA_STRING, id,
         	"seq",    "Sequence",DATA_INT, b[9],
@@ -172,7 +163,6 @@ ss_sensor_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *sensor_output_fields[] = {
-    "time",
     "model",
     "device",
     "seq",

--- a/src/devices/simplisafe.c
+++ b/src/devices/simplisafe.c
@@ -165,7 +165,7 @@ ss_sensor_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     } else if (b[2] == 0x44) {
         return ss_keypad_commands(decoder, bitbuffer, row);
     } else {
-        if (debug_output)
+        if (decoder->verbose)
             fprintf(stderr, "Unknown Message Type: %02x\n", b[2]);
         return 0;
     }

--- a/src/devices/simplisafe.c
+++ b/src/devices/simplisafe.c
@@ -146,7 +146,7 @@ ss_keypad_commands(bitbuffer_t *bitbuffer, int row)
 }
 
 static int
-ss_sensor_callback(bitbuffer_t *bitbuffer)
+ss_sensor_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     // Require two identical rows.
     int row = bitbuffer_find_repeated_row(bitbuffer, 2, 90);

--- a/src/devices/simplisafe.c
+++ b/src/devices/simplisafe.c
@@ -27,7 +27,7 @@ ss_get_id(char *id, uint8_t *b)
 }
 
 static int
-ss_sensor_parser(bitbuffer_t *bitbuffer, int row)
+ss_sensor_parser(r_device *decoder, bitbuffer_t *bitbuffer, int row)
 {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
@@ -64,13 +64,13 @@ ss_sensor_parser(bitbuffer_t *bitbuffer, int row)
         	"extradata",    "Extra Data",    DATA_STRING, extradata,
         	NULL
     );
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }
 
-static int 
-ss_pinentry_parser(bitbuffer_t *bitbuffer, int row)
+static int
+ss_pinentry_parser(r_device *decoder, bitbuffer_t *bitbuffer, int row)
 {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
@@ -101,13 +101,13 @@ ss_pinentry_parser(bitbuffer_t *bitbuffer, int row)
         	"extradata",    "Extra Data",    DATA_STRING, extradata,
         	NULL
     );
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }
 
-static int 
-ss_keypad_commands(bitbuffer_t *bitbuffer, int row)
+static int
+ss_keypad_commands(r_device *decoder, bitbuffer_t *bitbuffer, int row)
 {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
@@ -140,7 +140,7 @@ ss_keypad_commands(bitbuffer_t *bitbuffer, int row)
         	"extradata",    "",    DATA_STRING, extradata,
         	NULL
     );
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }
@@ -159,11 +159,11 @@ ss_sensor_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     bitbuffer_invert(bitbuffer);
 
     if (b[2] == 0x88) {
-        return ss_sensor_parser(bitbuffer, row);
+        return ss_sensor_parser(decoder, bitbuffer, row);
     } else if (b[2] == 0x66) {
-        return ss_pinentry_parser(bitbuffer, row);
+        return ss_pinentry_parser(decoder, bitbuffer, row);
     } else if (b[2] == 0x44) {
-        return ss_keypad_commands(bitbuffer, row);
+        return ss_keypad_commands(decoder, bitbuffer, row);
     } else {
         if (debug_output)
             fprintf(stderr, "Unknown Message Type: %02x\n", b[2]);

--- a/src/devices/smoke_gs558.c
+++ b/src/devices/smoke_gs558.c
@@ -103,7 +103,7 @@ static int smoke_gs558_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         "learn",         "",            DATA_INT, learn > 1,
         "code",          "Raw Code",    DATA_STRING, code_str,
         NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }

--- a/src/devices/smoke_gs558.c
+++ b/src/devices/smoke_gs558.c
@@ -43,7 +43,6 @@
 static int smoke_gs558_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
     uint8_t *b;
     int r;
     int learn = 0;
@@ -94,9 +93,7 @@ static int smoke_gs558_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     sprintf(code_str, "%02x%02x%02x", b[2], b[1], b[0]);
 
-    local_time_str(0, time_str);
     data = data_make(
-        "time",          "",            DATA_STRING, time_str,
         "model",         "",            DATA_STRING, "Smoke detector GS 558",
         "id"   ,         "",            DATA_INT, id,
         "unit",          "",            DATA_INT, unit,
@@ -109,7 +106,6 @@ static int smoke_gs558_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "unit",

--- a/src/devices/smoke_gs558.c
+++ b/src/devices/smoke_gs558.c
@@ -40,7 +40,8 @@
 
 #include "decoder.h"
 
-static int smoke_gs558_callback(bitbuffer_t *bitbuffer) {
+static int smoke_gs558_callback(r_device *decoder, bitbuffer_t *bitbuffer)
+{
     data_t *data;
     char time_str[LOCAL_TIME_BUFLEN];
     uint8_t *b;

--- a/src/devices/solight_te44.c
+++ b/src/devices/solight_te44.c
@@ -38,7 +38,7 @@
 
 extern int rubicson_crc_check(bitrow_t *bb);
 
-static int solight_te44_callback(bitbuffer_t *bitbuffer) {
+static int solight_te44_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
     data_t *data;
     char time_str[LOCAL_TIME_BUFLEN];

--- a/src/devices/solight_te44.c
+++ b/src/devices/solight_te44.c
@@ -81,7 +81,7 @@ static int solight_te44_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                      "temperature_C", "Temperature", DATA_FORMAT, "%.02f C", DATA_DOUBLE, temperature,
                      "mic",           "Integrity",   DATA_STRING, "CRC",
                      NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 

--- a/src/devices/solight_te44.c
+++ b/src/devices/solight_te44.c
@@ -41,7 +41,6 @@ extern int rubicson_crc_check(bitrow_t *bb);
 static int solight_te44_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
 
     uint8_t id;
     uint8_t channel;
@@ -57,7 +56,6 @@ static int solight_te44_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
     if (!rubicson_crc_check(bb)) return 0;
 
-    local_time_str(0, time_str);
 
     id = bb[0][0];
 
@@ -74,7 +72,7 @@ static int solight_te44_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
     temperature = (float) (((256 * multiplier) + temperature_raw) / 10.0);
 
-    data = data_make("time", "", DATA_STRING, time_str,
+    data = data_make(
                      "model", "", DATA_STRING, "Solight TE44",
                      "id", "Id", DATA_INT, id,
                      "channel", "Channel", DATA_INT, channel + 1,
@@ -88,7 +86,6 @@ static int solight_te44_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "channel",

--- a/src/devices/springfield.c
+++ b/src/devices/springfield.c
@@ -5,7 +5,6 @@
 
 static int springfield_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	int ret = 0;
-	char time_str[LOCAL_TIME_BUFLEN];
 	int row;
 	int cs;
 	int i;
@@ -18,7 +17,6 @@ static int springfield_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	unsigned tmpData;
 	unsigned savData = 0;
 
-	local_time_str(0, time_str);
 
 	for(row = 0; row < bitbuffer->num_rows; row++) {
 		if(bitbuffer->bits_per_row[row] == NUM_BITS || bitbuffer->bits_per_row[row] == NUM_BITS + 1) {
@@ -49,7 +47,6 @@ static int springfield_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 				uk1      =  nibble[8];	/* unknown. */
 
 				data = data_make(
-					"time",			"",				DATA_STRING,	time_str,
 					"model",		"",				DATA_STRING,	"Springfield Temperature & Moisture",
 					"sid",			"SID",			DATA_INT,		sid,
 					"channel",		"Channel",		DATA_INT,		channel,
@@ -68,7 +65,6 @@ static int springfield_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-	"time",
 	"model",
 	"sid",
 	"channel",

--- a/src/devices/springfield.c
+++ b/src/devices/springfield.c
@@ -3,7 +3,7 @@
 // Actually 37 bits for all but last transmission which is 36 bits
 #define	NUM_BITS	36
 
-static int springfield_callback(bitbuffer_t *bitbuffer) {
+static int springfield_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	int ret = 0;
 	char time_str[LOCAL_TIME_BUFLEN];
 	int row;

--- a/src/devices/springfield.c
+++ b/src/devices/springfield.c
@@ -59,7 +59,7 @@ static int springfield_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 					"moisture",		"Moisture",		DATA_INT,		moisture,
 //					"uk1",			"uk1",			DATA_INT,		uk1,
 					NULL);
-				data_acquired_handler(data);
+				decoder_output_data(decoder, data);
 				ret++;
 			}
 		}

--- a/src/devices/steelmate.c
+++ b/src/devices/steelmate.c
@@ -27,7 +27,7 @@
 
 #include "decoder.h"
 
-static int steelmate_callback(bitbuffer_t *bitbuffer) {
+static int steelmate_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	//if (debug_output >= 1) {
 	//	fprintf(stdout, "Steelmate TPMS decoder\n");
 	//	bitbuffer_print(bitbuffer);

--- a/src/devices/steelmate.c
+++ b/src/devices/steelmate.c
@@ -28,7 +28,7 @@
 #include "decoder.h"
 
 static int steelmate_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
-	//if (debug_output >= 1) {
+	//if (decoder->verbose) {
 	//	fprintf(stdout, "Steelmate TPMS decoder\n");
 	//	bitbuffer_print(bitbuffer);
 	//	fprintf(stdout, "\n");

--- a/src/devices/steelmate.c
+++ b/src/devices/steelmate.c
@@ -92,7 +92,7 @@ static int steelmate_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 			"battery_mV", "", DATA_INT, battery_mV,
 			"mic", "Integrity", DATA_STRING, "CHECKSUM",
 			NULL);
-		data_acquired_handler(data);
+		decoder_output_data(decoder, data);
 
 		return 1;
 	}

--- a/src/devices/steelmate.c
+++ b/src/devices/steelmate.c
@@ -34,8 +34,6 @@ static int steelmate_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	//	fprintf(stdout, "\n");
 	//}
 
-	char time_str[LOCAL_TIME_BUFLEN];
-	local_time_str(0, time_str);
 	bitrow_t *bb = bitbuffer->bb;
 
 	//Loop through each row of data
@@ -83,7 +81,7 @@ static int steelmate_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 		pressurePSI = (float)p1 / 2;
 		battery_mV = tmpbattery_mV * 2;
 
-		data = data_make("time", "", DATA_STRING, time_str,
+		data = data_make(
 			"type", "", DATA_STRING, "TPMS",
 			"model", "", DATA_STRING, "Steelmate",
 			"id", "", DATA_STRING, sensorIDhex,
@@ -102,7 +100,6 @@ static int steelmate_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-	"time",
 	"type",
 	"model",
 	"id",

--- a/src/devices/steffen.c
+++ b/src/devices/steffen.c
@@ -1,6 +1,6 @@
 #include "decoder.h"
 
-static int steffen_callback(bitbuffer_t *bitbuffer) {
+static int steffen_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
 
     if (bb[0][0]==0x00 && ((bb[1][0]&0x07)==0x07) && bb[1][0]==bb[2][0] && bb[2][0]==bb[3][0]) {

--- a/src/devices/tfa_pool_thermometer.c
+++ b/src/devices/tfa_pool_thermometer.c
@@ -10,7 +10,7 @@
 #include "decoder.h"
 
 
-static int pool_temperature_sensor_callback(bitbuffer_t *bitbuffer) {
+static int pool_temperature_sensor_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	bitrow_t *bb = bitbuffer->bb;
 	data_t *data;
 	char time_str[LOCAL_TIME_BUFLEN];

--- a/src/devices/tfa_pool_thermometer.c
+++ b/src/devices/tfa_pool_thermometer.c
@@ -13,8 +13,6 @@
 static int pool_temperature_sensor_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	bitrow_t *bb = bitbuffer->bb;
 	data_t *data;
-	char time_str[LOCAL_TIME_BUFLEN];
-	local_time_str(0, time_str);
 	int i,device,channel;
 	int iTemp;
 	float fTemp;
@@ -42,7 +40,7 @@ E: ?
 	fTemp=(iTemp > 2048 ? iTemp - 4096 : iTemp) / 10.0;
 	channel=(signed short)((bb[1][3]&0xC0)>>6);
 
-	data = data_make("time", 	"", 			DATA_STRING, 					time_str,
+	data = data_make(
 		"model",		"", 			DATA_STRING, 	"TFA pool temperature sensor",
 		"id",         	"Id",			DATA_FORMAT,	"\t %d",	DATA_INT,	device,
 		"channel",        	"Channel number",	DATA_FORMAT,	"\t %d",	DATA_INT,	channel,
@@ -55,7 +53,6 @@ E: ?
 }
 
 static char *output_fields[] = {
-	"time",
 	"model",
 	"id",
 	"channel",

--- a/src/devices/tfa_pool_thermometer.c
+++ b/src/devices/tfa_pool_thermometer.c
@@ -48,7 +48,7 @@ E: ?
 		"channel",        	"Channel number",	DATA_FORMAT,	"\t %d",	DATA_INT,	channel,
 		"temperature_C",	"Temperature",		DATA_FORMAT, 	"%.01f C",	DATA_DOUBLE,	fTemp,
 		NULL);
-	data_acquired_handler(data);
+	decoder_output_data(decoder, data);
 
 	return 1;
 

--- a/src/devices/tfa_twin_plus_30.3049.c
+++ b/src/devices/tfa_twin_plus_30.3049.c
@@ -52,7 +52,7 @@ inline static uint8_t reverse_byte(uint8_t byte)
     return byte;
 }
 
-static int tfa_twin_plus_303049_process_row(int row, const bitbuffer_t *bitbuffer)
+static int tfa_twin_plus_303049_process_row(r_device *decoder, int row, const bitbuffer_t *bitbuffer)
 {
     data_t *data;
     const uint8_t *b      = bitbuffer->bb[row];
@@ -98,7 +98,7 @@ static int tfa_twin_plus_303049_process_row(int row, const bitbuffer_t *bitbuffe
             "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, tempC,
             "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, humidity,
             NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
     }
 
     return 1;
@@ -108,7 +108,7 @@ static int tfa_twin_plus_303049_callback(r_device *decoder, bitbuffer_t *bitbuff
 {
     int counter = 0;
     for(int row=0; row<bitbuffer->num_rows; row++)
-        counter += tfa_twin_plus_303049_process_row(row, bitbuffer);
+        counter += tfa_twin_plus_303049_process_row(decoder, row, bitbuffer);
     return counter;
 }
 

--- a/src/devices/tfa_twin_plus_30.3049.c
+++ b/src/devices/tfa_twin_plus_30.3049.c
@@ -87,10 +87,8 @@ static int tfa_twin_plus_303049_process_row(r_device *decoder, int row, const bi
     float tempC = (negative_sign ? -( (1<<9) - temp ) : temp ) * 0.1F;
     {
         /* @todo: remove timestamp printing as soon as the controller takes this task */
-        char time_str[LOCAL_TIME_BUFLEN];
-        local_time_str(0, time_str);
 
-        data = data_make("time",          "",            DATA_STRING, time_str,
+        data = data_make(
             "model",         "",            DATA_STRING, "TFA-Twin-Plus-30.3049",
             "id",            "",            DATA_INT, sensor_id,
             "channel",       "",            DATA_INT, channel,
@@ -364,7 +362,6 @@ Passed 74/74 positive tests
 #endif
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "channel",

--- a/src/devices/tfa_twin_plus_30.3049.c
+++ b/src/devices/tfa_twin_plus_30.3049.c
@@ -104,7 +104,7 @@ static int tfa_twin_plus_303049_process_row(int row, const bitbuffer_t *bitbuffe
     return 1;
 }
 
-static int tfa_twin_plus_303049_callback(bitbuffer_t *bitbuffer)
+static int tfa_twin_plus_303049_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     int counter = 0;
     for(int row=0; row<bitbuffer->num_rows; row++)

--- a/src/devices/thermopro_tp11.c
+++ b/src/devices/thermopro_tp11.c
@@ -39,7 +39,6 @@ static int thermopro_tp11_sensor_callback(r_device *decoder, bitbuffer_t *bitbuf
     float fTemp;
     bitrow_t *bb = bitbuffer->bb;
     unsigned int device, value;
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
 
     // Compare first four bytes of rows that have 32 or 33 bits.
@@ -67,8 +66,7 @@ static int thermopro_tp11_sensor_callback(r_device *decoder, bitbuffer_t *bitbuf
     iTemp = value & 0xfff;
     fTemp = (iTemp - 200) / 10.;
 
-    local_time_str(0, time_str);
-    data = data_make("time",          "",            DATA_STRING, time_str,
+    data = data_make(
                      "model",         "",            DATA_STRING, "Thermopro TP11 Thermometer",
                      "id",            "Id",          DATA_FORMAT, "\t %d",   DATA_INT,    device,
                      "temperature_C", "Temperature", DATA_FORMAT, "%.01f C", DATA_DOUBLE, fTemp,
@@ -78,7 +76,6 @@ static int thermopro_tp11_sensor_callback(r_device *decoder, bitbuffer_t *bitbuf
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "temperature_C",

--- a/src/devices/thermopro_tp11.c
+++ b/src/devices/thermopro_tp11.c
@@ -34,7 +34,7 @@ static int valid(unsigned data, unsigned check) {
     return check == 0;
 }
 
-static int thermopro_tp11_sensor_callback(bitbuffer_t *bitbuffer) {
+static int thermopro_tp11_sensor_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     int i, j, iTemp, good = -1;
     float fTemp;
     bitrow_t *bb = bitbuffer->bb;

--- a/src/devices/thermopro_tp11.c
+++ b/src/devices/thermopro_tp11.c
@@ -73,7 +73,7 @@ static int thermopro_tp11_sensor_callback(r_device *decoder, bitbuffer_t *bitbuf
                      "id",            "Id",          DATA_FORMAT, "\t %d",   DATA_INT,    device,
                      "temperature_C", "Temperature", DATA_FORMAT, "%.01f C", DATA_DOUBLE, fTemp,
                      NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     return 1;
 }
 

--- a/src/devices/thermopro_tp12.c
+++ b/src/devices/thermopro_tp12.c
@@ -42,7 +42,7 @@ Layout appears to be:
 
 #define BITS_IN_VALID_ROW 40
 
-static int thermopro_tp12_sensor_callback(bitbuffer_t *bitbuffer) {
+static int thermopro_tp12_sensor_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     int iTemp1, iTemp2, good = -1;
     float fTemp1, fTemp2;
     uint8_t *bytes;

--- a/src/devices/thermopro_tp12.c
+++ b/src/devices/thermopro_tp12.c
@@ -47,7 +47,6 @@ static int thermopro_tp12_sensor_callback(r_device *decoder, bitbuffer_t *bitbuf
     float fTemp1, fTemp2;
     uint8_t *bytes;
     unsigned int device;
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
 
     // The device transmits 16 rows, let's check for 3 matching.
@@ -93,8 +92,7 @@ static int thermopro_tp12_sensor_callback(r_device *decoder, bitbuffer_t *bitbuf
     fTemp1 = (iTemp1 - 200) / 10.;
     fTemp2 = (iTemp2 - 200) / 10.;
 
-    local_time_str(0, time_str);
-    data = data_make("time",          "",            DATA_STRING, time_str,
+    data = data_make(
                      "model",         "",            DATA_STRING, "Thermopro TP12 Thermometer",
                      "id",            "Id",          DATA_FORMAT, "\t %d",   DATA_INT,    device,
                      "temperature_1_C", "Temperature 1 (Food)", DATA_FORMAT, "%.01f C", DATA_DOUBLE, fTemp1,
@@ -105,7 +103,6 @@ static int thermopro_tp12_sensor_callback(r_device *decoder, bitbuffer_t *bitbuf
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "temperature_1_C",

--- a/src/devices/thermopro_tp12.c
+++ b/src/devices/thermopro_tp12.c
@@ -72,7 +72,7 @@ static int thermopro_tp12_sensor_callback(r_device *decoder, bitbuffer_t *bitbuf
     // or long-press its power button, it pairs with the first device ID it hears.
     device = bytes[0];
 
-    if(debug_output) {
+    if(decoder->verbose) {
         // There is a mysterious checksum in bytes[4].  It may be the same as the checksum used by the TP-11,
         // which consisted of a lookup table containing, for each bit in the message, a byte to be xor-ed into
         // the checksum if the message bit was 1.  It should be possible to solve for that table using Gaussian

--- a/src/devices/thermopro_tp12.c
+++ b/src/devices/thermopro_tp12.c
@@ -100,7 +100,7 @@ static int thermopro_tp12_sensor_callback(r_device *decoder, bitbuffer_t *bitbuf
                      "temperature_1_C", "Temperature 1 (Food)", DATA_FORMAT, "%.01f C", DATA_DOUBLE, fTemp1,
                      "temperature_2_C", "Temperature 2 (Barbecue)", DATA_FORMAT, "%.01f C", DATA_DOUBLE, fTemp2,
                      NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     return 1;
 }
 

--- a/src/devices/tpms_citroen.c
+++ b/src/devices/tpms_citroen.c
@@ -88,7 +88,7 @@ static int tpms_citroen_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bi
     return 1;
 }
 
-static int tpms_citroen_callback(bitbuffer_t *bitbuffer) {
+static int tpms_citroen_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     unsigned bitpos = 0;
     int events = 0;
 

--- a/src/devices/tpms_citroen.c
+++ b/src/devices/tpms_citroen.c
@@ -28,7 +28,6 @@ static const unsigned char preamble_pattern[2] = { 0x55, 0x56 };
 
 static int tpms_citroen_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     unsigned int start_pos;
     bitbuffer_t packet_bits = {0};
@@ -69,9 +68,7 @@ static int tpms_citroen_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     battery = b[8];
     sprintf(code_str, "%02x%02x%02x", pressure, temperature, battery);
 
-    local_time_str(0, time_str);
     data = data_make(
-        "time",         "",     DATA_STRING, time_str,
         "model",        "",     DATA_STRING, "Citroen",
         "type",         "",     DATA_STRING, "TPMS",
         "state",        "",     DATA_STRING, state_str,
@@ -104,7 +101,6 @@ static int tpms_citroen_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "type",
     "state",

--- a/src/devices/tpms_citroen.c
+++ b/src/devices/tpms_citroen.c
@@ -26,7 +26,8 @@
 static const unsigned char preamble_pattern[2] = { 0x55, 0x56 };
 // full trailer is 01111110
 
-static int tpms_citroen_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos) {
+static int tpms_citroen_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
+{
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     unsigned int start_pos;
@@ -84,7 +85,7 @@ static int tpms_citroen_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bi
         "mic",          "",     DATA_STRING, "CHECKSUM",
         NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     return 1;
 }
 
@@ -95,7 +96,7 @@ static int tpms_citroen_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     // Find a preamble with enough bits after it that it could be a complete packet
     while ((bitpos = bitbuffer_search(bitbuffer, 0, bitpos, (uint8_t *)&preamble_pattern, 16)) + 178 <=
             bitbuffer->bits_per_row[0]) {
-        events += tpms_citroen_decode(bitbuffer, 0, bitpos + 16);
+        events += tpms_citroen_decode(decoder, bitbuffer, 0, bitpos + 16);
         bitpos += 2;
     }
 

--- a/src/devices/tpms_ford.c
+++ b/src/devices/tpms_ford.c
@@ -63,7 +63,7 @@ static int tpms_ford_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bitpo
     return 1;
 }
 
-static int tpms_ford_callback(bitbuffer_t *bitbuffer) {
+static int tpms_ford_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     int row;
     unsigned bitpos;
     int events = 0;

--- a/src/devices/tpms_ford.c
+++ b/src/devices/tpms_ford.c
@@ -21,7 +21,8 @@
 // full preamble is 55 55 55 56 (inverted: aa aa aa a9)
 static const uint8_t preamble_pattern[2] = { 0xaa, 0xa9 }; // 16 bits
 
-static int tpms_ford_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos) {
+static int tpms_ford_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
+{
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     unsigned int start_pos;
@@ -59,7 +60,7 @@ static int tpms_ford_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bitpo
         "mic",          "",     DATA_STRING, "CHECKSUM",
         NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     return 1;
 }
 
@@ -76,7 +77,7 @@ static int tpms_ford_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         while ((bitpos = bitbuffer_search(bitbuffer, row, bitpos,
                 (const uint8_t *)&preamble_pattern, 16)) + 144 <=
                 bitbuffer->bits_per_row[row]) {
-            events += tpms_ford_decode(bitbuffer, row, bitpos + 16);
+            events += tpms_ford_decode(decoder, bitbuffer, row, bitpos + 16);
             bitpos += 15;
         }
     }

--- a/src/devices/tpms_ford.c
+++ b/src/devices/tpms_ford.c
@@ -23,7 +23,6 @@ static const uint8_t preamble_pattern[2] = { 0xaa, 0xa9 }; // 16 bits
 
 static int tpms_ford_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     unsigned int start_pos;
     bitbuffer_t packet_bits = {0};
@@ -50,9 +49,7 @@ static int tpms_ford_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned 
     code = b[4]<<16 | b[5]<<8 | b[6];
     sprintf(code_str, "%06x", code);
 
-    local_time_str(0, time_str);
     data = data_make(
-        "time",         "",     DATA_STRING, time_str,
         "model",        "",     DATA_STRING, "Ford",
         "type",         "",     DATA_STRING, "TPMS",
         "id",           "",     DATA_STRING, id_str,
@@ -86,7 +83,6 @@ static int tpms_ford_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "type",
     "id",

--- a/src/devices/tpms_pmv107j.c
+++ b/src/devices/tpms_pmv107j.c
@@ -24,7 +24,8 @@
 // full preamble is (7 bits) 11111 10
 static const unsigned char preamble_pattern[1] = {0xf8}; // 6 bits
 
-static int tpms_pmv107j_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos) {
+static int tpms_pmv107j_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
+{
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     unsigned int start_pos;
@@ -90,7 +91,7 @@ static int tpms_pmv107j_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bi
         "mic",              "",     DATA_STRING,    "CRC",
         NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     return 1;
 }
 
@@ -101,7 +102,7 @@ static int tpms_pmv107j_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     // Find a preamble with enough bits after it that it could be a complete packet
     while ((bitpos = bitbuffer_search(bitbuffer, 0, bitpos, (const uint8_t *)&preamble_pattern, 6)) + 67*2 <=
             bitbuffer->bits_per_row[0]) {
-        events += tpms_pmv107j_decode(bitbuffer, 0, bitpos + 6);
+        events += tpms_pmv107j_decode(decoder, bitbuffer, 0, bitpos + 6);
         bitpos += 2;
     }
 

--- a/src/devices/tpms_pmv107j.c
+++ b/src/devices/tpms_pmv107j.c
@@ -94,7 +94,7 @@ static int tpms_pmv107j_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bi
     return 1;
 }
 
-static int tpms_pmv107j_callback(bitbuffer_t *bitbuffer) {
+static int tpms_pmv107j_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     unsigned bitpos = 0;
     int events = 0;
 

--- a/src/devices/tpms_pmv107j.c
+++ b/src/devices/tpms_pmv107j.c
@@ -26,7 +26,6 @@ static const unsigned char preamble_pattern[1] = {0xf8}; // 6 bits
 
 static int tpms_pmv107j_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     unsigned int start_pos;
     bitbuffer_t packet_bits = {0};
@@ -76,9 +75,7 @@ static int tpms_pmv107j_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
 
     sprintf(id_str, "%08x", id);
 
-    local_time_str(0, time_str);
     data = data_make(
-        "time",             "",     DATA_STRING,    time_str,
         "model",            "",     DATA_STRING,    "PMV-107J",
         "type",             "",     DATA_STRING,    "TPMS",
         "id",               "",     DATA_STRING,    id_str,
@@ -110,7 +107,6 @@ static int tpms_pmv107j_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "type",
     "id",

--- a/src/devices/tpms_pmv107j.c
+++ b/src/devices/tpms_pmv107j.c
@@ -41,13 +41,13 @@ static int tpms_pmv107j_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     if (start_pos - bitpos < 67*2) {
         return 0;
     }
-    if (debug_output > 1)
+    if (decoder->verbose > 1)
         bitbuffer_print(&packet_bits);
 
     // realign the buffer, prepending 6 bits of 0.
     b[0] = packet_bits.bb[0][0] >> 6;
     bitbuffer_extract_bytes(&packet_bits, 0, 2, b + 1, 64);
-    if (debug_output > 1) {
+    if (decoder->verbose > 1) {
         fprintf(stderr, "Realigned: ");
         bitrow_print(b, 72);
     }
@@ -69,7 +69,7 @@ static int tpms_pmv107j_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     temperature_c = temp - 40.0;
 
     if (pressure1 != pressure2) {
-        if (debug_output)
+        if (decoder->verbose)
             fprintf(stderr, "Toyota TPMS pressure check error: %02x vs %02x\n", pressure1, pressure2);
         return 0;
     }

--- a/src/devices/tpms_renault.c
+++ b/src/devices/tpms_renault.c
@@ -71,7 +71,7 @@ static int tpms_renault_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bi
     return 1;
 }
 
-static int tpms_renault_callback(bitbuffer_t *bitbuffer) {
+static int tpms_renault_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     int row;
     unsigned bitpos;
     int events = 0;

--- a/src/devices/tpms_renault.c
+++ b/src/devices/tpms_renault.c
@@ -21,7 +21,8 @@
 // full preamble is 55 55 55 56 (inverted: aa aa aa a9)
 static const uint8_t preamble_pattern[2] = { 0xaa, 0xa9 }; // 16 bits
 
-static int tpms_renault_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos) {
+static int tpms_renault_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
+{
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     unsigned int start_pos;
@@ -67,7 +68,7 @@ static int tpms_renault_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bi
         "mic",          "",     DATA_STRING, "CRC",
         NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     return 1;
 }
 
@@ -84,7 +85,7 @@ static int tpms_renault_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         while ((bitpos = bitbuffer_search(bitbuffer, row, bitpos,
                 (const uint8_t *)&preamble_pattern, 16)) + 160 <=
                 bitbuffer->bits_per_row[row]) {
-            events += tpms_renault_decode(bitbuffer, row, bitpos + 16);
+            events += tpms_renault_decode(decoder, bitbuffer, row, bitpos + 16);
             bitpos += 15;
         }
     }

--- a/src/devices/tpms_renault.c
+++ b/src/devices/tpms_renault.c
@@ -23,7 +23,6 @@ static const uint8_t preamble_pattern[2] = { 0xaa, 0xa9 }; // 16 bits
 
 static int tpms_renault_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     unsigned int start_pos;
     bitbuffer_t packet_bits = {0};
@@ -57,9 +56,7 @@ static int tpms_renault_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     maybe_temp = b[7]<<8 | b[6]; // little-endian
     sprintf(code_str, "%04x %04x", maybe_pressure, maybe_temp);
 
-    local_time_str(0, time_str);
     data = data_make(
-        "time",         "",     DATA_STRING, time_str,
         "model",        "",     DATA_STRING, "Renault",
         "type",         "",     DATA_STRING, "TPMS",
         "id",           "",     DATA_STRING, id_str,
@@ -94,7 +91,6 @@ static int tpms_renault_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "flags",

--- a/src/devices/tpms_toyota.c
+++ b/src/devices/tpms_toyota.c
@@ -80,7 +80,7 @@ static int tpms_toyota_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bit
     return 1;
 }
 
-static int tpms_toyota_callback(bitbuffer_t *bitbuffer) {
+static int tpms_toyota_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     unsigned bitpos = 0;
     int events = 0;
 

--- a/src/devices/tpms_toyota.c
+++ b/src/devices/tpms_toyota.c
@@ -29,7 +29,6 @@ static const unsigned char preamble_pattern[2] = {0x54, 0xf0}; // 12 bits
 
 static int tpms_toyota_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     unsigned int start_pos;
     bitbuffer_t packet_bits = {0};
@@ -65,9 +64,7 @@ static int tpms_toyota_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigne
 
     sprintf(id_str, "%08x", id);
 
-    local_time_str(0, time_str);
     data = data_make(
-        "time",             "",     DATA_STRING,    time_str,
         "model",            "",     DATA_STRING,    "Toyota",
         "type",             "",     DATA_STRING,    "TPMS",
         "id",               "",     DATA_STRING,    id_str,
@@ -96,7 +93,6 @@ static int tpms_toyota_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "type",
     "id",

--- a/src/devices/tpms_toyota.c
+++ b/src/devices/tpms_toyota.c
@@ -58,7 +58,7 @@ static int tpms_toyota_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigne
     pressure2 = b[7] ^ 0xff;
 
     if (pressure1 != pressure2) {
-        if (debug_output)
+        if (decoder->verbose)
             fprintf(stderr, "Toyota TPMS pressure check error: %02x vs %02x\n", pressure1, pressure2);
         return 0;
     }

--- a/src/devices/tpms_toyota.c
+++ b/src/devices/tpms_toyota.c
@@ -27,7 +27,8 @@
 // full preamble is 0101 0101 0011 11 = 55 3c
 static const unsigned char preamble_pattern[2] = {0x54, 0xf0}; // 12 bits
 
-static int tpms_toyota_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos) {
+static int tpms_toyota_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
+{
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     unsigned int start_pos;
@@ -76,7 +77,7 @@ static int tpms_toyota_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bit
         "mic",              "",     DATA_STRING,    "CRC",
         NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     return 1;
 }
 
@@ -87,7 +88,7 @@ static int tpms_toyota_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     // Find a preamble with enough bits after it that it could be a complete packet
     while ((bitpos = bitbuffer_search(bitbuffer, 0, bitpos, (const uint8_t *)&preamble_pattern, 12)) + 158 <=
             bitbuffer->bits_per_row[0]) {
-        events += tpms_toyota_decode(bitbuffer, 0, bitpos + 12);
+        events += tpms_toyota_decode(decoder, bitbuffer, 0, bitpos + 12);
         bitpos += 2;
     }
 

--- a/src/devices/ttx201.c
+++ b/src/devices/ttx201.c
@@ -103,7 +103,7 @@ ttx201_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned 
     data_t *data;
 
     if (bits != MSG_PACKET_MIN_BITS && bits != MSG_PACKET_BITS) {
-        if (debug_output > 1) {
+        if (decoder->verbose > 1) {
             if (row == 0) {
                 if (bits < MSG_PREAMBLE_BITS) {
                     fprintf(stderr, "Short preamble: %d bits (expected %d)\n",
@@ -124,7 +124,7 @@ ttx201_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned 
     checksum_calculated = checksum_calculate(b);
     postmark = b[5];
 
-    if (debug_output > 1) {
+    if (decoder->verbose > 1) {
         fprintf(stderr, "TTX201 received raw data: ");
         bitbuffer_print(bitbuffer);
         fprintf(stderr, "Data decoded:\n" \
@@ -147,14 +147,14 @@ ttx201_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned 
     }
 
     if (postmark != MSG_PACKET_POSTMARK) {
-        if (debug_output > 1)
+        if (decoder->verbose > 1)
             fprintf(stderr, "Packet #%d wrong postmark 0x%02x (expected 0x%02x).\n",
                     row, postmark, MSG_PACKET_POSTMARK);
         return 0;
     }
 
     if (checksum != checksum_calculated) {
-        if (debug_output > 1)
+        if (decoder->verbose > 1)
             fprintf(stderr, "Packet #%d checksum error.\n", row);
         return 0;
     }
@@ -189,7 +189,7 @@ ttx201_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (MSG_MIN_ROWS <= bitbuffer->num_rows && bitbuffer->num_rows <= MSG_MAX_ROWS) {
         for (row = 0; row < bitbuffer->num_rows; ++row) {
             events += ttx201_decode(decoder, bitbuffer, row, 0);
-            if (events && !debug_output) return events; // for now, break after first successful message
+            if (events && !decoder->verbose) return events; // for now, break after first successful message
         }
     }
 

--- a/src/devices/ttx201.c
+++ b/src/devices/ttx201.c
@@ -87,7 +87,7 @@ checksum_calculate(uint8_t *b)
 }
 
 static int
-ttx201_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
+ttx201_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     uint8_t b[MSG_PACKET_LEN];
     int bits = bitbuffer->bits_per_row[row];
@@ -175,7 +175,7 @@ ttx201_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
             "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature_c,
             "mic",           "MIC",         DATA_STRING, "CHECKSUM",
             NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }
@@ -188,7 +188,7 @@ ttx201_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     if (MSG_MIN_ROWS <= bitbuffer->num_rows && bitbuffer->num_rows <= MSG_MAX_ROWS) {
         for (row = 0; row < bitbuffer->num_rows; ++row) {
-            events += ttx201_decode(bitbuffer, row, 0);
+            events += ttx201_decode(decoder, bitbuffer, row, 0);
             if (events && !debug_output) return events; // for now, break after first successful message
         }
     }

--- a/src/devices/ttx201.c
+++ b/src/devices/ttx201.c
@@ -181,7 +181,7 @@ ttx201_decode(bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 }
 
 static int
-ttx201_callback(bitbuffer_t *bitbuffer)
+ttx201_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     int row;
     int events = 0;

--- a/src/devices/ttx201.c
+++ b/src/devices/ttx201.c
@@ -99,7 +99,6 @@ ttx201_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned 
     int channel;
     int temperature;
     float temperature_c;
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
 
     if (bits != MSG_PACKET_MIN_BITS && bits != MSG_PACKET_BITS) {
@@ -165,9 +164,7 @@ ttx201_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned 
     temperature = ((int8_t)((b[3] & 0x0f) << 4) << 4) | b[4]; // note the sign extend
     temperature_c = temperature / 10.0f;
 
-    local_time_str(0, time_str);
     data = data_make(
-            "time",          "",            DATA_STRING, time_str,
             "model",         "",            DATA_STRING, "Emos TTX201",
             "id",            "House Code",  DATA_INT,    device_id,
             "channel",       "Channel",     DATA_INT,    channel,
@@ -197,7 +194,6 @@ ttx201_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "channel",

--- a/src/devices/vaillant_vrt340f.c
+++ b/src/devices/vaillant_vrt340f.c
@@ -161,7 +161,7 @@ vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                          "water",   "Pre-heated Water", DATA_STRING, water_preheated ? "ON" : "off",
                          "battery", "Battery", DATA_STRING, isBatteryLow ? "Low" : "Ok",
                          NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
 
         return 1;
     }
@@ -180,7 +180,7 @@ vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                          "model",   "",	DATA_STRING,	"Vaillant VRT340f Central Heating Thermostat (RF Detection)",
                          "device",  "Device ID", DATA_INT, deviceID,
                          NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
 
         return 1;
     }

--- a/src/devices/vaillant_vrt340f.c
+++ b/src/devices/vaillant_vrt340f.c
@@ -92,7 +92,7 @@ get_battery_status(uint8_t * msg)
 }
 
 static int
-vaillant_vrt340_callback(bitbuffer_t *bitbuffer)
+vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     bitrow_t *bb = bitbuffer->bb;
 

--- a/src/devices/vaillant_vrt340f.c
+++ b/src/devices/vaillant_vrt340f.c
@@ -96,9 +96,7 @@ vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     bitrow_t *bb = bitbuffer->bb;
 
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
-    local_time_str(0, time_str);
 
     // TODO: Use repeat signal for error checking / correction!
 
@@ -153,7 +151,7 @@ vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         uint8_t water_preheated = get_water_preheated(bb[0]); // 1=Pre-heat, 0=no pre-heated water
         uint8_t isBatteryLow = get_battery_status(bb[0]);
 
-        data = data_make("time", "", DATA_STRING, time_str,
+        data = data_make(
                          "model",   "",	DATA_STRING,	"Vaillant VRT340f Central Heating Thermostat",
                          "device",  "Device ID", DATA_FORMAT, "0x%04X", DATA_INT, deviceID,
                          "heating", "Heating Mode", DATA_STRING, (heating_mode==0)?"OFF":((heating_mode==1)?"ON (2-point)":"ON (analogue)"),
@@ -176,7 +174,7 @@ vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         // Device ID starts at bit 12:
         uint16_t deviceID = get_device_id(bb[0], 11);
 
-        data = data_make("time", "", DATA_STRING, time_str,
+        data = data_make(
                          "model",   "",	DATA_STRING,	"Vaillant VRT340f Central Heating Thermostat (RF Detection)",
                          "device",  "Device ID", DATA_INT, deviceID,
                          NULL);
@@ -189,7 +187,6 @@ vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "device",
     "heating",

--- a/src/devices/vaillant_vrt340f.c
+++ b/src/devices/vaillant_vrt340f.c
@@ -31,14 +31,14 @@ calculate_checksum(uint8_t *buff, int from, int to) {
 }
 
 static int
-validate_checksum(uint8_t * msg, int from, int to, int cs_from, int cs_to)
+validate_checksum(r_device *decoder, uint8_t * msg, int from, int to, int cs_from, int cs_to)
 {
     // Fields cs_from and cs_to hold the 2-byte checksum as signed int
     int16_t expected = msg[cs_from]*0x100+ msg[cs_to];
     int16_t calculated = calculate_checksum(msg, from, to);
 
     if (expected != calculated) {
-        if (debug_output >= 1) {
+        if (decoder->verbose) {
             fprintf(stderr, "Checksum error in Vaillant VRT340f.  Expected: %04x  Calculated: %04x\n", expected, calculated);
             fprintf(stderr, "Message (data content of bytes %d-%d): ", from, to);
             bitrow_print(&msg[from], (to - from + 1) * 8);
@@ -142,7 +142,7 @@ vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     // "Normal package":
     if ((bb[0][0] == 0x00) && (bb[0][1] == 0x00) && (bb[0][2] == 0x7e) && (128 <= bitcount && bitcount <= 131)) {
 
-        if (!validate_checksum (bb[0], /* Data from-to: */3,11, /*Checksum from-to:*/12,13)) {
+        if (!validate_checksum(decoder, bb[0], /* Data from-to: */3,11, /*Checksum from-to:*/12,13)) {
             return 0;
         }
 
@@ -169,7 +169,7 @@ vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     // "RF detection package":
     if ((bb[0][0] == 0x00) && (bb[0][1] == 0x00) && (bb[0][2] == 0x7E) && (168 <= bitcount && bitcount <= 171)) {
 
-        if (!validate_checksum(bb[0], /* Data from-to: */3,16, /*Checksum from-to:*/17,18)) {
+        if (!validate_checksum(decoder, bb[0], /* Data from-to: */3,16, /*Checksum from-to:*/17,18)) {
             return 0;
         }
 

--- a/src/devices/valeo.c
+++ b/src/devices/valeo.c
@@ -11,7 +11,7 @@
 #include "decoder.h"
 
 
-static int valeo_callback(bitbuffer_t *bitbuffer) {
+static int valeo_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	bitrow_t *bb = bitbuffer->bb;
 
 	// Validate package

--- a/src/devices/waveman.c
+++ b/src/devices/waveman.c
@@ -13,7 +13,8 @@
  */
 #include "decoder.h"
 
-static int waveman_callback(bitbuffer_t *bitbuffer) {
+static int waveman_callback(r_device *decoder, bitbuffer_t *bitbuffer)
+{
     data_t *data;
     char time_str[LOCAL_TIME_BUFLEN];
     uint8_t *b = bitbuffer->bb[0];

--- a/src/devices/waveman.c
+++ b/src/devices/waveman.c
@@ -16,7 +16,6 @@
 static int waveman_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
     uint8_t *b = bitbuffer->bb[0];
     uint8_t nb[3] = {0}; // maps a pair of bits to two states, 1 0 -> 1 and 1 1 -> 0
     char id_str[2];
@@ -54,9 +53,7 @@ static int waveman_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     id_str[0] = 'A' + nb[0];
     id_str[1] = '\0';
 
-    local_time_str(0, time_str);
     data = data_make(
-        "time",     "",     DATA_STRING,    time_str,
         "model",    "",     DATA_STRING,    "Waveman Switch Transmitter",
         "id",       "",     DATA_STRING,    id_str,
         "channel",  "",     DATA_INT,       (nb[1] >> 2) + 1,
@@ -69,7 +66,6 @@ static int waveman_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "channel",

--- a/src/devices/waveman.c
+++ b/src/devices/waveman.c
@@ -63,7 +63,7 @@ static int waveman_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         "button",   "",     DATA_INT,       (nb[1] & 3) + 1,
         "state",    "",     DATA_STRING,    (nb[2] == 0xe) ? "on" : "off",
         NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }

--- a/src/devices/wg_pb12v1.c
+++ b/src/devices/wg_pb12v1.c
@@ -80,7 +80,7 @@ static int wg_pb12v1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             "temperature_C",    "Temperature",  DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
             "mic",              "Integrity",    DATA_STRING, "CRC",
             NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     return 1;
 }
 

--- a/src/devices/wg_pb12v1.c
+++ b/src/devices/wg_pb12v1.c
@@ -47,7 +47,6 @@
 static int wg_pb12v1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
     uint8_t *b;
 
     uint8_t id;
@@ -72,9 +71,7 @@ static int wg_pb12v1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     temp = ((b[1] & 0x0F) << 8) | b[2];
     temperature = ((float)temp / 10) - 40;
 
-    local_time_str(0, time_str);
     data = data_make(
-            "time",             "",             DATA_STRING, time_str,
             "model",            "",             DATA_STRING, "WG-PB12V1",
             "id",               "ID",           DATA_INT, id,
             "temperature_C",    "Temperature",  DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
@@ -85,7 +82,6 @@ static int wg_pb12v1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "temperature_C",

--- a/src/devices/wg_pb12v1.c
+++ b/src/devices/wg_pb12v1.c
@@ -44,7 +44,8 @@
 
 #include "decoder.h"
 
-static int wg_pb12v1_callback(bitbuffer_t *bitbuffer) {
+static int wg_pb12v1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
+{
     data_t *data;
     char time_str[LOCAL_TIME_BUFLEN];
     uint8_t *b;

--- a/src/devices/wssensor.c
+++ b/src/devices/wssensor.c
@@ -78,7 +78,7 @@ static int wssensor_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                      "temperature_C", "Temperature", DATA_FORMAT, "%.02f C", DATA_DOUBLE, temperature_c,
                      NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
     return 1;
 }
 

--- a/src/devices/wssensor.c
+++ b/src/devices/wssensor.c
@@ -30,7 +30,6 @@
 static int wssensor_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     uint8_t *b;
     data_t *data;
-    char time_str[LOCAL_TIME_BUFLEN];
 
     // the signal should have 23 repeats
     // require at least 4 received repeats
@@ -69,8 +68,7 @@ static int wssensor_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         fprintf(stdout, "TemperatureC	= %.1f\n", temperature_c);
     }
 
-    local_time_str(0, time_str);
-    data = data_make("time",          "",            DATA_STRING, time_str,
+    data = data_make(
                      "model",         "",            DATA_STRING, "WS Temperature Sensor",
                      "id",            "House Code",  DATA_INT, sensor_id,
                      "channel",       "Channel",     DATA_INT, channel,
@@ -83,7 +81,6 @@ static int wssensor_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "channel",

--- a/src/devices/wssensor.c
+++ b/src/devices/wssensor.c
@@ -56,7 +56,7 @@ static int wssensor_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
     temperature_c = temperature / 10.0f;
 
-    if (debug_output) {
+    if (decoder->verbose) {
         fprintf(stdout, "Hyundai WS SENZOR received raw data:\n");
         bitbuffer_print(bitbuffer);
         fprintf(stdout, "Sensor ID	= %01d = 0x%02x\n",  sensor_id, sensor_id);

--- a/src/devices/wssensor.c
+++ b/src/devices/wssensor.c
@@ -27,7 +27,7 @@
 #define WS_MINREPEATS	4
 #define WS_REPEATS	23
 
-static int wssensor_callback(bitbuffer_t *bitbuffer) {
+static int wssensor_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     uint8_t *b;
     data_t *data;
     char time_str[LOCAL_TIME_BUFLEN];

--- a/src/devices/wt0124.c
+++ b/src/devices/wt0124.c
@@ -31,7 +31,7 @@ X = xor checksum
 #include "decoder.h"
 
 
-static int wt1024_callback(bitbuffer_t *bitbuffer)
+static int wt1024_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;

--- a/src/devices/wt0124.c
+++ b/src/devices/wt0124.c
@@ -85,7 +85,7 @@ static int wt1024_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             "data",  "Data", DATA_INT,    value,
             NULL);
 
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     // Return 1 if message successfully decoded
     return 1;

--- a/src/devices/wt0124.c
+++ b/src/devices/wt0124.c
@@ -69,7 +69,7 @@ static int wt1024_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     /* unk */
     value = b[5];
 
-    if (debug_output) {
+    if (decoder->verbose) {
         fprintf(stderr, "wt1024_callback:");
         bitbuffer_print(bitbuffer);
     }

--- a/src/devices/wt0124.c
+++ b/src/devices/wt0124.c
@@ -33,7 +33,6 @@ X = xor checksum
 
 static int wt1024_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint8_t *b; // bits of a row
     uint16_t sensor_rid;
@@ -73,10 +72,8 @@ static int wt1024_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         fprintf(stderr, "wt1024_callback:");
         bitbuffer_print(bitbuffer);
     }
-    local_time_str(0, time_str);
 
     data = data_make(
-            "time",  "", DATA_STRING, time_str,
             "model", "", DATA_STRING, "WT0124 Pool Thermometer",
             "rid",    "Random ID", DATA_INT,    sensor_rid,
             "channel",       "Channel",     DATA_INT,    channel,
@@ -99,7 +96,6 @@ static int wt1024_callback(r_device *decoder, bitbuffer_t *bitbuffer)
  *
  */
 static char *output_fields[] = {
-    "time",
     "model",
     "rid",
     "channel",

--- a/src/devices/wt450.c
+++ b/src/devices/wt450.c
@@ -69,17 +69,15 @@ static int wt450_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     uint8_t bit;
     uint8_t parity = 0;
 
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
-    local_time_str(0, time_str);
 
 //bitbuffer_print(bitbuffer);
 
     if ( bitbuffer->bits_per_row[0] != 36 )
     {
         if (decoder->verbose)
-            fprintf(stderr, "%s wt450_callback: wrong size of bit per row %d\n",
-                    time_str, bitbuffer->bits_per_row[0]);
+            fprintf(stderr, "wt450_callback: wrong size of bit per row %d\n",
+                    bitbuffer->bits_per_row[0]);
 
         return 0;
     }
@@ -88,7 +86,7 @@ static int wt450_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     {
         if (decoder->verbose)
         {
-            fprintf(stderr, "%s wt450_callback: wrong preamble\n", time_str);
+            fprintf(stderr, "wt450_callback: wrong preamble\n");
             bitbuffer_print(bitbuffer);
         }
         return 0;
@@ -103,7 +101,7 @@ static int wt450_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     {
         if (decoder->verbose)
         {
-            fprintf(stderr, "%s wt450_callback: wrong parity\n", time_str);
+            fprintf(stderr, "wt450_callback: wrong parity\n");
             bitbuffer_print(bitbuffer);
         }
         return 0;
@@ -117,7 +115,7 @@ static int wt450_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     temp_fraction = ((b[3] & 0xF) << 3) + (b[4] >> 5);
     temp = (temp_whole - 50) + (temp_fraction/100.0);
 
-    data = data_make("time",          "",  DATA_STRING, time_str,
+    data = data_make(
         "model",         "",	   DATA_STRING, "WT450 sensor",
         "id",            "House Code", DATA_INT, house_code,
         "channel",       "Channel",    DATA_INT, channel,
@@ -131,7 +129,6 @@ static int wt450_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "channel",

--- a/src/devices/wt450.c
+++ b/src/devices/wt450.c
@@ -55,7 +55,7 @@
 
 #include "decoder.h"
 
-static int wt450_callback(bitbuffer_t *bitbuffer) {
+static int wt450_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     bitrow_t *bb = bitbuffer->bb;
     uint8_t *b = bb[0];
 

--- a/src/devices/wt450.c
+++ b/src/devices/wt450.c
@@ -77,7 +77,7 @@ static int wt450_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
     if ( bitbuffer->bits_per_row[0] != 36 )
     {
-        if (debug_output)
+        if (decoder->verbose)
             fprintf(stderr, "%s wt450_callback: wrong size of bit per row %d\n",
                     time_str, bitbuffer->bits_per_row[0]);
 
@@ -86,7 +86,7 @@ static int wt450_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
     if ( b[0]>>4 != 0xC )
     {
-        if (debug_output)
+        if (decoder->verbose)
         {
             fprintf(stderr, "%s wt450_callback: wrong preamble\n", time_str);
             bitbuffer_print(bitbuffer);
@@ -101,7 +101,7 @@ static int wt450_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
     if ( parity )
     {
-        if (debug_output)
+        if (decoder->verbose)
         {
             fprintf(stderr, "%s wt450_callback: wrong parity\n", time_str);
             bitbuffer_print(bitbuffer);

--- a/src/devices/wt450.c
+++ b/src/devices/wt450.c
@@ -125,7 +125,7 @@ static int wt450_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         "temperature_C", "Temperature",DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp,
         "humidity",      "Humidity",   DATA_FORMAT, "%u %%", DATA_INT, humidity,
         NULL);
-    data_acquired_handler(data);
+    decoder_output_data(decoder, data);
 
     return 1;
 }

--- a/src/devices/x10_rf.c
+++ b/src/devices/x10_rf.c
@@ -11,7 +11,7 @@
  */
 #include "decoder.h"
 
-static int X10_RF_callback(bitbuffer_t *bitbuffer) {
+static int X10_RF_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 	bitrow_t *bb = bitbuffer->bb;
 
 	uint8_t arrbKnownConstBitMask[4]  = {0x0B, 0x0B, 0x87, 0x87};

--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -88,7 +88,7 @@ static int x10_sec_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         local_time_str(0, time_str);
 
         /* debug output */
-        if (debug_output) {
+        if (decoder->verbose) {
             fprintf(stderr, "%20s  X10SEC: id=%02x%02x code=%02x event_str=%s\n", time_str, b[0], b[4], b[2], event_str);
             bitbuffer_print(bitbuffer);
         }

--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -25,7 +25,7 @@
 
 #include "decoder.h"
 
-static int x10_sec_callback(bitbuffer_t *bitbuffer) {
+static int x10_sec_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint16_t r;                          /* a row index              */

--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -26,7 +26,6 @@
 #include "decoder.h"
 
 static int x10_sec_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
-    char time_str[LOCAL_TIME_BUFLEN];
     data_t *data;
     uint16_t r;                          /* a row index              */
     uint8_t *b;                          /* bits of a row            */
@@ -82,20 +81,18 @@ static int x10_sec_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                 break;
         }
 
-        /* get x10_id_str, x10_code_str, and time_str ready for output */
+        /* get x10_id_str, x10_code_str ready for output */
         sprintf(x10_id_str, "%02x%02x", b[0], b[4]);
         sprintf(x10_code_str, "%02x", b[2]);
-        local_time_str(0, time_str);
 
         /* debug output */
         if (decoder->verbose) {
-            fprintf(stderr, "%20s  X10SEC: id=%02x%02x code=%02x event_str=%s\n", time_str, b[0], b[4], b[2], event_str);
+            fprintf(stderr, "X10SEC: id=%02x%02x code=%02x event_str=%s\n", b[0], b[4], b[2], event_str);
             bitbuffer_print(bitbuffer);
         }
 
         /* build and handle data set for normal output */
         data = data_make(
-                "time",     "",             DATA_STRING, time_str,
                 "model",    "",             DATA_STRING, "X10 Security",
                 "id",       "Device ID",    DATA_STRING, x10_id_str,
                 "code",     "Code",         DATA_STRING, x10_code_str,
@@ -108,7 +105,6 @@ static int x10_sec_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 }
 
 static char *output_fields[] = {
-    "time",
     "model",
     "id",
     "code",

--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -101,7 +101,7 @@ static int x10_sec_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                 "code",     "Code",         DATA_STRING, x10_code_str,
                 "event",    "Event",        DATA_STRING, event_str,
                 NULL);
-        data_acquired_handler(data);
+        decoder_output_data(decoder, data);
         return 1;
     }
     return 0;

--- a/src/pulse_demod.c
+++ b/src/pulse_demod.c
@@ -62,7 +62,7 @@ int pulse_demod_pcm(const pulse_data_t *pulses, r_device *device)
 				&& (bits.bits_per_row[0] > 0)		// Only if data has been accumulated
 		) {
 			if (device->json_callback) {
-				events += device->json_callback(&bits);
+				events += device->json_callback(device, &bits);
 			}
 			// Debug printout
 			if(!device->json_callback || (debug_output && events > 0)) {
@@ -93,7 +93,7 @@ int pulse_demod_ppm(const pulse_data_t *pulses, r_device *device) {
 		// End of Message?
 		} else {
 			if (device->json_callback) {
-				events += device->json_callback(&bits);
+				events += device->json_callback(device, &bits);
 			}
 			// Debug printout
 			if(!device->json_callback || (debug_output && events > 0)) {
@@ -185,7 +185,7 @@ int pulse_demod_pwm(const pulse_data_t *pulses, r_device *device)
 				|| (pulses->gap[n] > device->s_reset_limit)) // Long silence (OOK)
 				&& (bits.num_rows > 0)) { // Only if data has been accumulated
 			if (device->json_callback) {
-				events += device->json_callback(&bits);
+				events += device->json_callback(device, &bits);
 			}
 			// Debug printout
 			if (!device->json_callback || (debug_output && events > 0)) {
@@ -235,7 +235,7 @@ int pulse_demod_manchester_zerobit(const pulse_data_t *pulses, r_device *device)
 		if(pulses->gap[n] > device->s_reset_limit) {
 			int newevents = 0;
 			if (device->json_callback) {
-				events += device->json_callback(&bits);
+				events += device->json_callback(device, &bits);
 			}
 			// Debug printout
 			if(!device->json_callback || (debug_output && events > 0)) {
@@ -293,7 +293,7 @@ int pulse_demod_dmc(const pulse_data_t *pulses, r_device *device) {
 			&& bits.num_rows > 0) { // Only if data has been accumulated
 			//END message ?
 			if (device->json_callback) {
-				events += device->json_callback(&bits);
+				events += device->json_callback(device, &bits);
 			}
 			if(!device->json_callback || (debug_output && events > 0)) {
 				fprintf(stderr, "pulse_demod_dmc(): %s \n", device->name);
@@ -341,7 +341,7 @@ int pulse_demod_piwm_raw(const pulse_data_t *pulses, r_device *device) {
 				&& (bits.num_rows > 0)) { // Only if data has been accumulated
 			//END message ?
 			if (device->json_callback) {
-				events += device->json_callback(&bits);
+				events += device->json_callback(device, &bits);
 			}
 			if(!device->json_callback || (debug_output && events > 0)) {
 				fprintf(stderr, "pulse_demod_piwm_raw(): %s \n", device->name);
@@ -387,7 +387,7 @@ int pulse_demod_piwm_dc(const pulse_data_t *pulses, r_device *device) {
 				&& (bits.num_rows > 0)) { // Only if data has been accumulated
 			//END message ?
 			if (device->json_callback) {
-				events += device->json_callback(&bits);
+				events += device->json_callback(device, &bits);
 			}
 			if(!device->json_callback || (debug_output && events > 0)) {
 				fprintf(stderr, "pulse_demod_piwm_dc(): %s \n", device->name);
@@ -458,7 +458,7 @@ int pulse_demod_osv1(const pulse_data_t *pulses, r_device *device) {
 		}
 		if (n == pulses->num_pulses - 1 || pulses->gap[n] > device->s_reset_limit) {
 			if((bits.bits_per_row[bits.num_rows-1] == 32) && device->json_callback) {
-				events += device->json_callback(&bits);
+				events += device->json_callback(device,&bits);
 			}
 			return(events);
 		}
@@ -481,7 +481,7 @@ int pulse_demod_string(const char *code, r_device *device)
 	bitbuffer_parse(&bits, code);
 
 	if (device->json_callback) {
-		events += device->json_callback(&bits);
+		events += device->json_callback(device, &bits);
 	}
 	// Debug printout
 	if(!device->json_callback || (debug_output && events > 0)) {

--- a/src/pulse_demod.c
+++ b/src/pulse_demod.c
@@ -18,6 +18,7 @@
 #include <math.h>
 #include <limits.h>
 
+extern int debug_output;
 
 int pulse_demod_pcm(const pulse_data_t *pulses, r_device *device)
 {

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -498,6 +498,14 @@ void data_acquired_handler(data_t *data)
                 NULL);
     }
 
+    // always prepend "time"
+    char time_str[LOCAL_TIME_BUFLEN];
+    local_time_str(0, time_str);
+    data = data_prepend(data,
+            "time", "", DATA_STRING, time_str,
+            NULL);
+
+    // prepend "tag" if available
     if (cfg.output_tag) {
         char const *output_tag = cfg.output_tag;
         if (cfg.in_filename && !strcmp("PATH", cfg.output_tag)) {
@@ -1315,10 +1323,10 @@ static void parse_conf_option(struct app_cfg *cfg, int opt, char *arg)
     }
 }
 
-// well-known fields "msg" and "codes" are used to output general decoder messages
+// well-known fields "time", "msg" and "codes" are used to output general decoder messages
 // well-known field "tag" is only used when output tagging is requested
-static char const *well_known_with_tag[]  = {"msg", "codes", "tag", NULL};
-static char const *well_known_default[] = {"msg", "codes", NULL};
+static char const *well_known_with_tag[]  = {"time", "msg", "codes", "tag", NULL};
+static char const *well_known_default[] = {"time", "msg", "codes", NULL};
 static char const **well_known_output_fields(struct app_cfg *cfg)
 {
     if (cfg->output_tag) {

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -362,6 +362,16 @@ static void calc_rssi_snr(pulse_data_t *pulse_data)
     }
 }
 
+static char *time_pos_str(time_t time_secs, char *buf)
+{
+    if (sample_file_pos != -1.0) {
+        return sample_pos_str(sample_file_pos, buf);
+    }
+    else {
+        return local_time_str(0, buf);
+    }
+}
+
 /** Pass the data structure to all output handlers. Frees data afterwards. */
 void data_acquired_handler(data_t *data)
 {
@@ -500,7 +510,7 @@ void data_acquired_handler(data_t *data)
 
     // always prepend "time"
     char time_str[LOCAL_TIME_BUFLEN];
-    local_time_str(0, time_str);
+    time_pos_str(0, time_str);
     data = data_prepend(data,
             "time", "", DATA_STRING, time_str,
             NULL);
@@ -592,7 +602,7 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
             int p_events = 0; // Sensor events successfully detected per package
             package_type = pulse_detect_package(demod->am_buf, demod->buf.fm, n_samples, demod->level_limit, cfg.samp_rate, cfg.input_pos, &demod->pulse_data, &demod->fsk_pulse_data);
             if (package_type == 1) {
-                if (demod->analyze_pulses) fprintf(stderr, "Detected OOK package\t@ %s\n", local_time_str(0, time_str));
+                if (demod->analyze_pulses) fprintf(stderr, "Detected OOK package\t@ %s\n", time_pos_str(0, time_str));
                 for (i = 0; i < demod->r_dev_num; i++) {
                     switch (demod->r_devs[i]->modulation) {
                         case OOK_PULSE_PCM_RZ:
@@ -640,7 +650,7 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
                     pulse_analyzer(&demod->pulse_data, cfg.samp_rate);
                 }
             } else if (package_type == 2) {
-                if (demod->analyze_pulses) fprintf(stderr, "Detected FSK package\t@ %s\n", local_time_str(0, time_str));
+                if (demod->analyze_pulses) fprintf(stderr, "Detected FSK package\t@ %s\n", time_pos_str(0, time_str));
                 for (i = 0; i < demod->r_dev_num; i++) {
                     switch (demod->r_devs[i]->modulation) {
                         // OOK decoders

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -50,6 +50,8 @@
 
 r_device *flex_create_device(char *spec); // maybe put this in some header file?
 
+void data_acquired_handler(data_t *data);
+
 typedef enum {
     CONVERT_NATIVE,
     CONVERT_SI,
@@ -360,7 +362,7 @@ static void calc_rssi_snr(pulse_data_t *pulse_data)
     }
 }
 
-/* handles incoming structured data by dumping it */
+/** Pass the data structure to all output handlers. Frees data afterwards. */
 void data_acquired_handler(data_t *data)
 {
     if (cfg.conversion_mode == CONVERT_SI) {

--- a/src/util.c
+++ b/src/util.c
@@ -221,26 +221,27 @@ int byteParity(uint8_t inByte)
     return (0x6996 >> inByte) & 1;
 }
 
-
-char* local_time_str(time_t time_secs, char *buf)
+char *local_time_str(time_t time_secs, char *buf)
 {
     time_t etime;
     struct tm *tm_info;
 
     if (time_secs == 0) {
-        extern float sample_file_pos;
-        if (sample_file_pos != -1.0) {
-            snprintf(buf, LOCAL_TIME_BUFLEN, "@%fs", sample_file_pos);
-            return buf;
-        }
         time(&etime);
-    } else {
+    }
+    else {
         etime = time_secs;
     }
 
     tm_info = localtime(&etime); // note: win32 doesn't have localtime_r()
 
     strftime(buf, LOCAL_TIME_BUFLEN, "%Y-%m-%d %H:%M:%S", tm_info);
+    return buf;
+}
+
+char *sample_pos_str(float sample_file_pos, char *buf)
+{
+    snprintf(buf, LOCAL_TIME_BUFLEN, "@%fs", sample_file_pos);
     return buf;
 }
 


### PR DESCRIPTION
This decouples decoders from the CLI by replacing global references with a context.
Basically just adds a decoder reference to the device callbacks to reach the verbosity flag and the data_acquired callback.