### PR TITLE
Initial attempt to add support for the fine offset wh0290 air quality monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Supported device protocols:
     [123]* Jansite TPMS Model TY02S
     [124]  LaCrosse/ELV/Conrad WS7000/WS2500 weather sensors
     [125]  TS-FT002 Wireless Ultrasonic Tank Liquid Level Meter With Temperature Sensor
+    [126]  Companion WTR001 Temperature Sensor
 
 * Disabled by default, use -R n or -G
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Supported device protocols:
     [94]  Philips outdoor temperature sensor
     [95]  Schrader TPMS EG53MA4
     [96]  Nexa
-    [97]  Thermopro TP08/TP12 thermometer
+    [97]  Thermopro TP08/TP12/TP20 thermometer
     [98]  GE Color Effects
     [99]  X10 Security
     [100]  Interlogix GE UTC Security Devices

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -282,7 +282,7 @@ stop_after_successful_events false
   protocol 94  # Philips outdoor temperature sensor
   protocol 95  # Schrader TPMS EG53MA4
   protocol 96  # Nexa
-  protocol 97  # Thermopro TP08/TP12 thermometer
+  protocol 97  # Thermopro TP08/TP12/TP20 thermometer
   protocol 98  # GE Color Effects
   protocol 99  # X10 Security
   protocol 100 # Interlogix GE UTC Security Devices

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -311,6 +311,7 @@ stop_after_successful_events false
 # protocol 123 # Jansite TPMS Model TY02S
   protocol 124 # LaCrosse/ELV/Conrad WS7000/WS2500 weather sensors
   protocol 125 # TS-FT002 Wireless Ultrasonic Tank Liquid Level Meter With Temperature Sensor
+  protocol 126 # Companion WTR001 Temperature Sensor
 
 ## Flex devices (command line option "-X")
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -133,6 +133,7 @@
     DECL(tpms_jansite) \
     DECL(lacrosse_ws7000) \
     DECL(ts_ft002) \
+    DECL(companion_wtr001) \
     /* Add new decoders here. */
 
 #define DECL(name) extern r_device name;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(rtl_433
 	devices/calibeur.c
 	devices/cardin.c
 	devices/chuango.c
+	devices/companion_wtr001.c
 	devices/current_cost.c
 	devices/danfoss.c
 	devices/digitech_xc0324.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,6 +40,7 @@ rtl_433_SOURCES      = abuf.c \
                        devices/calibeur.c \
                        devices/cardin.c \
                        devices/chuango.c \
+                       devices/companion_wtr001.c \
                        devices/current_cost.c \
                        devices/danfoss.c \
                        devices/digitech_xc0324.c \

--- a/src/devices/companion_wtr001.c
+++ b/src/devices/companion_wtr001.c
@@ -27,7 +27,7 @@ E.g. rtl_433 -R 0 -X 'n=WTR001,m=OOK_PWM,s=732,l=2196,y=1464,r=2928,bits>=14,inv
 
 Data layout (14 bits):
 
-    DDDDDXTTTTTTTP
+    DDDDDXTT TTTTTP
 
 | Ordered Bits     | Description
 |------------------|-------------

--- a/src/devices/companion_wtr001.c
+++ b/src/devices/companion_wtr001.c
@@ -26,13 +26,15 @@ Final 1464 us is gap silence, though.
 E.g. rtl_433 -R 0 -X 'n=WTR001,m=OOK_PWM,s=732,l=2196,y=1464,r=2928,bits>=14,invert'
 
 Data layout (14 bits):
+
     DDDDDXTTTTTTTP
 
