### PR TITLE
Include sys/wait.h to fix undeclared wait() function

### DIFF
--- a/src/write_sigrok.c
+++ b/src/write_sigrok.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #ifndef _MSC_VER
 #include <unistd.h>
+#include <sys/wait.h>
 #endif
 
 #include "write_sigrok.h"


### PR DESCRIPTION
When compiling on a Linux platform, the `wait()` calls were throwing the warning below. Including `sys/wait.h` fixes that.

```
/home/xxx/Projects/rtl_433/src/write_sigrok.c: In function ‘write_sigrok’:
/home/xxx/Projects/rtl_433/src/write_sigrok.c:113:9: warning: implicit declaration of function ‘wait’; did you mean ‘write’? [-Wimplicit-function-declaration]
         wait(NULL);
         ^~~~
         write
```