### PR TITLE
Add length check for interlogix device and update return codes

### DIFF
--- a/src/devices/interlogix.c
+++ b/src/devices/interlogix.c
@@ -92,13 +92,11 @@
 
 #define INTERLOGIX_MSG_BIT_LEN 46
 
-#define MESSAGE_LENGTH 59
-
-// preamble message.  only searching for 0000 0001 (bottom 8 bits of the 13 bits preamble)
-static unsigned char preamble = 0x01;
-
 static int interlogix_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
+    // preamble message
+    // only searching for 0000 0001 (bottom 8 bits of the 13 bits preamble)
+    static const unsigned char preamble = 0x01;
     data_t *data;
     unsigned int row = 0;
     char device_type_id[2];
@@ -116,7 +114,10 @@ static int interlogix_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_ABORT_EARLY;
     }
 
-    if (bitbuffer->bits_per_row[0] != MESSAGE_LENGTH) {
+    // Check if the message length is between the length seen in test files (59)
+    // and the 64 bits discussed above.
+    if (bitbuffer->bits_per_row[0] < 59
+        || bitbuffer->bits_per_row[0] > 64) {
         return DECODE_ABORT_LENGTH;
     }
 


### PR DESCRIPTION
Add a check to the interlogix decoder that checks the message length. This was not done before and through a sort of fuzzing (pushing random data through rtl_433 using the `-y` function), I found the interlogix decoder gives a lot of false triggers. I can give lots of examples but here's one:

`rtl_433 -y {254}867dd09864b159556b6209c9705de08ba84f5347c46ef696680c4dea1c72349995c6563a66c80fbf80d9e883f0eb421bb9bb4cb34a3269d7a51a166f675478338cfdfe87c2dbf89f60f9bdcfced538412585503e9340a72239361d1363e3238e717715f27c37d658241203e47e75887fb60d19e7dee657abd43fae765fcc5bb520c3211e9cf1d373f5a4148d9d74940b2d26df0aeedcb7a90090f4b4a3b22e28614e7b4b5e109bedd2cdfc79892cbc118f172b0765185c46086c92a6846a51caa1ad29fbe1d14352a004974401822ff3da05817abea23d9afa30f706aac05a1fe58a48b04927ec31d8cb3b35e2efc5af6d91ace99edd2a0e3cc7bab8c102 -vvv`

This will trigger the interlogix decoder, even though the message length is unlike any other interlogix message. I've reviewed the interlogix messages in the rtl_433_tests repository, and they all have a bit length of 59. That's the length I've hardcoded into the source now.

I've also taken this opportunity to update the return codes for this decoder to the new format.