### PR TITLE
Improve Honeywell sensor support

### DIFF
--- a/src/devices/honeywell.c
+++ b/src/devices/honeywell.c
@@ -56,7 +56,7 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int reed;
     int contact;
     int heartbeat;
-    int alarm;
+    int motion;
     int tamper;
     int battery_low;
 
@@ -94,13 +94,13 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_FAIL_MIC; // Not a valid packet
 
     event = b[3];
-    // decoded event bits: CATRBHUU
+    // decoded event bits: CTRMBHUU
     // NOTE: not sure if these apply to all device types
     // NOTE: contact switch state is in bit 7 and reed switch state is in bit 5
     contact     = (event & 0x80) >> 7;
     tamper      = (event & 0x40) >> 6;
     reed        = (event & 0x20) >> 5;
-    alarm       = (event & 0x10) >> 4;
+    motion      = (event & 0x10) >> 4;
     battery_low = (event & 0x08) >> 3;
     heartbeat   = (event & 0x04) >> 2;
 
@@ -112,7 +112,7 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "event",        "", DATA_FORMAT, "%02x", DATA_INT, event,
             "contact_open", "", DATA_INT,    contact,
             "reed_open",    "", DATA_INT,    reed,
-            "alarm",        "", DATA_INT,    alarm,
+            "motion",       "", DATA_INT,    motion,
             "tamper",       "", DATA_INT,    tamper,
             "battery_ok",   "", DATA_INT,    !battery_low,
             "heartbeat",    "", DATA_INT,    heartbeat,

--- a/src/devices/honeywell.c
+++ b/src/devices/honeywell.c
@@ -56,7 +56,7 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int reed;
     int contact;
     int heartbeat;
-    int motion;
+    int alarm;
     int tamper;
     int battery_low;
 
@@ -94,13 +94,13 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_FAIL_MIC; // Not a valid packet
 
     event = b[3];
-    // decoded event bits: CTRMBHUU
+    // decoded event bits: CATRBHUU
     // NOTE: not sure if these apply to all device types
     // NOTE: contact switch state is in bit 7 and reed switch state is in bit 5
     contact     = (event & 0x80) >> 7;
     tamper      = (event & 0x40) >> 6;
     reed        = (event & 0x20) >> 5;
-    motion      = (event & 0x10) >> 4;
+    alarm       = (event & 0x10) >> 4;
     battery_low = (event & 0x08) >> 3;
     heartbeat   = (event & 0x04) >> 2;
 
@@ -112,7 +112,7 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "event",        "", DATA_FORMAT, "%02x", DATA_INT, event,
             "contact_open", "", DATA_INT,    contact,
             "reed_open",    "", DATA_INT,    reed,
-            "motion",       "", DATA_INT,    motion,
+            "alarm",        "", DATA_INT,    alarm,
             "tamper",       "", DATA_INT,    tamper,
             "battery_ok",   "", DATA_INT,    !battery_low,
             "heartbeat",    "", DATA_INT,    heartbeat,

--- a/src/devices/honeywell.c
+++ b/src/devices/honeywell.c
@@ -94,7 +94,7 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_FAIL_MIC; // Not a valid packet
 
     event = b[3];
-    // decoded event bits: CATRBHUU
+    // decoded event bits: CTRABHUU
     // NOTE: not sure if these apply to all device types
     contact     = (event & 0x80) >> 7;
     tamper      = (event & 0x40) >> 6;

--- a/src/devices/honeywell.c
+++ b/src/devices/honeywell.c
@@ -53,7 +53,8 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int event;
     uint16_t crc_calculated;
     uint16_t crc;
-    int state;
+    int reed;
+    int contact;
     int heartbeat;
     int alarm;
     int tamper;
@@ -96,9 +97,10 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     // decoded event bits: AATABHUU
     // NOTE: not sure if these apply to all device types
     // NOTE: contact switch state is in bit 7 and reed switch state is in bit 5
-    state       = (event & 0x80) && (event & 0x20);
-    alarm       = (event & 0xb0) >> 4;
+    contact     = (event & 0x80) >> 7;
     tamper      = (event & 0x40) >> 6;
+    reed        = (event & 0x20) >> 5;
+    alarm       = (event & 0xb0) >> 4;
     battery_low = (event & 0x08) >> 3;
     heartbeat   = (event & 0x04) >> 2;
 
