### PR TITLE
Normalize weather (rain/wind) keys

### DIFF
--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -120,7 +120,7 @@ static int acurite_rain_gauge_callback(r_device *decoder, bitbuffer_t *bitbuffer
         data = data_make(
             "model",    "",        DATA_STRING,    _X("Acurite-Rain","Acurite Rain Gauge"),
             "id",        "",        DATA_INT,    id,
-            "rain",     "Total Rain",    DATA_FORMAT,    "%.1f mm", DATA_DOUBLE, total_rain,
+            _X("rain_mm","rain"),     "Total Rain",    DATA_FORMAT,    "%.1f mm", DATA_DOUBLE, total_rain,
             NULL);
 
         decoder_output_data(decoder, data);
@@ -562,7 +562,7 @@ static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuf)
                     "message_type", NULL,   DATA_INT,       message_type,
                     "wind_speed_kph",   "wind_speed",   DATA_FORMAT,    "%.1f kph", DATA_DOUBLE,     wind_speed_kph,
                     "wind_dir_deg", NULL,   DATA_FORMAT,    "%.1f", DATA_DOUBLE,    wind_dir,
-                    "rain_inch", "Rainfall Accumulation",   DATA_FORMAT, "%.2f in", DATA_DOUBLE, raincounter * 0.01f,
+                    _X("rain_in","rain_inch"), "Rainfall Accumulation",   DATA_FORMAT, "%.2f in", DATA_DOUBLE, raincounter * 0.01f,
                     NULL);
 
                 decoder_output_data(decoder, data);
@@ -958,7 +958,8 @@ static int acurite_00275rm_callback(r_device *decoder, bitbuffer_t *bitbuf)
 static char *acurite_rain_gauge_output_fields[] = {
     "model",
     "id",
-    "rain",
+    "rain", // TODO: remove this
+    "rain_mm",
     NULL
 };
 
@@ -1016,7 +1017,8 @@ static char *acurite_txr_output_fields[] = {
     "wind_speed_mph",
     "wind_dir_deg",
     "wind_dir",
-    "rain_inch",
+    "rain_inch", // TODO: remove this
+    "rain_in",
     "temperature_F",
     NULL
 };

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -560,7 +560,7 @@ static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuf)
                     "sequence_num",  NULL,   DATA_INT,      sequence_num,
                     "battery",      NULL,   DATA_STRING,    battery_low ? "OK" : "LOW",
                     "message_type", NULL,   DATA_INT,       message_type,
-                    "wind_speed_kph",   "wind_speed",   DATA_FORMAT,    "%.1f kph", DATA_DOUBLE,     wind_speed_kph,
+                    _X("wind_avg_km_h","wind_speed_kph"),   "wind_speed",   DATA_FORMAT,    "%.1f km/h", DATA_DOUBLE,     wind_speed_kph,
                     "wind_dir_deg", NULL,   DATA_FORMAT,    "%.1f", DATA_DOUBLE,    wind_dir,
                     _X("rain_in","rain_inch"), "Rainfall Accumulation",   DATA_FORMAT, "%.2f in", DATA_DOUBLE, raincounter * 0.01f,
                     NULL);
@@ -583,7 +583,7 @@ static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuf)
                     "sequence_num",  NULL,   DATA_INT,      sequence_num,
                     "battery",      NULL,   DATA_STRING,    battery_low ? "OK" : "LOW",
                     "message_type", NULL,   DATA_INT,       message_type,
-                    "wind_speed_kph",   "wind_speed",   DATA_FORMAT,    "%.1f kph", DATA_DOUBLE,     wind_speed_kph,
+                    _X("wind_avg_km_h","wind_speed_kph"),   "wind_speed",   DATA_FORMAT,    "%.1f km/h", DATA_DOUBLE,     wind_speed_kph,
                     "temperature_F",     "temperature",    DATA_FORMAT,    "%.1f F", DATA_DOUBLE,    tempf,
                     "humidity",     NULL,    DATA_FORMAT,    "%d",   DATA_INT,   humidity,
                     NULL);
@@ -607,7 +607,7 @@ static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuf)
                     "sequence_num",  NULL,   DATA_INT,      sequence_num,
                     "battery",      NULL,   DATA_STRING,    battery_low ? "OK" : "LOW",
                     "message_type", NULL,   DATA_INT,       message_type,
-                    "wind_speed_mph",   "wind_speed",   DATA_FORMAT,    "%.1f mph", DATA_DOUBLE,     wind_speed_mph,
+                    _X("wind_avg_mi_h","wind_speed_mph"),   "wind_speed",   DATA_FORMAT,    "%.1f mi/h", DATA_DOUBLE,     wind_speed_mph,
                     "temperature_F",     "temperature",    DATA_FORMAT,    "%.1f F", DATA_DOUBLE,    tempf,
                     "humidity",     NULL,    DATA_FORMAT,    "%d",   DATA_INT,   humidity,
                     NULL);
