### PR TITLE
Add Digitech XC0346 support to Fine Offset WH1050

### DIFF
--- a/src/devices/fineoffset_wh1050.c
+++ b/src/devices/fineoffset_wh1050.c
@@ -35,14 +35,18 @@
 #include "decoder.h"
 
 #define CRC_POLY 0x31
-#define CRC_INIT 0xff
+
+// If you calculate the CRC over all 10 bytes including the preamble
+// byte (always 0xFF), then CRC_INIT is 0xFF. But we compare the preamble
+// byte and then discard it.
+#define CRC_INIT 0x00
 
 static unsigned short get_device_id(const uint8_t* br) {
-    return (br[1] << 4 & 0xf0 ) | (br[2] >> 4);
+    return (br[0] << 4 & 0xf0 ) | (br[1] >> 4);
 }
 
 static char* get_battery(const uint8_t* br) {
-    if (!(br[2] & 0x04)) {
+    if (!(br[1] & 0x04)) {
         return "OK";
     } else {
         return "LOW";
@@ -52,57 +56,57 @@ static char* get_battery(const uint8_t* br) {
 // ------------ WEATHER SENSORS DECODING ----------------------------------------------------
 
 static float get_temperature(const uint8_t* br) {
-    const int temp_raw = (br[2] << 8) + br[3];
+    const int temp_raw = (br[1] << 8) + br[2];
     return ((temp_raw & 0x03ff) - 0x190) / 10.0;
 }
 
 static int get_humidity(const uint8_t* br) {
-    return br[4];
+    return br[3];
 }
 
 static float get_wind_speed_raw(const uint8_t* br) {
-    return br[5]; // Raw
+    return br[4]; // Raw
 }
 
 static float get_wind_avg_ms(const uint8_t* br) {
-    return (br[5] * 34.0f) / 100; // Meters/sec.
+    return (br[4] * 34.0f) / 100; // Meters/sec.
 }
 
 static float get_wind_avg_mph(const uint8_t* br) {
-    return ((br[5] * 34.0f) / 100) * 2.23693629f; // Mph
+    return ((br[4] * 34.0f) / 100) * 2.23693629f; // Mph
 }
 
 static float get_wind_avg_kmh(const uint8_t* br) {
-    return ((br[5] * 34.0f) / 100) * 3.6f; // Km/h
+    return ((br[4] * 34.0f) / 100) * 3.6f; // Km/h
 }
 
 static float get_wind_avg_knot(const uint8_t* br) {
-    return ((br[5] * 34.0f) / 100) * 1.94384f; // Knots
+    return ((br[4] * 34.0f) / 100) * 1.94384f; // Knots
 }
 
 static float get_wind_gust_raw(const uint8_t* br) {
-    return br[6]; // Raw
+    return br[5]; // Raw
 }
 
 static float get_wind_gust_ms(const uint8_t* br) {
-    return (br[6] * 34.0f) / 100; // Meters/sec.
+    return (br[5] * 34.0f) / 100; // Meters/sec.
 }
 
 static float get_wind_gust_mph(const uint8_t* br) {
-    return ((br[6] * 34.0f) / 100) * 2.23693629f; // Mph
+    return ((br[5] * 34.0f) / 100) * 2.23693629f; // Mph
 
 }
 
 static float get_wind_gust_kmh(const uint8_t* br) {
-    return ((br[6] * 34.0f) / 100) * 3.6f; // Km/h
+    return ((br[5] * 34.0f) / 100) * 3.6f; // Km/h
 }
 
 static float get_wind_gust_knot(const uint8_t* br) {
-    return ((br[6] * 34.0f) / 100) * 1.94384f; // Knots
+    return ((br[5] * 34.0f) / 100) * 1.94384f; // Knots
 }
 
 static float get_rainfall(const uint8_t* br) {
-    return ((((unsigned short)br[7] & 0x0f) << 8) | br[8]) * 0.3f;
+    return ((((unsigned short)br[6] & 0x0f) << 8) | br[7]) * 0.3f;
 }
 
 //-------------------------------------------------------------------------------------
@@ -110,22 +114,33 @@ static float get_rainfall(const uint8_t* br) {
 
 static int fineoffset_wh1050_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     data_t *data;
+    uint8_t br[9];
 
     if (bitbuffer->num_rows != 1) {
         return 0;
     }
-    if (bitbuffer->bits_per_row[0] != 80) {
+
+    /* The normal preamble for WH1050 is 8 1s (0xFF) followed by 4 0s
+       for a total 80 bit message.
+       (The 4 0s is not confirmed to be preamble but seems to be zero on most devices)
+
+       Digitech XC0346 (and possibly other models) only sends 7 1 bits not 8 (0xFE)
+       for some reason (maybe transmitter module is slow to wake up), for a total
+       79 bit message.
+
+       In both cases, we extract the 72 bits after the preamble.
+    */
+    unsigned bits = bitbuffer->bits_per_row[0];
+    uint8_t preamble_byte = bitbuffer->bb[0][0];
+    if (bits == 79 && preamble_byte == 0xfe) {
+        bitbuffer_extract_bytes(bitbuffer, 0, 7, br, 72);
+    } else if (bits == 80 && preamble_byte == 0xff) {
+        bitbuffer_extract_bytes(bitbuffer, 0, 8, br, 72);
+    } else {
         return 0;
     }
 
-    const uint8_t *br = bitbuffer->bb[0];
-
-    if (br[0] != 0xff) {
-        // preamble missing
-        return 0;
-    }
-
-    if (br[9] != crc8(br, 9, CRC_POLY, CRC_INIT)) {
+    if (br[8] != crc8(br, 8, CRC_POLY, CRC_INIT)) {
         // crc mismatch
         return 0;
     }


### PR DESCRIPTION
Digitech XC0346 is a rebranded Fine Offset WH1050 on 433.920MHz, except on the unit I have the preamble pulse is 7 bits long not 8 bits.

Possibly the first bit is swallowed by the transmitter module while it is waking up...?

I couldn't find any WH1050 samples in the tests repo to compare, but even rolling back rtl_433 to the initial commit which added WH1050 support didn't work with signals from my Digitech one. This patch shouldn't change the behaviour of "standard" WH1050s.

Tests repo PR with samples: https://github.com/merbanan/rtl_433_tests/pull/249