### PR TITLE
Add preamble check for microchip hcs200 to reduce false positives

### DIFF
--- a/src/devices/hcs200.c
+++ b/src/devices/hcs200.c
@@ -26,10 +26,6 @@ rtl_433 -R 0 -X 'n=name,m=OOK_PWM,s=370,l=772,r=14000,g=4000,t=152,y=0,preamble=
 
 #include "decoder.h"
 
-// the preamble mentioned above, 0xfff (12 bits)
-static const uint8_t preamble_bits = 12;
-static const uint8_t preamble[2] = {0xff, 0xf0};
-
 static int hcs200_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
@@ -43,12 +39,10 @@ static int hcs200_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (78 != bitbuffer->bits_per_row[0])
         return DECODE_ABORT_LENGTH;
 
-    /* Reject codes with an incorrect preamble */
-    unsigned int location = bitbuffer_search(bitbuffer, 0, 0, preamble, preamble_bits);
-    // expect the preamble to start at bit 0
-    if (location != 0) {
+    /* Reject codes with an incorrect preamble (expected 0xfff) */
+    if (b[0] != 0xff || (b[1] & 0xf0) != 0xf0) {
         if (decoder->verbose > 1)
-            fprintf(stderr, "HCS200: Preamble not found %d\n", location);
+            fprintf(stderr, "HCS200: Preamble not found\n");
         return DECODE_ABORT_EARLY;
     }
 


### PR DESCRIPTION
The microchip decoder gives a reasonable amount of false positives on messages that don't have the preamble mentioned in the source file. I've added a check that checks that preamble. This seems to work fine with the provided files in the rtl_433_tests project, while reducing false positives.

Something that would trigger the decoder would be

`rtl_433 -y {78}f0f82145d6685ec6505b767c178e75caeb65ec9a3b23d7580f54711647c0e67b019c97b82c64e407330870b524397e7aadc355f5cd4af93aa3a0282dc7d1ea193ef30c18de7fa28fbafd0bc2e514 -v`

With this patch it does not trigger anymore, it will now trigger _only_ if the first 12 bits are ones.