@@ -1014,9 +1014,11 @@ static char *acurite_txr_output_fields[] = {
     "sequence_num",
     "battery",
     "message_type",
-    "wind_speed_mph",
+    "wind_speed_mph", // TODO: remove this
+    "wind_speed_kph", // TODO: remove this
+    "wind_avg_mi_h",
+    "wind_avg_km_h",
     "wind_dir_deg",
-    "wind_dir",
     "rain_inch", // TODO: remove this
     "rain_in",
     "temperature_F",

--- a/src/devices/alecto.c
+++ b/src/devices/alecto.c
@@ -174,7 +174,7 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                 "id",            "House Code", DATA_INT,    sensor_id,
                 "channel",       "Channel",    DATA_INT,    channel,
                 "battery",       "Battery",    DATA_STRING, battery_low ? "LOW" : "OK",
-                "rain_total",    "Total Rain", DATA_FORMAT, "%.02f mm", DATA_DOUBLE, rain_mm,
+                _X("rain_mm","rain_total"),    "Total Rain", DATA_FORMAT, "%.02f mm", DATA_DOUBLE, rain_mm,
                 "mic",           "Integrity",  DATA_STRING,    "CHECKSUM",
                 NULL);
         decoder_output_data(decoder, data);
@@ -217,7 +217,8 @@ static char *output_fields[] = {
     "battery",
     "temperature_C",
     "humidity",
-    "rain_total",
+    "rain_total", // TODO: remove this
+    "rain_mm",
     "wind_speed",
     "wind_gust",
     "wind_direction",

--- a/src/devices/alecto.c
+++ b/src/devices/alecto.c
@@ -155,8 +155,8 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                     "id",             "House Code", DATA_INT,    sensor_id,
                     "channel",        "Channel",    DATA_INT,    channel,
                     "battery",        "Battery",    DATA_STRING, battery_low ? "LOW" : "OK",
-                    "wind_speed",     "Wind speed", DATA_FORMAT, "%.2f m/s", DATA_DOUBLE, speed * 0.2F,
-                    "wind_gust",      "Wind gust",  DATA_FORMAT, "%.2f m/s", DATA_DOUBLE, gust * 0.2F,
+                    _X("wind_avg_m_s","wind_speed"),     "Wind speed", DATA_FORMAT, "%.2f m/s", DATA_DOUBLE, speed * 0.2F,
+                    _X("wind_max_m_s","wind_gust"),      "Wind gust",  DATA_FORMAT, "%.2f m/s", DATA_DOUBLE, gust * 0.2F,
                     "wind_direction", "Direction",  DATA_INT,    direction,
                     "mic",           "Integrity",   DATA_STRING,    "CHECKSUM",
                     NULL);
@@ -219,9 +219,12 @@ static char *output_fields[] = {
     "humidity",
     "rain_total", // TODO: remove this
     "rain_mm",
-    "wind_speed",
-    "wind_gust",
-    "wind_direction",
+    "wind_speed", // TODO: remove this
+    "wind_gust", // TODO: remove this
+    "wind_direction", // TODO: remove this
+    "wind_avg_km_h",
+    "wind_max_km_h",
+    "wind_dir_deg",
     "mic",
     NULL
 };

--- a/src/devices/bresser_5in1.c
+++ b/src/devices/bresser_5in1.c
@@ -116,8 +116,8 @@ static int bresser_5in1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             "id",               "",             DATA_INT,    sensor_id,
             "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
             "humidity",         "Humidity",     DATA_INT, humidity,
-            "wind_gust",        "Wind Gust",    DATA_FORMAT, "%.1f m/s",DATA_DOUBLE, wind_gust,
-            "wind_speed",       "Wind Speed",   DATA_FORMAT, "%.1f m/s",DATA_DOUBLE, wind_avg,
+            _X("wind_max_m_s","wind_gust"),        "Wind Gust",    DATA_FORMAT, "%.1f m/s",DATA_DOUBLE, wind_gust,
+            _X("wind_avg_m_s","wind_speed"),       "Wind Speed",   DATA_FORMAT, "%.1f m/s",DATA_DOUBLE, wind_avg,
             "wind_dir_deg",     "Direction",    DATA_FORMAT, "%.1f °",DATA_DOUBLE, wind_direction_deg,
             "rain_mm",          "Rain",         DATA_FORMAT, "%.1f mm",DATA_DOUBLE, rain,
             "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
