### PR TITLE
Add parametric decoder setup

### DIFF
--- a/include/decoder_util.h
+++ b/include/decoder_util.h
@@ -16,6 +16,9 @@
 #include "bitbuffer.h"
 #include "rtl_433_devices.h"
 
+/// Create a new r_device, copy from template if not NULL.
+r_device *create_device(r_device *template);
+
 /// Output data.
 void decoder_output_data(r_device *decoder, data_t *data);
 

--- a/include/list.h
+++ b/include/list.h
@@ -29,6 +29,9 @@ void list_push(list_t *list, void *p);
 /// Adds all elements of a NULL terminated list to the end of elems, allocs or grows the list if needed and ensures the list has a terminating NULL.
 void list_push_all(list_t *list, void **p);
 
+/// Remove element from the list, frees element with fn.
+void list_remove(list_t *list, size_t idx, list_elem_free_fn elem_free);
+
 /// Clear the list, frees each element with fn, does not free backing or list itself.
 void list_clear(list_t *list, list_elem_free_fn elem_free);
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -139,6 +139,7 @@ typedef struct r_device {
     float sync_width;
     float tolerance;
     int (*decode_fn)(struct r_device *decoder, struct bitbuffer *bitbuffer);
+    struct r_device *(*create_fn)(char *args);
     unsigned disabled;
     char **fields; // List of fields this decoder produces; required for CSV output. NULL-terminated.
 

--- a/src/decoder_util.c
+++ b/src/decoder_util.c
@@ -15,6 +15,17 @@
 #include "util.h"
 #include "decoder_util.h"
 
+// create decoder functions
+
+r_device *create_device(r_device *template)
+{
+    r_device *r_dev = malloc(sizeof (*r_dev));
+    if (template)
+        *r_dev = *template; // copy
+
+    return r_dev;
+}
+
 // variadic print functions
 
 void bitbuffer_printf(const bitbuffer_t *bitbuffer, char const *restrict format, ...)

--- a/src/devices/new_template.c
+++ b/src/devices/new_template.c
@@ -256,6 +256,6 @@ r_device template = {
     .gap_limit     = 300, // some distance above long
     .reset_limit   = 1000, // a bit longer than packet gap
     .decode_fn     = &template_callback,
-    .disabled      = 2, // disabled and hidden, use 0 if there is a MIC, 1 otherwise
+    .disabled      = 3, // disabled and hidden, use 0 if there is a MIC, 1 otherwise
     .fields        = output_fields,
 };

--- a/src/list.c
+++ b/src/list.c
@@ -38,6 +38,20 @@ void list_push_all(list_t *list, void **p)
         list_push(list, *iter);
 }
 
+void list_remove(list_t *list, size_t idx, list_elem_free_fn elem_free)
+{
+    if (idx >= list->len) {
+        return; // report error?
+    }
+    if (elem_free) {
+        elem_free(list->elems[idx]);
+    }
+    for (size_t i = idx; i < list->len; ++i) { // list might contain NULLs
+        list->elems[i] = list->elems[i + 1]; // ensures a terminating NULL
+    }
+    list->len--;
+}
+
 void list_clear(list_t *list, list_elem_free_fn elem_free)
 {
     if (elem_free) {


### PR DESCRIPTION
Adds a `create_fn` to decoders which is called with the argument from `-R` to register parametric decoder instances.