### PR TITLE
Improve: program exit with a special exit code in case of error

### DIFF
--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -52,7 +52,7 @@ typedef struct r_cfg {
     char const *in_filename;
     int do_exit;
     int do_exit_async;
-    int exit_code; // 0 : no err, 1 : params or cmd line err, 2 : sdr device error, 42 : usb init error
+    int exit_code; ///< 0=no err, 1=params or cmd line err, 2=sdr device read error, 3=usb init error, 5=USB error (reset), other=other error
     int frequencies;
     int frequency_index;
     uint32_t frequency[MAX_FREQS];

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -52,6 +52,7 @@ typedef struct r_cfg {
     char const *in_filename;
     int do_exit;
     int do_exit_async;
+    int exit_code; // 0 : no err, 1 : params or cmd line err, 2 : sdr device error, 42 : usb init error
     int frequencies;
     int frequency_index;
     uint32_t frequency[MAX_FREQS];

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1134,6 +1134,7 @@ static void sighandler(int signum)
     }
     else if (signum == SIGALRM) {
         fprintf(stderr, "Async read stalled, exiting!\n");
+	g_cfg.exit_code = 42;
     }
     else {
         fprintf(stderr, "Signal caught, exiting!\n");
@@ -1501,7 +1502,7 @@ int main(int argc, char **argv) {
     // Normal case, no test data, no in files
     r = sdr_open(&cfg->dev, &demod->sample_size, cfg->dev_query, cfg->verbosity);
     if (r < 0) {
-        exit(1);
+        exit(2);
     }
 
 #ifndef _WIN32
@@ -1588,9 +1589,12 @@ int main(int argc, char **argv) {
         flush_report_data(cfg);
     }
 
-    if (!cfg->do_exit)
+    if (!cfg->do_exit) {
         fprintf(stderr, "\nLibrary error %d, exiting...\n", r);
+	cfg->exit_code = r;
+    }
 
+    r = cfg->exit_code;
     r_free_cfg(cfg);
 
     return r >= 0 ? r : -r;

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1134,7 +1134,7 @@ static void sighandler(int signum)
     }
     else if (signum == SIGALRM) {
         fprintf(stderr, "Async read stalled, exiting!\n");
-	g_cfg.exit_code = 42;
+        g_cfg.exit_code = 3;
     }
     else {
         fprintf(stderr, "Signal caught, exiting!\n");
@@ -1591,10 +1591,11 @@ int main(int argc, char **argv) {
 
     if (!cfg->do_exit) {
         fprintf(stderr, "\nLibrary error %d, exiting...\n", r);
-	cfg->exit_code = r;
+        cfg->exit_code = r;
     }
 
-    r = cfg->exit_code;
+    if (cfg->exit_code >= 0)
+        r = cfg->exit_code;
     r_free_cfg(cfg);
 
     return r >= 0 ? r : -r;


### PR DESCRIPTION
Based on discussion here : https://github.com/merbanan/rtl_433/issues/1394#issuecomment-660213824
I added an exit code to indicate why the program exited. I use it to reset the USB port from time to time, when the libusb report a "stalled" status.