### PR TITLE
Added 'unique' to the flex decoders

### DIFF
--- a/conf/EV1527-4Button-Universal-Remote.conf
+++ b/conf/EV1527-4Button-Universal-Remote.conf
@@ -26,5 +26,6 @@ decoder {
         repeats>=3,
         invert,
         get=@0:{20}:code:[123456:REMOTE-A 987654:REMOTE-B],
-        get=@20:{4}:button:[1:A 2:B 3:AB 4:C 5:AC 6:BC 7:ABC 8:D 9:AD 10:BD 11:ABD 12:CD 13:ACD 14:BCD 15:ALL]
+        get=@20:{4}:button:[1:A 2:B 3:AB 4:C 5:AC 6:BC 7:ABC 8:D 9:AD 10:BD 11:ABD 12:CD 13:ACD 14:BCD 15:ALL],
+        unique
 }

--- a/conf/EV1527-PIR-Sgooway.conf
+++ b/conf/EV1527-PIR-Sgooway.conf
@@ -18,5 +18,6 @@ decoder {
         r=12000,
         repeats>=4,
         rows=25,
-        get=@0:{25}:channel:[12345678:1 98765432:2]
+        get=@0:{25}:channel:[12345678:1 98765432:2],
+        unique
 }


### PR DESCRIPTION
Using 'unique' in the flex decoder produces a cleaner out e.g. for direct MQTT publish.

Thank's Christian for making 'unique' available to it!