@@ -133,8 +133,10 @@ static char *output_fields[] = {
     "id",
     "temperature_C",
     "humidity",
-    "wind_gust",
-    "wind_speed",
+    "wind_gust", // TODO: delete this
+    "wind_speed", // TODO: delete this
+    "wind_max_m_s",
+    "wind_avg_m_s",
     "wind_dir_deg",
     "rain_mm",
     "mic",

--- a/src/devices/bt_rain.c
+++ b/src/devices/bt_rain.c
@@ -67,7 +67,7 @@ static int bt_rain_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
             "battery",          "Battery",          DATA_STRING, battery ? "LOW" : "OK",
             "transmit",         "Transmit",         DATA_STRING, transmit ? "MANUAL" : "AUTO",
             "temperature_C",    "Temperature",      DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp_c,
-            "rainrate",         "Rain per hour",    DATA_FORMAT, "%.02f mm/h", DATA_DOUBLE, rainrate,
+            _X("rain_rate_mm_h","rainrate"),         "Rain per hour",    DATA_FORMAT, "%.02f mm/h", DATA_DOUBLE, rainrate,
             NULL);
     decoder_output_data(decoder, data);
     return 1;
@@ -80,7 +80,8 @@ static char *output_fields[] = {
     "battery",
     "transmit",
     "temperature_C",
-    "rainrate",
+    "rainrate", // TODO: remove this
+    "rain_rate_mm_h",
     NULL
 };
 

--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -299,7 +299,7 @@ static int fineoffset_WH24_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         data_append(data,   "wind_speed_ms",    "Wind speed",       DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wind_speed_ms, NULL);
     if (gust_speed_raw != 0xff)
         data_append(data,   "gust_speed_ms",    "Gust speed",       DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, gust_speed_ms, NULL);
-    data_append(data,       "rainfall_mm",      "Rainfall",         DATA_FORMAT, "%.1f mm", DATA_DOUBLE, rainfall_mm, NULL);
+    data_append(data,       _X("rain_mm","rainfall_mm"),      "Rainfall",         DATA_FORMAT, "%.1f mm", DATA_DOUBLE, rainfall_mm, NULL);
     if (uv_raw         != 0xffff)
         data_append(data,   "uv",               "UV",               DATA_INT, uv_raw,
                             "uvi",              "UVI",              DATA_INT, uv_index, NULL);
@@ -450,7 +450,7 @@ static int fineoffset_WH0530_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             "model",            "",             DATA_STRING, _X("Fineoffset-WH0530","Fine Offset Electronics, WH0530 Temperature/Rain sensor"),
             "id",               "ID",           DATA_INT, id,
             "temperature_C",    "Temperature",  DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
-            "rain",             "Rain",         DATA_FORMAT, "%.01f mm", DATA_DOUBLE, rainfall,
+            _X("rain_mm","rain"),             "Rain",         DATA_FORMAT, "%.01f mm", DATA_DOUBLE, rainfall,
             "battery",          "Battery",      DATA_STRING, battery_low ? "LOW" : "OK",
             "mic",              "Integrity",    DATA_STRING, "CRC",
             NULL);
