### PR TITLE
Added support for WS4904P Pet immune PIR (0x03 subtype) ...

### DIFF
--- a/src/devices/dsc.c
+++ b/src/devices/dsc.c
@@ -174,7 +174,8 @@ static int dsc_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         switch (subtype) {
         case 0x6: subtype_str = "WS4939 key fob"; break;
-        case 0x2: subtype_str = "DW4917 door/window sensor"; break;
+        case 0x3: subtype_str = "WS4904P Pet immune pir detector"; break;
+        case 0x2: subtype_str = "DW4917/WS4945 door/window sensor"; break;
         default: subtype_str = "unknown"; break;
         }
 


### PR DESCRIPTION
Hey all. I have just discovered this usefull tool to catch my DSC alarm panel (Alexor). As I have also PIR sensors, I would like to add them as supported devices. It's just a subtype addition (0x03). At the same time, I have found that my WS4945 door sensors have the same subtype of already recognized DW4917, so updated the display string.
As I have some more time, I would like also to add support for remote keypad, but it will be not an easy work for me, as I have seen that it is not recognized using DSC security protocol (23) as it is configured.