### PR TITLE
CMake: Switch back to _GNU_SOURCE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,9 @@ if(("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" MATCHES 
     ADD_DEFINITIONS(-Wno-missing-field-initializers)
     ADD_DEFINITIONS(-std=c99)
     ADD_DEFINITIONS(-pedantic)
-    # for strdup, setenv
-    ADD_DEFINITIONS(-D_POSIX_C_SOURCE=200809)
+    # for strdup, setenv, use either
+    #ADD_DEFINITIONS(-D_POSIX_C_SOURCE=200809) # does not work with uClibc
+    ADD_DEFINITIONS(-D_GNU_SOURCE)
     #http://gcc.gnu.org/wiki/Visibility
     add_definitions(-fvisibility=hidden)
 


### PR DESCRIPTION
This fixes compilation with uClibc. Otherwise strdup is undefined.

A few solutions here. strdup can be replaced with strndup. _BSD_SOURCE can also be used. But replacing POSIX_C_SOURCE causes other functions to be undefined. _GNU_SOURCE is easiest.

edit: https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/rtl_433/compile.txt