@@ -478,7 +478,8 @@ static char *output_fields_WH25[] = {
     "wind_dir_deg",
     "wind_speed_ms",
     "gust_speed_ms",
-    "rainfall_mm",
+    "rainfall_mm", //TODO: remove this
+    "rain_mm",
     "uv",
     "uvi",
     "light_lux",
@@ -491,7 +492,8 @@ static char *output_fields_WH0530[] = {
     "model",
     "id",
     "temperature_C",
-    "rain",
+    "rain", //TODO: remove this
+    "rain_mm",
     "battery",
     "mic",
     NULL

--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -296,9 +296,9 @@ static int fineoffset_WH24_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (wind_dir       != 0x1ff)
         data_append(data,   "wind_dir_deg",     "Wind direction",   DATA_INT, wind_dir, NULL);
     if (wind_speed_raw != 0x1ff)
-        data_append(data,   "wind_speed_ms",    "Wind speed",       DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wind_speed_ms, NULL);
+        data_append(data,   _X("wind_avg_m_s","wind_speed_ms"),    "Wind speed",       DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wind_speed_ms, NULL);
     if (gust_speed_raw != 0xff)
-        data_append(data,   "gust_speed_ms",    "Gust speed",       DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, gust_speed_ms, NULL);
+        data_append(data,   _X("wind_max_m_s","gust_speed_ms"),    "Gust speed",       DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, gust_speed_ms, NULL);
     data_append(data,       _X("rain_mm","rainfall_mm"),      "Rainfall",         DATA_FORMAT, "%.1f mm", DATA_DOUBLE, rainfall_mm, NULL);
     if (uv_raw         != 0xffff)
         data_append(data,   "uv",               "UV",               DATA_INT, uv_raw,
@@ -476,8 +476,10 @@ static char *output_fields_WH25[] = {
     "pressure_hPa",
     // WH24
     "wind_dir_deg",
-    "wind_speed_ms",
-    "gust_speed_ms",
+    "wind_speed_ms", // TODO: delete this
+    "gust_speed_ms", // TODO: delete this
+    "wind_avg_m_s",
+    "wind_max_m_s",
     "rainfall_mm", //TODO: remove this
     "rain_mm",
     "uv",

--- a/src/devices/fineoffset_wh1050.c
+++ b/src/devices/fineoffset_wh1050.c
@@ -80,8 +80,8 @@ static int fineoffset_wh1050_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             "id",               "StationID",        DATA_FORMAT, "%04X",    DATA_INT,    device_id,
             "temperature_C",    "Temperature",      DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
             "humidity",         "Humidity",         DATA_FORMAT, "%u %%",   DATA_INT,    humidity,
-            "speed",            "Wind avg speed",   DATA_FORMAT, "%.02f",   DATA_DOUBLE, speed,
-            "gust",             "Wind gust",        DATA_FORMAT, "%.02f",   DATA_DOUBLE, gust,
+            _X("wind_avg_km_h","speed"),   "Wind avg speed",   DATA_FORMAT, "%.02f",   DATA_DOUBLE, speed,
+            _X("wind_max_km_h","gust"),   "Wind gust",        DATA_FORMAT, "%.02f",   DATA_DOUBLE, gust,
             _X("rain_mm","rain"),             "Total rainfall",   DATA_FORMAT, "%.01f",   DATA_DOUBLE, rain,
             "battery",          "Battery",          DATA_STRING, battery_low ? "LOW" : "OK",
             "mic",              "Integrity",        DATA_STRING, "CRC",
@@ -95,8 +95,10 @@ static char *output_fields[] = {
     "id",
     "temperature_C",
     "humidity",
-    "speed",
-    "gust",
+    "speed", // TODO: remove this
+    "gust", // TODO: remove this
+    "wind_avg_km_h",
+    "wind_max_km_h",
     "rain", // TODO: delete this
     "rain_mm",
     "battery",

--- a/src/devices/fineoffset_wh1050.c
+++ b/src/devices/fineoffset_wh1050.c
@@ -82,7 +82,7 @@ static int fineoffset_wh1050_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             "humidity",         "Humidity",         DATA_FORMAT, "%u %%",   DATA_INT,    humidity,
             "speed",            "Wind avg speed",   DATA_FORMAT, "%.02f",   DATA_DOUBLE, speed,
             "gust",             "Wind gust",        DATA_FORMAT, "%.02f",   DATA_DOUBLE, gust,
-            "rain",             "Total rainfall",   DATA_FORMAT, "%.01f",   DATA_DOUBLE, rain,
+            _X("rain_mm","rain"),             "Total rainfall",   DATA_FORMAT, "%.01f",   DATA_DOUBLE, rain,
             "battery",          "Battery",          DATA_STRING, battery_low ? "LOW" : "OK",
             "mic",              "Integrity",        DATA_STRING, "CRC",
             NULL);
@@ -97,7 +97,8 @@ static char *output_fields[] = {
     "humidity",
     "speed",
     "gust",
-    "rain",
+    "rain", // TODO: delete this
+    "rain_mm",
     "battery",
     NULL
 };

--- a/src/devices/fineoffset_wh1080.c
+++ b/src/devices/fineoffset_wh1080.c
@@ -235,7 +235,7 @@ static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                 "direction_deg",    "Wind degrees",     DATA_INT,       direction_deg,
                 "speed",            "Wind avg speed",   DATA_FORMAT,    "%.02f",    DATA_DOUBLE,    speed,
                 "gust",             "Wind gust",        DATA_FORMAT,    "%.02f",    DATA_DOUBLE,    gust,
-                "rain",             "Total rainfall",   DATA_FORMAT,    "%3.1f",    DATA_DOUBLE,    rain,
+                _X("rain_mm","rain"),             "Total rainfall",   DATA_FORMAT,    "%3.1f",    DATA_DOUBLE,    rain,
                 "battery",          "Battery",          DATA_STRING,    battery_low ? "LOW" : "OK",
                 "mic",              "Integrity",        DATA_STRING,    "CRC",
                 NULL);
@@ -278,7 +278,8 @@ static char *output_fields[] = {
     "direction_deg",
     "speed",
     "gust",
-    "rain",
+    "rain", // TODO: remove this
+    "rain_mm",
     "msg_type",
     "signal",
     "radio_clock",

--- a/src/devices/fineoffset_wh1080.c
+++ b/src/devices/fineoffset_wh1080.c
@@ -233,8 +233,8 @@ static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                 "temperature_C",    "Temperature",      DATA_FORMAT,    "%.01f C",  DATA_DOUBLE,    temperature,
                 "humidity",         "Humidity",         DATA_FORMAT,    "%u %%",    DATA_INT,       humidity,
                 "direction_deg",    "Wind degrees",     DATA_INT,       direction_deg,
-                "speed",            "Wind avg speed",   DATA_FORMAT,    "%.02f",    DATA_DOUBLE,    speed,
-                "gust",             "Wind gust",        DATA_FORMAT,    "%.02f",    DATA_DOUBLE,    gust,
+                _X("wind_avg_km_h","speed"),   "Wind avg speed",   DATA_FORMAT,    "%.02f",    DATA_DOUBLE,    speed,
+                _X("wind_max_km_h","gust"),   "Wind gust",        DATA_FORMAT,    "%.02f",    DATA_DOUBLE,    gust,
                 _X("rain_mm","rain"),             "Total rainfall",   DATA_FORMAT,    "%3.1f",    DATA_DOUBLE,    rain,
                 "battery",          "Battery",          DATA_STRING,    battery_low ? "LOW" : "OK",
                 "mic",              "Integrity",        DATA_STRING,    "CRC",
@@ -276,8 +276,10 @@ static char *output_fields[] = {
     "temperature_C",
     "humidity",
     "direction_deg",
-    "speed",
-    "gust",
+    "speed", // TODO: remove this
+    "gust", // TODO: remove this
+    "wind_avg_km_h",
+    "wind_max_km_h",
     "rain", // TODO: remove this
     "rain_mm",
     "msg_type",

--- a/src/devices/hideki.c
+++ b/src/devices/hideki.c
@@ -141,10 +141,10 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                 "channel",          "Channel",          DATA_INT, channel,
                 "battery",          "Battery",          DATA_STRING, battery_ok ? "OK": "LOW",
                 "temperature_C",    "Temperature",      DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp * 0.1f,
-                "wind_speed_mph",   "Wind Speed",       DATA_FORMAT, "%.02f mph", DATA_DOUBLE, wind_speed * 0.1f,
-                "gust_speed_mph",   "Gust Speed",       DATA_FORMAT, "%.02f mph", DATA_DOUBLE, gust_speed * 0.1f,
+                _X("wind_avg_mi_h","wind_speed_mph"),   "Wind Speed",       DATA_FORMAT, "%.02f mi/h", DATA_DOUBLE, wind_speed * 0.1f,
+                _X("wind_max_mi_h","gust_speed_mph"),   "Gust Speed",       DATA_FORMAT, "%.02f mi/h", DATA_DOUBLE, gust_speed * 0.1f,
                 "wind_approach",    "Wind Approach",    DATA_INT, wind_approach,
-                "wind_direction",   "Wind Direction",   DATA_FORMAT, "%.01f °", DATA_DOUBLE, wind_direction * 0.1f,
+                _X("wind_dir_deg","wind_direction"),   "Wind Direction",   DATA_FORMAT, "%.01f °", DATA_DOUBLE, wind_direction * 0.1f,
                 "mic",              "MIC",              DATA_STRING, "CRC",
                 NULL);
         decoder_output_data(decoder, data);
@@ -188,10 +188,13 @@ static char *output_fields[] = {
     "battery",
     "temperature_C",
     "humidity",
-    "wind_speed_mph",
-    "gust_speed_mph",
+    "wind_speed_mph", // TODO: remove this
+    "gust_speed_mph", // TODO: remove this
+    "wind_avg_mi_h",
+    "wind_max_mi_h",
     "wind_approach",
-    "wind_direction",
+    "wind_direction", // TODO: remove this
+    "wind_dir_deg",
     "rain_mm",
     "mic",
     NULL

--- a/src/devices/lacrossews.c
+++ b/src/devices/lacrossews.c
@@ -163,14 +163,14 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                     }
                 }
                 else {
-                    wind_key   = msg_type == 3 ? "wind_speed_ms" : "gust_speed_ms";
+                    wind_key   = msg_type == 3 ? _X("wind_avg_m_s","wind_speed_ms") : _X("wind_max_m_s","gust_speed_ms");
                     wind_label = msg_type == 3 ? "Wind speed" : "Gust speed";
 
                     data = data_make(
                             "model",            "",             DATA_STRING, _X("LaCrosse-WS","LaCrosse WS"),
                             "id",               "",             DATA_INT, sensor_id,
                             wind_key,           wind_label,     DATA_FORMAT, "%3.1f m/s", DATA_DOUBLE, wind_spd,
-                            "wind_direction",   "Direction",    DATA_DOUBLE, wind_dir, NULL);
+                            _X("wind_dir_deg","wind_direction"),   "Direction",    DATA_DOUBLE, wind_dir, NULL);
                     decoder_output_data(decoder, data);
                     events++;
                 }
@@ -196,9 +196,12 @@ static char *output_fields[] = {
     "humidity",
     "rainfall_mm", // TODO: delete this
     "rain_mm",
-    "wind_speed_ms",
-    "gust_speed_ms",
-    "wind_direction",
+    "wind_speed_ms", // TODO: delete this
+    "gust_speed_ms", // TODO: delete this
+    "wind_avg_m_s",
+    "wind_max_m_s",
+    "wind_direction", // TODO: delete this
+    "wind_dir_deg",
     NULL
 };
 

--- a/src/devices/lacrossews.c
+++ b/src/devices/lacrossews.c
@@ -146,7 +146,7 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                 data = data_make(
                         "model",            "",             DATA_STRING, _X("LaCrosse-WS","LaCrosse WS"),
                         "id",               "",             DATA_INT, sensor_id,
-                        "rainfall_mm",      "Rainfall",     DATA_FORMAT, "%3.2f mm", DATA_DOUBLE, rain_mm, NULL);
+                        _X("rain_mm","rainfall_mm"),      "Rainfall",     DATA_FORMAT, "%3.2f mm", DATA_DOUBLE, rain_mm, NULL);
                 decoder_output_data(decoder, data);
                 events++;
                 break;
@@ -194,7 +194,8 @@ static char *output_fields[] = {
     "id",
     "temperature_C",
     "humidity",
-    "rainfall_mm",
+    "rainfall_mm", // TODO: delete this
+    "rain_mm",
     "wind_speed_ms",
     "gust_speed_ms",
     "wind_direction",

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -339,8 +339,8 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
                         "id",                 "House Code", DATA_INT,        get_os_rollingcode(msg, sensor_id),
                         "channel",        "Channel",        DATA_INT,        get_os_channel(msg, sensor_id),
                         "battery",        "Battery",        DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
-                        "rain_rate",    "Rain Rate",    DATA_FORMAT, "%.02f mm/hr", DATA_DOUBLE, rain_rate,
-                        "total_rain", "Total Rain", DATA_FORMAT, "%.02f mm", DATA_DOUBLE, total_rain,
+                        _X("rain_rate_mm_h","rain_rate"),    "Rain Rate",    DATA_FORMAT, "%.02f mm/hr", DATA_DOUBLE, rain_rate,
+                        _X("rain_mm","total_rain"), "Total Rain", DATA_FORMAT, "%.02f mm", DATA_DOUBLE, total_rain,
                         NULL);
                 decoder_output_data(decoder, data);
             }
