### PR TITLE
Add new model keys option

### DIFF
--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -119,9 +119,11 @@ analyze_pulses false
 #   (this may also be accomplished by invocation with TZ environment variable set).
 # Use "protocol" / "noprotocol" to output the decoder protocol number meta data.
 # Use "level" to add Modulation, Frequency, RSSI, SNR, and Noise meta data.
+# Use "newmodel" to transition to new model keys. This will become the default someday.
 report_meta level
 report_meta hires
 report_meta protocol
+report_meta newmodel
 
 # as command line option:
 #   [-y <code>] Verify decoding of demodulated test data (e.g. "{25}fb2dd58") with enabled devices

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -81,6 +81,7 @@ typedef struct r_cfg {
     char *output_tag;
     list_t output_handler;
     struct dm_state *demod;
+    int new_model_keys;
 } r_cfg_t;
 
 #endif /* INCLUDE_RTL_433_H_ */

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -212,7 +212,7 @@ static int acurite_rain_gauge_callback(r_device *decoder, bitbuffer_t *bitbuffer
         data_t *data;
 
         data = data_make(
-            "model",    "",        DATA_STRING,    "Acurite Rain Gauge",
+            "model",    "",        DATA_STRING,    "Acurite-Rain\tAcurite Rain Gauge",
             "id",        "",        DATA_INT,    id,
             "rain",     "Total Rain",    DATA_FORMAT,    "%.1f mm", DATA_DOUBLE, total_rain,
             NULL);
@@ -277,7 +277,7 @@ static int acurite_th_callback(r_device *decoder, bitbuffer_t *bitbuf)
     humidity = bb[3];
 
     data = data_make(
-             "model",        "",        DATA_STRING,    "Acurite 609TXC Sensor",
+             "model",        "",        DATA_STRING,    "Acurite-609TXC\tAcurite 609TXC Sensor",
              "id",        "",        DATA_INT,    id,
              "battery",        "",        DATA_STRING,    battery_low ? "LOW" : "OK",
              "status",        "",        DATA_INT,    status,
@@ -506,7 +506,7 @@ static int acurite_6045_decode(r_device *decoder, bitrow_t bb, int browlen)
     }
 
     data = data_make(
-       "model",            "",            DATA_STRING,    "Acurite Lightning 6045M",
+       "model",            "",            DATA_STRING,    "Acurite-Lightning\tAcurite Lightning 6045M",
        "id",            NULL,              DATA_INT,    sensor_id,
        "channel",          NULL,             DATA_STRING,     channel_str,
        "temperature_F",     "temperature",        DATA_FORMAT,    "%.1f F",     DATA_DOUBLE,     tempf,
@@ -620,7 +620,7 @@ static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuf)
             battery_low = (bb[2] & 0x40) == 0;
 
             data = data_make(
-                    "model",                "",        DATA_STRING,    "Acurite tower sensor",
+                    "model",                "",        DATA_STRING,    "Acurite-Tower\tAcurite tower sensor",
                     "id",            "",        DATA_INT,    sensor_id,
                     "sensor_id",            NULL,          DATA_FORMAT,    "0x%04x",   DATA_INT,       sensor_id, // @todo hex output not working, delete at 1.0 release
                     "channel",          NULL,         DATA_STRING,     &channel_str,
@@ -653,7 +653,7 @@ static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuf)
                 raincounter = acurite_getRainfallCounter(bb[5], bb[6]);
 
                 data = data_make(
-                    "model",        "",   DATA_STRING,    "Acurite 5n1 sensor",
+                    "model",        "",   DATA_STRING,    "Acurite-5n1\tAcurite 5n1 sensor",
                     "sensor_id",    NULL, DATA_INT,       sensor_id, // @todo normaiize to "id" at 1.0 release.
                     "channel",      NULL,   DATA_STRING,    &channel_str,
                     "sequence_num",  NULL,   DATA_INT,      sequence_num,
@@ -673,7 +673,7 @@ static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuf)
                 humidity = acurite_getHumidity(bb[6]);
 
                 data = data_make(
-                    "model",        "",   DATA_STRING,    "Acurite 5n1 sensor",
+                    "model",        "",   DATA_STRING,    "Acurite-5n1\tAcurite 5n1 sensor",
                     "sensor_id",    NULL, DATA_INT,  sensor_id, // @todo normalize to "id" at 1.0 release.
                     "channel",      NULL,   DATA_STRING,    &channel_str,
                     "sequence_num",  NULL,   DATA_INT,      sequence_num,
@@ -693,7 +693,7 @@ static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuf)
                 wind_speed_mph = bb[6] & 0x7f; // seems to be plain MPH
 
                 data = data_make(
-                    "model",        "",   DATA_STRING,    "Acurite 3n1 sensor",
+                    "model",        "",   DATA_STRING,    "Acurite-3n1\tAcurite 3n1 sensor",
                     "sensor_id",    NULL,   DATA_FORMAT,    "0x%02X",   DATA_INT,       sensor_id,
                     "channel",      NULL,   DATA_STRING,    &channel_str,
                     "sequence_num",  NULL,   DATA_INT,      sequence_num,
@@ -853,7 +853,7 @@ static int acurite_986_callback(r_device *decoder, bitbuffer_t *bitbuf)
                     sensor_id, sensor_num, sensor_type, tempf);
 
         data = data_make(
-                "model",        "",        DATA_STRING,    "Acurite 986 Sensor",
+                "model",        "",        DATA_STRING,    "Acurite-986\tAcurite 986 Sensor",
                 "id",            NULL,        DATA_INT,    sensor_id,
                 "channel",        NULL,        DATA_STRING,    channel_str,
                 "temperature_F",    "temperature",    DATA_FORMAT, "%f F", DATA_DOUBLE,    (float)tempf,
@@ -947,7 +947,7 @@ static int acurite_606_callback(r_device *decoder, bitbuffer_t *bitbuf)
             battery = (bb[1][1] & 0x80) >> 7;
 
             data = data_make(
-                    "model",         "",            DATA_STRING, "Acurite 606TX Sensor",
+                    "model",         "",            DATA_STRING, "Acurite-606TX\tAcurite 606TX Sensor",
                     "id",            "",            DATA_INT, sensor_id,
                     "battery",          "Battery",     DATA_STRING, battery ? "OK" : "LOW",
                     "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
@@ -1018,7 +1018,7 @@ static int acurite_00275rm_callback(r_device *decoder, bitbuffer_t *bitbuf)
             humidity    = ((signal[0][6] & 0x1f) << 2) | (signal[0][7] >> 6);
             //  No probe
             data = data_make(
-                    "model",           "",             DATA_STRING,    model ? "00275rm" : "00276rm",
+                    "model",           "",             DATA_STRING,    model ? "Acurite-00275rm\t00275rm" : "Acurite-00276rm\t00276rm",
                     "probe",           "",             DATA_INT,       probe,
                     "id",              "",             DATA_INT,       id,
                     "battery",         "",             DATA_STRING,    battery_low ? "LOW" : "OK",

--- a/src/devices/akhan_100F14.c
+++ b/src/devices/akhan_100F14.c
@@ -39,7 +39,7 @@ static int akhan_rke_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         return 0;
 
     data = data_make(
-            "model",    "",             DATA_STRING, "Akhan 100F14 remote keyless entry",
+            "model",    "",             DATA_STRING, "Akhan-100F14\tAkhan 100F14 remote keyless entry",
             "id",       "ID (20bit)",   DATA_FORMAT, "0x%x", DATA_INT, id,
             "data",     "Data (4bit)",  DATA_STRING, cmd_str,
             NULL);

--- a/src/devices/alecto.c
+++ b/src/devices/alecto.c
@@ -151,7 +151,7 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             int direction = (reverse8(bb[5 + skip][2]) << 1) | (bb[5 + skip][1] & 0x1);
 
             data = data_make(
-                    "model",          "",           DATA_STRING, "AlectoV1 Wind Sensor",
+                    "model",          "",           DATA_STRING, "AlectoV1-Wind\tAlectoV1 Wind Sensor",
                     "id",             "House Code", DATA_INT,    sensor_id,
                     "channel",        "Channel",    DATA_INT,    channel,
                     "battery",        "Battery",    DATA_STRING, battery_low ? "LOW" : "OK",
@@ -170,7 +170,7 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         double rain_mm = ((reverse8(b[3]) << 8) | reverse8(b[2])) * 0.25F;
 
         data = data_make(
-                "model",         "",           DATA_STRING, "AlectoV1 Rain Sensor",
+                "model",         "",           DATA_STRING, "AlectoV1-Rain\tAlectoV1 Rain Sensor",
                 "id",            "House Code", DATA_INT,    sensor_id,
                 "channel",       "Channel",    DATA_INT,    channel,
                 "battery",       "Battery",    DATA_STRING, battery_low ? "LOW" : "OK",
@@ -195,7 +195,7 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             return 0;//extra detection false positive!! prologue is also 36bits and sometimes detected as alecto
 
         data = data_make(
-                "model",         "",            DATA_STRING, "AlectoV1 Temperature Sensor",
+                "model",         "",            DATA_STRING, "AlectoV1-Temperature\tAlectoV1 Temperature Sensor",
                 "id",            "House Code",  DATA_INT,    sensor_id,
                 "channel",       "Channel",     DATA_INT,    channel,
                 "battery",       "Battery",     DATA_STRING, battery_low ? "LOW" : "OK",

--- a/src/devices/ambient_weather.c
+++ b/src/devices/ambient_weather.c
@@ -46,7 +46,7 @@ ambient_weather_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, 
     humidity = b[4];
 
     data = data_make(
-            "model",          "",             DATA_STRING, "Ambient Weather F007TH Thermo-Hygrometer",
+            "model",          "",             DATA_STRING, "Ambientweather-F007TH\tAmbient Weather F007TH Thermo-Hygrometer",
             "device",         "House Code",   DATA_INT,    deviceID,
             "channel",        "Channel",      DATA_INT,    channel,
             "battery",        "Battery",      DATA_STRING, isBatteryLow ? "Low" : "Ok",

--- a/src/devices/brennenstuhl_rcs_2044.c
+++ b/src/devices/brennenstuhl_rcs_2044.c
@@ -88,7 +88,7 @@ static int brennenstuhl_rcs_2044_process_row(r_device *decoder, bitbuffer_t cons
         return 0; /* Pressing simultaneously ON and OFF key is not useful either */
 
     data = data_make(
-            "model",    "Model",    DATA_STRING, "Brennenstuhl RCS 2044",
+            "model",    "Model",    DATA_STRING, "Brennenstuhl-RCS2044\tBrennenstuhl RCS 2044",
             "id",       "id",       DATA_INT, system_code,
             "key",      "key",      DATA_STRING, key,
             "state",    "state",    DATA_STRING, (on_off == 0x02 ? "ON" : "OFF"),

--- a/src/devices/bresser_3ch.c
+++ b/src/devices/bresser_3ch.c
@@ -70,7 +70,7 @@ static int bresser_3ch_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     }
 
     data = data_make(
-            "model",         "",            DATA_STRING, "Bresser 3CH sensor",
+            "model",         "",            DATA_STRING, "Bresser-3CH\tBresser 3CH sensor",
             "id",            "Id",          DATA_INT,    id,
             "channel",       "Channel",     DATA_INT,    channel,
             "battery",       "Battery",     DATA_STRING, battery_low ? "LOW": "OK",

--- a/src/devices/esperanza_ews.c
+++ b/src/devices/esperanza_ews.c
@@ -84,7 +84,7 @@ static int esperanza_ews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     int humidity  = ((b[3] & 0x0f) << 4) | ((b[3] & 0xf0) >> 4);
 
     data = data_make(
-            "model",            "",             DATA_STRING, "Esperanza EWS", // "Esperanza-EWS"
+            "model",            "",             DATA_STRING, "Esperanza-EWS\tEsperanza EWS",
             "id",               "ID",           DATA_INT, device_id,
             "channel",          "Channel",      DATA_INT, channel,
             "temperature_F",    "Temperature",  DATA_FORMAT, "%.02f F", DATA_DOUBLE, temp_f,

--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -66,24 +66,24 @@ static int fineoffset_WH2_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     if (bitbuffer->bits_per_row[0] == 48 &&
             bb[0][0] == 0xFF) { // WH2
         bitbuffer_extract_bytes(bitbuffer, 0, 8, b, 40);
-        model = "Fine Offset Electronics, WH2 Temperature/Humidity sensor";
+        model = "Fineoffset-WH2\tFine Offset Electronics, WH2 Temperature/Humidity sensor";
 
     } else if (bitbuffer->bits_per_row[0] == 55 &&
             bb[0][0] == 0xFE) { // WH2A
         bitbuffer_extract_bytes(bitbuffer, 0, 7, b, 48);
-        model = "Fine Offset WH2A sensor";
+        model = "Fineoffset-WH2A\tFine Offset WH2A sensor";
 
     } else if (bitbuffer->bits_per_row[0] == 47 &&
             bb[0][0] == 0xFE) { // WH5
         bitbuffer_extract_bytes(bitbuffer, 0, 7, b, 40);
-        model = "Fine Offset WH5 sensor";
+        model = "Fineoffset-WH5\tFine Offset WH5 sensor";
         if (decoder->decode_ctx) // don't care for the actual value
             model = "Rosenborg-66796";
 
     } else if (bitbuffer->bits_per_row[0] == 49 &&
             bb[0][0] == 0xFF && (bb[0][1]&0x80) == 0x80) { // Telldus
         bitbuffer_extract_bytes(bitbuffer, 0, 9, b, 40);
-        model = "Telldus/Proove thermometer";
+        model = "Fineoffset-TelldusProove\tTelldus/Proove thermometer";
 
     } else
         return 0;
@@ -286,7 +286,7 @@ static int fineoffset_WH24_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // Output data
     data = data_make(
-            "model",            "",                 DATA_STRING, model == MODEL_WH24 ? "Fine Offset WH24" : "Fine Offset WH65B",
+            "model",            "",                 DATA_STRING, model == MODEL_WH24 ? "Fineoffset-WH24\tFine Offset WH24" : "Fineoffset-WH65B\tFine Offset WH65B",
             "id",               "ID",               DATA_INT, id,
             NULL);
     if (temp_raw       != 0x7ff)
@@ -382,7 +382,7 @@ static int fineoffset_WH25_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // Output data
     data = data_make(
-            "model",            "",             DATA_STRING, "Fine Offset Electronics, WH25",
+            "model",            "",             DATA_STRING, "Fineoffset-WH25\tFine Offset Electronics, WH25",
             "id",               "ID",           DATA_INT, id,
             "temperature_C",    "Temperature",  DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
             "humidity",         "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, humidity,
@@ -447,7 +447,7 @@ static int fineoffset_WH0530_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     float rainfall    = rainfall_raw * 0.3; // each tip is 0.3mm
 
     data = data_make(
-            "model",            "",             DATA_STRING, "Fine Offset Electronics, WH0530 Temperature/Rain sensor",
+            "model",            "",             DATA_STRING, "Fineoffset-WH0530\tFine Offset Electronics, WH0530 Temperature/Rain sensor",
             "id",               "ID",           DATA_INT, id,
             "temperature_C",    "Temperature",  DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
             "rain",             "Rain",         DATA_FORMAT, "%.01f mm", DATA_DOUBLE, rainfall,

--- a/src/devices/fineoffset_wh1050.c
+++ b/src/devices/fineoffset_wh1050.c
@@ -76,7 +76,7 @@ static int fineoffset_wh1050_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // PRESENTING DATA
     data = data_make(
-            "model",            "",                 DATA_STRING, "Fine Offset WH1050 weather station",
+            "model",            "",                 DATA_STRING, "Fineoffset-WH1050\tFine Offset WH1050 weather station",
             "id",               "StationID",        DATA_FORMAT, "%04X",    DATA_INT,    device_id,
             "temperature_C",    "Temperature",      DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
             "humidity",         "Humidity",         DATA_FORMAT, "%u %%",   DATA_INT,    humidity,

--- a/src/devices/fineoffset_wh1080.c
+++ b/src/devices/fineoffset_wh1080.c
@@ -227,7 +227,7 @@ static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     // PRESENTING DATA
     if (msg_type == 0) {
         data = data_make(
-                "model",            "",                 DATA_STRING,    "Fine Offset Electronics WH1080/WH3080 Weather Station",
+                "model",            "",                 DATA_STRING,    "Fineoffset-WHx080\tFine Offset Electronics WH1080/WH3080 Weather Station",
                 "msg_type",         "Msg type",         DATA_INT,       msg_type,
                 "id",               "Station ID",       DATA_INT,       device_id,
                 "temperature_C",    "Temperature",      DATA_FORMAT,    "%.01f C",  DATA_DOUBLE,    temperature,
@@ -242,7 +242,7 @@ static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     }
     else if (msg_type == 1) {
         data = data_make(
-                "model",            "",                 DATA_STRING,    "Fine Offset Electronics WH1080/WH3080 Weather Station",
+                "model",            "",                 DATA_STRING,    "Fineoffset-WHx080\tFine Offset Electronics WH1080/WH3080 Weather Station",
                 "msg_type",         "Msg type",         DATA_INT,       msg_type,
                 "id",               "Station ID",       DATA_INT,       device_id,
                 "signal",           "Signal Type",      DATA_STRING,    signal_type_str,
@@ -257,7 +257,7 @@ static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     }
     else {
         data = data_make(
-                "model",            "",                 DATA_STRING,    "Fine Offset Electronics WH3080 Weather Station",
+                "model",            "",                 DATA_STRING,    "Fineoffset-WHx080\tFine Offset Electronics WH3080 Weather Station",
                 "msg_type",         "Msg type",         DATA_INT,       msg_type,
                 "uv_sensor_id",     "UV Sensor ID",     DATA_INT,       uv_sensor_id,
                 "uv_status",        "Sensor Status",    DATA_STRING,    uv_status_ok ? "OK" : "ERROR",

--- a/src/devices/kedsum.c
+++ b/src/devices/kedsum.c
@@ -75,7 +75,7 @@ static int kedsum_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     int flags = (b[1] & 0xc0) | (b[4] >> 4);
 
     data = data_make(
-            "model",            "",             DATA_STRING, "Kedsum Temperature & Humidity Sensor", // "Kedsum-TH"
+            "model",            "",             DATA_STRING, "Kedsum-TH\tKedsum Temperature & Humidity Sensor",
             "id",               "ID",           DATA_INT, id,
             "channel",          "Channel",      DATA_INT, channel,
             "battery",          "Battery",      DATA_STRING, battery_str,

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -267,7 +267,7 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
             if (validate_os_v2_message(decoder, msg, 153, num_valid_v2_bits, 15) == 0) {
                 data = data_make(
                         "brand",                 "",                        DATA_STRING, "OS",
-                        "model",                 "",                        DATA_STRING, (sensor_id == ID_THGR122N) ? "THGR122N": "THGR968",
+                        "model",                 "",                        DATA_STRING, (sensor_id == ID_THGR122N) ? "Oregon-THGR122N\tTHGR122N": "Oregon-THGR968\tTHGR968",
                         "id",                        "House Code",    DATA_INT,        get_os_rollingcode(msg, sensor_id),
                         "channel",             "Channel",         DATA_INT,        get_os_channel(msg, sensor_id),
                         "battery",             "Battery",         DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
@@ -285,7 +285,7 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
                 float gustWindspeed = (msg[5]&0x0f) /10.0F + ((msg[6]>>4)&0x0f) *1.0F + (msg[6]&0x0f) / 10.0F;
                 data = data_make(
                         "brand",            "",                     DATA_STRING, "OS",
-                        "model",            "",                     DATA_STRING, "WGR968",
+                        "model",            "",                     DATA_STRING, "Oregon-WGR968\tWGR968",
                         "id",                 "House Code", DATA_INT,        get_os_rollingcode(msg, sensor_id),
                         "channel",        "Channel",        DATA_INT,        get_os_channel(msg, sensor_id),
                         "battery",        "Battery",        DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
@@ -315,7 +315,7 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
                 // fprintf(stdout, " (%s) Pressure: %dmbar (%s)\n", comfort_str, ((msg[7] & 0x0f) | (msg[8] & 0xf0))+856, forecast_str);
                 data = data_make(
                         "brand",            "",                             DATA_STRING, "OS",
-                        "model",            "",                             DATA_STRING, "BHTR968",
+                        "model",            "",                             DATA_STRING, "Oregon-BHTR968\tBHTR968",
                         "id",                 "House Code",         DATA_INT,        get_os_rollingcode(msg, sensor_id),
                         "channel",        "Channel",                DATA_INT,        get_os_channel(msg, sensor_id),
                         "battery",        "Battery",                DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
@@ -334,7 +334,7 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
 
                 data = data_make(
                         "brand",            "",                     DATA_STRING, "OS",
-                        "model",            "",                     DATA_STRING, "RGR968",
+                        "model",            "",                     DATA_STRING, "Oregon-RGR968\tRGR968",
                         "id",                 "House Code", DATA_INT,        get_os_rollingcode(msg, sensor_id),
                         "channel",        "Channel",        DATA_INT,        get_os_channel(msg, sensor_id),
                         "battery",        "Battery",        DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
@@ -351,7 +351,7 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
                 float temp_c = get_os_temperature(msg, sensor_id);
                 data = data_make(
                         "brand",                 "",                        DATA_STRING, "OS",
-                        "model",                 "",                        DATA_STRING, "THR228N",
+                        "model",                 "",                        DATA_STRING, "Oregon-THR228N\tTHR228N",
                         "id",                        "House Code",    DATA_INT,        get_os_rollingcode(msg, sensor_id),
                         "channel",             "Channel",         DATA_INT,        get_os_channel(msg, sensor_id),
                         "battery",             "Battery",         DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
@@ -367,7 +367,7 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
                 float temp_c = get_os_temperature(msg, sensor_id);
                 data = data_make(
                         "brand",                 "",                        DATA_STRING, "OS",
-                        "model",                 "",                        DATA_STRING, "THN132N",
+                        "model",                 "",                        DATA_STRING, "Oregon-THN132N\tTHN132N",
                         "id",                        "House Code",    DATA_INT,        get_os_rollingcode(msg, sensor_id),
                         "channel",             "Channel",         DATA_INT,        get_os_channel(msg, sensor_id),
                         "battery",             "Battery",         DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
@@ -382,7 +382,7 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
                 float temp_c = get_os_temperature(msg, sensor_id);
                 data = data_make(
                         "brand",                 "",                        DATA_STRING, "OS",
-                        "model",                 "",                        DATA_STRING, "RTGN129",
+                        "model",                 "",                        DATA_STRING, "Oregon-RTGN129\tRTGN129",
                         "id",                        "House Code",    DATA_INT,        get_os_rollingcode(msg, sensor_id),
                         "channel",             "Channel",         DATA_INT,        get_os_channel(msg, sensor_id), // 1 to 5
                         "battery",             "Battery",         DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
@@ -398,7 +398,7 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
                 float temp_c = get_os_temperature(msg, sensor_id);
                 data = data_make(
                         "brand",                 "",                        DATA_STRING, "OS",
-                        "model",                 "",                        DATA_STRING, "RTGN318",
+                        "model",                 "",                        DATA_STRING, "Oregon-RTGN318\tRTGN318",
                         "id",                        "House Code",    DATA_INT,        get_os_rollingcode(msg, sensor_id),
                         "channel",             "Channel",         DATA_INT,        get_os_channel(msg, sensor_id), // 1 to 5
                         "battery",             "Battery",         DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
@@ -418,7 +418,7 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
                 float temp_c = get_os_temperature(msg, sensor_id);
                 data = data_make(
                         "brand",                 "",                        DATA_STRING, "OS",
-                        "model",                 "",                        DATA_STRING, "THN129",
+                        "model",                 "",                        DATA_STRING, "Oregon-THN129\tTHN129",
                         "id",                        "House Code",    DATA_INT,        get_os_rollingcode(msg, sensor_id),
                         "channel",             "Channel",         DATA_INT,        get_os_channel(msg, sensor_id), // 1 to 5
                         "battery",             "Battery",         DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
@@ -435,7 +435,7 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
                 float pressure = get_os_pressure(decoder, msg, sensor_id);
                 data = data_make(
                         "brand",                 "",                        DATA_STRING, "OS",
-                        "model",                 "",                        DATA_STRING, "BTHGN129",
+                        "model",                 "",                        DATA_STRING, "Oregon-BTHGN129\tBTHGN129",
                         "id",                        "House Code",    DATA_INT,        get_os_rollingcode(msg, sensor_id),
                         "channel",             "Channel",         DATA_INT,        get_os_channel(msg, sensor_id), // 1 to 5
                         "battery",             "Battery",         DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
@@ -452,7 +452,7 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
                 if ((validate_os_v2_message(decoder, msg, 297, num_valid_v2_bits, 12) == 0)) {
                 int uvidx = get_os_uv(msg, sensor_id);
                 data = data_make(
-                    "model",                    "",                     DATA_STRING, "Oregon Scientific UVR128",
+                    "model",                    "",                     DATA_STRING, "Oregon-UVR128\tOregon Scientific UVR128",
                     "id",                         "House Code", DATA_INT,        get_os_rollingcode(msg, sensor_id),
                     "uv",                         "UV Index",     DATA_FORMAT, "%u", DATA_INT, uvidx,
                     "battery",                "Battery",        DATA_STRING, get_os_battery(msg, sensor_id)?"LOW":"OK",
@@ -546,7 +546,7 @@ static int oregon_scientific_v3_parser(r_device *decoder, bitbuffer_t *bitbuffer
                 int humidity = get_os_humidity(msg, sensor_id);
                 data = data_make(
                     "brand",                    "",                     DATA_STRING, "OS",
-                    "model",                    "",                     DATA_STRING, "THGR810",
+                    "model",                    "",                     DATA_STRING, "Oregon-THGR810\tTHGR810",
                     "id",                         "House Code", DATA_INT,        get_os_rollingcode(msg, sensor_id),
                     "channel",                "Channel",        DATA_INT,        get_os_channel(msg, sensor_id),
                     "battery",                "Battery",        DATA_STRING, get_os_battery(msg, sensor_id)?"LOW":"OK",
@@ -562,7 +562,7 @@ static int oregon_scientific_v3_parser(r_device *decoder, bitbuffer_t *bitbuffer
                     float temp_c = get_os_temperature(msg, sensor_id);
                     data = data_make(
                         "brand",                    "",                     DATA_STRING, "OS",
-                        "model",                    "",                     DATA_STRING, "THN802",
+                        "model",                    "",                     DATA_STRING, "Oregon-THN802\tTHN802",
                         "id",                         "House Code", DATA_INT,        get_os_rollingcode(msg, sensor_id),
                         "channel",                "Channel",        DATA_INT,        get_os_channel(msg, sensor_id),
                         "battery",                "Battery",        DATA_STRING, get_os_battery(msg, sensor_id)?"LOW":"OK",
@@ -577,7 +577,7 @@ static int oregon_scientific_v3_parser(r_device *decoder, bitbuffer_t *bitbuffer
                 int uvidx = get_os_uv(msg, sensor_id);
                 data = data_make(
                     "brand",                    "",                     DATA_STRING, "OS",
-                    "model",                    "",                     DATA_STRING, "UV800",
+                    "model",                    "",                     DATA_STRING, "Oregon-UV800\tUV800",
                     "id",                         "House Code", DATA_INT,        get_os_rollingcode(msg, sensor_id),
                     "channel",                "Channel",        DATA_INT,        get_os_channel(msg, sensor_id),
                     "battery",                "Battery",        DATA_STRING, get_os_battery(msg, sensor_id)?"LOW":"OK",
@@ -592,7 +592,7 @@ static int oregon_scientific_v3_parser(r_device *decoder, bitbuffer_t *bitbuffer
                 float total_rain=get_os_total_rain(msg, sensor_id);
                 data = data_make(
                     "brand",            "",                     DATA_STRING, "OS",
-                    "model",            "",                     DATA_STRING, "PCR800",
+                    "model",            "",                     DATA_STRING, "Oregon-PCR800\tPCR800",
                     "id",                 "House Code", DATA_INT,        get_os_rollingcode(msg, sensor_id),
                     "channel",        "Channel",        DATA_INT,        get_os_channel(msg, sensor_id),
                     "battery",        "Battery",        DATA_STRING, get_os_battery(msg, sensor_id)?"LOW":"OK",
@@ -609,7 +609,7 @@ static int oregon_scientific_v3_parser(r_device *decoder, bitbuffer_t *bitbuffer
                 float total_rain=get_os_total_rain(msg, sensor_id);
                 data = data_make(
                         "brand",            "",                     DATA_STRING, "OS",
-                        "model",            "",                     DATA_STRING, "PCR800a",
+                        "model",            "",                     DATA_STRING, "Oregon-PCR800a\tPCR800a",
                         "id",                 "House Code", DATA_INT,        get_os_rollingcode(msg, sensor_id),
                         "channel",        "Channel",        DATA_INT,        get_os_channel(msg, sensor_id),
                         "battery",        "Battery",        DATA_STRING, get_os_battery(msg, sensor_id)?"LOW":"OK",
@@ -627,7 +627,7 @@ static int oregon_scientific_v3_parser(r_device *decoder, bitbuffer_t *bitbuffer
                 float quadrant = (0x0f&(msg[4]>>4))*22.5F;
                 data = data_make(
                         "brand",            "",                     DATA_STRING,    "OS",
-                        "model",            "",                     DATA_STRING,    "WGR800",
+                        "model",            "",                     DATA_STRING,    "Oregon-WGR800\tWGR800",
                         "id",                 "House Code", DATA_INT,         get_os_rollingcode(msg, sensor_id),
                         "channel",        "Channel",        DATA_INT,         get_os_channel(msg, sensor_id),
                         "battery",        "Battery",        DATA_STRING,    get_os_battery(msg, sensor_id)?"LOW":"OK",
@@ -646,7 +646,7 @@ static int oregon_scientific_v3_parser(r_device *decoder, bitbuffer_t *bitbuffer
                 unsigned short int ipower = (rawAmp /(0.27*230)*1000);
                 data = data_make(
                         "brand",    "",                     DATA_STRING, "OS",
-                        "model",    "",                     DATA_STRING,    "CM160",
+                        "model",    "",                     DATA_STRING,    "Oregon-CM160\tCM160",
                         "id",         "House Code", DATA_INT, msg[1]&0x0F,
                         "power_W", "Power",         DATA_FORMAT,    "%d W", DATA_INT, ipower,
                         NULL);
@@ -666,7 +666,7 @@ static int oregon_scientific_v3_parser(r_device *decoder, bitbuffer_t *bitbuffer
                 if (itotal && valid == 0) {
                     data = data_make(
                             "brand",            "",                     DATA_STRING, "OS",
-                            "model",            "",                     DATA_STRING,    "CM180",
+                            "model",            "",                     DATA_STRING,    "Oregon-CM180\tCM180",
                             "id",                 "House Code", DATA_INT, msg[1]&0x0F,
                             "power_W",        "Power",            DATA_FORMAT,    "%d W",DATA_INT, ipower,
                             "energy_kWh", "Energy",         DATA_FORMAT,    "%2.1f kWh",DATA_DOUBLE, total_energy,
@@ -676,7 +676,7 @@ static int oregon_scientific_v3_parser(r_device *decoder, bitbuffer_t *bitbuffer
                 else if (!itotal) {
                     data = data_make(
                             "brand",    "",                     DATA_STRING, "OS",
-                            "model",    "",                     DATA_STRING,    "CM180",
+                            "model",    "",                     DATA_STRING,    "Oregon-CM180\tCM180",
                             "id",         "House Code", DATA_INT, msg[1]&0x0F,
                             "power_W", "Power",         DATA_FORMAT,    "%d W",DATA_INT, ipower,
                             NULL);

--- a/src/devices/s3318p.c
+++ b/src/devices/s3318p.c
@@ -86,7 +86,7 @@ static int s3318p_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     int battery_low = (b[4] & 0x40) >> 6;
 
     data = data_make(
-            "model",            "",             DATA_STRING, "S3318P Temperature & Humidity Sensor", // "Conrad-S3318P"
+            "model",            "",             DATA_STRING, "Conrad-S3318P\tS3318P Temperature & Humidity Sensor",
             "id",               "ID",           DATA_INT, id,
             "channel",          "Channel",      DATA_INT, channel,
             "battery",          "Battery",      DATA_STRING, battery_low ? "LOW" : "OK",

--- a/src/devices/simplisafe.c
+++ b/src/devices/simplisafe.c
@@ -54,7 +54,7 @@ ss_sensor_parser(r_device *decoder, bitbuffer_t *bitbuffer, int row)
     }
 
     data = data_make(
-            "model",        "",             DATA_STRING, "SimpliSafe Sensor",
+            "model",        "",             DATA_STRING, "SimpliSafe-Sensor\tSimpliSafe Sensor",
             "device",       "Device ID",    DATA_STRING, id,
             "seq",          "Sequence",     DATA_INT, seq,
             "state",        "State",        DATA_INT, state,
@@ -89,7 +89,7 @@ ss_pinentry_parser(r_device *decoder, bitbuffer_t *bitbuffer, int row)
     sprintf(extradata, "Disarm Pin: %x%x%x%x", digits[0], digits[1], digits[2], digits[3]);
 
     data = data_make(
-            "model",        "",             DATA_STRING, "SimpliSafe Keypad",
+            "model",        "",             DATA_STRING, "SimpliSafe-Keypad\tSimpliSafe Keypad",
             "device",       "Device ID",    DATA_STRING, id,
             "seq",          "Sequence",     DATA_INT, b[9],
             "extradata",    "Extra Data",   DATA_STRING, extradata,
@@ -125,7 +125,7 @@ ss_keypad_commands(r_device *decoder, bitbuffer_t *bitbuffer, int row)
     ss_get_id(id, b);
 
     data = data_make(
-            "model",        "",             DATA_STRING, "SimpliSafe Keypad",
+            "model",        "",             DATA_STRING, "SimpliSafe-Keypad\tSimpliSafe Keypad",
             "device",       "Device ID",    DATA_STRING, id,
             "seq",          "Sequence",     DATA_INT, b[9],
             "extradata",    "Extra Data",   DATA_STRING, extradata,

--- a/src/devices/solight_te44.c
+++ b/src/devices/solight_te44.c
@@ -73,7 +73,7 @@ static int solight_te44_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     temperature = (float) (((256 * multiplier) + temperature_raw) / 10.0);
 
     data = data_make(
-            "model", "", DATA_STRING, "Solight TE44",
+            "model", "", DATA_STRING, "Solight-TE44\tSolight TE44",
             "id", "Id", DATA_INT, id,
             "channel", "Channel", DATA_INT, channel + 1,
             "temperature_C", "Temperature", DATA_FORMAT, "%.02f C", DATA_DOUBLE, temperature,

--- a/src/devices/springfield.c
+++ b/src/devices/springfield.c
@@ -59,7 +59,7 @@ static int springfield_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         uk1      =  b[4] >> 4;    /* unknown. */
 
         data = data_make(
-                "model",            "",             DATA_STRING, "Springfield Temperature & Moisture",
+                "model",            "",             DATA_STRING, "Springfield-Soil\tSpringfield Temperature & Moisture",
                 "sid",              "SID",          DATA_INT,    sid,
                 "channel",          "Channel",      DATA_INT,    channel,
                 "battery",          "Battery",      DATA_STRING, battery ? "LOW" : "OK",

--- a/src/devices/thermopro_tp11.c
+++ b/src/devices/thermopro_tp11.c
@@ -62,7 +62,7 @@ static int thermopro_tp11_sensor_callback(r_device *decoder, bitbuffer_t *bitbuf
     temp_c = (temp_raw - 200) / 10.;
 
     data = data_make(
-            "model",         "",            DATA_STRING, "Thermopro TP11 Thermometer",
+            "model",         "",            DATA_STRING, "Thermopro-TP11\tThermopro TP11 Thermometer",
             "id",            "Id",          DATA_INT,    device,
             "temperature_C", "Temperature", DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp_c,
             NULL);

--- a/src/devices/thermopro_tp12.c
+++ b/src/devices/thermopro_tp12.c
@@ -94,7 +94,7 @@ static int thermopro_tp12_sensor_callback(r_device *decoder, bitbuffer_t *bitbuf
     temp2_c = (temp2_raw - 200) * 0.1;
 
     data = data_make(
-            "model",            "",            DATA_STRING, "Thermopro TP12 Thermometer",
+            "model",            "",            DATA_STRING, "Thermopro-TP12\tThermopro TP12 Thermometer",
             "id",               "Id",          DATA_INT,    device,
             "temperature_1_C",  "Temperature 1 (Food)", DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp1_c,
             "temperature_2_C",  "Temperature 2 (Barbecue)", DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp2_c,


### PR DESCRIPTION
This PR allows a way to transition to new unique, short, and uniform model "keys" instead of the old often descriptive model "names".

For now early adopter users can opt-in to new model keys using `-M newmodel`. At some point after the next release we can default to new model keys and offer a `-M oldmodel` for legancy use.

A few changed model keys are included as example.