### PR TITLE
fix bug where no closing brace would cause a crash

### DIFF
--- a/src/bitbuffer.c
+++ b/src/bitbuffer.c
@@ -346,10 +346,10 @@ void bitbuffer_parse(bitbuffer_t *bits, const char *code)
             }
 
             width = strtol(c + 1, (char **)&c, 0);
-            if (!*c)
-                break; // no closing brace and end of string
             if (width > BITBUF_COLS * 8)
                 width = BITBUF_COLS * 8;
+            if (!*c)
+                break; // no closing brace and end of string
             continue;
         }
         else if (*c == '/') {


### PR DESCRIPTION
This happens because the length check is only done after checking if there's a closing brace. Moved the length check so it's always normalized.

test case `rtl_433 -G -y {970000`