@@ -601,8 +601,8 @@ static int oregon_scientific_v3_parser(r_device *decoder, bitbuffer_t *bitbuffer
                     "id",                 "House Code", DATA_INT,        get_os_rollingcode(msg, sensor_id),
                     "channel",        "Channel",        DATA_INT,        get_os_channel(msg, sensor_id),
                     "battery",        "Battery",        DATA_STRING, get_os_battery(msg, sensor_id)?"LOW":"OK",
-                    "rain_rate",    "Rain Rate",    DATA_FORMAT, "%3.1f in/hr", DATA_DOUBLE, rain_rate,
-                    "rain_total", "Total Rain", DATA_FORMAT, "%3.1f in", DATA_DOUBLE, total_rain,
+                    _X("rain_rate_in_h","rain_rate"),    "Rain Rate",    DATA_FORMAT, "%3.1f in/hr", DATA_DOUBLE, rain_rate,
+                    _X("rain_in","rain_total"), "Total Rain", DATA_FORMAT, "%3.1f in", DATA_DOUBLE, total_rain,
                     NULL);
                 decoder_output_data(decoder, data);
             }
@@ -618,8 +618,8 @@ static int oregon_scientific_v3_parser(r_device *decoder, bitbuffer_t *bitbuffer
                         "id",                 "House Code", DATA_INT,        get_os_rollingcode(msg, sensor_id),
                         "channel",        "Channel",        DATA_INT,        get_os_channel(msg, sensor_id),
                         "battery",        "Battery",        DATA_STRING, get_os_battery(msg, sensor_id)?"LOW":"OK",
-                        "rain_rate",    "Rain Rate",    DATA_FORMAT, "%3.1f in/hr", DATA_DOUBLE, rain_rate,
-                        "rain_total", "Total Rain", DATA_FORMAT, "%3.1f in", DATA_DOUBLE, total_rain,
+                        _X("rain_rate_in_h","rain_rate"),    "Rain Rate",    DATA_FORMAT, "%3.1f in/hr", DATA_DOUBLE, rain_rate,
+                        _X("rain_in","rain_total"), "Total Rain", DATA_FORMAT, "%3.1f in", DATA_DOUBLE, total_rain,
                         NULL);
                 decoder_output_data(decoder, data);
             }
