### PR TITLE
Fix another clang warning

### DIFF
--- a/src/sdr.c
+++ b/src/sdr.c
@@ -868,6 +868,8 @@ int sdr_set_auto_gain(sdr_dev_t *dev, int verbose)
 
 int sdr_set_tuner_gain(sdr_dev_t *dev, char *gain_str, int verbose)
 {
+    int r = -1;
+    
     if (!gain_str || !*gain_str) {
         /* Enable automatic gain */
         return sdr_set_auto_gain(dev, verbose);
@@ -892,7 +894,7 @@ int sdr_set_tuner_gain(sdr_dev_t *dev, char *gain_str, int verbose)
 
 #ifdef RTLSDR
     /* Enable manual gain */
-    int r = rtlsdr_set_tuner_gain_mode(dev->rtlsdr_dev, 1);
+    r = rtlsdr_set_tuner_gain_mode(dev->rtlsdr_dev, 1);
     if (verbose)
         if (r < 0)
             fprintf(stderr, "WARNING: Failed to enable manual gain.\n");
@@ -905,10 +907,9 @@ int sdr_set_tuner_gain(sdr_dev_t *dev, char *gain_str, int verbose)
         else
             fprintf(stderr, "Tuner gain set to %f dB.\n", gain / 10.0);
     }
-    return r;
 #endif
 
-    return -1;
+    return r;
 }
 
 int sdr_set_sample_rate(sdr_dev_t *dev, uint32_t rate, int verbose)


### PR DESCRIPTION
Fix the clang warning:
```
src/sdr.c(911,13):  warning: 'return' will never be executed [-Wunreachable-code-return]
    return -1;
            ^
```
by using a local `r` as in `sdr_set_auto_gain()`.