### PR TITLE
Add MQTT topic format strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,13 +275,13 @@ Option -F:
 	Append output to file with :<filename> (e.g. -F csv:log.csv), defaults to stdout.
 	Specify MQTT server with e.g. -F mqtt://localhost:1883
 	Add MQTT options with e.g. -F "mqtt://host:1883,opt=arg"
-	MQTT options are: user=foo, pass=bar, retain[=0|1],
-		 usechannel=replaceid|afterid|beforeid|no, <format>[=topic]
+	MQTT options are: user=foo, pass=bar, retain[=0|1], <format>[=topic]
 	Supported MQTT formats: (default is all)
 	  events: posts JSON event data
 	  states: posts JSON state data
 	  devices: posts device and sensor info in nested topics
-	E.g. -F "mqtt://localhost:1883,user=USERNAME,pass=PASSWORD,retain=0,devices=/rtl_433"
+	The topic string will expand keys like [/model]
+	E.g. -F "mqtt://localhost:1883,user=USERNAME,pass=PASSWORD,retain=0,devices=rtl_433[/id]"
 	Specify host/port for syslog with e.g. -F syslog:127.0.0.1:1514
 
 Option -M:

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -167,12 +167,13 @@ signal_grabber none
 #     Append output to file with :<filename> (e.g. -F csv:log.csv), defaults to stdout.
 #     Specify MQTT server with e.g. -F mqtt://localhost:1883
 #     Add MQTT options with e.g. -F "mqtt://host:1883,opt=arg"
-#     MQTT options are: user=foo, pass=bar, retain[=0|1],
-#       usechannel=replaceid|afterid|beforeid|no, <format>[=topic]
+#     MQTT options are: user=foo, pass=bar, retain[=0|1], <format>[=topic]
 #     Supported MQTT formats: (default is all)
 #       events: posts JSON event data
 #       states: posts JSON state data
 #       devices: posts device and sensor info in nested topics
+#     The topic string will expand keys like [/model]
+#     E.g. -F "mqtt://localhost:1883,user=USERNAME,pass=PASSWORD,retain=0,devices=rtl_433[/id]"
 #     Specify host/port for syslog with e.g. -F syslog:127.0.0.1:1514
 # default is "kv", multiple outputs can be used.
 output json

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -182,13 +182,13 @@ static void help_output(void)
             "\tAppend output to file with :<filename> (e.g. -F csv:log.csv), defaults to stdout.\n"
             "\tSpecify MQTT server with e.g. -F mqtt://localhost:1883\n"
             "\tAdd MQTT options with e.g. -F \"mqtt://host:1883,opt=arg\"\n"
-            "\tMQTT options are: user=foo, pass=bar, retain[=0|1],\n"
-            "\t\t usechannel=replaceid|afterid|beforeid|no, <format>[=topic]\n"
+            "\tMQTT options are: user=foo, pass=bar, retain[=0|1], <format>[=topic]\n"
             "\tSupported MQTT formats: (default is all)\n"
             "\t  events: posts JSON event data\n"
             "\t  states: posts JSON state data\n"
             "\t  devices: posts device and sensor info in nested topics\n"
-            "\tE.g. -F \"mqtt://localhost:1883,user=USERNAME,pass=PASSWORD,retain=0,devices=/rtl_433\"\n"
+            "\tThe topic string will expand keys like [/model]\n"
+            "\tE.g. -F \"mqtt://localhost:1883,user=USERNAME,pass=PASSWORD,retain=0,devices=rtl_433[/id]\"\n"
             "\tSpecify host/port for syslog with e.g. -F syslog:127.0.0.1:1514\n");
     exit(0);
 }


### PR DESCRIPTION
S.a. #1078

> If a protocol does not have channels, then the random ID is used in generating the MQTT topic.
> It's likely more useful, if the channel value is set to "0" in that case or is omitted completely.

Not sure if `afterid` and `beforeid` should also use a default channel of `0`.
There might be cases where you want the channel only if it's available?

Maybe this needs to be an option like `defaultchannel=yes`?

Perhaps we should change to a format string for the topic, e.g. like:
- `%t` / `%T` : type if available / type or default
- `%b` / `%B` : brand if available / brand or default
- `%m` / `%M` : model if available / model or default
- `%s` / `%S` : subtype if available / subtype or default
- `%c` / `%C` : channel if available / channel or default
- `%i` / `%I` : id if available / id or default

Needs input and discussion, please!