### PR TITLE
Add write_sigrok.c / .h to visual studio project

### DIFF
--- a/vs15/rtl_433.vcxproj
+++ b/vs15/rtl_433.vcxproj
@@ -115,6 +115,7 @@
     <ClInclude Include="..\include\sdr.h" />
     <ClInclude Include="..\include\term_ctl.h" />
     <ClInclude Include="..\include\util.h" />
+    <ClInclude Include="..\include\write_sigrok.h" />
     <ClInclude Include="..\src\getopt\getopt.h" />
   </ItemGroup>
   <ItemGroup>
@@ -143,6 +144,7 @@
     <ClCompile Include="..\src\sdr.c" />
     <ClCompile Include="..\src\term_ctl.c" />
     <ClCompile Include="..\src\util.c" />
+    <ClCompile Include="..\src\write_sigrok.c" />
     <ClCompile Include="..\src\devices\acurite.c" />
     <ClCompile Include="..\src\devices\akhan_100F14.c" />
     <ClCompile Include="..\src\devices\alecto.c" />

--- a/vs15/rtl_433.vcxproj.filters
+++ b/vs15/rtl_433.vcxproj.filters
@@ -107,6 +107,9 @@
     <ClInclude Include="..\include\util.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\write_sigrok.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>    
     <ClInclude Include="..\src\getopt\getopt.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -185,6 +188,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\src\util.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\write_sigrok.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\src\getopt\getopt.c">


### PR DESCRIPTION
p.s.: I updated my build environment to visual studio 2019 so I won't check the consistency of our vs15 project as frequently as in the past.

I could place a PR with my new vs19 project (see https://github.com/winterrace/rtl_433_win/tree/master/vs19) which basically has the same inner structure. You should be able to adapt your scripts just by changing /vs15/ to /vs19/.

In that case, we could either keep the vs15 project or remove it. I don't have a strong preference.