### PR TITLE
Include <stdlib.h> too.

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -13,6 +13,7 @@
 #define INCLUDE_UTIL_H_
 
 #include <stdint.h>
+#include <stdlib.h>
 
 // Helper macros, collides with MSVC's stdlib.h unless NOMINMAX is used
 #ifndef max


### PR DESCRIPTION
Together with the patch for 'src/util.c', this squelches a redefinition warning for 'min/max' macros (MSVC).