### PR TITLE
Fix elv, the data format was incorrect

### DIFF
--- a/src/devices/elv.c
+++ b/src/devices/elv.c
@@ -70,11 +70,11 @@ static int em1000_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     data = data_make(
             "model",    "", DATA_STRING, "ELV-EM1000",
-            "id",       "", DATA_STRING, code,
+            "id",       "", DATA_INT, code,
             "seq",      "", DATA_INT, seqno,
-            "total",    "", DATA_STRING, total,
-            "current",  "", DATA_STRING, current,
-            "peak",     "", DATA_FORMAT, peak,
+            "total",    "", DATA_INT, total,
+            "current",  "", DATA_INT, current,
+            "peak",     "", DATA_INT, peak,
             NULL);
 
     decoder_output_data(decoder, data);


### PR DESCRIPTION
This contained a segfault because a string copy call went too far.
Ints are not null terminated.
I'm wondering if a FORMAT decoder with a character is better than INT?
Anyway, this at least prevents the crash.

I don't think anyone is using this as it will often result in a crash.
They'd have found out, I'd assume.

Testcase (`use the -G flag`):
[elv.zip](https://github.com/merbanan/rtl_433/files/3797024/elv.zip)
