### PR TITLE
Allow Analyser to differentiate between FSK/OOK flex decoder

### DIFF
--- a/include/pulse_detect.h
+++ b/include/pulse_detect.h
@@ -44,6 +44,12 @@ typedef struct pulse_data {
     float noise_db;
 } pulse_data_t;
 
+// Package types
+enum package_types {
+    OOK = 1,
+    FSK = 2,
+};
+
 typedef struct pulse_detect pulse_detect_t;
 
 /// Clear the content of a pulse_data_t structure.
@@ -89,7 +95,7 @@ void pulse_detect_free(pulse_detect_t *pulse_detect);
 int pulse_detect_package(pulse_detect_t *pulse_detect, int16_t const *envelope_data, int16_t const *fm_data, int len, int16_t level_limit, uint32_t samp_rate, uint64_t sample_offset, pulse_data_t *pulses, pulse_data_t *fsk_pulses);
 
 /// Analyze and print result.
-void pulse_analyzer(pulse_data_t *data);
+void pulse_analyzer(pulse_data_t *data, int package_type);
 
 
 #endif /* INCLUDE_PULSE_DETECT_H_ */

--- a/include/pulse_detect.h
+++ b/include/pulse_detect.h
@@ -46,8 +46,8 @@ typedef struct pulse_data {
 
 // Package types
 enum package_types {
-    OOK = 1,
-    FSK = 2,
+    PULSE_DATA_OOK = 1,
+    PULSE_DATA_FSK = 2,
 };
 
 typedef struct pulse_detect pulse_detect_t;

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -761,11 +761,7 @@ void pulse_analyzer(pulse_data_t *data, int package_type)
     }
     else if (hist_pulses.bins_count == 2 && hist_gaps.bins_count >= 3) {
         fprintf(stderr, "Pulse Width Modulation with multiple packets\n");
-        if (package_type == PULSE_DATA_OOK) {
-            device.modulation = OOK_PULSE_PWM;
-        } else if (package_type == PULSE_DATA_FSK) {
-            device.modulation = FSK_PULSE_PWM;
-        }
+        device.modulation = (package_type == PULSE_DATA_FSK) ? FSK_PULSE_PWM : OOK_PULSE_PWM;
         device.s_short_width = hist_pulses.bins[0].mean;
         device.s_long_width  = hist_pulses.bins[1].mean;
         device.s_gap_limit   = hist_gaps.bins[1].max + 1; // Set limit above second gap

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -467,7 +467,7 @@ int pulse_detect_package(pulse_detect_t *pulse_detect, int16_t const *envelope_d
                         pulses->end_ago = len - s->data_counter;
                         fsk_pulses->end_ago = len - s->data_counter;
                         s->ook_state = PD_OOK_STATE_IDLE;    // Ensure everything is reset
-                        return 2;    // FSK package detected!!!
+                        return FSK;
                     }
                 } // if
                 // FSK Demodulation (continue during short gap - we might return...)
@@ -489,7 +489,7 @@ int pulse_detect_package(pulse_detect_t *pulse_detect, int16_t const *envelope_d
                         pulses->ook_low_estimate = s->ook_low_estimate;
                         pulses->ook_high_estimate = s->ook_high_estimate;
                         pulses->end_ago = len - s->data_counter;
-                        return 1;    // End Of Package!!
+                        return OOK;    // End Of Package!!
                     }
 
                     s->pulse_length = 0;
@@ -507,7 +507,7 @@ int pulse_detect_package(pulse_detect_t *pulse_detect, int16_t const *envelope_d
                     pulses->ook_low_estimate = s->ook_low_estimate;
                     pulses->ook_high_estimate = s->ook_high_estimate;
                     pulses->end_ago = len - s->data_counter;
-                    return 1;    // End Of Package!!
+                    return OOK;    // End Of Package!!
                 }
                 break;
             default:
@@ -667,7 +667,7 @@ void histogram_print(histogram_t const *hist, uint32_t samp_rate)
 #define TOLERANCE (0.2f) // 20% tolerance should still discern between the pulse widths: 0.33, 0.66, 1.0
 
 /// Analyze the statistics of a pulse data structure and print result
