### PR TITLE
Add precision time and time report options

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,10 @@ Usage:	= General options =
 	[-F kv|json|csv|syslog|null] Produce decoded output in given format. Not yet supported by all drivers.
 		 Append output to file with :<filename> (e.g. -F csv:log.csv), defaults to stdout.
 		 Specify host/port for syslog with e.g. -F syslog:127.0.0.1:1514
-	[-M none|level] Add metadata on modulation, frequency, RSSI, SNR, and noise to every output line.
+	[-M time|reltime|notime|hires|utc|noutc|level] Add various meta data to every output line.
 	[-K FILE|PATH|<tag>] Add an expanded token or fixed tag to every output line.
 	[-C native|si|customary] Convert units in decoded output.
 	[-T <seconds>] Specify number of seconds to run
-	[-U] Print timestamps in UTC (this may also be accomplished by invocation with TZ environment variable set).
 	[-E] Stop after outputting successful event(s)
 	[-h] Output this usage help and exit
 		 Use -d, -g, -R, -X, -F, -M, -r, or -w without argument for more help

--- a/include/util.h
+++ b/include/util.h
@@ -15,7 +15,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <time.h>
-
+#include <sys/time.h>
 
 #if defined _MSC_VER // Microsoft Visual Studio
 	#define restrict  __restrict
@@ -115,8 +115,13 @@ uint16_t lfsr_digest16(uint32_t data, int bits, uint16_t gen, uint16_t key);
 /// @return 1 odd parity, 0 even parity
 int byteParity(uint8_t inByte);
 
-// buffer to hold localized timestamp YYYY-MM-DD HH:MM:SS
+// buffer to hold localized timestamp "YYYY-MM-DD HH:MM:SS.000000"
 #define LOCAL_TIME_BUFLEN	32
+
+/// Get current time with usec precision.
+///
+/// @param tv: output for current time
+void get_time_now(struct timeval *tv);
 
 /// Printable timestamp in local time
 ///
@@ -124,6 +129,13 @@ int byteParity(uint8_t inByte);
 /// @param buf: output buffer, long enough for "YYYY-MM-DD HH:MM:SS"
 /// @return buf pointer (for short hand use as operator)
 char* local_time_str(time_t time_secs, char *buf);
+
+/// Printable timestamp in local time with microseconds.
+///
+/// @param tv: NULL for now, or seconds and microseconds since the epoch
+/// @param buf: output buffer, long enough for "YYYY-MM-DD HH:MM:SS"
+/// @return buf pointer (for short hand use as operator)
+char *usecs_time_str(struct timeval *tv, char *buf);
 
 /// Printable sample position
 ///

--- a/rtl_433.example.conf
+++ b/rtl_433.example.conf
@@ -112,8 +112,15 @@ analyze_pulses false
 #out_block_size
 
 # as command line option:
-#   [-M level] Add metadata on modulation, frequency, RSSI, SNR, and noise to every output line.
-#report_meta level
+#   [-M time|reltime|notime|hires|utc|noutc|level] Add various meta data to every output line.
+# Use "time" to add current date and time meta data (preset for live inputs).
+# Use "reltime" to add sample position meta data (preset for read-file and stdin).
+# Use "notime" to remove time meta data.
+# Use "hires" to add microsecods to date time meta data.
+# Use "utc" to output timestamps in UTC (this may also be accomplished by invocation with TZ environment variable set).
+# Use "level" to add Modulation, Frequency, RSSI, SNR, and Noise meta data.
+report_meta level
+report_meta hires
 
 # as command line option:
 #   [-y <code>] Verify decoding of demodulated test data (e.g. "{25}fb2dd58") with enabled devices
@@ -155,10 +162,6 @@ convert si
 # as command line option:
 #   [-T] specify number of seconds to run
 #duration 0
-
-# as command line option:
-#   [-U] Print timestamps in UTC (this may also be accomplished by invocation with TZ environment variable set).
-utc_mode false
 
 # as command line option:
 #   [-E] Stop after outputting successful event(s)


### PR DESCRIPTION
Like @merbanan suggested this snapshots the current time when a buffer is received and reports time with exact frame start precision.
Adds meta data options to add microseconds on time output, select sample position or data/time output.
Sample position output now shows the exact frame start instead of buffer start.