### PR TITLE
Fix a clang warning

### DIFF
--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -534,7 +534,7 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx) {
     char time_str[LOCAL_TIME_BUFLEN];
     unsigned long n_samples;
 
-    for (size_t i = 0; i < cfg->output_handler.len; ++i) { // list might contain NULLs
+    for (i = 0; i < cfg->output_handler.len; ++i) { // list might contain NULLs
         data_output_poll(cfg->output_handler.elems[i]);
     }
 


### PR DESCRIPTION
Clang warning was:
 *  `declaration shadows a local variable [-Wshadow]`

No need to have 2 local `i` variables. Even though they are `int` and `size_t`.