### PR TITLE
Changes to allow LaCrosse TX141B to work properly

### DIFF
--- a/src/devices/lacrosse_tx141x.c
+++ b/src/devices/lacrosse_tx141x.c
@@ -75,7 +75,7 @@ A count enables us to determine the quality of radio transmission.
 The TX141-BV2 is the temperature only version of the TX141TH-BV2 sensor.
 
 Changes:
-- Changed minimum bit length to 31 (tx141b is temperature only)
+- Changed minimum bit length to 32 (tx141b is temperature only)
 - LACROSSE_TX141_BITLEN is 37 instead of 40.
 - The humidity variable has been removed for TX141.
 - Battery check bit is inverse of TX141TH.
@@ -123,7 +123,7 @@ static int lacrosse_tx141x_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // Find the most frequent data packet
     // reduce false positives, require at least 5 out of 12 repeats.
-    r = bitbuffer_find_repeated_row(bitbuffer, 5, 31); // 31
+    r = bitbuffer_find_repeated_row(bitbuffer, 5, 32); // 32
     if (r < 0) {
         // try again for TX141W/TX145wsdth, require at least 2 out of 3-7 repeats.
         r = bitbuffer_find_repeated_row(bitbuffer, 2, 64); // 65
@@ -250,7 +250,7 @@ static int lacrosse_tx141x_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     if (device == LACROSSE_TX141B) {
         /* clang-format off */
         data = data_make(
-                "model",         "",              DATA_STRING, _X("LaCrosse-TX141B","LaCrosse TX141-B sensor"),
+                "model",         "",              DATA_STRING, _X("LaCrosse-TX141B","LaCrosse TX141B sensor"),
                 "id",            "Sensor ID",     DATA_FORMAT, "%02x", DATA_INT, id,
                 "temperature_C", "Temperature",   DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
                 "battery",       "Battery",       DATA_STRING, battery_low ? "LOW" : "OK",

--- a/src/devices/lacrosse_tx141x.c
+++ b/src/devices/lacrosse_tx141x.c
@@ -75,6 +75,7 @@ A count enables us to determine the quality of radio transmission.
 The TX141-BV2 is the temperature only version of the TX141TH-BV2 sensor.
 
 Changes:
+- Changed minimum bit length to 31 (tx141b is temperature only)
 - LACROSSE_TX141_BITLEN is 37 instead of 40.
 - The humidity variable has been removed for TX141.
 - Battery check bit is inverse of TX141TH.
@@ -105,6 +106,7 @@ Addition of TX141W and TX145wsdth:
 #include "decoder.h"
 
 // Define the types of devices this file supports (uses expected bitlen)
+#define LACROSSE_TX141B 66
 #define LACROSSE_TX141 37
 #define LACROSSE_TX141TH 40
 #define LACROSSE_TX141BV3 33
@@ -121,7 +123,7 @@ static int lacrosse_tx141x_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // Find the most frequent data packet
     // reduce false positives, require at least 5 out of 12 repeats.
-    r = bitbuffer_find_repeated_row(bitbuffer, 5, 33); // 33
+    r = bitbuffer_find_repeated_row(bitbuffer, 5, 31); // 31
     if (r < 0) {
         // try again for TX141W/TX145wsdth, require at least 2 out of 3-7 repeats.
         r = bitbuffer_find_repeated_row(bitbuffer, 2, 64); // 65
@@ -148,7 +150,9 @@ static int lacrosse_tx141x_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     else if (bitbuffer->bits_per_row[r] >= 37) {
         device = LACROSSE_TX141;
     }
-    else {
+    else if (bitbuffer->bits_per_row[r] == 32) {
+        device = LACROSSE_TX141B;
+    } else {
         device = LACROSSE_TX141BV3;
     }
 
@@ -243,7 +247,17 @@ static int lacrosse_tx141x_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_FAIL_SANITY;
     }
 
-    if (device == LACROSSE_TX141) {
+    if (device == LACROSSE_TX141B) {
+        /* clang-format off */
+        data = data_make(
+                "model",         "",              DATA_STRING, _X("LaCrosse-TX141B","LaCrosse TX141-B sensor"),
+                "id",            "Sensor ID",     DATA_FORMAT, "%02x", DATA_INT, id,
+                "temperature_C", "Temperature",   DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
+                "battery",       "Battery",       DATA_STRING, battery_low ? "LOW" : "OK",
+                "test",          "Test?",         DATA_STRING, test ? "Yes" : "No",
+                NULL);
+        /* clang-format on */
+    } else if (device == LACROSSE_TX141) {
         /* clang-format off */
         data = data_make(
                 "model",         "",              DATA_STRING, _X("LaCrosse-TX141Bv2","LaCrosse TX141-Bv2 sensor"),

--- a/src/devices/lacrosse_tx141x.c
+++ b/src/devices/lacrosse_tx141x.c
@@ -106,7 +106,7 @@ Addition of TX141W and TX145wsdth:
 #include "decoder.h"
 
 // Define the types of devices this file supports (uses expected bitlen)
-#define LACROSSE_TX141B 66
+#define LACROSSE_TX141B 32
 #define LACROSSE_TX141 37
 #define LACROSSE_TX141TH 40
 #define LACROSSE_TX141BV3 33


### PR DESCRIPTION
This remote temperature sensor is similar to other TX141 sensors, however it uses a 32 bit message length which is shorter than the others. 

The main differences with this sensor are:

1.  No humidity reading.
2. No channel select.

I've verified battery flag and test flag are working.

Pictures and additional information can be found under https://github.com/merbanan/rtl_433/issues/1430
