### PR TITLE
cmake: use PROJECT_SOURCE_DIR instead of CMAKE_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_BUILD_TYPE)
 set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "")
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
 
 ########################################################################
 # Get version info from Git
@@ -153,14 +153,14 @@ endif()
 ########################################################################
 include_directories(
     BEFORE
-    ${CMAKE_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/include
 )
 
 ########################################################################
 # Create uninstall target
 ########################################################################
 configure_file(
-    ${CMAKE_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in
+    ${PROJECT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
 @ONLY)
 
@@ -203,7 +203,7 @@ include(CTest) # note: this adds a BUILD_TESTING which defaults to ON
 ########################################################################
 # Configure CI deploy
 ########################################################################
-configure_file(${CMAKE_SOURCE_DIR}/.bintray.json ${CMAKE_CURRENT_BINARY_DIR}/bintray.json)
+configure_file(${PROJECT_SOURCE_DIR}/.bintray.json ${CMAKE_CURRENT_BINARY_DIR}/bintray.json)
 
 ########################################################################
 # Add subdirectories


### PR DESCRIPTION
CMAKE_SOURCE_DIR refers to the top level CMakeLists.txt, which is not the case
when this CMake project is included in another CMake project

For this case CMAKE_CURRENT_SOURCE_DIR or PROJECT_SOURCE_DIR can be used.

Signed-off-by: Nuno Goncalves <nunojpg@gmail.com>