### PR TITLE
cosmetics: Remove or comment out unused variables and code

### DIFF
--- a/src/devices/ert.c
+++ b/src/devices/ert.c
@@ -48,7 +48,6 @@ https://web.archive.org/web/20090828043201/http://www.openamr.org/wiki/ItronERTM
 static int ert_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     static const uint8_t ERT_PREAMBLE[]  = {/*0xF*/ 0x2A, 0x60};
-    unsigned int bit_offset;
     uint8_t *b;
     uint8_t physical_tamper, ert_type, encoder_tamper;
     uint32_t consumption_data, ert_id;

--- a/src/devices/hideki.c
+++ b/src/devices/hideki.c
@@ -91,8 +91,8 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         return DECODE_FAIL_SANITY;
 
     int pkt_len  = (packet[2] >> 1) & 0x1f;
-    int pkt_seq  = packet[3] >> 6;
-    int pkt_type = packet[3] & 0x1f;
+    //int pkt_seq  = packet[3] >> 6;
+    //int pkt_type = packet[3] & 0x1f;
     // 0x0C Anemometer
     // 0x0D UV sensor
     // 0x0E Rain level meter

--- a/src/devices/norgo.c
+++ b/src/devices/norgo.c
@@ -123,7 +123,7 @@ static int norgo_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int impulse_gap;
     uint64_t impulses;
     int low_battery;
-    int maybe_overflow;
+    //int maybe_overflow;
     int checksum;
     int calc_chk;
 
@@ -192,7 +192,7 @@ static int norgo_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         impulses = (b[2] >> 4) | (b[3] << 4) | (b[4] << 12) | (b[5] << 20) | (((uint64_t)b[6] & 0x3F) << 28);
 
         low_battery    = (b[6] & 0x40) >> 6;
-        maybe_overflow = (b[6] & 0x80) >> 7;
+        //maybe_overflow = (b[6] & 0x80) >> 7;
 
         // Pulse count is totally 34 bits but we report only 32 bits,
         // should be enough for the duration of battery.

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -273,16 +273,16 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
     else if (sensor_id == ID_BHTR968) {
         if (validate_os_v2_message(decoder, msg, 92, msg_bits, 19) != 0)
             return 0;
-        unsigned int comfort = msg[7] >> 4;
-        char *comfort_str = "Normal";
-        if (comfort == 4) comfort_str = "Comfortable";
-        else if (comfort == 8) comfort_str = "Dry";
-        else if (comfort == 0xc) comfort_str = "Humid";
-        unsigned int forecast = msg[9] >> 4;
-        char *forecast_str = "Cloudy";
-        if (forecast == 3) forecast_str = "Rainy";
-        else if (forecast == 6) forecast_str = "Partly Cloudy";
-        else if (forecast == 0xc) forecast_str = "Sunny";
+        //unsigned int comfort = msg[7] >> 4;
+        //char *comfort_str = "Normal";
+        //if (comfort == 4) comfort_str = "Comfortable";
+        //else if (comfort == 8) comfort_str = "Dry";
+        //else if (comfort == 0xc) comfort_str = "Humid";
+        //unsigned int forecast = msg[9] >> 4;
+        //char *forecast_str = "Cloudy";
+        //if (forecast == 3) forecast_str = "Rainy";
+        //else if (forecast == 6) forecast_str = "Partly Cloudy";
+        //else if (forecast == 0xc) forecast_str = "Sunny";
         float temp_c = get_os_temperature(msg);
         float pressure = ((msg[7] & 0x0f) | (msg[8] & 0xf0)) + 856;
         // fprintf(stderr,"Weather Sensor BHTR968    Indoor        Temp: %3.1fC    %3.1fF     Humidity: %d%%", temp_c, ((temp_c*9)/5)+32, get_os_humidity(msg));
@@ -384,7 +384,7 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
 
         int year    = ((msg[9] & 0x0F) * 10) + ((msg[9] & 0xF0) >> 4) + 2000;
         int month   = ((msg[8] & 0xF0) >> 4);
-        int weekday = ((msg[8] & 0x0F));
+        //int weekday = ((msg[8] & 0x0F));
         int day     = ((msg[7] & 0x0F) * 10) + ((msg[7] & 0xF0) >> 4);
         int hours   = ((msg[6] & 0x0F) * 10) + ((msg[6] & 0xF0) >> 4);
         int minutes = ((msg[5] & 0x0F) * 10) + ((msg[5] & 0xF0) >> 4);

--- a/src/devices/tpms_jansite.c
+++ b/src/devices/tpms_jansite.c
@@ -32,7 +32,6 @@ Data layout (nibbles):
 static int tpms_jansite_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    unsigned int start_pos;
     bitbuffer_t packet_bits = {0};
     uint8_t *b;
     unsigned id;
@@ -42,7 +41,7 @@ static int tpms_jansite_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     int temperature;
     char code_str[7 * 2 + 1];
 
-    start_pos = bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 56);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 56);
     b = packet_bits.bb[0];
 
     // TODO: validate checksum

--- a/src/sdr.c
+++ b/src/sdr.c
@@ -360,6 +360,7 @@ static int rtlsdr_find_tuner_gain(sdr_dev_t *dev, int centigain, int verbose)
         return centigain; // NOTE: just aborts on alloc failure.
     }
     r = rtlsdr_get_tuner_gains(dev->rtlsdr_dev, gains);
+    // TODO: check return value and act upon it
 
     /* Find allowed gain */
     for (int i = 0; i < gains_count; ++i) {

--- a/tests/pulse-eval.c
+++ b/tests/pulse-eval.c
@@ -177,7 +177,6 @@ int main(int argc, char *argv[])
     size_t n_samples;
     int block_size = 4096000;
     unsigned sample_rate = 250000;
-    int ret = 0;
 
     int argi = 1;
     for (; argi < argc; ++argi) {


### PR DESCRIPTION
Should we remove this code, add them to the data fields or comment them out like in this PR? I don't think we should leave this enabled, as it might give a false idea of what code is actually doing anything.

Found these issues with `cppcheck --enable=all .` on the rtl_433 repository.