### PR TITLE
Modernize the signal grabber

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,10 @@ Usage:	= General options =
 	[-a] Analyze mode. Print a textual description of the signal.
 	[-A] Pulse Analyzer. Enable pulse analysis and decode attempt.
 		 Disable all decoders with -R 0 if you want analyzer output only.
-	[-I] Include only: 0 = all (default), 1 = unknown devices, 2 = known devices
 	[-y <code>] Verify decoding of demodulated test data (e.g. "{25}fb2dd58") with enabled devices
 	= File I/O options =
-	[-t] Test signal auto save. Use it together with analyze mode (-a -t). Creates one file per signal
-		 Note: Saves raw I/Q samples (uint8 pcm, 2 channel). Preferred mode for generating test files
+	[-S none|all|unknown|known] Signal auto save. Creates one file per signal.
+		 Note: Saves raw I/Q samples (uint8 pcm, 2 channel). Preferred mode for generating test files.
 	[-r <filename>] Read data from input file instead of a receiver
 	[-w <filename>] Save data stream to output file (a '-' dumps samples to stdout)
 	[-W <filename>] Save data stream to output file, overwrite existing file

--- a/include/pulse_detect.h
+++ b/include/pulse_detect.h
@@ -25,6 +25,8 @@
 /// Data for a compact representation of generic pulse train
 typedef struct {
 	uint64_t offset;			// Offset to first pulse in number of samples from start of stream
+	unsigned start_ago;			// Start of first pulse in number of samples ago
+	unsigned end_ago;			// End of last pulse in number of samples ago
 	unsigned int num_pulses;
 	int pulse[PD_MAX_PULSES];	// Contains width of a pulse	(high)
 	int gap[PD_MAX_PULSES];		// Width of gaps between pulses (low)

--- a/rtl_433.example.conf
+++ b/rtl_433.example.conf
@@ -108,10 +108,6 @@ analyze false
 analyze_pulses false
 
 # as command line option:
-#   [-I] Include only: 0 = all (default), 1 = unknown devices, 2 = known devices
-include_only 0
-
-# as command line option:
 #   [-b] Out block size: 262144 (default)
 #out_block_size
 
@@ -126,9 +122,9 @@ include_only 0
 ## File I/O options
 
 # as command line option:
-#   [-t] Test signal auto save. Use it together with analyze mode (-a -t). Creates one file per signal
-# 	 Note: Saves raw I/Q samples (uint8 pcm, 2 channel). Preferred mode for generating test files
-signal_grabber false
+#   [-S none|all|unknown|known] Signal auto save. Creates one file per signal.
+# 	 Note: Saves raw I/Q samples (uint8 pcm, 2 channel). Preferred mode for generating test files.
+signal_grabber none
 
 # as command line option:
 #   [-r <filename>] Read data from input file instead of a receiver

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -280,6 +280,9 @@ int pulse_detect_package(const int16_t *envelope_data, const int16_t *fm_data, i
 	pulse_state_t *s = &pulse_state;
 	s->ook_high_estimate = max(s->ook_high_estimate, OOK_MIN_HIGH_LEVEL);	// Be sure to set initial minimum level
 
+	pulses->start_ago += len;
+	fsk_pulses->start_ago += len;
+
 	// Process all new samples
 	while(s->data_counter < len) {
 		// Calculate OOK detection threshold and hysteresis
@@ -299,6 +302,8 @@ int pulse_detect_package(const int16_t *envelope_data, const int16_t *fm_data, i
 					pulse_data_clear(fsk_pulses);
 					pulses->offset = sample_offset + s->data_counter;
 					fsk_pulses->offset = sample_offset + s->data_counter;
+					pulses->start_ago = len - s->data_counter;
+					fsk_pulses->start_ago = len - s->data_counter;
 					s->pulse_length = 0;
 					s->max_pulse = 0;
 					s->FSK_state = (pulse_FSK_state_t){0};
@@ -361,6 +366,8 @@ int pulse_detect_package(const int16_t *envelope_data, const int16_t *fm_data, i
 						fsk_pulses->fsk_f2_est = s->FSK_state.fm_f2_est;
 						fsk_pulses->ook_low_estimate = s->ook_low_estimate;
 						fsk_pulses->ook_high_estimate = s->ook_high_estimate;
+						pulses->end_ago = len - s->data_counter;
+						fsk_pulses->end_ago = len - s->data_counter;
 						s->ook_state = PD_OOK_STATE_IDLE;	// Ensure everything is reset
 						return 2;	// FSK package detected!!!
 					}
@@ -383,6 +390,7 @@ int pulse_detect_package(const int16_t *envelope_data, const int16_t *fm_data, i
 						// Store estimates
 						pulses->ook_low_estimate = s->ook_low_estimate;
 						pulses->ook_high_estimate = s->ook_high_estimate;
+						pulses->end_ago = len - s->data_counter;
 						return 1;	// End Of Package!!
 					}
 
@@ -401,6 +409,7 @@ int pulse_detect_package(const int16_t *envelope_data, const int16_t *fm_data, i
 					// Store estimates
 					pulses->ook_low_estimate = s->ook_low_estimate;
 					pulses->ook_high_estimate = s->ook_high_estimate;
+					pulses->end_ago = len - s->data_counter;
 					return 1;	// End Of Package!!
 				}
 				break;

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -133,6 +133,9 @@ struct dm_state {
 
     pulse_data_t    pulse_data;
     pulse_data_t    fsk_pulse_data;
+    unsigned frame_event_count;
+    unsigned frame_start_ago;
+    unsigned frame_end_ago;
 };
 
 static void version(void)
@@ -559,6 +562,12 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
 
     n_samples = len / 2 / demod->sample_size;
 
+    // age the frame position if there is one
+    if (demod->frame_start_ago)
+        demod->frame_start_ago += n_samples;
+    if (demod->frame_end_ago)
+        demod->frame_end_ago += n_samples;
+
 #ifndef _WIN32
     alarm(3); // require callback to run every 3 second, abort otherwise
 #endif
@@ -596,7 +605,7 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
     }
 
     int d_events = 0; // Sensor events successfully detected
-    if (demod->r_dev_num || demod->analyze_pulses || (demod->dumper->spec)) {
+    if (demod->r_dev_num || demod->analyze_pulses || demod->dumper->spec || demod->samp_grab) {
         // Detect a package and loop through demodulators with pulse data
         int package_type = 1;  // Just to get us started
         for (file_info_t const *dumper = demod->dumper; dumper->spec && *dumper->spec; ++dumper) {
@@ -608,6 +617,13 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
         while (package_type) {
             int p_events = 0; // Sensor events successfully detected per package
             package_type = pulse_detect_package(demod->am_buf, demod->buf.fm, n_samples, demod->level_limit, cfg.samp_rate, cfg.input_pos, &demod->pulse_data, &demod->fsk_pulse_data);
+            if (package_type) {
+                // new package: set a first frame start if we are not tracking one already
+                if (!demod->frame_start_ago)
+                    demod->frame_start_ago = demod->pulse_data.start_ago;
+                // always update the last frame end
+                demod->frame_end_ago = demod->pulse_data.end_ago;
+            }
             if (package_type == 1) {
                 if (demod->analyze_pulses) fprintf(stderr, "Detected OOK package\t@ %s\n", time_pos_str(0, time_str));
                 for (i = 0; i < demod->r_dev_num; i++) {
@@ -696,6 +712,26 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
             d_events += p_events;
         } // while (package_type)...
 
+        // add event counter to the frames currently tracked
+        demod->frame_event_count += d_events;
+
+        // end frame tracking if older than a whole buffer
+        if (demod->frame_start_ago && demod->frame_end_ago > n_samples) {
+            if (demod->samp_grab) {
+                if (cfg.include_only == 0
+                        || (cfg.include_only == 1 && demod->frame_event_count == 0)
+                        || (cfg.include_only == 2 && demod->frame_event_count > 0)) {
+                    unsigned frame_pad = n_samples / 8; // this could also be a fixed value, e.g. 10000 samples
+                    unsigned start_padded = demod->frame_start_ago + frame_pad;
+                    unsigned end_padded = demod->frame_end_ago - frame_pad;
+                    unsigned len_padded = start_padded - end_padded;
+                    samp_grab_write(demod->samp_grab, len_padded, end_padded);
+                }
+            }
+            demod->frame_start_ago = 0;
+            demod->frame_event_count = 0;
+        }
+
         // dump partial pulse_data for this buffer
         for (file_info_t const *dumper = demod->dumper; dumper->spec && *dumper->spec; ++dumper) {
             if (dumper->format == U8_LOGIC) {
@@ -712,11 +748,7 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
     }
 
     if (demod->am_analyze) {
-        if (cfg.include_only == 0 || (cfg.include_only == 1 && d_events == 0) || (cfg.include_only == 2 && d_events > 0)) {
-            am_analyze(demod->am_analyze, demod->am_buf, n_samples, debug_output, demod->samp_grab);
-        } else {
-            am_analyze_skip(demod->am_analyze, n_samples);
-        }
+        am_analyze(demod->am_analyze, demod->am_buf, n_samples, debug_output, NULL);
     }
 
     for (file_info_t const *dumper = demod->dumper; dumper->spec && *dumper->spec; ++dumper) {


### PR DESCRIPTION
Use pulse detect to track and grab frames, instead of the fixed level AM Analyzer.
Deprecate option `-t` and `-I` for new `-S none|all|unknown|known`.

There is a deprecation note when using -t or -I instructing the user to use -S.

The signal grabber can now be run in normal decoding without analyzers.

Instead of `-a -t` users should now be adviced to use `-S all` or `-S unknown`.