### PR TITLE
Include <stdlib.h> ahead of "util.h"

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -9,10 +9,9 @@
     (at your option) any later version.
 */
 
-#include "util.h"
-#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include "util.h"
 
 uint8_t reverse8(uint8_t x)
 {


### PR DESCRIPTION
Since <stdlib.h> currently is NOT included in "util.h", this triggers this warning using MSVC:
  f:\ProgramFiler-x86\WindowsKits\Include\10.0.18309.0\ucrt\stdlib.h(1289): warning C4005: 
  'max': macro redefinition (compiling source file src/util.c)
(same for the 'min()' macro).

Fix by including <stdlib,h> in "util.h" AND including "util.h" last.