### PR TITLE
Fix elantra tmps return value with incorrect decodes

### DIFF
--- a/src/devices/tpms_elantra2012.c
+++ b/src/devices/tpms_elantra2012.c
@@ -123,7 +123,12 @@ static int tpms_elantra2012_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         while ((bitpos = bitbuffer_search(bitbuffer, row, bitpos,
                         (const uint8_t *)&preamble_pattern, 16)) + 128 <=
                 bitbuffer->bits_per_row[row]) {
-            events += tpms_elantra2012_decode(decoder, bitbuffer, row, bitpos + 16);
+            int event = tpms_elantra2012_decode(decoder, bitbuffer, row, bitpos + 16);
+            if (event > 0) {
+                // not very clean, we ideally want the event to bubble up for accounting.
+                // however, by adding them all together the accounting is wrong too.
+                events += event;
+            }
             bitpos += 15;
         }
     }


### PR DESCRIPTION
Test case: `rtl_433 -y '{480} 9c 55 5c 55 5c 55 5c 55 5c 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 c5 55 c5 55 c5 55 c5 55 c5 55 c5 55 c5 55 c5 55 c5 55 c5 55 00 00 00 00 00 00 00 00 00 00 00 00 00 00'`

I'm not sure if this is ideal or if another way might be used to bubble up the accounting events. At least it doesn't misbehave any more.

See  #1174