### PR TITLE
Convert read OOK pulse_data to current sample rate

### DIFF
--- a/include/pulse_detect.h
+++ b/include/pulse_detect.h
@@ -68,7 +68,7 @@ void pulse_data_print_vcd_header(FILE *file, uint32_t sample_rate);
 void pulse_data_print_vcd(FILE *file, pulse_data_t const *data, int ch_id);
 
 /// Read the next pulse_data_t structure from OOK text.
-void pulse_data_load(FILE *file, pulse_data_t *data);
+void pulse_data_load(FILE *file, pulse_data_t *data, uint32_t sample_rate);
 
 /// Print a header for the OOK text format.
 void pulse_data_print_pulse_header(FILE *file);

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -98,14 +98,15 @@ void pulse_data_print_vcd(FILE *file, pulse_data_t const *data, int ch_id)
         fprintf(file, "#%.f 0/\n", pos * scale);
 }
 
-void pulse_data_load(FILE *file, pulse_data_t *data)
+void pulse_data_load(FILE *file, pulse_data_t *data, uint32_t sample_rate)
 {
     char s[256];
     int i    = 0;
     int size = sizeof(data->pulse) / sizeof(int);
 
     pulse_data_clear(data);
-    data->sample_rate = 1000000; // assumes 1us timescale
+    data->sample_rate = sample_rate;
+    double to_sample = sample_rate / 1e6;
     // read line-by-line
     while (i < size && fgets(s, sizeof(s), file)) {
         // TODO: we should parse sample rate and timescale
@@ -130,8 +131,8 @@ void pulse_data_load(FILE *file, pulse_data_t *data)
         p          = endptr + 1;
         long space = strtol(p, &endptr, 10);
         //fprintf(stderr, "read: mark %ld space %ld\n", mark, space);
-        data->pulse[i] = (int)mark;
-        data->gap[i++] = (int)space;
+        data->pulse[i] = (int)(to_sample * mark);
+        data->gap[i++] = (int)(to_sample * space);
     }
     //fprintf(stderr, "read %d pulses\n", i);
     data->num_pulses = i;

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1253,7 +1253,7 @@ int main(int argc, char **argv) {
             // special case for pulse data file-inputs
             if (demod->load_info.format == PULSE_OOK) {
                 while (!cfg.do_exit) {
-                    pulse_data_load(in_file, &demod->pulse_data);
+                    pulse_data_load(in_file, &demod->pulse_data, cfg.samp_rate);
                     if (!demod->pulse_data.num_pulses)
                         break;
 


### PR DESCRIPTION
The saved OOK dumps weren't been decodable due to the sampling rate mismatch. Upon dump it is converted to usec based values, so we should convert back during load.