-| Bit              | Description
-| 4,3,2,1,0        | DDDDD
-| 5                | X - Always 0 in testing. Maybe battery_OK or fixed to determine inversion
-| 12,7,6,11,10,9,8 | TTTTTTT
-| 14               | P - Parity to ensure count of set bits in data is odd.
+| Ordered Bits     | Description
+|------------------|-------------
+| 4,3,2,1,0        | DDDDD: Fractional part of Temperature. (DDDDD - 10) / 10
+| 5                | X: Always 0 in testing. Maybe battery_OK or fixed
+| 12,7,6,11,10,9,8 | TTTTTTT: Temperature in Celcius = (TTTTTTT + ((DDDDD - 10) / 10)) - 41
+| 13               | P: Parity to ensure count of set bits in data is odd.
 
 Temperature in Celcius = (bin2dec(bits 12,7,6,11,10,9,8) + ((bin2dec(bits 4,3,2,1,0) - 10) / 10 ) - 41
 

--- a/src/devices/companion_wtr001.c
+++ b/src/devices/companion_wtr001.c
@@ -25,10 +25,10 @@ Final 1464 us is gap silence, though.
 
 E.g. rtl_433 -R 0 -X 'n=WTR001,m=OOK_PWM,s=732,l=2196,y=1464,r=2928,bits>=14,invert'
 
-Data layout:
-    DD DD DX TT TT TT TP
+Data layout (14 bits):
+    DDDDDXTTTTTTTP
 
-| Nibble           | Description
+| Bit              | Description
 | 4,3,2,1,0        | DDDDD
 | 5                | X - Always 0 in testing. Maybe battery_OK or fixed to determine inversion
 | 12,7,6,11,10,9,8 | TTTTTTT

--- a/src/devices/companion_wtr001.c
+++ b/src/devices/companion_wtr001.c
@@ -1,0 +1,151 @@
+/** @file
+    Companion WTR001 Temperature Sensor decoder.
+
+    Copyright (C) 2019 Karl Lohner <klohner@thespill.com>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+ */
+
+/**
+Companion WTR001 Temperature Sensor decoder.
+
+The device uses PWM encoding with 2928 us for each pulse plus gap.
+- Logical 0 is encoded as 732 us pulse and 2196 us gap,
+- Logical 1 is encoded as 2196 us pulse and 732 us gap,
+- SYNC is encoded as 1464 us and 1464 us gap.
+
+A transmission starts with the SYNC,
+there are 5 repeated packets, each ending with a SYNC.
+
+Full message is (1+5*(14+1))*2928 us = 304*2928us = 890,112 us.
+Final 1464 us is gap silence, though.
+
+E.g. rtl_433 -R 0 -X 'n=WTR001,m=OOK_PWM,s=732,l=2196,y=1464,r=2928,bits>=14,invert'
+
+Data layout:
+    DD DD DX TT TT TT TP
+
+| Nibble           | Description
+| 4,3,2,1,0        | DDDDD
+| 5                | X - Always 0 in testing. Maybe battery_OK or fixed to determine inversion
+| 12,7,6,11,10,9,8 | TTTTTTT
+| 14               | P - Parity to ensure count of set bits in data is odd.
+
+Temperature in Celcius = (bin2dec(bits 12,7,6,11,10,9,8) - 41) + ((bin2dec(bits 4,3,2,1,0) - 10) / 10 )
+
+Published range of device is -29.9C to 69.9C
+*/
+
+#include "decoder.h"
+
+#define MYDEVICE_BITLEN      14
+#define MYDEVICE_MINREPEATS  3
+
+static int companion_wtr001_decoder(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+
+    data_t *data;
+    int r; // a row index
+    uint8_t b[2];
+    float temperature;
+
+    // short pulse with long gap is 0, long pulse with short gap is 1.
+    // This is inverse of default OOK_PULSE_PWM behavior
+    bitbuffer_invert(bitbuffer);
+
+    r = bitbuffer_find_repeated_row(bitbuffer, MYDEVICE_MINREPEATS, MYDEVICE_BITLEN);
+    if (r < 0 || bitbuffer->bits_per_row[r] != 14) {
+        return 0;
+    }
+
+    bitbuffer_extract_bytes(bitbuffer, r, 0, b, 14);
+
+    // Make sure fixed bit in nibble 5 is not set
+    if ((b[0] & 0x04) == 0x04) {
+        if (decoder->verbose > 1) {
+            // fprintf(stderr, "companion_wtr001: Fixed Bit set (and it shouldn't be)\n");
+        }
+        return 0;
+    }
+
+    /* Parity check (must be ODD) */
+    if (!parity_bytes(b, 2)) {
+        if (decoder->verbose > 1) {
+            fprintf(stderr, "companion_wtr001: parity check failed (should be ODD)\n");
+        }
+        return 0;
+    }
+
+    // Get the tenth of a degree C as nibbles 0,1,2,3,4 reversed, minus 0x0a
+    uint8_t temp_tenth_raw = reverse8(b[0] & 0xf8);
+   
+    if (temp_tenth_raw < 0x0a) {
+        // Value is too low
+        if (decoder->verbose > 1) {
+            fprintf(stderr, "companion_wtr001: Temperature Degree Tenth too low (%d - 10 is less than 0\n", temp_tenth_raw);
+        }
+        return 0;
+    }
+    
+    if (temp_tenth_raw > 0x13) {
+        // Value is too high
+        if (decoder->verbose > 1) {
+            fprintf(stderr, "companion_wtr001: Temperature Degree Tenth too high (%d - 10 is greater than 9\n", temp_tenth_raw);
+        }
+        return 0;
+    }
+
+    temp_tenth_raw -= 0x0a;
+    
+    uint8_t temp_whole_raw = reverse8(b[1]&0xf0) | reverse8(b[0]&0x03)>>2 | (b[1]&0x08)<<3;
+
+    if (temp_whole_raw < 11) {
+        // Value is too low (outside published specs)
+        if (decoder->verbose > 1) {
+            fprintf(stderr, "companion_wtr001: Whole part of Temperature is too low (%d - 41 is less than -30)\n", temp_whole_raw);
+        }
+        return 0;
+    }
+    
+    if (temp_tenth_raw > 111) {
+        // Value is too high (outside published specs)
+        if (decoder->verbose > 1) {
+            fprintf(stderr, "companion_wtr001: Whole part of Temperature is too high (%d - 41 is greater than 70)\n", temp_whole_raw);
+        }
+        return 0;
+    }
+   
+    temperature = (temp_whole_raw + (temp_tenth_raw * 0.1f)) - 41.0f;
+
+    data = data_make(
+            "model", "", DATA_STRING, _X("WTR001","Companion WTR001 Temperature Sensor"),
+            "temperature_C", "Temperature", DATA_FORMAT, "%.1f", DATA_DOUBLE, temperature,
+            "mic",   "", DATA_STRING, "PARITY",
+            NULL);
+    decoder_output_data(decoder, data);
+
+    return 1;
+}
+
+static char *output_fields[] = {
+    "model",
+    "temperature_C",
+    "mic",
+    NULL
+};
+
+r_device companion_wtr001 = {
+        .name        = "Companion WTR001 Temperature Sensor",
+        .modulation  = OOK_PULSE_PWM,
+        .short_width = 732,  // 732 us pulse + 2196 us gap is 1 (will be inverted in code)
+        .long_width  = 2196, // 2196 us pulse + 732 us gap is 0 (will be inverted in code)
+        .gap_limit   = 4000, // max gap is 2928 us
+        .reset_limit = 8000, // 
+        .sync_width  = 1464, // 1464 us pulse + 1464 us gap between each row
+        .decode_fn   = &companion_wtr001_decoder,
+        .disabled    = 0,
+        .fields      = output_fields,
+};

--- a/src/devices/companion_wtr001.c
+++ b/src/devices/companion_wtr001.c
@@ -34,7 +34,7 @@ Data layout:
 | 12,7,6,11,10,9,8 | TTTTTTT
 | 14               | P - Parity to ensure count of set bits in data is odd.
 
-Temperature in Celcius = (bin2dec(bits 12,7,6,11,10,9,8) - 41) + ((bin2dec(bits 4,3,2,1,0) - 10) / 10 )
+Temperature in Celcius = (bin2dec(bits 12,7,6,11,10,9,8) + ((bin2dec(bits 4,3,2,1,0) - 10) / 10 ) - 41
 
 Published range of device is -29.9C to 69.9C
 */

--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -417,7 +417,7 @@ static int fineoffset_WH25_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     unsigned bit_offset;
 
     // Validate package
-    if (bitbuffer->bits_per_row[0] < 200) {
+    if (bitbuffer->bits_per_row[0] < 190) {
         return fineoffset_WH0290_callback(decoder, bitbuffer); // abort and try WH0290
     } else if (bitbuffer->bits_per_row[0] < 440) {  // Nominal size is 488 bit periods
         return fineoffset_WH24_callback(decoder, bitbuffer); // abort and try WH24, WH65B, HP1000

--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -318,6 +318,70 @@ static int fineoffset_WH24_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 /**
+Fine Offset Electronics WH0290 Wireless Air Quality Monitor
+Also: Ambient Weather PM25
+
+The sensor sends a package each ~10m. The bits are PCM modulated with Frequency Shift Keying.
+
+Data layout:
+    aa 2d d4 42 cc 41 9a 41 ae c1 99 9
+             FF DD ?P PP ?A AA ?? CC
+
+- F: 8 bit Family Code?
+- D: 8 bit device id?
+- ?: 2 bits ?
+- P: 14 bit PM2.5 reading in ug/m3
+- ?: 2 bits ?
+- A: 14 bit PM10 reading in ug/m3
+- ?: 8 bits ?
+- C: 8 bit Checksum of previous 7 bytes (binary sum truncated to 8 bit)
+
+*/
+static int fineoffset_WH0290_callback(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    data_t *data;
+    uint8_t const preamble[] = {0xAA, 0x2D, 0xD4};
+    uint8_t b[8];
+    unsigned bit_offset;
+
+    bit_offset = bitbuffer_search(bitbuffer, 0, 0, preamble, sizeof(preamble) * 8) + sizeof(preamble) * 8;
+    if (bit_offset + sizeof(b) * 8 > bitbuffer->bits_per_row[0]) {  // Did not find a big enough package
+        if (decoder->verbose)
+            bitbuffer_printf(bitbuffer, "Fineoffset_WH0290: short package. Row length: %u. Header index: %u\n", bitbuffer->bits_per_row[0], bit_offset);
+        return DECODE_ABORT_LENGTH;
+    }
+    bitbuffer_extract_bytes(bitbuffer, 0, bit_offset, b, sizeof(b) * 8);
+
+    // Verify checksum
+    int sum = (add_bytes(b, 7) & 0xff) - b[7];
+    if (sum) {
+        if (decoder->verbose)
+            bitrow_printf(b, sizeof (b) * 8, "Fineoffset_WH0290: Checksum error: ");
+        return DECODE_FAIL_MIC;
+    }
+
+    // Decode data
+    uint8_t family    = b[0];
+    uint8_t id        = b[1];
+    int pm25          = (b[2] & 0x3f) << 8 | b[3];
+    int pm100         = (b[4] & 0x3f) << 8 | b[5];
+
+
+    /* clang-format off */
+    data = data_make(
+            "model",            "",             DATA_STRING, _X("Fineoffset-WH0290","Fine Offset Electronics, WH0290"),
+            "id",               "ID",           DATA_INT,    id,
+            "25_particles",     "2.5 micron particles",  DATA_FORMAT, "%i ug/m3", DATA_INT, pm25/10,
+            "100_particles",     "10 micron particles",  DATA_FORMAT, "%i ug/m3", DATA_INT, pm100/10,
+            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+/**
 Fine Offset Electronics WH25 / WH32B Temperature/Humidity/Pressure sensor protocol.
 
 The sensor sends a package each ~64 s with a width of ~28 ms. The bits are PCM modulated with Frequency Shift Keying.
@@ -353,7 +417,9 @@ static int fineoffset_WH25_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     unsigned bit_offset;
 
     // Validate package
-    if (bitbuffer->bits_per_row[0] < 440) {  // Nominal size is 488 bit periods
+    if (bitbuffer->bits_per_row[0] < 200) {
+        return fineoffset_WH0290_callback(decoder, bitbuffer); // abort and try WH0290
+    } else if (bitbuffer->bits_per_row[0] < 440) {  // Nominal size is 488 bit periods
         return fineoffset_WH24_callback(decoder, bitbuffer); // abort and try WH24, WH65B, HP1000
     }
 
@@ -744,6 +810,9 @@ static char *output_fields_WH25[] = {
     "uv",
     "uvi",
     "light_lux",
+    //WH0290
+    "25_particles",
+    "100_particles",
     "battery",
     "mic",
     NULL,

--- a/src/devices/thermopro_tp12.c
+++ b/src/devices/thermopro_tp12.c
@@ -112,7 +112,7 @@ static char *output_fields[] = {
 };
 
 r_device thermopro_tp12 = {
-    .name          = "Thermopro TP08/TP12 thermometer",
+    .name          = "Thermopro TP08/TP12/TP20 thermometer",
     .modulation    = OOK_PULSE_PPM,
     .short_width   = 500,
     .long_width    = 1500,

--- a/vs15/rtl_433.vcxproj
+++ b/vs15/rtl_433.vcxproj
@@ -152,6 +152,7 @@
     <ClCompile Include="..\src\devices\calibeur.c" />
     <ClCompile Include="..\src\devices\cardin.c" />
     <ClCompile Include="..\src\devices\chuango.c" />
+    <ClCompile Include="..\src\devices\companion_wtr001.c" />
     <ClCompile Include="..\src\devices\current_cost.c" />
     <ClCompile Include="..\src\devices\danfoss.c" />
     <ClCompile Include="..\src\devices\digitech_xc0324.c" />

--- a/vs15/rtl_433.vcxproj.filters
+++ b/vs15/rtl_433.vcxproj.filters
@@ -217,6 +217,9 @@
     <ClCompile Include="..\src\devices\chuango.c">
       <Filter>Source Files\devices</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\devices\companion_wtr001.c">
+      <Filter>Source Files\devices</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\devices\current_cost.c">
       <Filter>Source Files\devices</Filter>
     </ClCompile>


### PR DESCRIPTION
I've tested for 24 hours.  There's still a battery indicator field that needs to be identified, but so far it's reliably report values.  I tested along side the WH25 and WH24 to ensure the code doesn't affect decoding of their packets.  Looks good so far.