@@ -729,8 +729,12 @@ static char *output_fields[] = {
     "battery",
     "temperature_C",
     "humidity",
-    "rain_rate",
-    "rain_total",
+    "rain_rate", // TODO: remove this
+    "rain_rate_mm_h",
+    "rain_rate_in_h",
+    "rain_total", // TODO: remove this
+    "rain_mm",
+    "rain_in",
     "gust",
     "average",
     "direction",

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -290,9 +290,9 @@ static int oregon_scientific_v2_1_parser(r_device *decoder, bitbuffer_t *bitbuff
                         "id",                 "House Code", DATA_INT,        get_os_rollingcode(msg, sensor_id),
                         "channel",        "Channel",        DATA_INT,        get_os_channel(msg, sensor_id),
                         "battery",        "Battery",        DATA_STRING, get_os_battery(msg, sensor_id) ? "LOW" : "OK",
-                        "gust",             "Gust",             DATA_FORMAT, "%2.1f m/s",DATA_DOUBLE, gustWindspeed,
-                        "average",        "Average",        DATA_FORMAT, "%2.1f m/s",DATA_DOUBLE, avgWindspeed,
-                        "direction",    "Direction",    DATA_FORMAT, "%3.1f degrees",DATA_DOUBLE, quadrant,
+                        _X("wind_max_m_s","gust"), "Gust",             DATA_FORMAT, "%2.1f m/s",DATA_DOUBLE, gustWindspeed,
+                        _X("wind_avg_m_s","average"), "Average",        DATA_FORMAT, "%2.1f m/s",DATA_DOUBLE, avgWindspeed,
+                        _X("wind_dir_deg","direction"),    "Direction",    DATA_FORMAT, "%3.1f degrees",DATA_DOUBLE, quadrant,
                         NULL);
                 decoder_output_data(decoder, data);
             }
