### PR TITLE
InfluxDB output module was missing from the traditional compilation

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,6 +16,7 @@ rtl_433_SOURCES      = abuf.c \
                        list.c \
                        mongoose.c \
                        optparse.c \
+                       output_influx.c \
                        output_mqtt.c \
                        pulse_demod.c \
                        pulse_detect.c \


### PR DESCRIPTION
The new InfluxDB output module was only added to cmake, but missing from the traditional make toolchain.