### PR TITLE
Fix Many False Positives

### DIFF
--- a/src/devices/calibeur.c
+++ b/src/devices/calibeur.c
@@ -40,6 +40,17 @@ static int calibeur_rf104_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     float humidity;
     bitrow_t *bb = bitbuffer->bb;
 
+    // row [0] is empty due to sync bit
+    // No need to decode/extract values for simple test
+    // check for 0x00 and 0xff
+    if ( (!bb[1][0] && !bb[1][1] && !bb[1][2])
+       || (bb[1][0] == 0xff && bb[1][1] == 0xff && bb[1][2] == 0xff)) {
+        if (decoder->verbose > 1) {
+            fprintf(stderr, "%s: DECODE_FAIL_SANITY data all 0x00 or 0xFF\n", __func__);
+        }
+        return DECODE_FAIL_SANITY;
+    }
+
     bitbuffer_invert(bitbuffer);
     // Validate package (row [0] is empty due to sync bit)
     int valid = (bitbuffer->bits_per_row[1] == 21)  // Don't waste time on a long/short package

--- a/src/devices/efth800.c
+++ b/src/devices/efth800.c
@@ -54,6 +54,16 @@ static int eurochron_efth800_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_ABORT_LENGTH;
 
     b = bitbuffer->bb[row];
+
+    // This is actially a 0x00 packet error ( bitbuffer_invert )
+    // No need to decode/extract values for simple test
+    if ( b[0] == 0xff &&  b[1] == 0xff && b[2] == 0xFF && b[4] == 0xFF )  {
+        if (decoder->verbose > 1) {
+            fprintf(stderr, "%s: DECODE_FAIL_SANITY data all 0xff\n", __func__);
+        }
+        return DECODE_FAIL_SANITY;
+    }
+
     bitbuffer_invert(bitbuffer);
 
     if (crc8(b, 6, 0x31, 0x00))

--- a/src/devices/ert.c
+++ b/src/devices/ert.c
@@ -57,6 +57,16 @@ static int ert_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_ABORT_LENGTH;
 
     b = bitbuffer->bb[0];
+
+    // No need to decode/extract values for simple test
+    // check id tamper type crc  value not all zero'ed
+    if ( !b[0] && !b[1] && !b[2] && !b[3] ) {
+        if (decoder->verbose > 1) {
+            fprintf(stderr, "%s: DECODE_FAIL_SANITY data all 0x00\n", __func__);
+        }
+        return DECODE_FAIL_SANITY;
+    }
+
     if (crc16(&b[2], 10, 0x6F63, 0))
         return DECODE_FAIL_MIC;
 

--- a/src/devices/generic_motion.c
+++ b/src/devices/generic_motion.c
@@ -37,6 +37,7 @@ static int generic_motion_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         // strictly validate package as there is no checksum
         if ((bitbuffer->bits_per_row[i] != 20)
                 || ((b[1] == 0) && (b[2] == 0))
+                || ((b[1] == 0xff) && (b[2] == 0xff))
                 || count_repeats(bitbuffer, i) < 3)
             continue; // DECODE_ABORT_EARLY
 

--- a/src/devices/gt_tmbbq05.c
+++ b/src/devices/gt_tmbbq05.c
@@ -90,9 +90,9 @@ static int gt_tmbbq05_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     bitbuffer_extract_bytes(bitbuffer, r, 1, b, 32);
 
     // Prevent false positives from 'allzero' 
-    // reject if Checksum channelhumidity and temperature are all zero 
+    // reject if Checksum Id and temperature are all zero 
     // No need to decode/extract values for simple test
