### PR TITLE
Add support for Missil ML0757

### DIFF
--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -164,6 +164,7 @@
     DECL(scmplus) \
     DECL(fineoffset_wh1080_fsk) \
     DECL(tpms_abarth124) \
+    DECL(missil_ml0757) \
 
     /* Add new decoders here. */
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,6 +107,7 @@ add_library(r_433 STATIC
     devices/maverick_et73.c
     devices/maverick_et73x.c
     devices/mebus.c
+    devices/missil_ml0757.c
     devices/new_template.c
     devices/newkaku.c
     devices/nexa.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -106,6 +106,7 @@ rtl_433_SOURCES      = abuf.c \
                        devices/maverick_et73.c \
                        devices/maverick_et73x.c \
                        devices/mebus.c \
+					   devices/missil_ml0757.c \
                        devices/new_template.c \
                        devices/newkaku.c \
                        devices/nexa.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -106,7 +106,7 @@ rtl_433_SOURCES      = abuf.c \
                        devices/maverick_et73.c \
                        devices/maverick_et73x.c \
                        devices/mebus.c \
-					   devices/missil_ml0757.c \
+                       devices/missil_ml0757.c \
                        devices/new_template.c \
                        devices/newkaku.c \
                        devices/nexa.c \

--- a/src/devices/missil_ml0757.c
+++ b/src/devices/missil_ml0757.c
@@ -1,0 +1,151 @@
+/** @file
+    Missil ML0757 weather station with temperature, wind and rain sensor.
+
+    Copyright (C) 2020 Marius Lindvall
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+/**
+The unit sends two different alternating packets, one for temperature and one
+for rainfall and wind. All packets are 40 bits and are transferred 9 times.
+Packet structure appears to be as follows:
+
+                         BIT
+          0   1   2   3   4   5   6   7   8
+      0x0 +---+---+---+---+---+---+---+---+
+          | Device ID                     |
+      0x1 +---+---+---+---+---+---+---+---+
+    B     |BAT| ? | ? | ? | ? |RWP| ? | ? | <-- FLAGS BYTE
+    Y 0x2 +---+---+---+---+---+---+---+---+
+    T     | Data field 1                 >|
+    E 0x3 +---+---+---+---+---+---+---+---+
+          |<Data field 1  | Data field 2 >|
+      0x4 +---+---+---+---+---+---+---+---+
+          |<Data field 2  | 1 | 1 | 1 | 1 |
+      0x5 +---+---+---+---+---+---+---+---+
+
+When flag bit RWP is not set, data field 1 is (temp in °C * 10) as a signed
+12-bit integer, and data field 2 (8 bits) is unknown.
+
+Where when bit RWP is set, data field 1 is accumulated rainfall in number of
+steps as a signed 12-bit integer, where each step is 0.45 mm of rain, but when
+the sign bit flips, the counter appears to reset to 0. Data field 2 is wind
+speed as an 8 bit integer where 0x00 = 0 km/h, 0x80 = 1.4 km/h, 0xC0 = 2.8 km/h,
+and any other value is ((value + 2) * 1.4) km/h. I know this doesn't intuitively
+make sense, but it's what my testing has come up with and it matches what is
+shown on the display.
+
+The BAT flag is set if the transmitter has low battery. The other flags could
+not be determined.
+
+Packets are sent in sequences of type temp, rain+wind, temp, rain+wind, etc.
+with ~36-37 seconds between each packet.
+
+All packets begin with an empty row in addition to the 9 rows of repeated data.
+*/
+
+#include "decoder.h"
+
+#define MISSIL_ML0757_FLAG_RWP  0x04; // Rain+Wind packet flag
+#define MISSIL_ML0757_FLAG_BAT  0x80; // Battery low flag
+
+static int missil_ml0757_callback(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    data_t *data;
+    uint8_t *b;
+    int id, flags, f12bit, f8bit;
+    float temp_c, rainfall, wind_kph;
+    int flag_bat, flag_rwp;
+
+    int r = bitbuffer_find_repeated_row(bitbuffer, 5, 40);
+    if (r < 0)
+        return DECODE_ABORT_EARLY;
+
+    b = bitbuffer->bb[r];
+
+    if (bitbuffer->bits_per_row[0] > 0)
+        return DECODE_ABORT_EARLY; // First row must be 0-length
+
+    if (bitbuffer->bits_per_row[r] > 40)
+        return DECODE_ABORT_LENGTH; // Message too long
+
+    if ((b[4] & 0x0F) != 0x0F)
+        return DECODE_ABORT_EARLY; // Tail bits not 1111
+
+    // Read fields from sensor data
+    id       = b[0];
+    flags    = b[1];
+    f12bit   = (int16_t)((b[2] << 4) | (b[3] >> 4)) & 0xFFF;
+    f8bit    = (((b[3] & 0x0F) << 4) | (b[4] >> 4)) & 0xFF;
+
+    // Parse flags
+    flag_bat = flags & MISSIL_ML0757_FLAG_BAT;
+    flag_rwp = flags & MISSIL_ML0757_FLAG_RWP;
+
+    // Parse temperature
+    if (f12bit & 0x800) // Sign bit set; negative temperature
+        temp_c = (0x1000 - f12bit) * -0.1f;
+    else
+        temp_c = f12bit * 0.1f;
+
+    // Parse rainfall
+    rainfall = f12bit * 0.45f;
+
+    // Parse wind speed
+    switch (f8bit) {
+        case 0x00: wind_kph = 0.0f; break;
+        case 0x80: wind_kph = 1.4f; break;
+        case 0xC0: wind_kph = 2.8f; break;
+        default:   wind_kph = (f8bit + 2) * 1.4f; break;
+    }
+
+    if (flag_rwp) { // Rainwall and wind
+        /* clang-format off */
+        data = data_make(
+                "model",            "",             DATA_STRING, _X("ML0757-RainWind","Missil 0757 Rain/Wind"),
+                "id",               "ID",           DATA_INT, id,
+                "battery_ok",       "Battery OK",   DATA_INT, !flag_bat,
+                "rain_mm",          "Total rain",   DATA_FORMAT, "%.02f mm", DATA_DOUBLE, rainfall,
+                "wind_avg_km_h",    "Wind speed",   DATA_FORMAT, "%.02f km/h", DATA_DOUBLE, wind_kph,
+                NULL);
+        /* clang-format on */
+    }
+    else { // Temperature
+        /* clang-format off */
+        data = data_make(
+                "model",            "",             DATA_STRING, _X("ML0757-Temp","Missil ML0757 Temperature"),
+                "id",               "ID",           DATA_INT, id,
+                "battery_ok",       "Battery OK",   DATA_INT, !flag_bat,
+                "temperature_C",    "Temperature",  DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
+                NULL);
+        /* clang-format on */
+    }
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+static char *output_fields[] = {
+        "model",
+        "id",
+        "battery_ok"
+        "temperature_C",
+        "wind_avg_km_h",
+        "rain_mm",
+        NULL,
+};
+
+r_device missil_ml0757 = {
+        .name        = "Missil ML0757 weather station",
+        .modulation  = OOK_PULSE_PPM,
+        .short_width = 975,
+        .long_width  = 1950,
+        .gap_limit   = 2500,
+        .reset_limit = 4500,
+        .tolerance   = 100,
+        .decode_fn   = &missil_ml0757_callback,
+        .fields      = output_fields,
+};

--- a/src/devices/missil_ml0757.c
+++ b/src/devices/missil_ml0757.c
@@ -9,6 +9,8 @@
     (at your option) any later version.
 */
 /**
+Missil ML0757 weather station with temperature, wind and rain sensor.
+
 The unit sends two different alternating packets, one for temperature and one
 for rainfall and wind. All packets are 40 bits and are transferred 9 times.
 Packet structure appears to be as follows:
@@ -106,7 +108,6 @@ static int missil_ml0757_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         /* clang-format off */
         data = data_make(
                 "model",            "",             DATA_STRING, "Missil-ML0757",
-                "subtype",          "Sensor(s)",    DATA_STRING, "RainfallWind",
                 "id",               "ID",           DATA_INT, id,
                 "battery_ok",       "Battery OK",   DATA_INT, !flag_bat,
                 "rain_mm",          "Total rain",   DATA_FORMAT, "%.02f mm", DATA_DOUBLE, rainfall,
@@ -118,7 +119,6 @@ static int missil_ml0757_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         /* clang-format off */
         data = data_make(
                 "model",            "",             DATA_STRING, "Missil-ML0757",
-                "subtype",          "Sensor(s)",    DATA_STRING, "Temperature",
                 "id",               "ID",           DATA_INT, id,
                 "battery_ok",       "Battery OK",   DATA_INT, !flag_bat,
                 "temperature_C",    "Temperature",  DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
@@ -132,7 +132,6 @@ static int missil_ml0757_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
 static char *output_fields[] = {
         "model",
-        "subtype",
         "id",
         "battery_ok"
         "temperature_C",

--- a/src/devices/missil_ml0757.c
+++ b/src/devices/missil_ml0757.c
@@ -105,7 +105,8 @@ static int missil_ml0757_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (flag_rwp) { // Rainwall and wind
         /* clang-format off */
         data = data_make(
-                "model",            "",             DATA_STRING, _X("ML0757-RainWind","Missil 0757 Rain/Wind"),
+                "model",            "",             DATA_STRING, "Missil-ML0757",
+                "subtype",          "Sensor(s)",    DATA_STRING, "RainfallWind",
                 "id",               "ID",           DATA_INT, id,
                 "battery_ok",       "Battery OK",   DATA_INT, !flag_bat,
                 "rain_mm",          "Total rain",   DATA_FORMAT, "%.02f mm", DATA_DOUBLE, rainfall,
@@ -116,7 +117,8 @@ static int missil_ml0757_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     else { // Temperature
         /* clang-format off */
         data = data_make(
-                "model",            "",             DATA_STRING, _X("ML0757-Temp","Missil ML0757 Temperature"),
+                "model",            "",             DATA_STRING, "Missil-ML0757",
+                "subtype",          "Sensor(s)",    DATA_STRING, "Temperature",
                 "id",               "ID",           DATA_INT, id,
                 "battery_ok",       "Battery OK",   DATA_INT, !flag_bat,
                 "temperature_C",    "Temperature",  DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
@@ -130,6 +132,7 @@ static int missil_ml0757_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
 static char *output_fields[] = {
         "model",
+        "subtype",
         "id",
         "battery_ok"
         "temperature_C",


### PR DESCRIPTION
This device is a weather station that records wind speed, rainfall and temperature and transmits it back to a receiver device that display this data, along with the receiver's temperature and humidity. This is my first time delving into the `rtl_433` project.

## Row format

<id: 8 bits> <flags: 8 bits> <field 1: 12 bits> <field 2: 8 bits> <tail: 4 bits>

## Flags

1. Battery low bit
2. Unknown
3. Unknown
4. Unknown
5. Unknown
6. Packet type
7. Unknown
8. Unknown

## Data

When bit 6 is **set**, field 1 is accumulated rainfall in steps of 0.45 mm, and field 2 is wind speed as (field value + 2) * 1.4 km/h with special cases for 0-3 km/h.

When bit 6 is **not set**, field 1 is temperature (signed) in 1/10ths °C, and field 2 is **unknown** at this time.

## Temperature packet field 2

I don't know what the 8-bit field in the temperature packet is.

Here are some samples:

```
0110 0111 0000 0000 0000 1110 0000 0011 0110 1111
0110 0111 0000 0000 0000 1110 0011 0011 0110 1111
0010 1100 0000 0000 0001 0000 0011 0011 0101 1111
0110 0111 0000 0000 0000 1110 0100 0011 0110 1111
0110 0111 0000 0000 0000 1110 0100 0011 0110 1111
0110 0111 0000 0000 0000 1110 0101 0011 0110 1111
0110 0111 0000 0000 0000 1110 0101 0011 0110 1111
0110 0111 0000 0000 0000 1110 0101 0011 0110 1111
1000 1011 1000 0000 0000 1111 0011 0011 0110 1111
0110 0111 0000 0000 0000 1111 0000 0011 0110 1111
0110 0111 0000 0000 0001 0010 0110 0011 0101 1111
0110 0111 0000 0000 0001 0010 1100 0011 0101 1111
0110 0111 0000 0000 0001 0010 1111 0011 0101 1111
0110 0111 0000 0000 0000 0011 0100 0011 1000 1111
0110 0111 0000 0000 1111 1100 1100 0011 1000 1111 
0010 1100 0000 0000 0001 0000 0011 0011 0101 1111
0010 1100 0000 0000 0001 0000 1100 0011 0101 1111
0010 1100 0000 0000 0001 0000 1111 0011 0101 1111
```

In all of these, the field is either 0x35, 0x36 or 0x38. What I have ruled out:

- It is **not** humidity. I put it in the bathroom while taking a long shower, with all seals and protective covers removed, and there was no difference.
- It is **not** battery voltage. The unit takes 2xAA batteries and thus receives 3.0V from the batteries.
- It is **not** battery percentage. I put in bad batteries in the unit, which didn't change the field, but raised flag bit 1 instead.
- It does not appear to be a checksum. It remains the same even when the input data varies wildly, and is only picked from a select few possible values. Also, it is only sent with the temperature packet, and not the rain packet, as wind speed uses that field in the rain packet.