### PR TITLE
Fix humidity value bellow 16 on Nexus sensor

### DIFF
--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -74,7 +74,7 @@ static int nexus_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         humidity = (uint8_t)(((bb[r][3]&0x0F)<<4)|(bb[r][4]>>4));
 
         // Thermo
-        if (bb[r][3] == 0xF0 && (bb[r][4] >> 4) == 0x0) {
+        if (humidity == 0x00) {
         data = data_make(
                 "model",         "",            DATA_STRING, "Nexus Temperature",
                 "id",            "House Code",  DATA_INT, id,

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -74,7 +74,7 @@ static int nexus_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         humidity = (uint8_t)(((bb[r][3]&0x0F)<<4)|(bb[r][4]>>4));
 
         // Thermo
-        if (bb[r][3] == 0xF0) {
+        if (bb[r][3] == 0xF0 && (bb[r][4] >> 4) == 0x0) {
         data = data_make(
                 "model",         "",            DATA_STRING, "Nexus Temperature",
                 "id",            "House Code",  DATA_INT, id,


### PR DESCRIPTION
The code was not detecting Auriol 2013/Nexus sensor humidity if it was 0xf (15) or lower due to only checking upper nibble.

Example data for the scenario:
> [00] { 0}                : 
> [01] {36} ac 10 2e f0 d0 : 10101100 00010000 00101110 11110000 1101
> [02] {36} ac 10 2e f0 d0 : 10101100 00010000 00101110 11110000 1101
> [03] {36} ac 10 2e f0 d0 : 10101100 00010000 00101110 11110000 1101
> ...

For comparison, Nexus(-like) sensor in neighbourhood without humidity sensor has last nibble set to 0:
> [00] {36} 91 8f e3 f0 00 : 10010001 10001111 11100011 11110000 0000
> [01] {36} 91 8f e3 f0 00 : 10010001 10001111 11100011 11110000 0000
> ...
