### PR TITLE
Change time meta option format

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Usage:		= General options =
   [-F kv | json | csv | mqtt | syslog | null | help] Produce decoded output in given format.
        Append output to file with :<filename> (e.g. -F csv:log.csv), defaults to stdout.
        Specify host/port for syslog with e.g. -F syslog:127.0.0.1:1514
-  [-M time | reltime | notime | hires | utc | protocol | level | stats | bits | help] Add various meta data to each output.
+  [-M time[:<options>] | protocol | level | stats | bits | help] Add various meta data to each output.
   [-K FILE | PATH | <tag>] Add an expanded token or fixed tag to every output line.
   [-C native | si | customary] Convert units in decoded output.
   [-T <seconds>] Specify number of seconds to run
@@ -285,13 +285,16 @@ Option -F:
 	Specify host/port for syslog with e.g. -F syslog:127.0.0.1:1514
 
 Option -M:
-[-M time|reltime|notime|hires|level] Add various metadata to every output line.
+[-M time[:<options>]|protocol|level|stats|bits|newmodel] Add various metadata to every output line.
 	Use "time" to add current date and time meta data (preset for live inputs).
-	Use "reltime" to add sample position meta data (preset for read-file and stdin).
-	Use "notime" to remove time meta data.
-	Use "hires" to add microsecods to date time meta data.
-	Use "utc" / "noutc" to output timestamps in UTC.
+	Use "time:rel" to add sample position meta data (preset for read-file and stdin).
+	Use "time:unix" to show the seconds since unix epoch as time meta data.
+	Use "time:iso" to show the time with ISO-8601 format (YYYY-MM-DD"T"hh:mm:ss).
+	Use "time:off" to remove time meta data.
+	Use "time:usec" to add microseconds to date time meta data.
+	Use "time:utc" to output time in UTC.
 		(this may also be accomplished by invocation with TZ environment variable set).
+		"usec" and "utc" can be combined with other options, eg. "time:unix:utc:usec".
 	Use "protocol" / "noprotocol" to output the decoder protocol number meta data.
 	Use "level" to add Modulation, Frequency, RSSI, SNR, and Noise meta data.
 	Use "stats[:[<level>][:<interval>]]" to report statistics (default: 600 seconds).

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -115,13 +115,16 @@ analyze_pulses false
 #out_block_size
 
 # as command line option:
-#   [-M time|reltime|notime|hires|level] Add various metadata to every output line.
+#   [-M time[:<options>]|protocol|level|stats|bits|newmodel] Add various metadata to every output line.
 # Use "time" to add current date and time meta data (preset for live inputs).
-# Use "reltime" to add sample position meta data (preset for read-file and stdin).
-# Use "notime" to remove time meta data.
-# Use "hires" to add microsecods to date time meta data.
-# Use "utc" / "noutc" to output timestamps in UTC.
+# Use "time:rel" to add sample position meta data (preset for read-file and stdin).
+# Use "time:unix" to show the seconds since unix epoch as time meta data.
+# Use "time:iso" to show the time with ISO-8601 format (YYYY-MM-DD"T"hh:mm:ss).
+# Use "time:off" to remove time meta data.
+# Use "time:usec" to add microseconds to date time meta data.
+# Use "time:utc" to output time in UTC.
 #   (this may also be accomplished by invocation with TZ environment variable set).
+#   "usec" and "utc" can be combined with other options, eg. "time:unix:utc:usec".
 # Use "protocol" / "noprotocol" to output the decoder protocol number meta data.
 # Use "level" to add Modulation, Frequency, RSSI, SNR, and Noise meta data.
 # Use "stats[:[<level>][:<interval>]]" to report statistics (default: 600 seconds).
@@ -129,7 +132,7 @@ analyze_pulses false
 # Use "newmodel" to transition to new model keys. This will become the default someday.
 report_meta level
 report_meta stats
-report_meta hires
+report_meta time:usec
 report_meta protocol
 report_meta newmodel
 

--- a/include/r_util.h
+++ b/include/r_util.h
@@ -35,19 +35,21 @@ void get_time_now(struct timeval *tv);
 
 /** Printable timestamp in local time.
 
+    @param buf[out]: output buffer, long enough for "YYYY-MM-DD HH:MM:SS"
+    @param format: time format string, uses "%Y-%m-%d %H:%M:%S" if NULL
     @param time_secs: 0 for now, or seconds since the epoch
-    @param buf: output buffer, long enough for "YYYY-MM-DD HH:MM:SS"
     @return buf pointer (for short hand use as operator)
 */
-char* local_time_str(time_t time_secs, char *buf);
+char *format_time_str(char *buf, char const *format, time_t time_secs);
 
 /** Printable timestamp in local time with microseconds.
 
+    @param buf[out]: output buffer, long enough for "YYYY-MM-DD HH:MM:SS.uuuuuu"
+    @param format: time format string without usec, uses "%Y-%m-%d %H:%M:%S" if NULL
     @param tv: NULL for now, or seconds and microseconds since the epoch
-    @param buf: output buffer, long enough for "YYYY-MM-DD HH:MM:SS"
     @return buf pointer (for short hand use as operator)
 */
