### PR TITLE
Fix Acurite 899 rain_mm conversion value

### DIFF
--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -633,7 +633,7 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 // Rain Fall Gauge 899
                 // The high 2 bits of byte zero are the channel (bits 7,6), 00 = A, 01 = B, 10 = C
                 channel     = bb[0] >> 6;
-                raincounter = ((bb[5] & 0x7f) << 7) | (bb[6] & 0x7f); // one tip is 0.2mm
+                raincounter = ((bb[5] & 0x7f) << 7) | (bb[6] & 0x7f); // one tip is 0.01 inch, i.e. 0.254mm 
 
                 /* clang-format off */
                 data = data_make(
@@ -641,7 +641,7 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                         "id",               "",                         DATA_INT,    sensor_id,
                         "channel",          "",                         DATA_INT,    channel,
                         "battery_ok",       "Battery",                  DATA_INT,    !battery_low,
-                        "rain_mm",          "Rainfall Accumulation",    DATA_FORMAT, "%d mm", DATA_DOUBLE, raincounter * 0.2,
+                        "rain_mm",          "Rainfall Accumulation",    DATA_FORMAT, "%.2f mm", DATA_DOUBLE, raincounter * 0.254,
                         NULL);
                 /* clang-format on */
 


### PR DESCRIPTION
The 899 documentation rounded the conversion value. The 899 appears to measure in 0.01" per count. Using 0.254 now matches the display even after a large number of count. The print output was wrong with the %d. 