### PR TITLE
Fix return values for nexa and proove decoder

### DIFF
--- a/src/devices/nexa.c
+++ b/src/devices/nexa.c
@@ -22,7 +22,7 @@ static int nexa_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
     /* Reject codes of wrong length */
     if (bitbuffer->bits_per_row[1] != 64 && bitbuffer->bits_per_row[1] != 72)
-      return 0;
+      return DECODE_ABORT_LENGTH;
 
 
     bitbuffer_t databits = {0};
@@ -30,7 +30,7 @@ static int nexa_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
     /* Reject codes when Manchester decoding fails */
     if (pos != 64 && pos != 72)
-      return 0;
+      return DECODE_ABORT_LENGTH;
 
     bitrow_t *bb = databits.bb;
     uint8_t *b = bb[0];
@@ -46,15 +46,15 @@ static int nexa_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     data = data_make(
                      "model",         "",            DATA_STRING, _X("Nexa-Security","Nexa"),
                      "id",            "House Code",  DATA_INT, sensor_id,
-                     "group",         "Group",       DATA_INT, group_code,
                      "channel",       "Channel",     DATA_INT, channel_code,
                      "state",         "State",       DATA_STRING, on_bit ? "OFF" : "ON",
                      "unit",          "Unit",        DATA_INT, unit_bit,
+                     "group",         "Group",       DATA_INT, group_code,
                       NULL);
 
     decoder_output_data(decoder, data);
 
-    return 0;
+    return 1;
 }
 
 static char *output_fields[] = {

--- a/src/devices/proove.c
+++ b/src/devices/proove.c
@@ -39,14 +39,14 @@ static int proove_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
     /* Reject codes of wrong length */
     if (bitbuffer->bits_per_row[1] != 64)
-      return 0;
+      return DECODE_ABORT_LENGTH;
 
     bitbuffer_t databits = {0};
     unsigned pos = bitbuffer_manchester_decode(bitbuffer, 1, 0, &databits, 64);
 
     /* Reject codes when Manchester decoding fails */
     if (pos != 64)
-      return 0;
+      return DECODE_ABORT_LENGTH;
 
     bitrow_t *bb = databits.bb;
     uint8_t *b = bb[0];
@@ -70,7 +70,7 @@ static int proove_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
     decoder_output_data(decoder, data);
 
-    return 0;
+    return 1;
 }
 
 static char *output_fields[] = {


### PR DESCRIPTION
This issue is related to #1028, but does not actually solve the issue there. It does solve an issue found upon researching that issue however.

Fix return values for the nexa and proove decoder, so they'll signal data is found. Took the opportunity to introduce the values given in https://github.com/merbanan/rtl_433/blob/42560751c80147f62fff306338645ddea0cde9e9/include/r_device.h#L23-L33

Reordered the fields so they're equal in the proove and nexa sensor, giving somewhat nicer output.
![proove-next](https://user-images.githubusercontent.com/9799623/55358269-425f0e00-54cf-11e9-8471-530ce4001725.png)
Before the fields were ordered differently, giving a different ordering in the output.

Should an issue be opened to do all of the sensors with these return values or does something like that exist already? Is a good issue for the tag `first-issue` or `up-for-grabs` or `beginner` or something. I might also do it if it's something that is wanted.