### PR TITLE
Add CMake option to choose driver support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
 
 # Test with Precise default (GCC 4.6.3, CMake 2.8.7) and no libs
     - compiler: gcc
-      env: NOTE=No-RTL-SDR
+      env: RTLSDR=OFF
       dist: precise
       addons:
         apt:
@@ -55,7 +55,7 @@ matrix:
 
 # Test with Precise Clang (clang 3.4, CMake 2.8.7) and no libs
     - compiler: clang
-      env: NOTE=No-RTL-SDR
+      env: RTLSDR=OFF
       dist: precise
       addons:
         apt:
@@ -121,7 +121,7 @@ matrix:
 
 # Test with Xenial default (gcc 5.4, cmake 3.12) RTL-SDR and SoapySDR
     - compiler: gcc
-      env: NOTE=RTLSDR-and-SoapySDR
+      env: SOAPYSDR=ON
       dist: xenial
       addons:
         apt:
@@ -136,7 +136,7 @@ matrix:
             - cmake
 # Test with Xenial default (gcc 5.4, cmake 3.12) only SoapySDR
     - compiler: gcc
-      env: NOTE=Only-SoapySDR
+      env: RTLSDR=OFF SOAPYSDR=ON
       dist: xenial
       addons:
         apt:
@@ -163,7 +163,7 @@ matrix:
             - cmake
 # Test with mingw 32 bit
     - compiler: i686-w64-mingw32-gcc
-      env: CMAKE_TOOLCHAIN_FILE=cmake/Toolchain-gcc-mingw-w64-i686.cmake
+      env: RTLSDR=OFF CMAKE_TOOLCHAIN_FILE=cmake/Toolchain-gcc-mingw-w64-i686.cmake
       dist: trusty
       addons:
         apt:
@@ -176,7 +176,7 @@ matrix:
             - gcc-multilib
 # Test with mingw 64 bit
     - compiler: x86_64-w64-mingw32-gcc
-      env: CMAKE_TOOLCHAIN_FILE=cmake/Toolchain-gcc-mingw-w64-x86-64.cmake
+      env: RTLSDR=OFF CMAKE_TOOLCHAIN_FILE=cmake/Toolchain-gcc-mingw-w64-x86-64.cmake
       dist: trusty
       addons:
         apt:
@@ -202,7 +202,7 @@ matrix:
 # Full test suite
     - language: python
       compiler: gcc
-      env: RUN_RTL_433_TESTS=1
+      env: RTLSDR=OFF RUN_RTL_433_TESTS=1
       dist: trusty
       python:
           - "2.7"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,10 @@ endif()
 ########################################################################
 # Find build dependencies
 ########################################################################
+set(ENABLE_RTLSDR AUTO CACHE STRING "Enable RTL-SDR (lbrtlsdr) driver support")
+set_property(CACHE ENABLE_RTLSDR PROPERTY STRINGS AUTO ON OFF)
+if(ENABLE_RTLSDR) # AUTO / ON
+
 find_package(PkgConfig)
 find_package(LibRTLSDR)
 find_package(LibUSB)
@@ -92,9 +96,19 @@ if(LIBRTLSDR_FOUND AND LIBUSB_FOUND)
     include_directories(${LIBRTLSDR_INCLUDE_DIRS} ${LIBUSB_INCLUDE_DIRS})
     list(APPEND SDR_LIBRARIES ${LIBRTLSDR_LIBRARIES} ${LIBUSB_LIBRARIES})
     ADD_DEFINITIONS(-DRTLSDR)
-else()
+elseif(ENABLE_RTLSDR STREQUAL "AUTO")
     message(STATUS "RTL-SDR development files not found, RTL-SDR device input won't be possible.")
+else()
+    message(FATAL_ERROR "RTL-SDR development files not found.")
 endif()
+
+else()
+    message(STATUS "RTL-SDR device input disabled.")
+endif()
+
+set(ENABLE_SOAPYSDR AUTO CACHE STRING "Enable SoapySDR driver support")
+set_property(CACHE ENABLE_SOAPYSDR PROPERTY STRINGS AUTO ON OFF)
+if(ENABLE_SOAPYSDR) # AUTO / ON
 
 find_package(SoapySDR "0.6" NO_MODULE)
 if(SoapySDR_FOUND)
@@ -102,8 +116,14 @@ if(SoapySDR_FOUND)
     include_directories(${SoapySDR_INCLUDE_DIRS})
     list(APPEND SDR_LIBRARIES ${SoapySDR_LIBRARIES})
     ADD_DEFINITIONS(-DSOAPYSDR)
-else()
+elseif(ENABLE_SOAPYSDR STREQUAL "AUTO")
     message(STATUS "SoapySDR development files not found, SoapySDR device input won't be possible.")
+else()
+    message(FATAL_ERROR "SoapySDR development files not found.")
+endif()
+
+else()
+    message(STATUS "SoapySDR device input disabled.")
 endif()
 
 # cmake -DCMAKE_BUILD_TYPE=Profile ..

--- a/do_build.sh
+++ b/do_build.sh
@@ -1,11 +1,22 @@
 #!/bin/sh
 set -e
+
+# performs a standard out-of-tree build and transform environment vars to cmake options
+# set RTLSDR=ON/OFF/AUTO (default: ON)
+# set SOAPYSDR=ON/OFF/AUTO (default: AUTO)
+# set CMAKE_TOOLCHAIN_FILE=file (default: unset)
+# set RUN_RTL_433_TESTS=1 (default: unset)
+
+RTLSDR="${RTLSDR:-ON}"
+SOAPYSDR="${SOAPYSDR:-AUTO}"
+set -- -DENABLE_RTLSDR=$RTLSDR -DENABLE_SOAPYSDR=$SOAPYSDR
+
 mkdir -p build
 cd build
 if [ -n "$CMAKE_TOOLCHAIN_FILE" ] ; then
-cmake -DCMAKE_TOOLCHAIN_FILE=../$CMAKE_TOOLCHAIN_FILE ..
+cmake $@ -DCMAKE_TOOLCHAIN_FILE=../$CMAKE_TOOLCHAIN_FILE ..
 else
-cmake ..
+cmake $@ ..
 fi
 make
 # make install


### PR DESCRIPTION
This adds explicit CMake options to choose RTL-SDR and SoapySDR driver support.
Use ENABLE_RTLSDR=ON/OFF/AUTO (default: ON) and ENABLE_SOAPYSDR=ON/OFF/AUTO (default: AUTO).