### PR TITLE
Remove the dependency on the order of command line arguments

### DIFF
--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1900,6 +1900,8 @@ int main(int argc, char **argv) {
     // register default decoders if nothing is configured
     if (!cfg.no_default_devices) {
         register_all_protocols(&cfg, 0); // register all defaults
+    } else {
+        update_protocols(&cfg);
     }
 
     // check if we need FM demod


### PR DESCRIPTION
Currently, device specific configuration parameters (e.g. verbosity or `-M newmodel`) have to be listed on the command line before the devices are listed. This commit makes the order of command line arguments irrelevant.

The issue can be easily reproduced:
`rtl_433 -M newmodel -vv -R 20` -> verbosity and new model parameters are correctly reflected in the output
`rtl_433 -R 20 -M newmodel -vv` -> output is non-verbose and old model parameters are used