### PR TITLE
Update BUILDING.md

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -31,9 +31,13 @@ Debian:
 
     sudo apt-get install libtool libusb-1.0-0-dev librtlsdr-dev rtl-sdr build-essential autoconf cmake pkg-config
 
-Centos/Fedora/RHEL (for Centos/RHEL with enabled EPEL):
+Centos/Fedora/RHEL with EPEL repo using cmake:
 
-    sudo dnf install libtool libusb-devel rtl-sdr-devel rtl-sdr
+  * If `dnf` doesn't exist, use `yum`.
+
+````
+sudo dnf install libtool libusbx-devel rtl-sdr-devel rtl-sdr cmake
+````
 
 Mac OS X with MacPorts:
 


### PR DESCRIPTION
CentOS/Fedora/RHEL require the libusbx and libusbx-devel packages to build. The libusb-devel package lacks the function definition for libusb_error_name() in libusb.h required to build rtl_433.