### PR TITLE
prevent crash in accounting if decoder misbehaves

### DIFF
--- a/src/pulse_demod.c
+++ b/src/pulse_demod.c
@@ -28,8 +28,12 @@ static int account_event(r_device *device, int ret)
         device->decode_ok += 1;
         device->decode_messages += ret;
     }
-    else {
+    else if (ret >= DECODE_FAIL_SANITY) {
         device->decode_fails[-ret] += 1;
+        ret = 0;
+    }
+    else {
+        fprintf(stderr, "Decoder gave invalid return value %d: notify maintainer\n", ret);
         ret = 0;
     }
     return ret;


### PR DESCRIPTION
Related to  #1174.

Is this a good way to notify the user?