### PR TITLE
Drop rtl*.conf comment lines

### DIFF
--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -662,6 +662,9 @@ static void parse_conf_text(r_cfg_t *cfg, char *conf)
 
     while ((opt = getconf(&p, conf_keywords, &arg)) != -1) {
         parse_conf_option(cfg, opt, arg);
+        /* Advance to next .conf line */
+        p = trim_ws(p);
+        p = asepc(&p, '#');
     }
 }
 


### PR DESCRIPTION
The parsing of a `RTL*.conf` is broken with a large number of messages like these:
```
  Protocol [3] "Prologue, FreeTec NC-7104, NC-7159-675 temperature sensor" does not take arguments ", FreeTec NC-7104, NC-7159-675 temperature sensor"!
  Protocol [19] "Nexus, FreeTec NC-7345, NX-3980 temperature/humidity sensor" does not take arguments ", FreeTec NC-7345, NX-3980 temperature/humidity sensor"!
```

Since a trailing comment string seems to have an effect on the next key/value lookup.