### PR TITLE
ascii codec error

### DIFF
--- a/maintainer_update.py
+++ b/maintainer_update.py
@@ -112,6 +112,7 @@ repl += get_help_text('-F') + '\n'
 repl += get_help_text('-M') + '\n'
 repl += get_help_text('-r') + '\n'
 repl += get_help_text('-w') + '\n'
+repl = repl.encode('utf-8')
 replace_block(r'```',
               r'```', repl, 'README.md')
 


### PR DESCRIPTION
This fixes the error in [maintainer_update.py](merbanan/rtl_433/blob/master/maintainer_update.py) :

UnicodeEncodeError: 'ascii' codec can't encode character u'\xe4' in position 10325: ordinal not in range(128)

generated from the "ä"  in IKEA Sparsn**ä**s in [ikea_sparsnas.c](/merbanan/rtl_433/blob/master/src/devices/ikea_sparsnas.c#L295)