### PR TITLE
Drop extra semi-colon

### DIFF
--- a/tests/baseband-test.c
+++ b/tests/baseband-test.c
@@ -43,7 +43,7 @@ typedef SSIZE_T ssize_t;
         clock_t stop   = clock();                                          \
         double elapsed = (double)(stop - start) * 1000.0 / CLOCKS_PER_SEC; \
         printf("Time elapsed in ms: %f for: %s\n", elapsed, label);        \
-    } while (0);
+    } while (0)
 
 int read_buf(const char *filename, void *buf, size_t nbyte)
 {


### PR DESCRIPTION
A real tiny patch to silence this clang-cl warning:
```
tests/baseband-test.c(120,6): warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning
      [-Wextra-semi-stmt]
    );
     ^
```