-char *usecs_time_str(struct timeval *tv, char *buf);
+char *usecs_time_str(char *buf, char const *format, struct timeval *tv);
 
 /** Printable sample position.
 

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -40,6 +40,8 @@ typedef enum {
     REPORT_TIME_DEFAULT,
     REPORT_TIME_DATE,
     REPORT_TIME_SAMPLES,
+    REPORT_TIME_UNIX,
+    REPORT_TIME_ISO,
     REPORT_TIME_OFF,
 } time_mode_t;
 

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -64,7 +64,7 @@ void pulse_data_print_vcd_header(FILE *file, uint32_t sample_rate)
         timescale = "1 us";
     else
         timescale = "100 ns";
-    fprintf(file, "$date %s $end\n", local_time_str(0, time_str));
+    fprintf(file, "$date %s $end\n", format_time_str(time_str, NULL, 0));
     fprintf(file, "$version rtl_433 0.1.0 $end\n");
     fprintf(file, "$comment Acquisition at %s Hz $end\n", nice_freq(sample_rate));
     fprintf(file, "$timescale %s $end\n", timescale);
@@ -145,7 +145,7 @@ void pulse_data_print_pulse_header(FILE *file)
     fprintf(file, ";version 1\n");
     fprintf(file, ";timescale 1us\n");
     //fprintf(file, ";samplerate %u\n", data->sample_rate);
-    fprintf(file, ";created %s\n", local_time_str(0, time_str));
+    fprintf(file, ";created %s\n", format_time_str(time_str, NULL, 0));
 }
 
 void pulse_data_dump(FILE *file, pulse_data_t *data)

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -259,10 +259,16 @@ char *time_pos_str(r_cfg_t *cfg, unsigned samples_ago, char *buf)
         }
         ago.tv_usec -= usecs_ago;
 
+        char const *format = NULL;
+        if (cfg->report_time == REPORT_TIME_UNIX)
+            format = "%s";
+        else if (cfg->report_time == REPORT_TIME_ISO)
+            format = "%Y-%m-%dT%H:%M:%S";
+
         if (cfg->report_time_hires)
-            return usecs_time_str(&ago, buf);
+            return usecs_time_str(buf, format, &ago);
         else
-            return local_time_str(ago.tv_sec, buf);
+            return format_time_str(buf, format, ago.tv_sec);
     }
 }
 

--- a/src/r_util.c
+++ b/src/r_util.c
@@ -21,7 +21,7 @@ void get_time_now(struct timeval *tv)
         perror("gettimeofday");
 }
 
-char *local_time_str(time_t time_secs, char *buf)
+char *format_time_str(char *buf, char const *format, time_t time_secs)
 {
     time_t etime;
     struct tm tm_info;
@@ -39,11 +39,14 @@ char *local_time_str(time_t time_secs, char *buf)
     localtime_r(&etime, &tm_info); // thread-safe
 #endif
 
-    strftime(buf, LOCAL_TIME_BUFLEN, "%Y-%m-%d %H:%M:%S", &tm_info);
+    if (!format || !*format)
+        format = "%Y-%m-%d %H:%M:%S";
+
+    strftime(buf, LOCAL_TIME_BUFLEN, format, &tm_info);
     return buf;
 }
 
-char *usecs_time_str(struct timeval *tv, char *buf)
+char *usecs_time_str(char *buf, char const *format, struct timeval *tv)
 {
     struct timeval now;
     struct tm *tm_info;
@@ -56,7 +59,10 @@ char *usecs_time_str(struct timeval *tv, char *buf)
     time_t t_secs = tv->tv_sec;
     tm_info = localtime(&t_secs); // note: win32 doesn't have localtime_r()
 
-    size_t l = strftime(buf, LOCAL_TIME_BUFLEN, "%Y-%m-%d %H:%M:%S", tm_info);
+    if (!format || !*format)
+        format = "%Y-%m-%d %H:%M:%S";
+
+    size_t l = strftime(buf, LOCAL_TIME_BUFLEN, format, tm_info);
     snprintf(buf + l, LOCAL_TIME_BUFLEN - l, ".%06ld", (long)tv->tv_usec);
     return buf;
 }


### PR DESCRIPTION
This unclutters the time format meta option `-M time` and offers additional formats:

- `time` (or `time:1`, `time:on`, `time:yes`)
- `time:off` (or `time:0`, `time:off`, `time:no`)
- `time:rel`
- `time:unix`
- `time:iso`
- `time:usec`
- `time:utc`

Options can be combined, e.g. `time:unix:utc:usec`. S.a. #1021