### PR TITLE
Change code to quit on invalid return value decoder

### DIFF
--- a/src/pulse_demod.c
+++ b/src/pulse_demod.c
@@ -34,7 +34,7 @@ static int account_event(r_device *device, int ret)
     }
     else {
         fprintf(stderr, "Decoder gave invalid return value %d: notify maintainer\n", ret);
-        ret = 0;
+        exit(1);
     }
     return ret;
 }


### PR DESCRIPTION
This helps when fuzzing and when someone is building a decoder.
They won't get away with just returning bogus values, because rtl_433
will then quit.

As discussed in #1174 