### PR TITLE
Use local_time_str() for syslog-printer

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -53,6 +53,7 @@
 #include "term_ctl.h"
 #include "abuf.h"
 
+#include "util.h"
 #include "data.h"
 
 #ifdef _WIN32
@@ -977,18 +978,9 @@ static void print_syslog_data(data_output_t *output, data_t *data, char *format)
     char message[1024];
     abuf_init(&syslog->msg, message, 1024);
 
-    time_t now;
-    struct tm tm_info;
-    time(&now);
-#ifdef _MSC_VER
-    gmtime_s(&tm_info, &now);
-#else
-    gmtime_r(&now, &tm_info);
-#endif    
-    char timestamp[21];
-    strftime(timestamp, 21, "%Y-%m-%dT%H:%M:%SZ", &tm_info);
-
-    abuf_printf(&syslog->msg, "<%d>1 %s %s rtl_433 - - - ", syslog->pri, timestamp, syslog->hostname);
+    char timestamp [LOCAL_TIME_BUFLEN];
+    abuf_printf(&syslog->msg, "<%d>1 %s %s rtl_433 - - - ", 
+                syslog->pri, local_time_str(0, timestamp), syslog->hostname);
 
     print_syslog_object(output, data, format);
 


### PR DESCRIPTION
Instead of having calls to `gmtime_x()` and `strftime()` in several places, 
use the `src/util.c` function `local_time_str()` to obtain the local time string.

I'm not sure how the `data-test` program then should be linked. It would need `src/util.c`.

The syslog message received in my syslog-client now looks like:
```
2018.22.12-16:27:53 127.0.0.1, 1 2018-12-22 16:27:53 Intel-I7 rtl_433 - - - {"time":"2018-12-22 16:27:51.789813", ...
```
I.e. no longer UTC; all times are local. Is this okay? Or maybe use `mg_gmt_time_string()`.