### PR TITLE
ADD: Missing delay and low battery codes for DS10A door sensor.

### DIFF
--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -13,6 +13,12 @@
  * on limited observations, doesn't take into account bits that might
  * be set to indicate something like a low battery condition.
  *
+ * DS10A door/window sensor bitmask : CUUUUDUB
+ *      C = Door/window closed flag.
+ *      U = Unknown. Cleared in all samples.
+ *      D = Delay setting. Min=1. Max=0.
+ *      B = Battery low flag.
+ *
  * Copyright (C) 2018 Anthony Kava
  * Based on code provided by Willi 'wherzig' in issue #30 (2014-04-21)
  *
@@ -32,6 +38,8 @@ static int x10_sec_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     char *event_str = "UNKNOWN";         /* human-readable event     */
     char x10_id_str[12] = "";            /* string showing hex value */
     char x10_code_str[5] = "";           /* string showing hex value */
+    int battery_low = 0;                 /* battery indicator (DS10A) */
+    int delay = 0;                       /* delay setting (DS10A) */
 
     for (r=0; r < bitbuffer->num_rows; ++r) {
         b = bitbuffer->bb[r];
@@ -44,19 +52,19 @@ static int x10_sec_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         if ((b[0] ^ b[1]) != 0x0f || (b[2] ^ b[3]) != 0xff)
             continue; // DECODE_FAIL_SANITY
 
+        battery_low = b[2] & 0x01;
+
         /* set event_str based on code received */
-        switch (b[2]) {
+        switch (b[2] & 0xfe) {
             case 0x00:
-                event_str = "DS10A DOOR/WINDOW OPEN/DELAY";
-                break;
-            case 0x01:
-                event_str = "DS10A DOOR/WINDOW OPEN/DELAY - BATTERY LOW";
-                break;
             case 0x04:
                 event_str = "DS10A DOOR/WINDOW OPEN";
+                delay = !(b[2] & 0x04);
                 break;
-            case 0x05:
-                event_str = "DS10A DOOR/WINDOW OPEN - BATTERY LOW";
+            case 0x80:
+            case 0x84:
+                event_str = "DS10A DOOR/WINDOW CLOSED";
+                delay = !(b[2] & 0x04);
                 break;
             case 0x06:
                 event_str = "KR10A KEY-FOB ARM";
@@ -67,20 +75,8 @@ static int x10_sec_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
             case 0x46:
                 event_str = "KR10A KEY-FOB LIGHTS-ON";
                 break;
-            case 0x80:
-                event_str = "DS10A DOOR/WINDOW CLOSED/DELAY";
-                break;
-            case 0x81:
-                event_str = "DS10A DOOR/WINDOW CLOSED/DELAY - BATTERY LOW";
-                break;
             case 0x82:
                 event_str = "SH624 SEC-REMOTE DISARM";
-                break;
-            case 0x84:
-                event_str = "DS10A DOOR/WINDOW CLOSED";
-                break;
-            case 0x85:
-                event_str = "DS10A DOOR/WINDOW CLOSED - BATTERY LOW ";
                 break;
             case 0x86:
                 event_str = "KR10A KEY-FOB DISARM";
@@ -116,6 +112,20 @@ static int x10_sec_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
                 "code",     "Code",         DATA_STRING, x10_code_str,
                 "event",    "Event",        DATA_STRING, event_str,
                 NULL);
+
+        /* append delay indicator if set */
+        if (delay) {
+            data = data_append(data,
+                    "delay",        "Delay",        DATA_INT, delay,
+                    NULL);
+        }
+        /* append battery indicator if set */
+        if (battery_low) {
+            data = data_append(data,
+                    "battery_ok",   "Battery OK",   DATA_INT, !battery_low,
+                    NULL);
+        }
+
         decoder_output_data(decoder, data);
         return 1;
     }
@@ -128,6 +138,8 @@ static char *output_fields[] = {
     "id",
     "code",
     "event",
+    "delay"
+    "battery_ok",
     NULL
 };
 

--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -46,8 +46,17 @@ static int x10_sec_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
         /* set event_str based on code received */
         switch (b[2]) {
+            case 0x00:
+                event_str = "DS10A DOOR/WINDOW OPEN/DELAY";
+                break;
+            case 0x01:
+                event_str = "DS10A DOOR/WINDOW OPEN/DELAY - BATTERY LOW";
+                break;
             case 0x04:
                 event_str = "DS10A DOOR/WINDOW OPEN";
+                break;
+            case 0x05:
+                event_str = "DS10A DOOR/WINDOW OPEN - BATTERY LOW";
                 break;
             case 0x06:
                 event_str = "KR10A KEY-FOB ARM";
@@ -58,11 +67,20 @@ static int x10_sec_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
             case 0x46:
                 event_str = "KR10A KEY-FOB LIGHTS-ON";
                 break;
+            case 0x80:
+                event_str = "DS10A DOOR/WINDOW CLOSED/DELAY";
+                break;
+            case 0x81:
+                event_str = "DS10A DOOR/WINDOW CLOSED/DELAY - BATTERY LOW";
+                break;
             case 0x82:
                 event_str = "SH624 SEC-REMOTE DISARM";
                 break;
             case 0x84:
                 event_str = "DS10A DOOR/WINDOW CLOSED";
+                break;
+            case 0x85:
+                event_str = "DS10A DOOR/WINDOW CLOSED - BATTERY LOW ";
                 break;
             case 0x86:
                 event_str = "KR10A KEY-FOB DISARM";


### PR DESCRIPTION
Tested with several DS10A on min, max and low battery 