-    if (b[0] == 0 && b[1] == 0 && b[2] == 0 && b[3] == 0) {
+    if (!b[0] && !b[1] && !b[2] && !b[3]) {
         if (decoder->verbose > 1) {
             fprintf(stderr, "%s: DECODE_FAIL_SANITY data all zero\n", __func__);
         }

--- a/src/devices/hcs200.c
+++ b/src/devices/hcs200.c
@@ -48,6 +48,14 @@ static int hcs200_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_ABORT_EARLY;
     }
 
+    // No need to decode/extract values for simple test
+    if (b[0] == 0xff &&  b[2] == 0xff && b[5] == 0xFF && b[6] == 0xFF)  {
+        if (decoder->verbose > 1) {
+            fprintf(stderr, "%s: DECODE_FAIL_SANITY data all 0xff\n", __func__);
+        }
+        return DECODE_FAIL_SANITY;
+    }
+
     // align buffer, shifting by 4 bits
     for (i = 1; i < 10; i++) {
         b[i] = (b[i] << 4) | (b[i + 1] >> 4);

--- a/src/devices/honeywell_wdb.c
+++ b/src/devices/honeywell_wdb.c
@@ -56,7 +56,6 @@ static int honeywell_wdb_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     }
     bytes = bitbuffer->bb[row];
 
-
     if (bitbuffer->bits_per_row[row] != 48)
         return DECODE_ABORT_LENGTH;
 
@@ -64,6 +63,15 @@ static int honeywell_wdb_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
 
     /* Parity check (must be EVEN) */
     parity = parity_bytes(bytes, 6);
+
+    // No need to decode/extract values for simple test
+    if ((!bytes[0] && !bytes[2] && !bytes[4] && !bytes[5])
+       || (bytes[0] == 0xff && bytes[2] == 0xff && bytes[4] == 0xff && bytes[5] == 0xff)) {
+        if (decoder->verbose > 1) {
+            fprintf(stderr, "%s: DECODE_FAIL_SANITY data all 0x00 or 0xFF\n", __func__);
+        }
+        return DECODE_FAIL_SANITY;
+    }
 
     if (parity) { // ODD parity detected
         if (decoder->verbose > 1) {

--- a/src/devices/kerui.c
+++ b/src/devices/kerui.c
@@ -46,6 +46,14 @@ static int kerui_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
         return DECODE_ABORT_LENGTH;
     b = bitbuffer->bb[r];
 
+    // No need to decode/extract values for simple test
+    if ( !b[0] && !b[1] && !b[2] ) {
+        if (decoder->verbose > 1) {
+            fprintf(stderr, "%s: DECODE_FAIL_SANITY data all 0x00\n", __func__);
+        }
+        return DECODE_FAIL_SANITY;
+    }
+
     //invert bits, short pulse is 0, long pulse is 1
     b[0] = ~b[0];
     b[1] = ~b[1];

--- a/src/devices/maverick_et73.c
+++ b/src/devices/maverick_et73.c
@@ -56,7 +56,8 @@ static int maverick_et73_sensor_callback(r_device *decoder, bitbuffer_t *bitbuff
     }
 
     bytes = bitbuffer->bb[row];
-    if (!bytes[0] && !bytes[1] && !bytes[2] && !bytes[3]) {
+    if ( (!bytes[0] && !bytes[1] && !bytes[2] && !bytes[3])
+    || (bytes[0] == 0xFF && bytes[1] == 0xFF && bytes[2] == 0xFF && bytes[3] == 0xFF))  {
         return DECODE_ABORT_EARLY; // reduce false positives
     }
 
@@ -76,12 +77,15 @@ static int maverick_et73_sensor_callback(r_device *decoder, bitbuffer_t *bitbuff
     temp1_c = temp1_raw * 0.1f;
     temp2_c = temp2_raw * 0.1f;
 
+    /* clang-format off */
     data = data_make(
             "model",            "",                 DATA_STRING, _X("Maverick-ET73","Maverick ET73"),
             _X("id","rid"),              "Random Id",        DATA_INT, device,
             "temperature_1_C",  "Temperature 1",    DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp1_c,
             "temperature_2_C",  "Temperature 2",    DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp2_c,
             NULL);
+    /* clang-format on */
+
     decoder_output_data(decoder, data);
     return 1;
 }

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -54,6 +54,7 @@ static int nexus_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     // it doesn't match. By guesstimate it should generate a correct crc 1/255% of the times.
     // So less then 0.5% which should be acceptable.
     if (b[0] == 0 || b[2] == 0 || b[3] == 0
+            || ( b[0] == 0xff &&  b[2] == 0xff && b[3] == 0xFF)
             || rubicson_crc_check(b))
         return DECODE_ABORT_EARLY;
 

--- a/src/devices/opus_xt300.c
+++ b/src/devices/opus_xt300.c
@@ -33,7 +33,16 @@ static int opus_xt300_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         if (bitbuffer->bits_per_row[row] != 48) {
             continue; // DECODE_ABORT_LENGTH
         }
+
         b = bitbuffer->bb[row];
+
+        if (!b[0] && !b[1] && !b[2] && !b[3]) {
+            if (decoder->verbose > 1) {
+                fprintf(stderr, "%s: DECODE_FAIL_SANITY data all 0x00\n", __func__);
+            }
+            continue; // DECODE_FAIL_SANITY;
+        }
+
         if (b[0] != 0xFF && ((b[1] | 0x1) & 0xFD) == 0x55) {
             continue; // DECODE_ABORT_EARLY
         }

--- a/src/devices/oregon_scientific_sl109h.c
+++ b/src/devices/oregon_scientific_sl109h.c
@@ -39,6 +39,16 @@ static int oregon_scientific_sl109h_callback(r_device *decoder, bitbuffer_t *bit
             continue; // DECODE_ABORT_LENGTH
 
         msg = bitbuffer->bb[row_index];
+
+        // No need to decode/extract values for simple test
+        // check id channel temperature humidity value not zero
+        if ( !msg[0] && !msg[1] && !msg[2] && !msg[3] ) {
+            if (decoder->verbose > 1) {
+                fprintf(stderr, "%s: DECODE_FAIL_SANITY data all 0x00\n", __func__);
+            }
+            continue; // DECODE_FAIL_SANITY
+        }
+
         chk = msg[0] >> 4;
 
         // align the channel "half nibble"

--- a/src/devices/oregon_scientific_v1.c
+++ b/src/devices/oregon_scientific_v1.c
@@ -38,6 +38,16 @@ static int oregon_scientific_v1_callback(r_device *decoder, bitbuffer_t *bitbuff
                 cs += nibble[i * 2] + 16 * nibble[i * 2 + 1];
         }
 
+
+        // No need to decode/extract values for simple test
+        if ( bitbuffer->bb[row][0] == 0xFF && bitbuffer->bb[row][1] == 0xFF
+            && bitbuffer->bb[row][2] == 0xFF && bitbuffer->bb[row][3] == 0xFF )  {
+            if (decoder->verbose > 1) {
+                fprintf(stderr, "%s: DECODE_FAIL_SANITY data all 0xff\n", __func__);
+            }
+            continue; //  DECODE_FAIL_SANITY
+        }
+
         cs = (cs & 0xFF) + (cs >> 8);
         checksum = nibble[6] + (nibble[7] << 4);
         /* reject 0x00 checksums to reduce false positives */

--- a/src/devices/philips_aj7010.c
+++ b/src/devices/philips_aj7010.c
@@ -70,6 +70,14 @@ static int philips_aj7010_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     b = bitbuffer->bb[0];
 
+    // No need to decode/extract values for simple test
+    if (!b[0] && !b[2] && !b[3] && !b[4]) {
+        if (decoder->verbose > 1) {
+            fprintf(stderr, "%s: DECODE_FAIL_SANITY data all 0xff\n", __func__);
+        }
+        return DECODE_FAIL_SANITY;
+    }
+
     // Correct start sequence?
     if (b[0] != 0x00) {
         if (decoder->verbose) {

--- a/src/devices/quhwa.c
+++ b/src/devices/quhwa.c
@@ -21,6 +21,14 @@ static int quhwa_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     uint8_t *b = bitbuffer->bb[r];
 
+    // No need to decode/extract values for simple test
+    if (!b[0] && !b[1] && !b[2]) {
+        if (decoder->verbose > 1) {
+            fprintf(stderr, "%s: DECODE_FAIL_SANITY data all 0x00\n", __func__);
+        }
+        return DECODE_FAIL_SANITY;
+    }
+
     b[0] = ~b[0];
     b[1] = ~b[1];
     b[2] = ~b[2];
@@ -32,10 +40,12 @@ static int quhwa_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     uint32_t id = (b[0] << 8) | b[1];
 
+    /* clang-format off */
     data_t *data = data_make(
-            "model", "", DATA_STRING, _X("Quhwa-Doorbell","Quhwa doorbell"),
-            "id", "ID", DATA_INT, id,
+            "model",  "",    DATA_STRING, _X("Quhwa-Doorbell","Quhwa doorbell"),
+            "id",     "ID",  DATA_INT, id,
             NULL);
+    /* clang-format on */
 
     decoder_output_data(decoder, data);
 

--- a/src/devices/s3318p.c
+++ b/src/devices/s3318p.c
@@ -74,6 +74,15 @@ static int s3318p_callback(r_device *decoder, bitbuffer_t *bitbuffer) {
     // remove the two leading 0-bits and align the data
     bitbuffer_extract_bytes(bitbuffer, r, 2, b, 40);
 
+    // No need to decode/extract values for simple test
+    // check id channel temperature humidity value not zero
+    if (!b[0] && !b[1] && !b[2] && !b[3]) {
+        if (decoder->verbose > 1) {
+            fprintf(stderr, "%s: DECODE_FAIL_SANITY data all 0x00\n", __func__);
+        }
+        return DECODE_FAIL_SANITY;
+    }
+
     // CRC-4 poly 0x3, init 0x0 over 32 bits then XOR the next 4 bits
     int crc = crc4(b, 4, 0x3, 0x0) ^ (b[4] >> 4);
     if (crc != (b[4] & 0xf))

--- a/src/devices/schraeder.c
+++ b/src/devices/schraeder.c
@@ -109,6 +109,15 @@ static int schrader_EG53MA4_callback(r_device *decoder, bitbuffer_t *bitbuffer) 
     /* Discard the first 40 bits */
     bitbuffer_extract_bytes(bitbuffer, 0, 40, b, 80);
 
+    // No need to decode/extract values for simple test
+    // check serial flags pressure temperature value not zero
+    if ( !b[1] && !b[2] && !b[4] && !b[5] && !b[7] && !b[8] ) {
+        if (decoder->verbose > 1) {
+            fprintf(stderr, "%s: DECODE_FAIL_SANITY data all 0x00\n", __func__);
+        }
+        return DECODE_FAIL_SANITY;
+    }
+
     /* Calculate the checksum */
     checksum = add_bytes(b, 9) & 0xff;
     if (checksum != b[9]) {

--- a/src/devices/thermopro_tp11.c
+++ b/src/devices/thermopro_tp11.c
@@ -40,18 +40,30 @@ static int thermopro_tp11_sensor_callback(r_device *decoder, bitbuffer_t *bitbuf
         return DECODE_FAIL_MIC;
     }
 
+
+    // No need to decode/extract values for simple test
+    if ( (!bb[row][0] && !bb[row][1] && !bb[row][2] && !bb[row][3])
+       || (bb[row][0] == 0xff && bb[row][1] == 0xff && bb[row][2] == 0xff && bb[row][3] == 0xff)) {
+        if (decoder->verbose > 1) {
+            fprintf(stderr, "%s: DECODE_FAIL_SANITY data all 0x00 or 0xFF\n", __func__);
+        }
+        return DECODE_FAIL_SANITY;
+    }
+
     value = (bb[row][0] << 16) + (bb[row][1] << 8) + bb[row][2];
     device = value >> 12;
 
     temp_raw = value & 0xfff;
     temp_c = (temp_raw - 200) * 0.1f;
 
+    /* clang-format off */
     data = data_make(
             "model",         "",            DATA_STRING, _X("Thermopro-TP11","Thermopro TP11 Thermometer"),
             "id",            "Id",          DATA_INT,    device,
             "temperature_C", "Temperature", DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp_c,
             "mic",           "Integrity",   DATA_STRING, "CRC",
             NULL);
+    /* clang-format on */
     decoder_output_data(decoder, data);
     return 1;
 }

--- a/src/devices/visonic_powercode.c
+++ b/src/devices/visonic_powercode.c
@@ -67,6 +67,15 @@ static int visonic_powercode_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // extract message, drop leading start bit, include trailing LRC nibble
     bitbuffer_extract_bytes(bitbuffer, row, 1, msg, 36);
+
+    // No need to decode/extract values for simple test
+    if (!msg[0] && !msg[1] && !msg[2] && !msg[3] && !msg[4]) {
+        if (decoder->verbose > 1) {
+            fprintf(stderr, "%s: DECODE_FAIL_SANITY data all 0x00\n", __func__);
+        }
+        return DECODE_FAIL_SANITY;
+    }
+
     lrc = xor_bytes(msg, 5);
     if (((lrc >> 4) ^ (lrc & 0xf)) != 0)
        return DECODE_FAIL_MIC;

--- a/src/devices/wssensor.c
+++ b/src/devices/wssensor.c
@@ -44,6 +44,15 @@ static int wssensor_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     b = bitbuffer->bb[r];
 
+    // No need to decode/extract values for simple test
+    if ((!b[0] && !b[1] && !b[2])
+       || (b[0] == 0xff && b[1] == 0xff && b[2] == 0xff)) {
+        if (decoder->verbose > 1) {
+            fprintf(stderr, "%s: DECODE_FAIL_SANITY data all 0x00 or 0xFF\n", __func__);
+        }
+        return DECODE_FAIL_SANITY;
+    }
+
     int temperature;
     int battery_status;
     int startup;


### PR DESCRIPTION
Addresses same issue described in #1441 regarding false positives with all 0x00 or all 0xFF "packets"

Simple manual testing was made to validate Protocol still worked on samples from test repo

Issues/Files Fixed 

Protocol|  Name                 |  0x00  | 0xff | src_file
--------|  -----                |  ----  | ---- | --------
19      |  Nexus-TH             |        |  *   |  nexus.c
21      |  Calibeur-RF104       |    *   |  *   |  calibeur.c
47      |  Conrad-S3318P        |    *   |      |  s3318p.c
49      |  Quhwa-Doorbell       |    *   |      |  quhwa.c
50      |  Oregon-v1            |        |  *   |  oregon_scientific_v1.c
54      |  Oregon-SL109H        |    *   |      |  oregon_scientific_sl109h.c
68      |  Kerui-Security       |    *   |      |  kerui.c
84      |  Thermopro-TP11       |    *   |  *   |  thermopro_tp11.c
87      |  Generic-Motion       |        |  *   |  generic_motion.c
95      |  Schrader-EG53MA4     |    *   |      |  schraeder.c
108     |  Hyundai-WS           |    *   |  *   |  wssensor.c
114     |  Maverick-ET73        |        |  *   |  maverick_et73.c
115     |  Honeywell-ActivLink  |    *   |  *   |  honeywell_wdb.c
116     |  Honeywell-ActivLink  |    *   |  *   |  honeywell_wdb.c
121     |  Opus-XT300           |    *   |      |  opus_xt300.c
131     |  Microchip-HCS200     |        |  *   |  hcs200.c
135     |  Philips-AJ7010       |        |  *   |  philips_aj7010.c
137     |  GT-TMBBQ05           |    *   |      |  gt_tmbbq05.c
149     |  ERT-SCM              |    *   |      |  ert.c
151     |  Visonic-Powercode    |    *   |      |  visonic_powercode.c
152     |  Eurochron-EFTH800    |        |  *   |  efth800.c


_Enjoy_