### PR TITLE
Print to terminal with colour-codes inlined (2)

### DIFF
--- a/src/term_ctl.c
+++ b/src/term_ctl.c
@@ -10,6 +10,7 @@
  */
 
 #include <stdio.h>
+#include <stdarg.h>
 #ifndef _WIN32
 #include <unistd.h>
 #include <sys/ioctl.h>
@@ -147,8 +148,8 @@ static void *_term_init(FILE *fp)
         console->file = fp;
     }
     console->redirected = (console->hnd == INVALID_HANDLE_VALUE) ||
-            (!GetConsoleScreenBufferInfo(console->hnd, &console->info)) ||
-            (GetFileType(console->hnd) != FILE_TYPE_CHAR);
+                         (!GetConsoleScreenBufferInfo(console->hnd, &console->info)) ||
+                         (GetFileType(console->hnd) != FILE_TYPE_CHAR);
 
     _term_set_color(console, FALSE, TERM_COLOR_RESET); /* Set 'console->fg' and 'console->bg' */
 
@@ -165,7 +166,7 @@ int term_get_columns(void *ctx)
      * we called '_term_init()'.
      */
     CONSOLE_SCREEN_BUFFER_INFO c_info;
-    
+
     if (!console->hnd || console->hnd == INVALID_HANDLE_VALUE)
        return (80);
 
@@ -243,4 +244,87 @@ void term_set_bg(void *ctx, term_color_t color)
     else
         fprintf(fp, "\033[%d;1m", color + 10);
 #endif
+}
+
+#define DIM(array) (int) (sizeof(array) / sizeof(array[0]))
+
+static term_color_t color_map[] = {
+                    TERM_COLOR_RESET,     /* "~0" */
+                    TERM_COLOR_GREEN,
+                    TERM_COLOR_WHITE,     /* "~2" */
+                    TERM_COLOR_BLUE,
+                    TERM_COLOR_CYAN,      /* "~4" */
+                    TERM_COLOR_MAGENTA,
+                    TERM_COLOR_YELLOW,    /* "~6" */
+                    TERM_COLOR_BLACK,
+                    TERM_COLOR_RED,       /* "~8" */
+                  };
+
+int term_set_color_map(int ascii_idx, term_color_t color)
+{
+    ascii_idx -= '0';
+    if (ascii_idx < 0 || ascii_idx > DIM(color_map))
+        return (-1);
+    color_map [ascii_idx] = color;
+    return (ascii_idx);
+}
+
+int term_get_color_map(int ascii_idx)
+{
+    int i;
+
+    ascii_idx -= '0';
+    for (i = 0; ascii_idx >= 0 && i < DIM(color_map); i++)
+        if (i == ascii_idx)
+           return (int) color_map[i];
+    return (-1);
+}
+
+int term_puts(void *ctx, const char *buf)
+{
+    const char *p = buf;
+    int   i, len, buf_len, color;
+    FILE *fp;
+
+#ifdef _WIN32
+    console_t *console = (console_t *)ctx;
+    fp = console->file;
+#else
+    fp = (FILE *)ctx;
+#endif
+
+    if (!fp)
+        fp = stderr;
+
+    buf_len = strlen(buf);
+    for (i = len = 0; *p && i < buf_len; i++, p++) {
+        if (*p != '~') {
+            fputc(*p, fp);
+            len++;
+        }
+        else {
+            p++;
+            color = ctx ? term_get_color_map(*p) : -1;
+            if (color >= 0)
+                term_set_fg(ctx, (term_color_t)color);
+        }
+    }
+    return (len);
+}
+
+int term_printf(void *ctx, const char *format, ...)
+{
+    int     len;
+    va_list args;
+    char buf [3000];
+
+    va_start(args, format);
+
+   /* Terminate first in case a buggy '_MSC_VER < 1900' is used.
+    */
+    buf [sizeof(buf)-1] = '\0';
+    vsnprintf(buf, sizeof(buf)-1, format, args);
+    len = term_puts(ctx, buf);
+    va_end (args);
+    return (len);
 }


### PR DESCRIPTION
The diff for allowing an inline print of text and colours.
My idea was to change the `usage()` screen into something more readable like this:
![rtl_433-help-2](https://user-images.githubusercontent.com/945271/50380196-fd217980-065f-11e9-9495-899429e23c98.png)

Accomplished by:
```c
   void *term = term_init(stderr);
   term_printf(term, "\n  ~1General options~0:\n");
   term_puts(term,
              "    ~2-V~0 Output the version string and exit.\n"
              "    ~2-v~0 Increase verbosity (can be used multiple times).\n"
              "       ~2-v~0: simple verbosity, ~2-vv~0: verbose decoders, ~2-vvv~0: debug decoders, ~2-vvvv~0: trace decoding).\n"
              "    ~2-c <path>~0 Read config options from a file.\n");
....
```
The actual colours for index 2 etc. could come from the *config file*?
