### PR TITLE
radiohead-ask: Fix issue where calloc with negative number leads to segfault

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -165,6 +165,9 @@ static bool import_values(void *dst, void *src, int num_values, data_type_t type
 
 data_array_t *data_array(int num_values, data_type_t type, void *values)
 {
+    if (num_values < 0) {
+      return NULL;
+    }
     data_array_t *array = calloc(1, sizeof(data_array_t));
     if (!array) {
         WARN_CALLOC("data_array()");

--- a/src/devices/radiohead_ask.c
+++ b/src/devices/radiohead_ask.c
@@ -149,6 +149,8 @@ static int radiohead_ask_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         return msg_len; // pass error code on
     }
     data_len = msg_len - RH_ASK_HEADER_LEN - 3;
+    if (data_len <= 0)
+      return DECODE_FAIL_SANITY;
 
     header_to = rh_payload[1];
     header_from = rh_payload[2];


### PR DESCRIPTION
I caught this by removing all CRC/checksum/parity checking from code.
Even before starting fuzzing one of my corpus inputs triggered this already.
