### PR TITLE
Add pulse data file and input support

### DIFF
--- a/include/fileformat.h
+++ b/include/fileformat.h
@@ -40,6 +40,7 @@ enum file_type {
     F_IQ       = F_I | F_Q << 4,
     F_LOGIC    = 5 << 16,
     F_VCD      = 6 << 16,
+    F_OOK      = 7 << 16,
     // format types
     F_U8       = F_1CH | F_UNSIGNED | F_INT | F_W8,
     F_S8       = F_1CH | F_SIGNED   | F_INT | F_W8,
@@ -67,6 +68,7 @@ enum file_type {
     F32_Q      = F_F32 | F_Q,
     U8_LOGIC   = F_LOGIC | F_U8,
     VCD_LOGIC  = F_VCD,
+    PULSE_OOK  = F_OOK,
 };
 
 typedef struct {

--- a/include/pulse_detect.h
+++ b/include/pulse_detect.h
@@ -59,6 +59,15 @@ void pulse_data_print_vcd_header(FILE *file, uint32_t sample_rate);
 /// Print the content of a pulse_data_t structure in VCD format
 void pulse_data_print_vcd(FILE *file, pulse_data_t const *data, int ch_id, uint32_t sample_rate);
 
+/// Read the next pulse_data_t structure from OOK text
+void pulse_data_load(FILE *file, pulse_data_t *data);
+
+/// Print a header for the OOK text format
+void pulse_data_print_pulse_header(FILE *file);
+
+/// Print the content of a pulse_data_t structure as OOK text
+void pulse_data_dump(FILE *file, pulse_data_t *data);
+
 pulse_detect_t *pulse_detect_create(void);
 
 void pulse_detect_free(pulse_detect_t *pulse_detect);

--- a/src/fileformat.c
+++ b/src/fileformat.c
@@ -41,7 +41,8 @@ void check_read_file_info(file_info_t *info)
     if (info->format != CU8_IQ
             && info->format != CS16_IQ
             && info->format != CF32_IQ
-            && info->format != S16_AM) {
+            && info->format != S16_AM
+            && info->format != PULSE_OOK) {
         fprintf(stderr, "File type not supported as input (%s).\n", info->spec);
         exit(1);
     }
@@ -78,7 +79,8 @@ char const *file_info_string(file_info_t *info)
     case F32_I:     return "F32 I (1ch float32)"; break;
     case F32_Q:     return "F32 Q (1ch float32)"; break;
     case VCD_LOGIC: return "VCD logic (text)"; break;
-    case U8_LOGIC:  return "U8 logic (text)"; break;
+    case U8_LOGIC:  return "U8 logic (1ch uint8)"; break;
+    case PULSE_OOK: return "OOK pulse data (text)"; break;
     default:        return "Unknown";  break;
     }
 }
@@ -108,6 +110,7 @@ static uint32_t file_type_guess_auto_format(uint32_t type)
     else if (type == F_U8) return U8_LOGIC;
     else if (type == F_Q) return F32_Q;
     else if (type == F_VCD) return VCD_LOGIC;
+    else if (type == F_OOK) return PULSE_OOK;
     else if (type == F_CS16) return CS16_IQ;
     else if (type == F_CF32) return CF32_IQ;
     else return type;
@@ -184,6 +187,7 @@ static void file_type(char const *filename, file_info_t *info)
             else if (len == 3 && !strncasecmp("s32", t, 3)) file_type_set_format(&info->format, F_S32);
             else if (len == 3 && !strncasecmp("f32", t, 3)) file_type_set_format(&info->format, F_F32);
             else if (len == 3 && !strncasecmp("vcd", t, 3)) file_type_set_content(&info->format, F_VCD);
+            else if (len == 3 && !strncasecmp("ook", t, 3)) file_type_set_content(&info->format, F_OOK);
             else if (len == 4 && !strncasecmp("cs16", t, 4)) file_type_set_format(&info->format, F_CS16);
             else if (len == 4 && !strncasecmp("cs32", t, 4)) file_type_set_format(&info->format, F_CS32);
             else if (len == 4 && !strncasecmp("cf32", t, 4)) file_type_set_format(&info->format, F_CF32);
@@ -218,7 +222,7 @@ Parse "[A-Za-z][0-9A-Za-z]+" as format or content specifier:
 
 2ch formats: "cu8", "cs8", "cs16", "cs32", "cf32"
 1ch formats: "u8", "s8", "s16", "u16", "s32", "u32", "f32"
-text formats: "vcd"
+text formats: "vcd", "ook"
 content types: "iq", "i", "q", "am", "fm", "logic"
 
 Parses left to right, with the exception of a prefix up to the last colon ":"


### PR DESCRIPTION
This adds pulse data file input and OOK receiver support.
- convert a file to pulse data with e.g. `rtl_433 -w pulse.ook g001_433.92M_250k.cu8`
- read a pulse data file with e.g. `rtl_433 pulse.ook`
- read receiver data (e.g. WiringPi python script) and pass "`<pulse µs> <gap µs>`" lines to `rtl_433 OOK:-` (until proper receiver input is added)

WIP preview for now.