### PR TITLE
Add report model description option

### DIFF
--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -74,6 +74,7 @@ typedef struct r_cfg {
     time_mode_t report_time;
     int report_time_hires;
     int report_time_utc;
+    int report_description;
     int no_default_devices;
     struct r_device *devices;
     uint16_t num_r_devices;


### PR DESCRIPTION
In preparation for #986 this adds a report option for the device description (the "name" field).
This is intended for first time discovery and exploration of devices with KV output. Example output:
```
time      : @0.129760s
Description: Fine Offset Electronics, WH2, WH5, Telldus Temperature/Humidity/Rain Sensor
model     : Fineoffset-WH2             ID        : 151
Temperature: 23.2 C      Humidity  : 22 %          Integrity : CRC
```