### PR TITLE
The 899 raincounter should be formatted as an integer

### DIFF
--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -109,7 +109,7 @@ static int acurite_rain_896_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     // This needs more validation to positively identify correct sensor type, but it basically works if message is really from acurite raingauge and it doesn't have any errors
     if (bitbuffer->bits_per_row[0] < 24)
         return DECODE_ABORT_LENGTH;
-    
+
     if ((b[0] == 0) || (b[1] == 0) || (b[2] == 0) || (b[3] != 0) || (b[4] != 0))
         return DECODE_ABORT_EARLY;
 
@@ -641,7 +641,7 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                         "id",               "",                         DATA_INT,    sensor_id,
                         "channel",          "",                         DATA_INT,    channel,
                         "battery_ok",       "Battery",                  DATA_INT,    !battery_low,
-                        "rain_mm",          "Rainfall Accumulation",    DATA_FORMAT, "%d mm", DATA_DOUBLE, raincounter,
+                        "rain_mm",          "Rainfall Accumulation",    DATA_FORMAT, "%d mm", DATA_INT, raincounter,
                         NULL);
                 /* clang-format on */
 


### PR DESCRIPTION
As part of debugging #972, I couldn't get any data output for the Acurite 899. Fiddling with the `data_make()` call it looks like the encoding for the rainfall accumulation value was in there as a `DATA_DOUBLE` when it should have been a `DATA_INT`.

With this fix I see output where before I only saw timestamps:

```sh
$ src/rtl_433 ~/Downloads/g001_433.92M_250k.cu8
rtl_433 version 19.08-14-g42abf41 branch 899-fix-format at 201909211427 inputs file rtl_tcp RTL-SDR
Use -h for usage help and see https://triq.org/ for documentation.
Trying conf file at "rtl_433.conf"...
Trying conf file at "/Users/iandees/.config/rtl_433/rtl_433.conf"...
Trying conf file at "/usr/local/etc/rtl_433/rtl_433.conf"...
Trying conf file at "/etc/rtl_433/rtl_433.conf"...

	Consider using "-M newmodel" to transition to new model keys. This will become the default someday.
	A table of changes and discussion is at https://github.com/merbanan/rtl_433/pull/986.

Registered 108 out of 138 device decoding protocols [ 1-4 8 11-12 15-17 19-21 23 25-26 29-36 38-60 63 67-71 73-100 102-103 108-116 119 121 124-128 131-138 ]
Test mode active. Reading samples from file: /Users/iandees/Downloads/g001_433.92M_250k.cu8
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
time      : @0.317064s
model     : Acurite-Rain899                        id        : 2935
channel   : 0            Battery   : 0             Rainfall Accumulation: 5 mm
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
time      : @0.317064s
model     : Acurite-Rain899                        id        : 2935
channel   : 0            Battery   : 0             Rainfall Accumulation: 5 mm
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
time      : @0.317064s
model     : Acurite-Rain899                        id        : 2935
channel   : 0            Battery   : 0             Rainfall Accumulation: 5 mm
```