### PR TITLE
Free output files of data printer modules

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -470,6 +470,9 @@ static void data_output_json_free(data_output_t *output)
     if (!output)
         return;
 
+    if (output->file != stdout)
+        fclose(output->file);
+
     free(output);
 }
 
@@ -654,6 +657,9 @@ static void data_output_kv_free(data_output_t *output)
     if (!output)
         return;
 
+    if (output->file != stdout)
+        fclose(output->file);
+
     if (kv->color)
         term_free(kv->term);
 
@@ -819,6 +825,9 @@ alloc_error:
 static void data_output_csv_free(data_output_t *output)
 {
     data_output_csv_t *csv = (data_output_csv_t *)output;
+
+    if (output->file != stdout)
+        fclose(output->file);
 
     free(csv->fields);
     free(csv);


### PR DESCRIPTION
The output files should be closed.

This isn't too important for now, since the program will shortly be shutting down anyway.
But it will be important with rtl_433's  progress towards a lib.