@@ -108,7 +110,8 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "id",           "", DATA_FORMAT, "%05x", DATA_INT, device_id,
             "channel",      "", DATA_INT,    channel,
             "event",        "", DATA_FORMAT, "%02x", DATA_INT, event,
-            "state",        "", DATA_STRING, state ? "open" : "closed",
+            "contact_open", "", DATA_INT,    contact,
+            "reed_open",    "", DATA_INT,    reed,
             "alarm",        "", DATA_INT,    alarm,
             "tamper",       "", DATA_INT,    tamper,
             "battery_ok",   "", DATA_INT,    !battery_low,

--- a/src/devices/honeywell.c
+++ b/src/devices/honeywell.c
@@ -95,7 +95,8 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     event = b[3];
     // decoded event bits: AATABHUU
     // NOTE: not sure if these apply to all device types
-    state       = (event & 0x80) >> 7;
+    // NOTE: contact switch state is in bit 7 and reed switch state is in bit 5
+    state       = (event & 0x80) && (event & 0x20);
     alarm       = (event & 0xb0) >> 4;
     tamper      = (event & 0x40) >> 6;
     battery_low = (event & 0x08) >> 3;

--- a/src/devices/honeywell.c
+++ b/src/devices/honeywell.c
@@ -96,6 +96,7 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     event = b[3];
     // decoded event bits: CTRMBHUU
     // NOTE: not sure if these apply to all device types
+    // NOTE: contact switch state is in bit 7 and reed switch state is in bit 5
     contact     = (event & 0x80) >> 7;
     tamper      = (event & 0x40) >> 6;
     reed        = (event & 0x20) >> 5;
@@ -105,16 +106,16 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",          "", DATA_STRING, _X("Honeywell-Security","Honeywell Door/Window Sensor"),
-            "id",             "", DATA_FORMAT, "%05x", DATA_INT, device_id,
-            "channel",        "", DATA_INT,    channel,
-            "event",          "", DATA_FORMAT, "%02x", DATA_INT, event,
-            "contact_open_E", "", DATA_INT,    contact,
-            "reed_open_E",    "", DATA_INT,    reed,
-            "motion_E",       "", DATA_INT,    motion,
-            "tamper_E",       "", DATA_INT,    tamper,
-            "battery_low_E",  "", DATA_INT,    battery_low,
-            "heartbeat_E",    "", DATA_INT,    heartbeat,
+            "model",        "", DATA_STRING, _X("Honeywell-Security","Honeywell Door/Window Sensor"),
+            "id",           "", DATA_FORMAT, "%05x", DATA_INT, device_id,
+            "channel",      "", DATA_INT,    channel,
+            "event",        "", DATA_FORMAT, "%02x", DATA_INT, event,
+            "contact_open", "", DATA_INT,    contact,
+            "reed_open",    "", DATA_INT,    reed,
+            "motion",       "", DATA_INT,    motion,
+            "tamper",       "", DATA_INT,    tamper,
+            "battery_ok",   "", DATA_INT,    !battery_low,
+            "heartbeat",    "", DATA_INT,    heartbeat,
             NULL);
     /* clang-format on */
 
@@ -127,12 +128,11 @@ static char *output_fields[] = {
         "id",
         "channel",
         "event",
-        "contact_open_E",
-        "reed_open_E",
-        "motion_E",
-        "tamper_E",
-        "battery_low_E",
-        "heartbeat_E",
+        "state",
+        "alarm",
+        "tamper",
+        "battery_ok",
+        "heartbeat",
         NULL,
 };
 

--- a/src/devices/honeywell.c
+++ b/src/devices/honeywell.c
@@ -94,13 +94,13 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_FAIL_MIC; // Not a valid packet
 
     event = b[3];
-    // decoded event bits: AATABHUU
+    // decoded event bits: CATRBHUU
     // NOTE: not sure if these apply to all device types
     // NOTE: contact switch state is in bit 7 and reed switch state is in bit 5
     contact     = (event & 0x80) >> 7;
     tamper      = (event & 0x40) >> 6;
     reed        = (event & 0x20) >> 5;