@@ -636,9 +636,9 @@ static int oregon_scientific_v3_parser(r_device *decoder, bitbuffer_t *bitbuffer
                         "id",                 "House Code", DATA_INT,         get_os_rollingcode(msg, sensor_id),
                         "channel",        "Channel",        DATA_INT,         get_os_channel(msg, sensor_id),
                         "battery",        "Battery",        DATA_STRING,    get_os_battery(msg, sensor_id)?"LOW":"OK",
-                        "gust",             "Gust",             DATA_FORMAT,    "%2.1f m/s",DATA_DOUBLE, gustWindspeed,
-                        "average",        "Average",        DATA_FORMAT,    "%2.1f m/s",DATA_DOUBLE, avgWindspeed,
-                        "direction",    "Direction",    DATA_FORMAT,    "%3.1f degrees",DATA_DOUBLE, quadrant,
+                        _X("wind_max_m_s","gust"),             "Gust",             DATA_FORMAT,    "%2.1f m/s",DATA_DOUBLE, gustWindspeed,
+                        _X("wind_avg_m_s","average"),        "Average",        DATA_FORMAT,    "%2.1f m/s",DATA_DOUBLE, avgWindspeed,
+                        _X("wind_dir_deg","direction"),    "Direction",    DATA_FORMAT,    "%3.1f degrees",DATA_DOUBLE, quadrant,
                         NULL);
                 decoder_output_data(decoder, data);
             }
@@ -735,9 +735,12 @@ static char *output_fields[] = {
     "rain_total", // TODO: remove this
     "rain_mm",
     "rain_in",
-    "gust",
-    "average",
-    "direction",
+    "gust", // TODO: remove this
+    "average", // TODO: remove this
+    "direction", // TODO: remove this
+    "wind_max_m_s",
+    "wind_avg_m_s",
+    "wind_dir_deg",
     "pressure_hPa",
     "uv",
     "power_W",

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -468,13 +468,23 @@ void data_acquired_handler(r_device *r_dev, data_t *data)
                 free(d->format);
                 d->format = new_format_label;
             }
