### PR TITLE
Fix issue where bt_rain decoder uses -1 as index

### DIFF
--- a/src/devices/bt_rain.c
+++ b/src/devices/bt_rain.c
@@ -35,14 +35,16 @@ static int bt_rain_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     float temp_c, rainrate;
 
     row = bitbuffer_find_repeated_row(bitbuffer, 4, NUM_BITS);
+    if (row < 0)
+        return DECODE_ABORT_EARLY;
 
     if (bitbuffer->bits_per_row[row] != NUM_BITS && bitbuffer->bits_per_row[row] != NUM_BITS + 1)
-        return 0;
+        return DECODE_ABORT_LENGTH;
 
     b = bitbuffer->bb[row];
 
     if (b[0] == 0xff && b[1] == 0xff && b[2] == 0xff && b[3] == 0xff)
-        return 0; // prevent false positive checksum
+        return DECODE_FAIL_SANITY; // prevent false positive checksum
 
     id       = b[0];
     battery  = b[1] >> 7;


### PR DESCRIPTION
reproduce by doing rtl_433 -G -y {0}0.
ASAN will warn about this.
```
rtl-sdr/433mhz/rtl_433/src/devices/bt_rain.c:39:9: runtime error: index -1 out of bounds for type 'uint16_t [25]'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior rtl-sdr/433mhz/rtl_433/src/devices/bt_rain.c:39:9 in 
rtl-sdr/433mhz/rtl_433/src/devices/bt_rain.c:39:53: runtime error: index -1 out of bounds for type 'uint16_t [25]'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior rtl-sdr/433mhz/rtl_433/src/devices/bt_rain.c:39:53 in 
```

I've checked other decoders for this, but this is the only offender.
Also updated return codes while I was at it.