### PR TITLE
DirecTV - use standard "id" field name

### DIFF
--- a/src/devices/directv.c
+++ b/src/devices/directv.c
@@ -375,7 +375,7 @@ static int directv_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     // Populate our return fields
     data = data_make(
             "model",         "",            DATA_STRING, "DirecTV-RC66RX",
-            "device_id",     "",            DATA_FORMAT, "%06d", DATA_INT, dtv_device_id,
+            "id",            "",            DATA_FORMAT, "%06d", DATA_INT, dtv_device_id,
             "button_id",     "",            DATA_FORMAT, "0x%02X", DATA_INT, dtv_button_id,
             "button_name",   "",            DATA_FORMAT, "[%s]", DATA_STRING, get_dtv_button_label(dtv_button_id),
             "event",         "",            DATA_STRING, row_sync_len > ROW_SYNC_SHORT_LEN ? "INITIAL" : "REPEAT",
@@ -389,7 +389,7 @@ static int directv_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
 static char *output_fields[] = {
     "model",
-    "device_id",
+    "id",
     "button_id",
     "button_name",
     "event",

--- a/src/devices/directv.c
+++ b/src/devices/directv.c
@@ -374,7 +374,7 @@ static int directv_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // Populate our return fields
     data = data_make(
-            "model",         "",            DATA_STRING, _X("DirecTV-RC66RX","DirecTV RC66RX Remote"),
+            "model",         "",            DATA_STRING, "DirecTV-RC66RX",
             "id",            "",            DATA_FORMAT, "%06d", DATA_INT, dtv_device_id,
             "button_id",     "",            DATA_FORMAT, "0x%02X", DATA_INT, dtv_button_id,
             "button_name",   "",            DATA_FORMAT, "[%s]", DATA_STRING, get_dtv_button_label(dtv_button_id),

--- a/src/devices/directv.c
+++ b/src/devices/directv.c
@@ -374,7 +374,7 @@ static int directv_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // Populate our return fields
     data = data_make(
-            "model",         "",            DATA_STRING, "DirecTV-RC66RX",
+            "model",         "",            DATA_STRING, _X("DirecTV-RC66RX","DirecTV RC66RX Remote"),
             "id",            "",            DATA_FORMAT, "%06d", DATA_INT, dtv_device_id,
             "button_id",     "",            DATA_FORMAT, "0x%02X", DATA_INT, dtv_button_id,
             "button_name",   "",            DATA_FORMAT, "[%s]", DATA_STRING, get_dtv_button_label(dtv_button_id),


### PR DESCRIPTION
I think I should be using the standard "id" field name in this device driver to better align with output from other device drivers.