-void pulse_analyzer(pulse_data_t *data)
+void pulse_analyzer(pulse_data_t *data, int package_type)
 {
     double to_ms = 1e3 / data->sample_rate;
     double to_us = 1e6 / data->sample_rate;
@@ -761,7 +761,11 @@ void pulse_analyzer(pulse_data_t *data)
     }
     else if (hist_pulses.bins_count == 2 && hist_gaps.bins_count >= 3) {
         fprintf(stderr, "Pulse Width Modulation with multiple packets\n");
-        device.modulation    = OOK_PULSE_PWM;
+        if (package_type == OOK) {
+            device.modulation = OOK_PULSE_PWM;
+        } else if (package_type == FSK) {
+            device.modulation = FSK_PULSE_PWM;
+        }
         device.s_short_width = hist_pulses.bins[0].mean;
         device.s_long_width  = hist_pulses.bins[1].mean;
         device.s_gap_limit   = hist_gaps.bins[1].max + 1; // Set limit above second gap
@@ -816,6 +820,13 @@ void pulse_analyzer(pulse_data_t *data)
             break;
         case OOK_PULSE_PWM:
             fprintf(stderr, "Use a flex decoder with -X 'n=name,m=OOK_PWM,s=%.0f,l=%.0f,r=%.0f,g=%.0f,t=%.0f,y=%.0f'\n",
+                    device.s_short_width * to_us, device.s_long_width * to_us, device.s_reset_limit * to_us,
+                    device.s_gap_limit * to_us, device.s_tolerance * to_us, device.s_sync_width * to_us);
+            data->gap[data->num_pulses - 1] = device.s_reset_limit + 1; // Be sure to terminate package
+            pulse_demod_pwm(data, &device);
+            break;
+        case FSK_PULSE_PWM:
+            fprintf(stderr, "Use a flex decoder with -X 'n=name,m=FSK_PWM,s=%.0f,l=%.0f,r=%.0f,g=%.0f,t=%.0f,y=%.0f'\n",
                     device.s_short_width * to_us, device.s_long_width * to_us, device.s_reset_limit * to_us,
                     device.s_gap_limit * to_us, device.s_tolerance * to_us, device.s_sync_width * to_us);
             data->gap[data->num_pulses - 1] = device.s_reset_limit + 1; // Be sure to terminate package

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -761,7 +761,7 @@ void pulse_analyzer(pulse_data_t *data, int package_type)
     }
     else if (hist_pulses.bins_count == 2 && hist_gaps.bins_count >= 3) {
         fprintf(stderr, "Pulse Width Modulation with multiple packets\n");
-        device.modulation = (package_type == PULSE_DATA_FSK) ? FSK_PULSE_PWM : OOK_PULSE_PWM;
+        device.modulation    = (package_type == PULSE_DATA_FSK) ? FSK_PULSE_PWM : OOK_PULSE_PWM;
         device.s_short_width = hist_pulses.bins[0].mean;
         device.s_long_width  = hist_pulses.bins[1].mean;
         device.s_gap_limit   = hist_gaps.bins[1].max + 1; // Set limit above second gap

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -467,7 +467,7 @@ int pulse_detect_package(pulse_detect_t *pulse_detect, int16_t const *envelope_d
                         pulses->end_ago = len - s->data_counter;
                         fsk_pulses->end_ago = len - s->data_counter;
                         s->ook_state = PD_OOK_STATE_IDLE;    // Ensure everything is reset
-                        return FSK;
+                        return PULSE_DATA_FSK;
                     }
                 } // if
                 // FSK Demodulation (continue during short gap - we might return...)
@@ -489,7 +489,7 @@ int pulse_detect_package(pulse_detect_t *pulse_detect, int16_t const *envelope_d
                         pulses->ook_low_estimate = s->ook_low_estimate;
                         pulses->ook_high_estimate = s->ook_high_estimate;
                         pulses->end_ago = len - s->data_counter;
-                        return OOK;    // End Of Package!!
+                        return PULSE_DATA_OOK;    // End Of Package!!
                     }
 
                     s->pulse_length = 0;
@@ -507,7 +507,7 @@ int pulse_detect_package(pulse_detect_t *pulse_detect, int16_t const *envelope_d
                     pulses->ook_low_estimate = s->ook_low_estimate;
                     pulses->ook_high_estimate = s->ook_high_estimate;
                     pulses->end_ago = len - s->data_counter;
-                    return OOK;    // End Of Package!!
+                    return PULSE_DATA_OOK;    // End Of Package!!
                 }
                 break;
             default:
@@ -761,9 +761,9 @@ void pulse_analyzer(pulse_data_t *data, int package_type)
     }
     else if (hist_pulses.bins_count == 2 && hist_gaps.bins_count >= 3) {
         fprintf(stderr, "Pulse Width Modulation with multiple packets\n");
-        if (package_type == OOK) {
+        if (package_type == PULSE_DATA_OOK) {
             device.modulation = OOK_PULSE_PWM;
-        } else if (package_type == FSK) {
+        } else if (package_type == PULSE_DATA_FSK) {
             device.modulation = FSK_PULSE_PWM;
         }
         device.s_short_width = hist_pulses.bins[0].mean;

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -321,7 +321,7 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx)
     int d_events = 0; // Sensor events successfully detected
     if (demod->r_devs.len || demod->analyze_pulses || demod->dumper.len || demod->samp_grab) {
         // Detect a package and loop through demodulators with pulse data
-        int package_type = OOK;  // Just to get us started
+        int package_type = PULSE_DATA_OOK;  // Just to get us started
         for (void **iter = demod->dumper.elems; iter && *iter; ++iter) {
             file_info_t const *dumper = *iter;
             if (dumper->format == U8_LOGIC) {
@@ -339,7 +339,7 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx)
                 // always update the last frame end
                 demod->frame_end_ago = demod->pulse_data.end_ago;
             }
-            if (package_type == OOK) {
+            if (package_type == PULSE_DATA_OOK) {
                 calc_rssi_snr(cfg, &demod->pulse_data);
                 if (demod->analyze_pulses) fprintf(stderr, "Detected OOK package\t%s\n", time_pos_str(cfg, demod->pulse_data.start_ago, time_str));
 
@@ -359,7 +359,7 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx)
                     pulse_analyzer(&demod->pulse_data, package_type);
                 }
 
-            } else if (package_type == FSK) {
+            } else if (package_type == PULSE_DATA_FSK) {
                 calc_rssi_snr(cfg, &demod->fsk_pulse_data);
                 if (demod->analyze_pulses) fprintf(stderr, "Detected FSK package\t%s\n", time_pos_str(cfg, demod->fsk_pulse_data.start_ago, time_str));
 

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -321,7 +321,7 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx)
     int d_events = 0; // Sensor events successfully detected
     if (demod->r_devs.len || demod->analyze_pulses || demod->dumper.len || demod->samp_grab) {
         // Detect a package and loop through demodulators with pulse data
-        int package_type = 1;  // Just to get us started
+        int package_type = OOK;  // Just to get us started
         for (void **iter = demod->dumper.elems; iter && *iter; ++iter) {
             file_info_t const *dumper = *iter;
             if (dumper->format == U8_LOGIC) {
@@ -339,7 +339,7 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx)
                 // always update the last frame end
                 demod->frame_end_ago = demod->pulse_data.end_ago;
             }
-            if (package_type == 1) {
+            if (package_type == OOK) {
                 calc_rssi_snr(cfg, &demod->pulse_data);
                 if (demod->analyze_pulses) fprintf(stderr, "Detected OOK package\t%s\n", time_pos_str(cfg, demod->pulse_data.start_ago, time_str));
 
@@ -356,10 +356,10 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx)
 
                 if (cfg->verbosity > 2) pulse_data_print(&demod->pulse_data);
                 if (demod->analyze_pulses && (cfg->grab_mode <= 1 || (cfg->grab_mode == 2 && p_events == 0) || (cfg->grab_mode == 3 && p_events > 0)) ) {
-                    pulse_analyzer(&demod->pulse_data);
+                    pulse_analyzer(&demod->pulse_data, package_type);
                 }
 
-            } else if (package_type == 2) {
+            } else if (package_type == FSK) {
                 calc_rssi_snr(cfg, &demod->fsk_pulse_data);
                 if (demod->analyze_pulses) fprintf(stderr, "Detected FSK package\t%s\n", time_pos_str(cfg, demod->fsk_pulse_data.start_ago, time_str));
 
@@ -376,7 +376,7 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx)
 
                 if (cfg->verbosity > 2) pulse_data_print(&demod->fsk_pulse_data);
                 if (demod->analyze_pulses && (cfg->grab_mode <= 1 || (cfg->grab_mode == 2 && p_events == 0) || (cfg->grab_mode == 3 && p_events > 0)) ) {
-                    pulse_analyzer(&demod->fsk_pulse_data);
+                    pulse_analyzer(&demod->fsk_pulse_data, package_type);
                 }
             } // if (package_type == ...
             d_events += p_events;


### PR DESCRIPTION
I encountered a problem while learning to analyse signals where the analyser would spot:

1. `FSK` package
2. `PWM` modulation

but it then recommends: `Use a flex decoder with -X 'n=name,m=OOK_PWM,s=408,l=820,r=44192,g=828,t=164,y=0'`.   In this case it should be suggesting, `FSK_PWM`, which works to decode the signal.

Here's an example run that demonstrates the error:

```
rtl_433 -r g394_432.859M_250k.cu8 -A -a -X 'n=blip,m=FSK_PWM,s=408,l=820,r=44212,g=0,t=0,y=0,preamble={32}0xffff0faf'
rtl_433 version 18.12-210-g7ab2894 branch master at 201905261917 inputs file rtl_tcp RTL-SDR
Trying conf file at "rtl_433.conf"...
Trying conf file at "/Users/omar/.config/rtl_433/rtl_433.conf"...
Trying conf file at "/usr/local/etc/rtl_433/rtl_433.conf"...
Trying conf file at "/etc/rtl_433/rtl_433.conf"...

	Consider using "-M newmodel" to transition to new model keys. This will become the default someday.
	A table of changes and discussion is at https://github.com/merbanan/rtl_433/pull/986.

Registered 100 out of 126 device decoding protocols [ 1-4 8 11-12 15-17 19-21 23 25-26 29-36 38-60 62-63 67-71 73-100 102-103 108-116 119 121 124-126 ]
Test mode active. Reading samples from file: g394_432.859M_250k.cu8
Detected FSK package	@0.073628s
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
time      : @0.073628s
model     : blip         count     : 1             num_rows  : 1             rows      :
len       : 50           data      : 6ffabffffbbfc
codes     : {50}6ffabffffbbfc
Analyzing pulses...
Total count:   83,  width: 122.26 ms		(30565 S)
Pulse width distribution:
 [ 0] count:    1,  width:    0 us [0;0]	(   0 S)
 [ 1] count:   69,  width:  408 us [408;412]	( 102 S)
 [ 2] count:   13,  width:  820 us [820;824]	( 205 S)
Gap width distribution:
 [ 0] count:    1,  width: 44188 us [44188;44188]	(11047 S)
 [ 1] count:   67,  width:  408 us [408;412]	( 102 S)
 [ 2] count:   14,  width:  820 us [820;824]	( 205 S)
Pulse period distribution:
 [ 0] count:    1,  width: 44188 us [44188;44188]	(11047 S)
 [ 1] count:   62,  width:  820 us [820;824]	( 205 S)
 [ 2] count:   11,  width: 1232 us [1232;1236]	( 308 S)
 [ 3] count:    8,  width: 1640 us [1640;1644]	( 410 S)
Level estimates [high, low]:   1000,     49
RSSI: -12.1 dB SNR: 13.0 dB Noise: -25.2 dB
Frequency offsets [F1, F2]:   14772,  -2331	(+56.4 kHz, -8.9 kHz)
Guessing modulation: Pulse Width Modulation with multiple packets
Attempting demodulation... short_width: 408, long_width: 820, reset_limit: 44192, sync_width: 0
Use a flex decoder with -X 'n=name,m=OOK_PWM,s=408,l=820,r=44192,g=828,t=164,y=0'
pulse_demod_pwm(): Analyzer Device
bitbuffer:: Number of rows: 1
[00] {82} ff ff 0f af 6f fa bf ff fb bf c0
```

I'm new to the codebase so tried to minimise changes.  It seemed better to contain the logic inside of `pulse_detect` and just pass the existing `package_type` flag through.   I considered adding the flag to the `pulse_data_t` struct but thought better of it.  

There might be other modulations that can be either FSK or OOK.  I don't know enough here so I only changed this for FSK/OOK PWM where I have an example.