-    alarm       = (event & 0xb0) >> 4;
+    alarm       = (event & 0x10) >> 4;
     battery_low = (event & 0x08) >> 3;
     heartbeat   = (event & 0x04) >> 2;
 

--- a/src/devices/honeywell.c
+++ b/src/devices/honeywell.c
@@ -96,7 +96,6 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     event = b[3];
     // decoded event bits: CATRBHUU
     // NOTE: not sure if these apply to all device types
-    // NOTE: contact switch state is in bit 7 and reed switch state is in bit 5
     contact     = (event & 0x80) >> 7;
     tamper      = (event & 0x40) >> 6;
     reed        = (event & 0x20) >> 5;
@@ -110,6 +109,7 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "id",           "", DATA_FORMAT, "%05x", DATA_INT, device_id,
             "channel",      "", DATA_INT,    channel,
             "event",        "", DATA_FORMAT, "%02x", DATA_INT, event,
+            "state",        "", DATA_STRING, contact ? "open" : "closed", // Ignore the reed switch legacy.
             "contact_open", "", DATA_INT,    contact,
             "reed_open",    "", DATA_INT,    reed,
             "alarm",        "", DATA_INT,    alarm,
@@ -129,6 +129,8 @@ static char *output_fields[] = {
         "channel",
         "event",
         "state",
+        "contact_open",
+        "reed_open",
         "alarm",
         "tamper",
         "battery_ok",

--- a/src/devices/honeywell.c
+++ b/src/devices/honeywell.c
@@ -96,7 +96,6 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     event = b[3];
     // decoded event bits: CTRMBHUU
     // NOTE: not sure if these apply to all device types
-    // NOTE: contact switch state is in bit 7 and reed switch state is in bit 5
     contact     = (event & 0x80) >> 7;
     tamper      = (event & 0x40) >> 6;
     reed        = (event & 0x20) >> 5;
@@ -106,16 +105,16 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",        "", DATA_STRING, _X("Honeywell-Security","Honeywell Door/Window Sensor"),
-            "id",           "", DATA_FORMAT, "%05x", DATA_INT, device_id,
-            "channel",      "", DATA_INT,    channel,
-            "event",        "", DATA_FORMAT, "%02x", DATA_INT, event,
-            "contact_open", "", DATA_INT,    contact,
-            "reed_open",    "", DATA_INT,    reed,
-            "motion",       "", DATA_INT,    motion,
-            "tamper",       "", DATA_INT,    tamper,
-            "battery_ok",   "", DATA_INT,    !battery_low,
-            "heartbeat",    "", DATA_INT,    heartbeat,
+            "model",          "", DATA_STRING, _X("Honeywell-Security","Honeywell Door/Window Sensor"),
+            "id",             "", DATA_FORMAT, "%05x", DATA_INT, device_id,
+            "channel",        "", DATA_INT,    channel,
+            "event",          "", DATA_FORMAT, "%02x", DATA_INT, event,
+            "contact_open_E", "", DATA_INT,    contact,
+            "reed_open_E",    "", DATA_INT,    reed,
+            "motion_E",       "", DATA_INT,    motion,
+            "tamper_E",       "", DATA_INT,    tamper,
+            "battery_low_E",  "", DATA_INT,    battery_low,
+            "heartbeat_E",    "", DATA_INT,    heartbeat,
             NULL);
     /* clang-format on */
 
@@ -128,11 +127,12 @@ static char *output_fields[] = {
         "id",
         "channel",
         "event",
-        "state",
-        "alarm",
-        "tamper",
-        "battery_ok",
-        "heartbeat",
+        "contact_open_E",
+        "reed_open_E",
+        "motion_E",
+        "tamper_E",
+        "battery_low_E",
+        "heartbeat_E",
         NULL,
 };
 


### PR DESCRIPTION
At least some models (eg Honeywell 5816, 2GIG DW10) support both wired
contact switches and magnetic reed switches to detect door/window state.
Contact switch state is encoded in bit 7 of the event field, and reed
switch state is encoded in bit 5.  Previously, only contact switch state
was reflected in the reported state.  This change determines the
reported state from both sensors; if either bit is zero, the state is
reported as "closed."

As reported in #1383.

EDIT: I split the states of the two sensors into discrete fields. This is a breaking change, but I think it is a better approach.