### PR TITLE
Add timezone offset print option

### DIFF
--- a/include/r_util.h
+++ b/include/r_util.h
@@ -24,7 +24,7 @@
     #endif
 #endif
 
-// buffer to hold localized timestamp "YYYY-MM-DD HH:MM:SS.000000"
+// buffer to hold localized timestamp "YYYY-MM-DD HH:MM:SS.000000+0000"
 #define LOCAL_TIME_BUFLEN 32
 
 /** Get current time with usec precision.
@@ -35,21 +35,23 @@ void get_time_now(struct timeval *tv);
 
 /** Printable timestamp in local time.
 
-    @param[out] buf output buffer, long enough for "YYYY-MM-DD HH:MM:SS"
+    @param[out] buf output buffer, long enough for "YYYY-MM-DD HH:MM:SS+0000"
     @param format time format string, uses "%Y-%m-%d %H:%M:%S" if NULL
+    @param with_tz 1 to add a time offset, 0 otherwise
     @param time_secs 0 for now, or seconds since the epoch
     @return buf pointer (for short hand use as operator)
 */
-char *format_time_str(char *buf, char const *format, time_t time_secs);
+char *format_time_str(char *buf, char const *format, int with_tz, time_t time_secs);
 
 /** Printable timestamp in local time with microseconds.
 
-    @param[out] buf output buffer, long enough for "YYYY-MM-DD HH:MM:SS.uuuuuu"
+    @param[out] buf output buffer, long enough for "YYYY-MM-DD HH:MM:SS.uuuuuu+0000"
     @param format time format string without usec, uses "%Y-%m-%d %H:%M:%S" if NULL
+    @param with_tz 1 to add a time offset, 0 otherwise
     @param tv NULL for now, or seconds and microseconds since the epoch
     @return buf pointer (for short hand use as operator)
 */
-char *usecs_time_str(char *buf, char const *format, struct timeval *tv);
+char *usecs_time_str(char *buf, char const *format, int with_tz, struct timeval *tv);
 
 /** Printable sample position.
 

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -81,6 +81,7 @@ typedef struct r_cfg {
     int report_protocol;
     time_mode_t report_time;
     int report_time_hires;
+    int report_time_tz;
     int report_time_utc;
     int report_description;
     int report_stats;

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -74,7 +74,7 @@ void pulse_data_print_vcd_header(FILE *file, uint32_t sample_rate)
         timescale = "1 us";
     else
         timescale = "100 ns";
-    chk_ret(fprintf(file, "$date %s $end\n", format_time_str(time_str, NULL, 0)));
+    chk_ret(fprintf(file, "$date %s $end\n", format_time_str(time_str, NULL, 0, 0)));
     chk_ret(fprintf(file, "$version rtl_433 0.1.0 $end\n"));
     chk_ret(fprintf(file, "$comment Acquisition at %s Hz $end\n", nice_freq(sample_rate)));
     chk_ret(fprintf(file, "$timescale %s $end\n", timescale));
@@ -156,7 +156,7 @@ void pulse_data_print_pulse_header(FILE *file)
     chk_ret(fprintf(file, ";version 1\n"));
     chk_ret(fprintf(file, ";timescale 1us\n"));
     //chk_ret(fprintf(file, ";samplerate %u\n", data->sample_rate));
-    chk_ret(fprintf(file, ";created %s\n", format_time_str(time_str, NULL, 0)));
+    chk_ret(fprintf(file, ";created %s\n", format_time_str(time_str, NULL, 1, 0)));
 }
 
 void pulse_data_dump(FILE *file, pulse_data_t *data)

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -267,9 +267,9 @@ char *time_pos_str(r_cfg_t *cfg, unsigned samples_ago, char *buf)
             format = "%Y-%m-%dT%H:%M:%S";
 
         if (cfg->report_time_hires)
-            return usecs_time_str(buf, format, &ago);
+            return usecs_time_str(buf, format, cfg->report_time_tz, &ago);
         else
-            return format_time_str(buf, format, ago.tv_sec);
+            return format_time_str(buf, format, cfg->report_time_tz, ago.tv_sec);
     }
 }
 

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -216,6 +216,7 @@ static void help_meta(void)
             "\tUse \"time:iso\" to show the time with ISO-8601 format (YYYY-MM-DD\"T\"hh:mm:ss).\n"
             "\tUse \"time:off\" to remove time meta data.\n"
             "\tUse \"time:usec\" to add microseconds to date time meta data.\n"
+            "\tUse \"time:tz\" to output time with timezone offset.\n"
             "\tUse \"time:utc\" to output time in UTC.\n"
             "\t\t(this may also be accomplished by invocation with TZ environment variable set).\n"
             "\t\t\"usec\" and \"utc\" can be combined with other options, eg. \"time:unix:utc:usec\".\n"
@@ -858,6 +859,10 @@ static void parse_conf_option(r_cfg_t *cfg, int opt, char *arg)
                     cfg->report_time_hires = 1;
                 else if (!strncasecmp(p, "sec", 3))
                     cfg->report_time_hires = 0;
+                else if (!strncasecmp(p, "tz", 2))
+                    cfg->report_time_tz = 1;
+                else if (!strncasecmp(p, "notz", 4))
+                    cfg->report_time_tz = 0;
                 else if (!strncasecmp(p, "utc", 3))
                     cfg->report_time_utc = 1;
                 else if (!strncasecmp(p, "local", 5))


### PR DESCRIPTION
Picks up the idea from #1206 to add the timezone offset to ISO-8601 outputs.
The offset will always be `+1234` (never `Z`).

Currently optional with `tz` flag, perhaps `iso` should always output TZ?