### PR TITLE
ADD: rolling code transmitter decoder

### DIFF
--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -157,7 +157,8 @@
     DECL(tfa_drop_303233) \
     DECL(dsc_security_ws4945) \
     DECL(ert_amr) \
-    DECL(klimalogg)
+    DECL(klimalogg) \
+    DECL(rolling_code)
 
     /* Add new decoders here. */
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,6 +123,7 @@ add_library(r_433 STATIC
     devices/quhwa.c
     devices/radiohead_ask.c
     devices/rftech.c
+    devices/rolling_code.c
     devices/rubicson.c
     devices/rubicson_48659.c
     devices/s3318p.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -122,6 +122,7 @@ rtl_433_SOURCES      = abuf.c \
                        devices/quhwa.c \
                        devices/radiohead_ask.c \
                        devices/rftech.c \
+                       devices/rolling_code.c \
                        devices/rubicson.c \
                        devices/rubicson_48659.c \
                        devices/s3318p.c \

--- a/src/devices/rolling_code.c
+++ b/src/devices/rolling_code.c
@@ -23,6 +23,9 @@
  16 trit device ID,  3 id trits (key pressed), and a 1 trit button id.
  All of the data is obfuscated and a 1 length and a 3 length packet are
  required to successfully decode a transmission.
+
+ NOTE: This code is made available for legal uses ONLY - any other use is expressly
+ forbidden.
  */
 
 #include <stdlib.h>

--- a/src/devices/rolling_code.c
+++ b/src/devices/rolling_code.c
@@ -23,9 +23,6 @@
  16 trit device ID,  3 id trits (key pressed), and a 1 trit button id.
  All of the data is obfuscated and a 1 length and a 3 length packet are
  required to successfully decode a transmission.
-
- NOTE: This code is made available for legal uses ONLY - any other use is expressly
- forbidden.
  */
 
 #include <stdlib.h>

--- a/src/devices/rolling_code.c
+++ b/src/devices/rolling_code.c
@@ -326,11 +326,11 @@ static int rolling_code_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             decoder_output_data(decoder, data);
         }
     } else {
+        *prev_1_r_raw = NOT_SET;    // Not used for legacy codes
+
         if (start_width == 2) {
             memcpy(prev_1_a_corrected, trinary, RAW_SIZE);
-        }
-
-        if (*prev_1_a_corrected != NOT_SET && start_width == 6) {
+        } else if (*prev_1_a_corrected != NOT_SET && start_width == 6) {
             char buffer[RAW_SIZE + 1];
 
             memcpy(trinary + RAW_SIZE, trinary, RAW_SIZE);

--- a/src/devices/rolling_code.c
+++ b/src/devices/rolling_code.c
@@ -169,14 +169,14 @@ static int rolling_code_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     printf("ACODE: ");
     for (int i = 0; i < 10; i++) {
-	a_buffer[i] = '0' + trinary[i * 2];
+	a_buffer[i] = '0' + trinary[i * 2 + 1];
         printf("%d ", trinary[i * 2]);
     }       
     printf("\n");
 
     printf("ROLL:  ");
     for (int i = 0; i < 10; i++) {
-	r_buffer[i] = '0' + trinary[i * 2 + 1];
+	r_buffer[i] = '0' + trinary[i * 2];
         printf("%d ", trinary[i * 2 + 1]);
     }
     printf("\n");

--- a/src/devices/rolling_code.c
+++ b/src/devices/rolling_code.c
@@ -28,14 +28,14 @@
 #include <stdlib.h>
 #include "decoder.h"
 
-#define MIN_BITS		80
-#define TRINARY_SIZE		20
-#define RAW_SIZE		10
-#define SPECIAL_BITS		4
-#define DEV_ID_SIZE		(RAW_SIZE * 2 - SPECIAL_BITS)
-#define NOT_SET			'.'
-#define BUTTON_TRIT		9
-#define ID_TBIT_START		6
+#define MIN_BITS        80
+#define TRINARY_SIZE    20
+#define RAW_SIZE        10
+#define SPECIAL_BITS    4
+#define DEV_ID_SIZE     (RAW_SIZE * 2 - SPECIAL_BITS)
+#define NOT_SET         '.'
+#define BUTTON_TRIT     9
+#define ID_TBIT_START   6
 
 static int get_start_bit_width(uint8_t *buffer, int *index, int num_bits, int debug_output) {
     int start = 0;
@@ -73,23 +73,25 @@ static uint8_t get_trits(uint8_t *nibble_buffer, uint8_t *bit_buffer, int *bit_i
     if (num_bits - *bit_index < MIN_BITS) {
         if (debug_output > 1) {
             fprintf(stderr, "Too few bits: %d\n", num_bits - *bit_index);
-	}
+        }
 
-	return 1;
+        return 1;
     }
 
     int nibble_index = 0;
-   while (nibble_index < TRINARY_SIZE && *bit_index <= num_bits - 4) {
-        uint8_t nibble = bitrow_get_bit(bit_buffer, (*bit_index)++) << 3 | bitrow_get_bit(bit_buffer, (*bit_index)++) << 2 | 
-            bitrow_get_bit(bit_buffer, (*bit_index)++) << 1 | bitrow_get_bit(bit_buffer, (*bit_index)++);
+    while (nibble_index < TRINARY_SIZE && *bit_index <= num_bits - 4) {
+        uint8_t nibble = bitrow_get_bit(bit_buffer, (*bit_index)++) << 3 | 
+            bitrow_get_bit(bit_buffer, (*bit_index)++) << 2 | 
+            bitrow_get_bit(bit_buffer, (*bit_index)++) << 1 | 
+            bitrow_get_bit(bit_buffer, (*bit_index)++);
         
-	if (nibble == 0x01) nibble_buffer[nibble_index++] = 0;
-	else if (nibble == 0x03) nibble_buffer[nibble_index++] = 1;
-	else if (nibble == 0x07) nibble_buffer[nibble_index++] = 2;
-	else {
-		fprintf(stderr, "Unknown nibble %02x\n", nibble);
-		return 1;
-	}
+        if (nibble == 0x01) nibble_buffer[nibble_index++] = 0;
+        else if (nibble == 0x03) nibble_buffer[nibble_index++] = 1;
+        else if (nibble == 0x07) nibble_buffer[nibble_index++] = 2;
+        else {
+            fprintf(stderr, "Unknown nibble %02x\n", nibble);
+            return 1;
+        }
     }
 
     if (nibble_index != TRINARY_SIZE) {
@@ -105,21 +107,21 @@ static void fix_a_code(uint8_t *a_raw, uint8_t *r_raw, uint8_t *dst) {
     uint8_t prev = 0;
     for (int i = 0; i < RAW_SIZE; i++) {
         int16_t x = a_raw[i] - r_raw[i];
-	if (x < 0) x += 3;
-	x = x - prev;
-	if (x < 0) x += 3;
-	dst[i] = x & 0xff;
-	prev = a_raw[i];
+        if (x < 0) x += 3;
+        x = x - prev;
+        if (x < 0) x += 3;
+        dst[i] = x & 0xff;
+        prev = a_raw[i];
     }
 }
 
 // Buffer has to be len + 1 bytes long.
 static void raw_to_chars(uint8_t *src, char *dst, int len) {
-	for (int i = 0; i < len; i++) {
-		dst[i] = src[i] + '0';
-	}
+    for (int i = 0; i < len; i++) {
+        dst[i] = src[i] + '0';
+    }
 
-	dst[len] = '\0';
+    dst[len] = '\0';
 }
 
 static uint32_t raw_to_uint(uint8_t *ptr, int len) {
@@ -192,12 +194,12 @@ static int rolling_code_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int debug_output = decoder->verbose;
 
     if (debug_output > 1) {
-    	bitbuffer_printf(bitbuffer, "%s: ", __func__);
+        bitbuffer_printf(bitbuffer, "%s: ", __func__);
     }
 
     if (bitbuffer->num_rows < 1) {
-	*prev_1_a_corrected = NOT_SET;
-	*prev_1_r_raw = NOT_SET;
+        *prev_1_a_corrected = NOT_SET;
+        *prev_1_r_raw = NOT_SET;
 
         return 0;
     }
@@ -212,8 +214,8 @@ static int rolling_code_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             fprintf(stderr, "Start bit width invalid: %d\n", start_width);
         }
 
-	*prev_1_a_corrected = NOT_SET;
-	*prev_1_r_raw = NOT_SET;
+        *prev_1_a_corrected = NOT_SET;
+        *prev_1_r_raw = NOT_SET;
 
         return 0;
     }
@@ -223,10 +225,10 @@ static int rolling_code_decode(r_device *decoder, bitbuffer_t *bitbuffer)
      * start parsing data.
      */
 
-     if (get_trits(trinary, b, &index, num_bits, debug_output)) {
+    if (get_trits(trinary, b, &index, num_bits, debug_output)) {
         fprintf(stderr, "get_trits failed\n");
-	*prev_1_a_corrected = NOT_SET;
-	*prev_1_r_raw = NOT_SET;
+        *prev_1_a_corrected = NOT_SET;
+        *prev_1_r_raw = NOT_SET;
 
         return 0;
     }
@@ -235,8 +237,8 @@ static int rolling_code_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         char buffer[TRINARY_SIZE + 1];
         raw_to_chars(trinary, buffer, TRINARY_SIZE);
         data = data_append(data, 
-		"raw_trinary", "", DATA_STRING, buffer,
-        	"start_width", "", DATA_INT, start_width, NULL);
+            "raw_trinary", "", DATA_STRING, buffer,
+            "start_width", "", DATA_INT, start_width, NULL);
     }
 
     // Tease out the individual parts of the message
@@ -247,54 +249,56 @@ static int rolling_code_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // Pull out A and R bits
     for (int i = 0; i < RAW_SIZE; i++) {
-	a_raw[i] = trinary[i * 2 + 1];
-	r_raw[i] = trinary[i * 2];
+        a_raw[i] = trinary[i * 2 + 1];
+        r_raw[i] = trinary[i * 2];
     }       
 
     fix_a_code(a_raw, r_raw, a_corrected);
 
     if (debug_output > 1) {
-	char buffer[RAW_SIZE + 1];
-	raw_to_chars(a_raw, buffer, RAW_SIZE);
+        char buffer[RAW_SIZE + 1];
+        raw_to_chars(a_raw, buffer, RAW_SIZE);
         data = data_append(data, "raw_a", "", DATA_STRING, buffer, NULL);
-	raw_to_chars(r_raw, buffer, RAW_SIZE);
+            raw_to_chars(r_raw, buffer, RAW_SIZE);
         data = data_append(data, "raw_r", "", DATA_STRING, buffer, NULL);
-	raw_to_chars(a_corrected, buffer, RAW_SIZE);
+            raw_to_chars(a_corrected, buffer, RAW_SIZE);
         data = data_append(data, "corrected_a", "", DATA_STRING, buffer, NULL);
     }
 
     if (start_width == 1) {
-	memcpy(prev_1_a_corrected, a_corrected, RAW_SIZE);
-	memcpy(prev_1_r_raw, r_raw, RAW_SIZE);
+        memcpy(prev_1_a_corrected, a_corrected, RAW_SIZE);
+        memcpy(prev_1_r_raw, r_raw, RAW_SIZE);
     }
 
     if (*prev_1_r_raw != NOT_SET && start_width == 3) {
-	char buffer[RAW_SIZE + 1];
-	uint32_t counter = get_rolling_code(raw_to_uint(prev_1_r_raw, RAW_SIZE), raw_to_uint(r_raw, RAW_SIZE));
-    	sprintf(buffer, "%u", counter);
-	data = data_append(data, 
-		"counter", "", DATA_STRING, buffer, NULL);
-	sprintf(buffer, "%08x", counter);
-	data = data_append(data, 
-		"counter_hex", "", DATA_STRING, buffer,
-        	"button_pressed", "", DATA_INT, (int) a_corrected[BUTTON_TRIT],
-        	"id_bits", "", DATA_INT, a_corrected[ID_TBIT_START] * 9 + a_corrected[ID_TBIT_START + 1] * 3 + a_corrected[ID_TBIT_START + 2], NULL);
+        char buffer[RAW_SIZE + 1];
+        uint32_t counter = get_rolling_code(
+            raw_to_uint(prev_1_r_raw, RAW_SIZE), 
+            raw_to_uint(r_raw, RAW_SIZE));
+        sprintf(buffer, "%u", counter);
+        data = data_append(data, "counter", "", DATA_STRING, buffer, NULL);
 
-	uint8_t device_id[DEV_ID_SIZE];
-	memset(device_id, 0, DEV_ID_SIZE);
-	memcpy(device_id + RAW_SIZE, a_corrected, RAW_SIZE - SPECIAL_BITS);
-	
-	memcpy(device_id, prev_1_a_corrected, RAW_SIZE);
-	uint32_t value = raw_to_uint(device_id, DEV_ID_SIZE);
-	sprintf(buffer, "%08x", value);
-	data = data_append(data, 
-		"device_id", "", DATA_INT, value,
-		"device_id_hex", "", DATA_STRING, buffer, NULL);
+        sprintf(buffer, "%08x", counter);
+        data = data_append(data, 
+            "counter_hex", "", DATA_STRING, buffer,
+            "button_pressed", "", DATA_INT, (int) a_corrected[BUTTON_TRIT],
+            "id_bits", "", DATA_INT, a_corrected[ID_TBIT_START] * 9 + a_corrected[ID_TBIT_START + 1] * 3 + a_corrected[ID_TBIT_START + 2], NULL);
+
+        uint8_t device_id[DEV_ID_SIZE];
+        memset(device_id, 0, DEV_ID_SIZE);
+        memcpy(device_id + RAW_SIZE, a_corrected, RAW_SIZE - SPECIAL_BITS);
+    
+        memcpy(device_id, prev_1_a_corrected, RAW_SIZE);
+        uint32_t value = raw_to_uint(device_id, DEV_ID_SIZE);
+        sprintf(buffer, "%08x", value);
+        data = data_append(data, 
+            "device_id", "", DATA_INT, value, 
+            "device_id_hex", "", DATA_STRING, buffer, NULL);
     }
 
     if (data != NULL) {
-	data = data_prepend(data, "model", "", DATA_STRING, "Rolling Code Transmitter", NULL);
-    	decoder_output_data(decoder, data);
+        data = data_prepend(data, "model", "", DATA_STRING, "Rolling Code Transmitter", NULL);
+        decoder_output_data(decoder, data);
     }
 
     // Return 1 if message successfully decoded
@@ -309,23 +313,23 @@ static int rolling_code_decode(r_device *decoder, bitbuffer_t *bitbuffer)
  *
  */
 static char *output_fields[] = {
-	"model",
-        "device_id",
-        "device_id_hex",
-        "counter",
-	"counter_hex",
-	"id_bits",
-	"button_pressed",
-        NULL,
+    "model",
+    "device_id",
+    "device_id_hex",
+    "counter",
+    "counter_hex",
+    "id_bits",
+    "button_pressed",
+    NULL,
 };
 
 r_device rolling_code = {
-        .name        = "Rolling Code Transmitter (-f 315M)",
-        .modulation  = OOK_PULSE_PCM_RZ,
-        .short_width = 500,  // trits are multiples of 500 uS in size
-        .long_width  = 500,  // trits are multiples of 500 uS in size
-        .reset_limit = 2000, // this is short enough so we only get 1 row
-        .decode_fn   = &rolling_code_decode,
-        .disabled    = 1, // disabled and hidden, use 0 if there is a MIC, 1 otherwise
-        .fields      = output_fields,
+    .name        = "Rolling Code Transmitter (-f 315M)",
+    .modulation  = OOK_PULSE_PCM_RZ,
+    .short_width = 500,  // trits are multiples of 500 uS in size
+    .long_width  = 500,  // trits are multiples of 500 uS in size
+    .reset_limit = 2000, // this is short enough so we only get 1 row
+    .decode_fn   = &rolling_code_decode,
+    .disabled    = 1, // disabled and hidden, use 0 if there is a MIC, 1 otherwise
+    .fields      = output_fields,
 };

--- a/src/devices/rolling_code.c
+++ b/src/devices/rolling_code.c
@@ -96,7 +96,10 @@ static uint8_t get_trits(uint8_t packet_type, uint8_t *nibble_buffer, uint8_t *b
             else if (nibble == 0x03) nibble_buffer[nibble_index++] = 1;
             else if (nibble == 0x07) nibble_buffer[nibble_index++] = 2;
             else {
-                fprintf(stderr, "Unknown nibble %02x\n", nibble);
+                if (debug_output > 1) {
+                    fprintf(stderr, "Unknown nibble %02x\n", nibble);
+                }
+
                 return 1;
             }
         } else if (packet_type == LEGACY) {
@@ -104,14 +107,19 @@ static uint8_t get_trits(uint8_t packet_type, uint8_t *nibble_buffer, uint8_t *b
             else if (nibble == 0x0f) nibble_buffer[nibble_index++] = 1;
             else if (nibble == 0x3f) nibble_buffer[nibble_index++] = 2;
             else {
-                fprintf(stderr, "Unknown nibble %02x\n", nibble);
+                if (debug_output > 1) {
+                    fprintf(stderr, "Unknown nibble %02x\n", nibble);
+                }
+
                 return 1;
             }
         }
     }
 
     if (nibble_index != num_trits) {
-        fprintf(stderr, "Not enough bits for %d nibbles\n", num_trits);
+        if (debug_output > 1) {
+            fprintf(stderr, "Not enough bits for %d nibbles\n", num_trits);
+        }
 
         return 1;
     } else {
@@ -250,7 +258,10 @@ static int rolling_code_decode(r_device *decoder, bitbuffer_t *bitbuffer)
      */
 
     if (get_trits(packet_type, trinary, b, &index, num_bits, debug_output)) {
-        fprintf(stderr, "get_trits failed\n");
+        if (debug_output > 1) {
+            fprintf(stderr, "get_trits failed\n");
+        }
+
         *prev_1_a_corrected = NOT_SET;
         *prev_1_r_raw = NOT_SET;
 

--- a/src/devices/rolling_code.c
+++ b/src/devices/rolling_code.c
@@ -271,12 +271,14 @@ static int rolling_code_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     if (*prev_1_r_raw != '.' && start_width == 3) {
-	char buffer[9];
+	char buffer[11];
 	uint32_t counter = get_rolling_code(raw_to_uint(prev_1_r_raw, RAW_SIZE), raw_to_uint(r_raw, RAW_SIZE));
-    	sprintf(buffer, "%08x", counter);
+    	sprintf(buffer, "%u", counter);
+	data = data_append(data, 
+		"counter", "", DATA_STRING, buffer, NULL);
+	sprintf(buffer, "%08x", counter);
 	data = data_append(data, 
 		"counter_hex", "", DATA_STRING, buffer,
-		"counter", "", DATA_INT, counter,
         	"button_pressed", "", DATA_INT, (int) a_corrected[9],
         	"id_bits", "", DATA_INT, a_corrected[6] * 9 + a_corrected[7] * 3 + a_corrected[8], NULL);
 

--- a/src/devices/rolling_code.c
+++ b/src/devices/rolling_code.c
@@ -1,0 +1,258 @@
+/** @file
+    Decoder for Rolling Code Transmitter
+
+    Copyright (C) 2020 Flemi Oisterhocker
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+ */
+
+/**
+(this is a markdown formatted section to describe the decoder)
+(describe the modulation, timing, and transmission, e.g.)
+ * The device uses OOK_PULSE_PCM_RZ encoding,
+ * The packet starts with either a narrow (500 uS) start pulse or a long (1500 uS) pulse.
+ * 0 is defined as a 1500 uS gap to the next pulse.
+ * 1 is defined as a 1000 uS gap to the next pulse.
+ * 2 is defined as a 500 uS gap to the next pulse.
+
+*/
+
+#include <stdlib.h>
+#include "decoder.h"
+
+/*
+ * Hypothetical template device
+ *
+ * Message is 68 bits long
+ * Messages start with 0xAA
+ * The message is repeated as 5 packets,
+ * require at least 3 repeated packets.
+ *
+ */
+
+#define MIN_BITS		80
+
+static int get_start_bit_width(uint8_t *buffer, int *index, int num_bits, int debug_output) {
+    int start = 0;
+
+    while (*index < num_bits && bitrow_get_bit(buffer, *index) == 0) {
+        (*index)++;
+    }
+
+    if (*index == num_bits) {
+        if (debug_output > 1) {
+            fprintf(stderr, "No 1 bit in row\n");
+        }
+
+        return -1;
+    }
+
+    start = (*index)++;
+
+    while (*index < num_bits && bitrow_get_bit(buffer, *index) == 1) {
+        (*index)++;
+    }
+
+    if (*index == num_bits) {
+        if (debug_output > 1) {
+            fprintf(stderr, "No 0 bit after start bit in row\n");
+        }
+
+        return -1;
+    }
+
+    return *index - start;
+}
+
+static uint8_t get_trits(uint8_t *nibble_buffer, uint8_t *bit_buffer, int *bit_index, int num_bits, int debug_output) {
+    if (num_bits - *bit_index < MIN_BITS) {
+        if (debug_output > 1) {
+            fprintf(stderr, "Too few bits: %d\n", num_bits - *bit_index);
+	}
+
+	return 1;
+    }
+
+    int nibble_index = 0;
+    while (nibble_index < 20 && *bit_index <= num_bits - 4) {
+        uint8_t nibble = bitrow_get_bit(bit_buffer, (*bit_index)++) << 3 | bitrow_get_bit(bit_buffer, (*bit_index)++) << 2 | 
+            bitrow_get_bit(bit_buffer, (*bit_index)++) << 1 | bitrow_get_bit(bit_buffer, (*bit_index)++);
+        
+	if (nibble == 0x01) nibble_buffer[nibble_index++] = 0;
+	else if (nibble == 0x03) nibble_buffer[nibble_index++] = 1;
+	else if (nibble == 0x07) nibble_buffer[nibble_index++] = 2;
+	else {
+		fprintf(stderr, "Unknown nibble %02x\n", nibble);
+		return 1;
+	}
+    }
+
+    if (nibble_index != 20) {
+        fprintf(stderr, "Not enough bits for 20 nibbles\n");
+
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+static void cleanup(uint8_t **ptr) {
+    if (*ptr != NULL) {
+       free(*ptr);
+    }
+
+    *ptr = NULL;
+}
+
+static int rolling_code_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    // This holds a previous start width 1 packet for counter decoding
+    // once we have a start width 3 packet.
+    static uint8_t *prev_packet = NULL;
+
+    data_t *data = NULL;
+    int index = 0; // a row index
+    uint8_t *b = NULL; // bits of a row
+    int num_bits = 0;
+    int start_width = 0;
+    uint8_t trinary[20] = {0};
+    int debug_output = decoder->verbose;
+
+    if (debug_output > 1) {
+    	bitbuffer_printf(bitbuffer, "%s: ", __func__);
+    }
+
+    if (bitbuffer->num_rows < 1) {
+	cleanup(&prev_packet);
+
+        return 0;
+    }
+
+    b = bitbuffer->bb[0];
+    num_bits = bitbuffer->bits_per_row[0];
+
+    start_width = get_start_bit_width(b, &index, num_bits, debug_output);
+
+    if (start_width != 1 && start_width != 3) {
+        if (debug_output > 1) {
+            fprintf(stderr, "Start bit width invalid: %d\n", start_width);
+        }
+
+	cleanup(&prev_packet);
+
+        return 0;
+    }
+
+    /*
+     * Now that message "envelope" has been validated,
+     * start parsing data.
+     */
+
+     if (get_trits(trinary, b, &index, num_bits, debug_output)) {
+        fprintf(stderr, "get_trits failed\n");
+	cleanup(&prev_packet);
+
+        return 0;
+    }
+    
+    printf("START WIDTH %d CODE: ", start_width);
+    for (int i = 0; i < 20; i++) {
+        printf("%d ", trinary[i]);
+    }   
+    printf("\n");
+    
+    char a_buffer[11] = {0};
+    char r_buffer[11] = {0};
+
+    printf("ACODE: ");
+    for (int i = 0; i < 10; i++) {
+	a_buffer[i] = '0' + trinary[i * 2];
+        printf("%d ", trinary[i * 2]);
+    }       
+    printf("\n");
+
+    printf("ROLL:  ");
+    for (int i = 0; i < 10; i++) {
+	r_buffer[i] = '0' + trinary[i * 2 + 1];
+        printf("%d ", trinary[i * 2 + 1]);
+    }
+    printf("\n");
+
+    if (start_width == 1) {
+	prev_packet = malloc(sizeof(trinary));
+        memcpy(prev_packet, trinary, sizeof(trinary));
+    }
+
+    int counter = -1;
+
+    if (prev_packet != NULL && start_width == 3) {
+        counter = 123;
+    }
+    
+    /* clang-format off */
+    data = data_make(
+            "model", "", DATA_STRING, "Rolling Code Transmitter",
+            "a_code","", DATA_STRING, a_buffer,
+            "rolling_code",  "", DATA_STRING, r_buffer,
+            "start_width", "", DATA_INT, start_width,
+            "counter",   "", DATA_INT, counter,
+            NULL);
+    /* clang-format on */
+    decoder_output_data(decoder, data);
+
+    // Return 1 if message successfully decoded
+    return 1;
+}
+
+/*
+ * List of fields that may appear in the output
+ *
+ * Used to determine what fields will be output in what
+ * order for this device when using -F csv.
+ *
+ */
+static char *output_fields[] = {
+	"model",
+        "a_code",
+        "rolling_code",
+	"start_width",
+	"counter",
+        NULL,
+};
+
+/*
+ * r_device - registers device/callback. see rtl_433_devices.h
+ *
+ * Timings:
+ *
+ * short, long, and reset - specify pulse/period timings in [us].
+ *     These timings will determine if the received pulses
+ *     match, so your callback will fire after demodulation.
+ *
+ * Modulation:
+ *
+ * The function used to turn the received signal into bits.
+ * See:
+ * - pulse_demod.h for descriptions
+ * - r_device.h for the list of defined names
+ *
+ * This device is disabled and hidden, it can not be enabled.
+ *
+ * To enable your device, add it to the list in include/rtl_433_devices.h
+ * and to src/CMakeLists.txt and src/Makefile.am or run ./maintainer_update.py
+ *
+ */
+r_device rolling_code = {
+        .name        = "Rolling Code Transmitter",
+        .modulation  = OOK_PULSE_PCM_RZ,
+        .short_width = 500,  // short gap is 132 us
+        .long_width  = 500,  // long gap is 224 us
+        // .gap_limit   = 2000,  // some distance above long
+        .reset_limit = 2000, // was 61500, // a bit longer than packet gap
+        .decode_fn   = &rolling_code_decode,
+        .disabled    = 1, // disabled and hidden, use 0 if there is a MIC, 1 otherwise
+        .fields      = output_fields,
+};

--- a/src/devices/rolling_code.c
+++ b/src/devices/rolling_code.c
@@ -384,12 +384,12 @@ static char *output_fields[] = {
 };
 
 r_device rolling_code = {
-    .name        = "Rolling Code Transmitter (-f 315M)",
+    .name        = "Rolling Code Transmitter (-f 433.92M | 315M | 390M)",
     .modulation  = OOK_PULSE_PCM_RZ,
     .short_width = 500,  // trits are multiples of 500 uS in size
     .long_width  = 500,  // trits are multiples of 500 uS in size
     .reset_limit = 5000, // this is short enough so we only get 1 row
     .decode_fn   = &rolling_code_decode,
-    .disabled    = 1, // disabled and hidden, use 0 if there is a MIC, 1 otherwise
+    .disabled    = 0, // disabled and hidden, use 0 if there is a MIC, 1 otherwise
     .fields      = output_fields,
 };

--- a/src/devices/rolling_code.c
+++ b/src/devices/rolling_code.c
@@ -10,28 +10,23 @@
  */
 
 /**
-(this is a markdown formatted section to describe the decoder)
-(describe the modulation, timing, and transmission, e.g.)
- * The device uses OOK_PULSE_PCM_RZ encoding.
- * The packet starts with either a narrow (500 uS) start pulse or a long (1500 uS) pulse.
- * 0 is defined as a 1500 uS gap followed by a  500 uS pulse.
- * 1 is defined as a 1000 uS gap followed by a 1000 uS pulse.
- * 2 is defined as a  500 uS gap followed by a 1500 uS pulse.
+ The device uses OOK_PULSE_PCM_RZ encoding.
+ The packet starts with either a narrow (500 uS) start pulse or a long (1500 uS) pulse.
+ - 0 is defined as a 1500 uS gap followed by a  500 uS pulse.
+ - 1 is defined as a 1000 uS gap followed by a 1000 uS pulse.
+ - 2 is defined as a  500 uS gap followed by a 1500 uS pulse.
 
-*/
+ Transmissions consist of a '1' length packet of 20 'trits' (trinary digits)
+ followed by a '3' length packet of 20 trits. These two packets are repeated
+ some number of times.
+ The trits represent a rolling code that changes on each keypress, a fixed
+ 16 trit device ID,  3 id trits (key pressed), and a 1 trit button id.
+ All of the data is obfuscated and a 1 length and a 3 length packet are
+ required to successfully decode a transmission.
+ */
 
 #include <stdlib.h>
 #include "decoder.h"
-
-/*
- * Message consists of a '1' length packet of 20 'trits' (trinary digits)
- * followed by a '3' length packet of 20 trits. These two packets are repeated
- * some number of times.
- * The trits represent a rolling code that changes on each keypress, a fixed
- * 16 trit device ID,  3 id trits (key pressed), and a 1 trit button id.
- * All of the data is obfuscated and a 1 length and a 3 length packet are
- * required to successfully decode a transmission.
- */
 
 #define MIN_BITS		80
 #define TRINARY_SIZE		20
@@ -322,30 +317,8 @@ static char *output_fields[] = {
         NULL,
 };
 
-/*
- * r_device - registers device/callback. see rtl_433_devices.h
- *
- * Timings:
- *
- * short, long, and reset - specify pulse/period timings in [us].
- *     These timings will determine if the received pulses
- *     match, so your callback will fire after demodulation.
- *
- * Modulation:
- *
- * The function used to turn the received signal into bits.
- * See:
- * - pulse_demod.h for descriptions
- * - r_device.h for the list of defined names
- *
- * This device is disabled and hidden, it can not be enabled.
- *
- * To enable your device, add it to the list in include/rtl_433_devices.h
- * and to src/CMakeLists.txt and src/Makefile.am or run ./maintainer_update.py
- *
- */
 r_device rolling_code = {
-        .name        = "Rolling Code Transmitter",
+        .name        = "Rolling Code Transmitter (-f 315M)",
         .modulation  = OOK_PULSE_PCM_RZ,
         .short_width = 500,  // trits are multiples of 500 uS in size
         .long_width  = 500,  // trits are multiples of 500 uS in size


### PR DESCRIPTION
This decoder handles common rolling code transmissions. It extracts the corrected 'fixed' and 'rolling' portions of the transmission as well as the id bits and the button pressed. 