### PR TITLE
fix ERT Endpoint Type extraction

### DIFF
--- a/src/devices/ert.c
+++ b/src/devices/ert.c
@@ -65,7 +65,9 @@ static int ert_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* Extract parameters */
     physical_tamper = (b[3]&0xC0) >> 6;
-    ert_type = (b[3]&0x60) >> 2;
+    /* endpoint type is 4 bits and starts at position 26.
+     * xref https://github.com/bemasher/rtlamr/wiki/Protocol */
+    ert_type = (b[3]&0x36) >> 2;
     encoder_tamper = b[3]&0x03;
     consumption_data = (b[4]<<16) | (b[5]<<8) | b[6];
     ert_id = ((b[2]&0x06)<<23) | (b[7]<<16) | (b[8]<<8) | b[9];

--- a/src/devices/ert.c
+++ b/src/devices/ert.c
@@ -64,6 +64,7 @@ static int ert_decode(r_device *decoder, bitbuffer_t *bitbuffer)
      * CRC and extract the parameters from the back */
 
     /* Extract parameters */
+    physical_tamper = (b[3]&0xC0) >> 6;
     ert_type = (b[3]>>2) & 0x0F;
     encoder_tamper = b[3]&0x03;
     consumption_data = (b[4]<<16) | (b[5]<<8) | b[6];

--- a/src/devices/ert.c
+++ b/src/devices/ert.c
@@ -67,7 +67,7 @@ static int ert_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     physical_tamper = (b[3]&0xC0) >> 6;
     /* endpoint type is 4 bits and starts at position 26.
      * xref https://github.com/bemasher/rtlamr/wiki/Protocol */
-    ert_type = (b[3]&0x36) >> 2;
+    ert_type = (b[3]>>2) & 0x0F;
     encoder_tamper = b[3]&0x03;
     consumption_data = (b[4]<<16) | (b[5]<<8) | b[6];
     ert_id = ((b[2]&0x06)<<23) | (b[7]<<16) | (b[8]<<8) | b[9];

--- a/src/devices/ert.c
+++ b/src/devices/ert.c
@@ -64,9 +64,6 @@ static int ert_decode(r_device *decoder, bitbuffer_t *bitbuffer)
      * CRC and extract the parameters from the back */
 
     /* Extract parameters */
-    physical_tamper = (b[3]&0xC0) >> 6;
-    /* endpoint type is 4 bits and starts at position 26.
-     * xref https://github.com/bemasher/rtlamr/wiki/Protocol */
     ert_type = (b[3]>>2) & 0x0F;
     encoder_tamper = b[3]&0x03;
     consumption_data = (b[4]<<16) | (b[5]<<8) | b[6];


### PR DESCRIPTION
Putative fix for ERT Endpoint Type (149) decoding as per discussion on https://groups.google.com/forum/#!topic/rtl_433/loZFvPhCxOE

Output is now consistent wrt rtlamr. 