### PR TITLE
Fix parsing of time specification with trailing spaces

### DIFF
--- a/src/am_analyze.c
+++ b/src/am_analyze.c
@@ -75,7 +75,7 @@ void am_analyze(am_analyze_t *a, int16_t *am_buf, unsigned n_samples, int debug_
                 a->signal_pulse_counter++;
                 if (a->signal_pulse_counter >= PULSE_DATA_SIZE) {
                     a->signal_pulse_counter = 0;
-                    fprintf(stderr, "To many pulses detected, probably bad input data or input parameters\n");
+                    fprintf(stderr, "Too many pulses detected, probably bad input data or input parameters\n");
                     return;
                 }
             }

--- a/src/optparse.c
+++ b/src/optparse.c
@@ -177,8 +177,9 @@ int atoi_time(const char *str, const char *error_hint)
             if (colons == 0) {
                 // assume seconds
                 val += num;
+                break;
             }
-            break;
+	    __attribute__ ((fallthrough));
         case ':':
             ++colons;
             if (colons == 1)

--- a/src/optparse.c
+++ b/src/optparse.c
@@ -160,7 +160,7 @@ int atoi_time(const char *str, const char *error_hint)
     double val      = 0.0;
     unsigned colons = 0;
 
-    while (*endptr) {
+    do {
         double num = strtod(str, &endptr);
 
         if (str == endptr) {
@@ -177,8 +177,8 @@ int atoi_time(const char *str, const char *error_hint)
             if (colons == 0) {
                 // assume seconds
                 val += num;
-                break;
             }
+            break;
         case ':':
             ++colons;
             if (colons == 1)
@@ -218,8 +218,13 @@ int atoi_time(const char *str, const char *error_hint)
             fprintf(stderr, "%sunknown time suffix (%s)\n", error_hint, endptr);
             exit(1);
         }
+
+        // chew up any remaining whitespace
+        while (*endptr == ' ' || *endptr == '\t')
+            ++endptr;
         str = endptr;
-    }
+
+    } while (*endptr);
 
     if (val > INT_MAX || val < INT_MIN) {
         fprintf(stderr, "%stime argument too big (%f)\n", error_hint, val);

--- a/src/optparse.c
+++ b/src/optparse.c
@@ -179,7 +179,7 @@ int atoi_time(const char *str, const char *error_hint)
                 val += num;
                 break;
             }
-	    __attribute__ ((fallthrough));
+            // intentional fallthrough
         case ':':
             ++colons;
             if (colons == 1)

--- a/tests/style-check.c
+++ b/tests/style-check.c
@@ -26,6 +26,8 @@ static int style_check(char *path)
 {
     FILE *fp = fopen(path, "r");
     assert(fp);
+    if(!fp)
+      exit(EXIT_FAILURE);
 
     int read_errors = 0;
     int long_errors = 0;


### PR DESCRIPTION
There exists a unit test for a time spec of ' -1 M ', but it was failing on both my Debian and Arch machines. This is due to the change from 2019-08-07, "Improve time arg parsing". It looks like that's where support for the (undocumented) colon syntax was added, but it broke this test.

I have fixed up time parsing so that all tests pass. I haven't updated the usage summary, because I'm not entirely sure of the intended colon syntax's semantics. The usage summary could stand an update for 'T', I am thinking, and the colon syntax could use some unit tests. But this gets things going once more.