### PR TITLE
 Normalize odd well-known keys on some devices

### DIFF
--- a/src/devices/ambient_weather.c
+++ b/src/devices/ambient_weather.c
@@ -47,7 +47,7 @@ ambient_weather_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, 
 
     data = data_make(
             "model",          "",             DATA_STRING, _X("Ambientweather-F007TH","Ambient Weather F007TH Thermo-Hygrometer"),
-            "device",         "House Code",   DATA_INT,    deviceID,
+            _X("id","device"),         "House Code",   DATA_INT,    deviceID,
             "channel",        "Channel",      DATA_INT,    channel,
             "battery",        "Battery",      DATA_STRING, isBatteryLow ? "Low" : "Ok",
             "temperature_F",  "Temperature",  DATA_FORMAT, "%.1f F", DATA_DOUBLE, temperature,
@@ -91,7 +91,8 @@ ambient_weather_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
 static char *output_fields[] = {
     "model",
-    "device",
+    "device", // TODO: delete this
+    "id",
     "channel",
     "battery",
     "temperature_F",

--- a/src/devices/current_cost.c
+++ b/src/devices/current_cost.c
@@ -41,7 +41,7 @@ static int current_cost_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         data = data_make(
                 "model",         "",              DATA_STRING, _X("CurrentCost-TX","CurrentCost TX"), //TODO: it may have different CC Model ? any ref ?
                 //"rc",            "Rolling Code",  DATA_INT, rc, //TODO: add rolling code b[1] ? test needed
-                "dev_id",       "Device Id",     DATA_FORMAT, "%d", DATA_INT, device_id,
+                _X("id","dev_id"),       "Device Id",     DATA_FORMAT, "%d", DATA_INT, device_id,
                 "power0",       "Power 0",       DATA_FORMAT, "%d W", DATA_INT, watt0,
                 "power1",       "Power 1",       DATA_FORMAT, "%d W", DATA_INT, watt1,
                 "power2",       "Power 2",       DATA_FORMAT, "%d W", DATA_INT, watt2,
@@ -58,7 +58,7 @@ static int current_cost_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
        uint32_t c_impulse = (unsigned)packet[4] << 24 | packet[5] <<16 | packet[6] <<8 | packet[7] ;
        data = data_make(
                "model",        "",              DATA_STRING, _X("CurrentCost-Counter","CurrentCost Counter"), //TODO: it may have different CC Model ? any ref ?
-               "dev_id",       "Device Id",     DATA_FORMAT, "%d", DATA_INT, device_id,
+               _X("id","dev_id"),       "Device Id",     DATA_FORMAT, "%d", DATA_INT, device_id,
                "sensor_type",  "Sensor Id",     DATA_FORMAT, "%d", DATA_INT, sensor_type, //Could "friendly name" this?
                //"counter",      "Counter",       DATA_FORMAT, "%d", DATA_INT, c_impulse,
                "power0",       "Counter",       DATA_FORMAT, "%d", DATA_INT, c_impulse,
@@ -72,7 +72,8 @@ static int current_cost_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
 static char *output_fields[] = {
     "model",
-    "dev_id",
+    "dev_id", // TODO: delete this
+    "id",
     "power0",
     "power1",
     "power2",

--- a/src/devices/emontx.c
+++ b/src/devices/emontx.c
@@ -114,7 +114,7 @@ static int emontx_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 				 "ct2", "", DATA_FORMAT, "%d", DATA_INT, (int16_t)words[1],
 				 "ct3", "", DATA_FORMAT, "%d", DATA_INT, (int16_t)words[2],
 				 "ct4", "", DATA_FORMAT, "%d", DATA_INT, (int16_t)words[3],
-				 "Vrms/batt", "", DATA_FORMAT, "%.2f", DATA_DOUBLE, vrms,
+				 _X("batt_Vrms","Vrms/batt"), "", DATA_FORMAT, "%.2f", DATA_DOUBLE, vrms,
 				 "pulse", "", DATA_FORMAT, "%u", DATA_INT, words[11] | ((uint32_t)words[12] << 16),
 				 // Slightly horrid... a value of 300.0°C means 'no reading'. So omit them completely.
 				 words[5] == 3000 ? NULL : "temp1_C", "", DATA_FORMAT, "%.1f", DATA_DOUBLE, (double)words[5] / 10.0,
@@ -137,7 +137,8 @@ static char *output_fields[] = {
 	"ct2",
 	"ct3",
 	"ct4",
-	"Vrms/batt",
+	"Vrms/batt", // TODO: delete this
+	"batt_Vrms",
 	"temp1_C",
 	"temp2_C",
 	"temp3_C",

--- a/src/devices/fineoffset_wh1080.c
+++ b/src/devices/fineoffset_wh1080.c
@@ -241,17 +241,16 @@ static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                 NULL);
     }
     else if (msg_type == 1) {
+        char clock_str[20];
+        sprintf(clock_str, "%04d-%02d-%02dT%02d:%02d:%02d",
+                year, month, day, hours, minutes, seconds);
+
         data = data_make(
                 "model",            "",                 DATA_STRING,    _X("Fineoffset-WHx080","Fine Offset Electronics WH1080/WH3080 Weather Station"),
                 "msg_type",         "Msg type",         DATA_INT,       msg_type,
                 "id",               "Station ID",       DATA_INT,       device_id,
                 "signal",           "Signal Type",      DATA_STRING,    signal_type_str,
-                "hours",            "Hours",            DATA_FORMAT,    "%02d",     DATA_INT,   hours,
-                "minutes",          "Minutes",          DATA_FORMAT,    "%02d",     DATA_INT,   minutes,
-                "seconds",          "Seconds",          DATA_FORMAT,    "%02d",     DATA_INT,   seconds,
-                "year",             "Year",             DATA_FORMAT,    "%02d",     DATA_INT,   year,
-                "month",            "Month",            DATA_FORMAT,    "%02d",     DATA_INT,   month,
-                "day",              "Day",              DATA_FORMAT,    "%02d",     DATA_INT,   day,
+                "radio_clock",      "Radio Clock",      DATA_STRING,    clock_str,
                 "mic",              "Integrity",        DATA_STRING,    "CRC",
                 NULL);
     }
@@ -282,12 +281,7 @@ static char *output_fields[] = {
     "rain",
     "msg_type",
     "signal",
-    "hours",
-    "minutes",
-    "seconds",
-    "year",
-    "month",
-    "day",
+    "radio_clock",
     "battery",
     "sensor_code",
     "uv_status",

--- a/src/devices/hideki.c
+++ b/src/devices/hideki.c
@@ -117,7 +117,7 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         humidity = ((packet[6] & 0xF0) >> 4) * 10 + (packet[6] & 0x0F);
         data = data_make(
                 "model",            "",                 DATA_STRING, _X("Hideki-TS04","HIDEKI TS04 sensor"),
-                "rc",               "Rolling Code",     DATA_INT, rc,
+                _X("id","rc"),               "Rolling Code",     DATA_INT, rc,
                 "channel",          "Channel",          DATA_INT, channel,
                 "battery",          "Battery",          DATA_STRING, battery_ok ? "OK": "LOW",
                 "temperature_C",    "Temperature",      DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp/10.f,
@@ -137,7 +137,7 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
         data = data_make(
                 "model",            "",                 DATA_STRING, _X("Hideki-Wind","HIDEKI Wind sensor"),
-                "rc",               "Rolling Code",     DATA_INT, rc,
+                _X("id","rc"),               "Rolling Code",     DATA_INT, rc,
                 "channel",          "Channel",          DATA_INT, channel,
                 "battery",          "Battery",          DATA_STRING, battery_ok ? "OK": "LOW",
                 "temperature_C",    "Temperature",      DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp * 0.1f,
@@ -153,7 +153,7 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     if (sensortype == HIDEKI_TEMP) {
         data = data_make(
                 "model",            "",                 DATA_STRING, _X("Hideki-Temperature","HIDEKI Temperature sensor"),
-                "rc",               "Rolling Code",     DATA_INT, rc,
+                _X("id","rc"),               "Rolling Code",     DATA_INT, rc,
                 "channel",          "Channel",          DATA_INT, channel,
                 "battery",          "Battery",          DATA_STRING, battery_ok ? "OK": "LOW",
                 "temperature_C",    "Temperature",      DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp * 0.1f,
@@ -168,7 +168,7 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
         data = data_make(
                 "model",            "",                 DATA_STRING, _X("Hideki-Rain","HIDEKI Rain sensor"),
-                "rc",               "Rolling Code",     DATA_INT, rc,
+                _X("id","rc"),               "Rolling Code",     DATA_INT, rc,
                 "channel",          "Channel",          DATA_INT, channel,
                 "battery",          "Battery",          DATA_STRING, battery_ok ? "OK": "LOW",
                 "rain_mm",          "Rain",             DATA_FORMAT, "%.01f mm", DATA_DOUBLE, rain_units * 0.7f,
@@ -182,7 +182,8 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
 static char *output_fields[] = {
     "model",
-    "rc",
+    "rc", // TODO: delete this
+    "id",
     "channel",
     "battery",
     "temperature_C",

--- a/src/devices/hondaremote.c
+++ b/src/devices/hondaremote.c
@@ -44,7 +44,7 @@ static int hondaremote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         data = data_make(
                 "model",        "",     DATA_STRING, _X("Honda-CarRemote","Honda Remote"),
-                "device id",    "",    DATA_INT, device_id,
+                _X("id","device id"),    "",    DATA_INT, device_id,
                 "code",         "",    DATA_STRING, code,
                 NULL);
 
@@ -56,7 +56,8 @@ static int hondaremote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
 static char *output_fields[] = {
     "model",
-    "device id",
+    "device_id", // TODO: delete this
+    "id",
     "code",
     NULL
 };

--- a/src/devices/interlogix.c
+++ b/src/devices/interlogix.c
@@ -196,8 +196,8 @@ static int interlogix_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     data = data_make(
             "model",       "Model",         DATA_STRING, _X("Interlogix-Security","Interlogix"),
+            _X("subtype","device_type"),     "Device Type",   DATA_STRING, device_type,
             "id",          "ID",            DATA_STRING, device_serial,
-            "device_type", "Device Type",   DATA_STRING, device_type,
             "raw_message", "Raw Message",   DATA_STRING, raw_message,
             "battery",     "Battery",       DATA_STRING, low_battery,
             "switch1",     "Switch1 State", DATA_STRING, f1_latch_state,
@@ -214,8 +214,9 @@ static int interlogix_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
 static char *output_fields[] = {
     "model",
+    "subtype",
     "id",
-    "device_type",
+    "device_type", // TODO: delete this
     "raw_message",
     "battery",
     "switch1",

--- a/src/devices/lacrossews.c
+++ b/src/devices/lacrossews.c
@@ -118,7 +118,6 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                 temp_c = (msg_value_bcd - 300.0) / 10.0;
                 data = data_make(
                         "model",            "",             DATA_STRING, _X("LaCrosse-WS","LaCrosse WS"),
-                        "ws_id",            "",             DATA_INT, ws_id,
                         "id",               "",             DATA_INT, sensor_id,
                         "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
                         NULL);
@@ -134,7 +133,6 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                 else {
                     data = data_make(
                             "model",         "",            DATA_STRING, _X("LaCrosse-WS","LaCrosse WS"),
-                            "ws_id",         "",            DATA_INT, ws_id,
                             "id",            "",            DATA_INT, sensor_id,
                             "humidity",      "Humidity",    DATA_INT, msg_value_bcd2,
                             NULL);
@@ -147,7 +145,6 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                 rain_mm = 0.5180 * msg_value_bin;
                 data = data_make(
                         "model",            "",             DATA_STRING, _X("LaCrosse-WS","LaCrosse WS"),
-                        "ws_id",            "",             DATA_INT, ws_id,
                         "id",               "",             DATA_INT, sensor_id,
                         "rainfall_mm",      "Rainfall",     DATA_FORMAT, "%3.2f mm", DATA_DOUBLE, rain_mm, NULL);
                 decoder_output_data(decoder, data);
@@ -171,7 +168,6 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
                     data = data_make(
                             "model",            "",             DATA_STRING, _X("LaCrosse-WS","LaCrosse WS"),
-                            "ws_id",            "",             DATA_INT, ws_id,
                             "id",               "",             DATA_INT, sensor_id,
                             wind_key,           wind_label,     DATA_FORMAT, "%3.1f m/s", DATA_DOUBLE, wind_spd,
                             "wind_direction",   "Direction",    DATA_DOUBLE, wind_dir, NULL);
@@ -195,7 +191,6 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
 static char *output_fields[] = {
     "model",
-    "ws_id",
     "id",
     "temperature_C",
     "humidity",

--- a/src/devices/maverick_et73.c
+++ b/src/devices/maverick_et73.c
@@ -78,7 +78,7 @@ static int maverick_et73_sensor_callback(r_device *decoder, bitbuffer_t *bitbuff
 
     data = data_make(
             "model",            "",                 DATA_STRING, _X("Maverick-ET73","Maverick ET73"),
-            "rid",              "Random Id",        DATA_INT, device,
+            _X("id","rid"),              "Random Id",        DATA_INT, device,
             "temperature_1_C",  "Temperature 1",    DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp1_c,
             "temperature_2_C",  "Temperature 2",    DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp2_c,
             NULL);
@@ -88,7 +88,8 @@ static int maverick_et73_sensor_callback(r_device *decoder, bitbuffer_t *bitbuff
 
 static char *output_fields[] = {
     "model",
-    "rid",
+    "rid", // TODO: delete this
+    "id",
     "temperature_1_C",
     "temperature_2_C",
     NULL

--- a/src/devices/oregon_scientific_v1.c
+++ b/src/devices/oregon_scientific_v1.c
@@ -58,7 +58,7 @@ static int oregon_scientific_v1_callback(r_device *decoder, bitbuffer_t *bitbuff
 		data = data_make(
 				"brand",		"",				DATA_STRING,	"OS",
 				"model",		"",				DATA_STRING,	_X("Oregon-v1","OSv1 Temperature Sensor"),
-				"sid",			"SID",			DATA_INT,		sid,
+				_X("id","sid"),			"SID",			DATA_INT,		sid,
 				"channel",		"Channel",		DATA_INT,		channel,
 				"battery",		"Battery",		DATA_STRING,	battery ? "LOW" : "OK",
 				"temperature_C","Temperature",	DATA_FORMAT,	"%.01f C",				DATA_DOUBLE,	tempC,
@@ -72,6 +72,7 @@ static int oregon_scientific_v1_callback(r_device *decoder, bitbuffer_t *bitbuff
 static char *output_fields[] = {
 	"brand",
 	"model",
+	"sid", // TODO: delete this
 	"id",
 	"channel",
 	"battery",

--- a/src/devices/prologue.c
+++ b/src/devices/prologue.c
@@ -73,8 +73,8 @@ static int prologue_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         data = data_make(
                 "model",         "",            DATA_STRING, _X("Prologue-TH","Prologue sensor"),
-                "id",            "",            DATA_INT, type, // this should be named "type"
-                "rid",           "",            DATA_INT, id, // this should be named "id"
+                _X("subtype","id"),       "",            DATA_INT, type,
+                _X("id","rid"),            "",            DATA_INT, id,
                 "channel",       "Channel",     DATA_INT, channel,
                 "battery",       "Battery",     DATA_STRING, battery ? "OK" : "LOW",
                 "button",        "Button",      DATA_INT, button,
@@ -90,8 +90,9 @@ static int prologue_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
 static char *output_fields[] = {
     "model",
+    "subtype",
     "id",
-    "rid",
+    "rid", // TODO: delete this
     "channel",
     "battery",
     "button",

--- a/src/devices/simplisafe.c
+++ b/src/devices/simplisafe.c
@@ -55,7 +55,7 @@ ss_sensor_parser(r_device *decoder, bitbuffer_t *bitbuffer, int row)
 
     data = data_make(
             "model",        "",             DATA_STRING, _X("SimpliSafe-Sensor","SimpliSafe Sensor"),
-            "device",       "Device ID",    DATA_STRING, id,
+            _X("id","device"),       "Device ID",    DATA_STRING, id,
             "seq",          "Sequence",     DATA_INT, seq,
             "state",        "State",        DATA_INT, state,
             "extradata",    "Extra Data",   DATA_STRING, extradata,
@@ -90,7 +90,7 @@ ss_pinentry_parser(r_device *decoder, bitbuffer_t *bitbuffer, int row)
 
     data = data_make(
             "model",        "",             DATA_STRING, _X("SimpliSafe-Keypad","SimpliSafe Keypad"),
-            "device",       "Device ID",    DATA_STRING, id,
+            _X("id","device"),       "Device ID",    DATA_STRING, id,
             "seq",          "Sequence",     DATA_INT, b[9],
             "extradata",    "Extra Data",   DATA_STRING, extradata,
             NULL
@@ -126,7 +126,7 @@ ss_keypad_commands(r_device *decoder, bitbuffer_t *bitbuffer, int row)
 
     data = data_make(
             "model",        "",             DATA_STRING, _X("SimpliSafe-Keypad","SimpliSafe Keypad"),
-            "device",       "Device ID",    DATA_STRING, id,
+            _X("id","device"),       "Device ID",    DATA_STRING, id,
             "seq",          "Sequence",     DATA_INT, b[9],
             "extradata",    "Extra Data",   DATA_STRING, extradata,
             NULL
@@ -164,7 +164,8 @@ ss_sensor_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
 static char *sensor_output_fields[] = {
     "model",
-    "device",
+    "device", // TODO: delete this
+    "id",
     "seq",
     "state",
     "extradata",

--- a/src/devices/springfield.c
+++ b/src/devices/springfield.c
@@ -60,7 +60,7 @@ static int springfield_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         data = data_make(
                 "model",            "",             DATA_STRING, _X("Springfield-Soil","Springfield Temperature & Moisture"),
-                "sid",              "SID",          DATA_INT,    sid,
+                _X("id","sid"),              "SID",          DATA_INT,    sid,
                 "channel",          "Channel",      DATA_INT,    channel,
                 "battery",          "Battery",      DATA_STRING, battery ? "LOW" : "OK",
                 "transmit",         "Transmit",     DATA_STRING, transmit ? "MANUAL" : "AUTO",
@@ -77,7 +77,8 @@ static int springfield_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
 static char *output_fields[] = {
     "model",
-    "sid",
+    "sid", // TODO: delete this
+    "id",
     "channel",
     "battery",
     "transmit",

--- a/src/devices/vaillant_vrt340f.c
+++ b/src/devices/vaillant_vrt340f.c
@@ -153,7 +153,7 @@ vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         data = data_make(
                 "model",   "", DATA_STRING, _X("Vaillant-VRT340f","Vaillant VRT340f Central Heating Thermostat"),
-                "device",  "Device ID", DATA_FORMAT, "0x%04X", DATA_INT, deviceID,
+                _X("id","device"),  "Device ID", DATA_FORMAT, "0x%04X", DATA_INT, deviceID,
                 "heating", "Heating Mode", DATA_STRING, (heating_mode==0)?"OFF":((heating_mode==1)?"ON (2-point)":"ON (analogue)"),
                 "heating_temp", "Heating Water Temp.", DATA_FORMAT, "%d", DATA_INT, (int16_t)target_temperature,
                 "water",   "Pre-heated Water", DATA_STRING, water_preheated ? "ON" : "off",
@@ -176,7 +176,7 @@ vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         data = data_make(
                 "model",   "", DATA_STRING, _X("Vaillant-VRT340f","Vaillant VRT340f Central Heating Thermostat (RF Detection)"),
-                "device",  "Device ID", DATA_INT, deviceID,
+                _X("id","device"),  "Device ID", DATA_INT, deviceID,
                 NULL);
         decoder_output_data(decoder, data);
 
@@ -188,7 +188,8 @@ vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
 static char *output_fields[] = {
     "model",
-    "device",
+    "device", // TODO: delete this
+    "id",
     "heating",
     "heating_temp",
     "water",

--- a/src/devices/wt0124.c
+++ b/src/devices/wt0124.c
@@ -75,7 +75,7 @@ static int wt1024_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     data = data_make(
             "model", "", DATA_STRING, _X("WT0124-Pool","WT0124 Pool Thermometer"),
-            "rid",    "Random ID", DATA_INT,    sensor_rid,
+            _X("id","rid"),    "Random ID", DATA_INT,    sensor_rid,
             "channel",       "Channel",     DATA_INT,    channel,
             "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
             "mic",      "Integrity",      DATA_STRING, "CHECKSUM",
@@ -97,7 +97,8 @@ static int wt1024_callback(r_device *decoder, bitbuffer_t *bitbuffer)
  */
 static char *output_fields[] = {
     "model",
-    "rid",
+    "rid", // TODO: delete this
+    "id",
     "channel",
     "temperature_C",
     "mic",


### PR DESCRIPTION
*This is a breaking change!*

Normalizes odd named keys to well-known ones on some devices.

The general structure of data should be:
- `model`
- (`type` -- on some special devices like TPMS)
- (`subtype` -- on multipurpose devices e.g. Motion/Doorbell/Keyfob)
- `id`
- (`channel` -- if available)
- ...
- (`mic` -- if applicable)

A structured output (like e.g. MQTT) should compose entries like:

    [<type>] <model> [<subtype>] [<channel>] <id>

## Summary of changes:

- ambient_weather.c:
  - `Ambientweather-F007TH`/`Ambient Weather F007TH Thermo-Hygrometer`
    - `device` -> `id`
- current_cost.c:
  - `CurrentCost-TX`/`CurrentCost TX`
  - `CurrentCost-Counter`/`CurrentCost Counter`
    - `dev_id` -> `id`
- emontx.c:
  - `emonTx-Energy`/`emonTx`
    - `Vrms/batt` -> `batt_Vrms`
- fineoffset_wh1080.c:
  - `Fineoffset-WHx080`/`Fine Offset Electronics WH1080/WH3080 Weather Station`
    - `hours`,`minutes`,`seconds`,`year`,`month`,`day` -> `radio_clock`
- hideki.c:
  - `Hideki-TS04`/`HIDEKI TS04 sensor`
  - `Hideki-Wind`/`HIDEKI Wind sensor`
  - `Hideki-Temperature`/`HIDEKI Temperature sensor`
  - `Hideki-Rain`/`HIDEKI Rain sensor`
    - `rc` -> `id`
- hondaremote.c:
  - `Honda-CarRemote`/`Honda Remote`
    - `device id` -> `id`
- interlogix.c:
  - `Interlogix-Security`/`Interlogix`
    - `device_type` -> `subtype`
- lacrossews.c:
  - `LaCrosse-WS`/`LaCrosse WS`
    - `ws_id` (removed)
- maverick_et73.c:
  - `Maverick-ET73`/`Maverick ET73`
    - `rid` -> `id`
- oregon_scientific_v1.c:
  - `Oregon-v1`/`OSv1 Temperature Sensor`
    - `sid` -> `id`
- prologue.c:
  - `Prologue-TH`/`Prologue sensor`
    - `id` -> `subtype`
    - `rid` -> `id`
- simplisafe.c:
  - `SimpliSafe-Sensor`/`SimpliSafe Sensor`
  - `SimpliSafe-Keypad`/`SimpliSafe Keypad`
  - `SimpliSafe-Keypad`/`SimpliSafe Keypad`
    - `device` -> `id`
- springfield.c:
  - `Springfield-Soil`/`Springfield Temperature & Moisture`
    - `sid` -> `id`
- vaillant_vrt340f.c:
  - `Vaillant-VRT340f`/`Vaillant VRT340f Central Heating Thermostat`
  - `Vaillant-VRT340f`/`Vaillant VRT340f Central Heating Thermostat (RF Detection)`
    - `device` -> `id`
- wt0124.c:
  - `WT0124-Pool`/`WT0124 Pool Thermometer`
    - `rid` -> `id`
