### PR TITLE
Add Klimalogg decoder and needed nrzs demodulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [147]  TFA Drop Rain Gauge 30.3233.01
     [148]  DSC Security Contact (WS4945)
     [149]  ERT SCM
+    [150]* Klimalogg/30.3180.IT (-f 868950000 -s 2400000)
+
 
 * Disabled by default, use -R n or -G
 

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -335,6 +335,7 @@ stop_after_successful_events false
   protocol 147 # TFA Drop Rain Gauge 30.3233.01
   protocol 148 # DSC Security Contact (WS4945)
   protocol 149 # ERT SCM
+  protocol 150 # Klimalogg/30.3180.IT
 
 ## Flex devices (command line option "-X")
 

--- a/include/pulse_demod.h
+++ b/include/pulse_demod.h
@@ -141,6 +141,8 @@ int pulse_demod_piwm_raw(const pulse_data_t *pulses, r_device *device);
 /// @return number of events processed
 int pulse_demod_piwm_dc(const pulse_data_t *pulses, r_device *device);
 
+int pulse_demod_nrzs(const pulse_data_t *pulses, r_device *device);
+
 int pulse_demod_osv1(const pulse_data_t *pulses, r_device *device);
 
 /// Simulate demodulation using a given signal code string.

--- a/include/r_device.h
+++ b/include/r_device.h
@@ -15,6 +15,7 @@ enum modulation_types {
     OOK_PULSE_PIWM_DC            = 11, ///< Level shift for each bit. Short interval = 1, Long = 0.
     OOK_PULSE_DMC                = 9,  ///< Level shift within the clock cycle.
     OOK_PULSE_PWM_OSV1           = 10, ///< Pulse Width Modulation. Oregon Scientific v1.
+    OOK_PULSE_NRZS               = 19, ///< NRZS modulation
     FSK_DEMOD_MIN_VAL            = 16, ///< Dummy. FSK demodulation must start at this value.
     FSK_PULSE_PCM                = 16, ///< FSK, Pulse Code Modulation.
     FSK_PULSE_PWM                = 17, ///< FSK, Pulse Width Modulation. Short pulses = 1, Long = 0.

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -156,7 +156,8 @@
     DECL(auriol_afw2a1) \
     DECL(tfa_drop_303233) \
     DECL(dsc_security_ws4945) \
-    DECL(ert_amr)
+    DECL(ert_amr) \
+    DECL(klimalogg)
 
     /* Add new decoders here. */
 

--- a/man/man1/rtl_433.1
+++ b/man/man1/rtl_433.1
@@ -574,6 +574,10 @@ DSC Security Contact (WS4945)
 .TP
 [ \fB149\fI\fP ]
 ERT SCM
+.TP
+[ \fB149\fI\fP ]
+Klimalogg/30.3180.IT
+
 
 * Disabled by default, use \-R n or \-G
 .SS "Input device selection"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,6 +94,7 @@ add_library(r_433 STATIC
     devices/intertechno.c
     devices/kedsum.c
     devices/kerui.c
+    devices/klimalogg.c
     devices/lacrosse.c
     devices/lacrosse_tx141x.c
     devices/lacrosse_tx35.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -93,6 +93,7 @@ rtl_433_SOURCES      = abuf.c \
                        devices/intertechno.c \
                        devices/kedsum.c \
                        devices/kerui.c \
+                       devices/klimalogg.c \
                        devices/lacrosse.c \
                        devices/lacrosse_tx141x.c \
                        devices/lacrosse_tx35.c \

--- a/src/devices/klimalogg.c
+++ b/src/devices/klimalogg.c
@@ -1,0 +1,129 @@
+/** @file
+    Klimalogg/30.3180.IT sensor decoder
+
+    Copyright (C) 2020 Benjamin Larsson
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#include "decoder.h"
+
+/**
+
+Random information:
+
+Working decoder
+https://github.com/baycom/tfrec
+
+Information from https://github.com/baycom/tfrec
+// Telegram format
+// 0x2d 0xd4 ID ID sT TT HH BB SS 0x56 CC
+// 2d d4: Sync bytes
+// ID(14:0): 15 bit ID of sensor (printed on the back and displayed after powerup)
+// ID(15) is either 1 or 0 (fixed, depends on the sensor)
+// s(3:0): Learning sequence 0...f, after learning fixed 8
+// TTT: Temperatur in BCD in .1degC steps, offset +40degC (-> -40...+60)
+// HH(6:0): rel. Humidity in % (binary coded, no BCD!)
+// BB(7): Low battery if =1
+// BB(6:4): 110 or 111 (for 3199)
+// SS(7:4): sequence number (0...f)
+// SS(3:0): 0000 (fixed)
+// 56: Type?
+// CC: CRC8 from ID to 0x56 (polynome x^8 + x^5 + x^4  + 1)
+
+
+Note: The rtl_433 generic dsp code does not work well with these signals
+play with the -l option (5000-15000 range) or a high sample rate.
+
+*/
+
+static uint8_t bcd_decode8(uint8_t x)
+{
+    return ((x & 0xF0) >> 4) * 10 + (x & 0x0F);
+}
+
+
+static int klimalogg_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    static const uint8_t KLIMA_PREAMBLE[]  = {0xB4, 0x2B };  // 0x2d, 0xd4 bit reversed
+    unsigned int bit_offset;
+    uint8_t *b;
+    uint8_t msg[12] = {0};
+    uint8_t crc, sequence_nr, temp_ad, humidity, battery_low;
+    int16_t id, temp_bd;
+    char temperature_str[8] = {0};
+    data_t *data;
+
+    if (bitbuffer->bits_per_row[0] < 12*8) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    bit_offset = bitbuffer_search(bitbuffer, 0, 0, KLIMA_PREAMBLE, sizeof(KLIMA_PREAMBLE)*8);
+    if (bit_offset + sizeof(b) * 8 > bitbuffer->bits_per_row[0]) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    bitbuffer_extract_bytes(bitbuffer, 0, bit_offset, msg, 12*8);
+
+    if (msg[9] != 0x6a) // 0x56 bit reversed
+        return DECODE_FAIL_SANITY;
+
+
+    for (int i=0 ; i<11 ; i++) {
+        msg[i] = reverse8(msg[i]);
+    }
+
+    crc = crc8(&msg[2], 8, 0x31, 0);
+    if (crc != msg[10])
+        return DECODE_FAIL_MIC;
+
+    /* Extract parameters */
+    id = (msg[2]&0x7f)<<8 | msg[3];
+    temp_bd = bcd_decode8((msg[4]&0x0F)<<4 | (msg[5]&0xF0)>>4) - 40;
+    temp_ad = bcd_decode8((msg[5]&0x0F));
+    sprintf(temperature_str, "%d.%d C", temp_bd, temp_ad);
+    humidity = msg[6]&0x7F;
+    battery_low = (msg[7]&0x80) >> 7;
+    sequence_nr = (msg[8]&0xF0) >> 4;
+    /* clang-format off */
+    data = data_make(
+            "model",           "",                 DATA_STRING, "Klimalogg Pro",
+            "id",              "Id",               DATA_FORMAT,    "%04x", DATA_INT, id,
+            "battery",          "Battery",         DATA_STRING, battery_low ? "LOW" : "OK",
+            "temperature_C", "Temperature",        DATA_STRING, temperature_str,
+            "humidity",        "Humidity",         DATA_INT, humidity,
+            "sequence_nr","Sequence Number",       DATA_INT, sequence_nr,
+            "mic",             "Integrity",        DATA_STRING, "CRC",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 0;
+}
+
+static char *output_fields[] = {
+        "model",
+        "id",
+        "temperature_C",
+        "battery",
+        "humidity",
+        "sequence_nr",
+        "mic",
+        NULL,
+};
+
+r_device klimalogg = {
+        .name        = "Klimalogg",
+        .modulation  = OOK_PULSE_NRZS,
+        .short_width = 26,
+        .long_width  = 0,
+        .gap_limit   = 0,
+        .reset_limit = 1000,
+        .tolerance   = 3,
+        .decode_fn   = &klimalogg_decode,
+        .disabled    = 1,
+        .fields      = output_fields,
+};

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -413,6 +413,9 @@ int run_ook_demods(list_t *r_devs, pulse_data_t *pulse_data)
         case OOK_PULSE_PWM_OSV1:
             p_events += pulse_demod_osv1(pulse_data, r_dev);
             break;
+        case OOK_PULSE_NRZS:
+            p_events += pulse_demod_nrzs(pulse_data, r_dev);
+            break;
         // FSK decoders
         case FSK_PULSE_PCM:
         case FSK_PULSE_PWM:
@@ -444,6 +447,7 @@ int run_fsk_demods(list_t *r_devs, pulse_data_t *fsk_pulse_data)
         case OOK_PULSE_PIWM_DC:
         case OOK_PULSE_DMC:
         case OOK_PULSE_PWM_OSV1:
+        case OOK_PULSE_NRZS:
             break;
         case FSK_PULSE_PCM:
             p_events += pulse_demod_pcm(fsk_pulse_data, r_dev);

--- a/vs15/rtl_433.vcxproj
+++ b/vs15/rtl_433.vcxproj
@@ -209,6 +209,7 @@
     <ClCompile Include="..\src\devices\intertechno.c" />
     <ClCompile Include="..\src\devices\kedsum.c" />
     <ClCompile Include="..\src\devices\kerui.c" />
+    <ClCompile Include="..\src\devices\klimalogg.c" />
     <ClCompile Include="..\src\devices\lacrosse.c" />
     <ClCompile Include="..\src\devices\lacrosse_tx141x.c" />
     <ClCompile Include="..\src\devices\lacrosse_tx35.c" />

--- a/vs15/rtl_433.vcxproj.filters
+++ b/vs15/rtl_433.vcxproj.filters
@@ -388,6 +388,9 @@
     <ClCompile Include="..\src\devices\kerui.c">
       <Filter>Source Files\devices</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\devices\klimalogg.c">
+      <Filter>Source Files\devices</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\devices\lacrosse.c">
       <Filter>Source Files\devices</Filter>
     </ClCompile>


### PR DESCRIPTION
With -l 15000 the decoder works.

src/rtl_433 -l 15000 -s 1536k -r ../rtl_433_tests/tests/TFA-KlimaLogg-30.3180.IT/01/g*.cu8

The decoder code is ok but needs some polish before merge. But the pulse recovery is not working well out of the box and documentation for setting the .short_width properly is missing.

In theory one could tune the l-parameter to receive one sensor well but it might not work fine on others. A redesign of the pulse recovery flow is needed to be able to handle this sensor. I'm not sure that will happen.