### PR TITLE
Plug a mem-leak in sdr_close()

### DIFF
--- a/src/sdr.c
+++ b/src/sdr.c
@@ -728,6 +728,7 @@ int sdr_close(sdr_dev_t *dev)
 #endif
 
     free(dev->buffer);
+    free(dev);
     return ret;
 }
 


### PR DESCRIPTION
A small fix to free the memory allocated in `rtltcp_open()`, `sdr_open_rtl()` or `sdr_open_soapy()`. 

(There are more leaks. More PRs coming up?).