-            // Convert double type fields ending in _mph to _kph
-            else if ((d->type == DATA_DOUBLE) && str_endswith(d->key, "_inch")) {
+            // Convert double type fields ending in _in to _mm
+            else if ((d->type == DATA_DOUBLE) && str_endswith(d->key, "_in")) {
                 *(double*)d->value = inch2mm(*(double*)d->value);
-                char *new_label = str_replace(d->key, "_inch", "_mm");
+                char *new_label = str_replace(d->key, "_in", "_mm");
                 free(d->key);
                 d->key = new_label;
-                char *new_format_label = str_replace(d->format, "inch", "mm");
+                char *new_format_label = str_replace(d->format, "in", "mm");
+                free(d->format);
+                d->format = new_format_label;
+            }
+            // Convert double type fields ending in _in_h to _mm_h
+            else if ((d->type == DATA_DOUBLE) && str_endswith(d->key, "_in_h")) {
+                *(double*)d->value = inch2mm(*(double*)d->value);
+                char *new_label = str_replace(d->key, "_in_h", "_mm_h");
+                free(d->key);
+                d->key = new_label;
+                char *new_format_label = str_replace(d->format, "in/h", "mm/h");
                 free(d->format);
                 d->format = new_format_label;
             }
@@ -526,10 +536,20 @@ void data_acquired_handler(r_device *r_dev, data_t *data)
             // Convert double type fields ending in _mm to _inch
             else if ((d->type == DATA_DOUBLE) && str_endswith(d->key, "_mm")) {
                 *(double*)d->value = mm2inch(*(double*)d->value);
-                char *new_label = str_replace(d->key, "_mm", "_inch");
+                char *new_label = str_replace(d->key, "_mm", "_in");
                 free(d->key);
                 d->key = new_label;
-                char *new_format_label = str_replace(d->format, "mm", "inch");
+                char *new_format_label = str_replace(d->format, "mm", "in");
+                free(d->format);
+                d->format = new_format_label;
+            }
+            // Convert double type fields ending in _mm_h to _in_h
+            else if ((d->type == DATA_DOUBLE) && str_endswith(d->key, "_mm_h")) {
+                *(double*)d->value = mm2inch(*(double*)d->value);
+                char *new_label = str_replace(d->key, "_mm_h", "_in_h");
+                free(d->key);
+                d->key = new_label;
+                char *new_format_label = str_replace(d->format, "mm/h", "in/h");
                 free(d->format);
                 d->format = new_format_label;
             }

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -464,7 +464,17 @@ void data_acquired_handler(r_device *r_dev, data_t *data)
                 char *new_label = str_replace(d->key, "_mph", "_kph");
                 free(d->key);
                 d->key = new_label;
-                char *new_format_label = str_replace(d->format, "mph", "kph");
+                char *new_format_label = str_replace(d->format, "mi/h", "km/h");
+                free(d->format);
+                d->format = new_format_label;
+            }
+            // Convert double type fields ending in _mi_h to _km_h
+            else if ((d->type == DATA_DOUBLE) && str_endswith(d->key, "_mi_h")) {
+                *(double*)d->value = mph2kmph(*(double*)d->value);
+                char *new_label = str_replace(d->key, "_mi_h", "_km_h");
+                free(d->key);
+                d->key = new_label;
+                char *new_format_label = str_replace(d->format, "mi/h", "km/h");
                 free(d->format);
                 d->format = new_format_label;
             }
@@ -529,7 +539,17 @@ void data_acquired_handler(r_device *r_dev, data_t *data)
                 char *new_label = str_replace(d->key, "_kph", "_mph");
                 free(d->key);
                 d->key = new_label;
-                char *new_format_label = str_replace(d->format, "kph", "mph");
+                char *new_format_label = str_replace(d->format, "km/h", "mi/h");
+                free(d->format);
+                d->format = new_format_label;
+            }
+            // Convert double type fields ending in _km_h to _mi_h
+            else if ((d->type == DATA_DOUBLE) && str_endswith(d->key, "_km_h")) {
+                *(double*)d->value = kmph2mph(*(double*)d->value);
+                char *new_label = str_replace(d->key, "_km_h", "_mi_h");
+                free(d->key);
+                d->key = new_label;
+                char *new_format_label = str_replace(d->format, "km/h", "mi/h");
                 free(d->format);
                 d->format = new_format_label;
             }


### PR DESCRIPTION
This normalizes weather (rain/wind) related keys. The change is selected only with the `newmodel` option.
The new keys are:
- `rain_mm`
- `rain_in`
- `rain_rate_mm_h`
- `rain_rate_in_h`
- `wind_avg_km_h`
- `wind_avg_mi_h`
- `wind_avg_m_s`
- `wind_max_km_h`
- `wind_max_mi_h`
- `wind_max_m_s`
- `wind_dir_deg`

Should "gust_speed_" perhaps be named "wind_gust_" to relate it closer to "wind_speed_"? Not sure, please comment.