### PR TITLE
Always print version, register decoder ranges, quiet default add -v

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Running:
 
 ```
 Usage:	= General options =
-	[-q] Quiet mode, suppress non-data messages
-	[-D] Print debug info on event (repeat for more info)
 	[-V] Output the version string and exit
+	[-v] Increase verbosity (can be used multiple times).
+		 -v : verbose, -vv : verbose decoders, -vvv : debug decoders, -vvvv : trace decoding).
 	[-c <path>] Read config options from a file
 	= Tuner options =
 	[-d <RTL-SDR USB device index> | :<RTL-SDR USB device serial> | <SoapySDR device query> | rtl_tcp]

--- a/rtl_433.example.conf
+++ b/rtl_433.example.conf
@@ -19,13 +19,9 @@
 ## General options
 
 # as command line option:
-#   [-q] Quiet mode, suppress non-data messages
-# alias of "verbose = 0"
-#quiet
-
-# as command line option:
-#   [-D] Print debug info on event (repeat for more info)
-# 0=quiet, 1=normal, 2=verbose, 3=debug, 4=trace
+#   [-v] Increase verbosity (can be used multiple times).
+#        -v : verbose, -vv : verbose decoders, -vvv : debug decoders, -vvvv : trace decoding).
+# 0 = normal, 1 = verbose, 2 = verbose decoders, 3 = debug decoders, 4 = trace decoding
 #verbose
 
 # as command line option:


### PR DESCRIPTION
Always print the version.
Print registered decoder ranges.
Quiet by default.
Add -v verbosity option, deprecated -q and -D

Output looks like
```
rtl_433 version 18.05-355-g4faf491 branch feat-quiet at 201812151704
Registered 95 out of 119 device decoding protocols [ 1-4 8 11-12 15-21 23 25-26 29-36 38-60 62-64 67-71 73-100 102-103 108-116 ]
```