### PR TITLE
Add XDG_CONFIG_HOME compatability 

### DIFF
--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -12,6 +12,7 @@
 #
 # If no -c option is given the first found of this list will be loaded:
 # - ./rtl_433.conf
+# - ~/.config/rtl_433/rtl_433.conf
 # - ~/.rtl_433/rtl_433.conf
 # - /usr/local/etc/rtl_433.conf
 # - /etc/rtl_433.conf

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -13,7 +13,6 @@
 # If no -c option is given the first found of this list will be loaded:
 # - ./rtl_433.conf
 # - ~/.config/rtl_433/rtl_433.conf
-# - ~/.rtl_433/rtl_433.conf
 # - /usr/local/etc/rtl_433.conf
 # - /etc/rtl_433.conf
 

--- a/src/compat_paths.c
+++ b/src/compat_paths.c
@@ -15,7 +15,7 @@
 
 char **compat_get_default_conf_paths()
 {
-    static char *paths[6] = { NULL };
+    static char *paths[5] = { NULL };
     static char buf[256] = "";
     char *env_config_home = getenv("XDG_CONFIG_HOME");
     if (!paths[0]) {

--- a/src/compat_paths.c
+++ b/src/compat_paths.c
@@ -8,7 +8,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
-#include <stdio.h> 
+#include <stdio.h>
 #include <stdlib.h>
 
 #include "compat_paths.h"
@@ -17,17 +17,17 @@ char **compat_get_default_conf_paths()
 {
     static char *paths[6] = { NULL };
     static char buf[256] = "";
-    static char conf[256] = "";
+    char *env_config_home = getenv("XDG_CONFIG_HOME");
     if (!paths[0]) {
         paths[0] = "rtl_433.conf";
-        snprintf(buf, sizeof(buf), "%s%s", getenv("XDG_CONFIG_HOME"), "/rtl_433/rtl_433.conf");
+        if (env_config_home && *env_config_home)
+            snprintf(buf, sizeof(buf), "%s%s", env_config_home, "/rtl_433/rtl_433.conf");
+        else
+            snprintf(buf, sizeof(buf), "%s%s", getenv("HOME"), "/.config/rtl_433/rtl_433.conf");
         paths[1] = buf;
-        // If xdg_conf_home not set, check usual conf location
-        snprintf(conf, sizeof(conf), "%s%s", getenv("HOME"), "/.config/rtl_433/rtl_433.conf");
-        paths[2] = conf;
-        paths[3] = "/usr/local/etc/rtl_433/rtl_433.conf";
-        paths[4] = "/etc/rtl_433/rtl_433.conf";
-        paths[5] = NULL;
+        paths[2] = "/usr/local/etc/rtl_433/rtl_433.conf";
+        paths[3] = "/etc/rtl_433/rtl_433.conf";
+        paths[4] = NULL;
     };
     return paths;
 }

--- a/src/compat_paths.c
+++ b/src/compat_paths.c
@@ -20,10 +20,11 @@ char **compat_get_default_conf_paths()
     static char conf[256] = "";
     if (!paths[0]) {
         paths[0] = "rtl_433.conf";
+        snprintf(buf, sizeof(buf), "%s%s", getenv("XDG_CONFIG_HOME"), "/rtl_433/rtl_433.conf");
+        paths[2] = buf;
+        // If xdg_conf_home not set, check usual conf location
         snprintf(conf, sizeof(conf), "%s%s", getenv("HOME"), "/.config/rtl_433/rtl_433.conf");
         paths[1] = conf;
-        snprintf(buf, sizeof(buf), "%s%s", getenv("HOME"), "/.rtl_433/rtl_433.conf");
-        paths[2] = buf;
         paths[3] = "/usr/local/etc/rtl_433/rtl_433.conf";
         paths[4] = "/etc/rtl_433/rtl_433.conf";
         paths[5] = NULL;

--- a/src/compat_paths.c
+++ b/src/compat_paths.c
@@ -21,10 +21,10 @@ char **compat_get_default_conf_paths()
     if (!paths[0]) {
         paths[0] = "rtl_433.conf";
         snprintf(buf, sizeof(buf), "%s%s", getenv("XDG_CONFIG_HOME"), "/rtl_433/rtl_433.conf");
-        paths[2] = buf;
+        paths[1] = buf;
         // If xdg_conf_home not set, check usual conf location
         snprintf(conf, sizeof(conf), "%s%s", getenv("HOME"), "/.config/rtl_433/rtl_433.conf");
-        paths[1] = conf;
+        paths[2] = conf;
         paths[3] = "/usr/local/etc/rtl_433/rtl_433.conf";
         paths[4] = "/etc/rtl_433/rtl_433.conf";
         paths[5] = NULL;

--- a/src/compat_paths.c
+++ b/src/compat_paths.c
@@ -15,15 +15,18 @@
 
 char **compat_get_default_conf_paths()
 {
-    static char *paths[5] = { NULL };
+    static char *paths[6] = { NULL };
     static char buf[256] = "";
+    static char conf[256] = "";
     if (!paths[0]) {
         paths[0] = "rtl_433.conf";
+        snprintf(conf, sizeof(conf), "%s%s", getenv("HOME"), "/.config/rtl_433/rtl_433.conf");
+        paths[1] = conf;
         snprintf(buf, sizeof(buf), "%s%s", getenv("HOME"), "/.rtl_433/rtl_433.conf");
-        paths[1] = buf;
-        paths[2] = "/usr/local/etc/rtl_433/rtl_433.conf";
-        paths[3] = "/etc/rtl_433/rtl_433.conf";
-        paths[4] = NULL;
+        paths[2] = buf;
+        paths[3] = "/usr/local/etc/rtl_433/rtl_433.conf";
+        paths[4] = "/etc/rtl_433/rtl_433.conf";
+        paths[5] = NULL;
     };
     return paths;
 }


### PR DESCRIPTION
## Background
The currently implemented config dir search paths do not follow Linux XDG standards.

## Implementation
This PR enables the program to search in the standard `$(HOME)/.config/` path, according to [XDG Standards](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

This PR simply adds an additional path on top of the currently defined config dirs, so there is little chance for regression if the other paths were used.

------ 

Thanks for a great program! Hope to continue contributing where possible in the future!