### PR TITLE
Change KV printer to prettier console output

### DIFF
--- a/include/term_ctl.h
+++ b/include/term_ctl.h
@@ -1,0 +1,49 @@
+/**
+ * Terminal control utility functions.
+ *
+ * Copyright (C) 2018 Christian Zuckschwerdt
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef INCLUDE_TERM_CTL_H_
+#define INCLUDE_TERM_CTL_H_
+
+#include <stdio.h>
+
+int term_get_columns(int fd);
+
+int term_has_color(FILE *fp);
+
+void term_init(FILE *fp);
+
+void term_ring_bell(FILE *fp);
+
+typedef enum term_color {
+    TERM_COLOR_RESET          = 0,
+    TERM_COLOR_BLACK          = 30,
+    TERM_COLOR_RED            = 31,
+    TERM_COLOR_GREEN          = 32,
+    TERM_COLOR_YELLOW         = 33,
+    TERM_COLOR_BLUE           = 34,
+    TERM_COLOR_MAGENTA        = 35,
+    TERM_COLOR_CYAN           = 36,
+    TERM_COLOR_WHITE          = 37,
+    TERM_COLOR_BRIGHT_BLACK   = 90,
+    TERM_COLOR_BRIGHT_RED     = 91,
+    TERM_COLOR_BRIGHT_GREEN   = 92,
+    TERM_COLOR_BRIGHT_YELLOW  = 93,
+    TERM_COLOR_BRIGHT_BLUE    = 94,
+    TERM_COLOR_BRIGHT_MAGENTA = 95,
+    TERM_COLOR_BRIGHT_CYAN    = 96,
+    TERM_COLOR_BRIGHT_WHITE   = 97,
+} term_color_t;
+
+void term_set_fg(FILE *fp, term_color_t color);
+
+void term_set_bg(FILE *fp, term_color_t color);
+
+#endif /* INCLUDE_TERM_CTL_H_ */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(rtl_433
 	rtl_433.c
 	samp_grab.c
 	sdr.c
+	term_ctl.c
 	util.c
 	devices/acurite.c
 	devices/akhan_100F14.c
@@ -132,7 +133,7 @@ add_executable(rtl_433
 	devices/x10_sec.c
 )
 
-add_library(data data.c)
+add_library(data data.c term_ctl.c)
 target_link_libraries(data ${NET_LIBRARIES})
 
 target_link_libraries(rtl_433

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,6 +16,7 @@ rtl_433_SOURCES      = am_analyze.c \
                        rtl_433.c \
                        samp_grab.c \
                        sdr.c \
+                       term_ctl.c \
                        util.c \
                        devices/acurite.c \
                        devices/akhan_100F14.c \

--- a/src/term_ctl.c
+++ b/src/term_ctl.c
@@ -1,0 +1,80 @@
+/**
+ * Terminal control utility functions.
+ *
+ * Copyright (C) 2018 Christian Zuckschwerdt
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#ifndef _WIN32
+#include <sys/ioctl.h>
+#endif
+
+#include "term_ctl.h"
+
+int term_get_columns(int fd)
+{
+#ifndef _WIN32
+    struct winsize w;
+    ioctl(fd, TIOCGWINSZ, &w);
+    return w.ws_col;
+#else
+    return 80; // default
+#endif
+}
+
+int term_has_color(FILE *fp)
+{
+#ifndef _WIN32
+    return isatty(fileno(fp)); // || get_env("force_color")
+#else
+    return 0; // default
+#endif
+}
+
+void term_init(FILE *fp)
+{
+#ifndef _WIN32
+    // nothing to do
+#else
+    // ...
+#endif
+}
+
+void term_ring_bell(FILE *fp)
+{
+#ifndef _WIN32
+    fprintf(fp, "\a");
+#else
+    // nop
+#endif
+}
+
+void term_set_fg(FILE *fp, term_color_t color)
+{
+#ifndef _WIN32
+    if (color == TERM_COLOR_RESET)
+        fprintf(fp, "\033[0m");
+    else
+        fprintf(fp, "\033[%d;1m", color);
+#else
+    // nop
+#endif
+}
+
+void term_set_bg(FILE *fp, term_color_t color)
+{
+#ifndef _WIN32
+    if (color == TERM_COLOR_RESET)
+        fprintf(fp, "\033[0m");
+    else
+        fprintf(fp, "\033[%d;1m", color + 10);
+#else
+    // nop
+#endif
+}

--- a/vs15/rtl_433.vcxproj
+++ b/vs15/rtl_433.vcxproj
@@ -100,6 +100,7 @@
     <ClInclude Include="..\include\rtl_433_devices.h" />
     <ClInclude Include="..\include\samp_grab.h" />
     <ClInclude Include="..\include\sdr.h" />
+    <ClInclude Include="..\include\term_ctl.h" />
     <ClInclude Include="..\include\util.h" />
     <ClInclude Include="..\src\getopt\getopt.h" />
   </ItemGroup>
@@ -117,6 +118,7 @@
     <ClCompile Include="..\src\rtl_433.c" />
     <ClCompile Include="..\src\samp_grab.c" />
     <ClCompile Include="..\src\sdr.c" />
+    <ClCompile Include="..\src\term_ctl.c" />
     <ClCompile Include="..\src\util.c" />
     <ClCompile Include="..\src\devices\acurite.c" />
     <ClCompile Include="..\src\devices\akhan_100F14.c" />

--- a/vs15/rtl_433.vcxproj.filters
+++ b/vs15/rtl_433.vcxproj.filters
@@ -62,6 +62,9 @@
     <ClInclude Include="..\include\sdr.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\term_ctl.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\include\util.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -110,6 +113,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\src\sdr.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\term_ctl.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\src\util.c">


### PR DESCRIPTION
I never use the KV output, it is however the first thing new users see as it's the default output. And it really makes a bad first impression.
Most decoder outputs omit (part) of the pretty_keys. I guess that feature was intended for well-known keys like "time" and for compound keys like model/id. The KV output just omits the key and put all values in-line. The result very often looks like broken CSV.

I assume KV output doesn't need to be machine parseable (it currently isn't).
All values should have a key (fallback to key if there is no pretty_key), users can't be expected to guess field names from values.
Each data_acquired output should be delimited. The output should make use of "columns" to be as compact as possible. We can possibly detect the terminal width, otherwise assume 80 characters. That should fit three Key : Value columns. We should also break before/after certain known keys for a mostly consistent output layout.
If the output goes to a terminal we can add escape sequences to colorize important bits.

There is certainly more to be considered, happy to incorporate all ideas. This PR is a very rough sketch how things could look.