### PR TITLE
Add Nexus-TE82s compatibility note

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [16]  AlectoV1 Weather Sensor (Alecto WS3500 WS4500 Ventus W155/W044 Oregon)
     [17]  Cardin S466-TX2
     [18]  Fine Offset Electronics, WH2, WH5, Telldus Temperature/Humidity/Rain Sensor
-    [19]  Nexus, FreeTec NC-7345, NX-3980 temperature/humidity sensor
+    [19]  Nexus, FreeTec NC-7345, NX-3980, Solight TE82S temperature/humidity sensor
     [20]  Ambient Weather Temperature Sensor
     [21]  Calibeur RF-104 Sensor
     [22]* X10 RF

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -204,7 +204,7 @@ stop_after_successful_events false
   protocol 16  # AlectoV1 Weather Sensor (Alecto WS3500 WS4500 Ventus W155/W044 Oregon)
   protocol 17  # Cardin S466-TX2
   protocol 18  # Fine Offset Electronics, WH2, WH5, Telldus Temperature/Humidity/Rain Sensor
-  protocol 19  # Nexus, FreeTec NC-7345, NX-3980 temperature/humidity sensor
+  protocol 19  # Nexus, FreeTec NC-7345, NX-3980, Solight TE82S temperature/humidity sensor
   protocol 20  # Ambient Weather Temperature Sensor
   protocol 21  # Calibeur RF-104 Sensor
 # protocol 22  # X10 RF

--- a/man/man1/rtl_433.1
+++ b/man/man1/rtl_433.1
@@ -189,7 +189,7 @@ Cardin S466\-TX2
 Fine Offset Electronics, WH2, WH5, Telldus Temperature/Humidity/Rain Sensor
 .TP
 [ \fB19\fI\fP ]
-Nexus, FreeTec NC\-7345, NX\-3980 temperature/humidity sensor
+Nexus, FreeTec NC\-7345, NX\-3980, Solight TE82S temperature/humidity sensor
 .TP
 [ \fB20\fI\fP ]
 Ambient Weather Temperature Sensor

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -11,7 +11,8 @@
 Nexus sensor protocol with ID, temperature and optional humidity
 
 also FreeTec (Pearl) NC-7345 sensors for FreeTec Weatherstation NC-7344,
-also infactory/FreeTec (Pearl) NX-3980 sensors for infactory/FreeTec NX-3974 station.
+also infactory/FreeTec (Pearl) NX-3980 sensors for infactory/FreeTec NX-3974 station,
+also Solight TE82S sensors for Solight TE76/TE82/TE83/TE84 stations.
 
 The sensor sends 36 bits 12 times,
 the packets are ppm modulated (distance coding) with a pulse of ~500 us

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -112,7 +112,7 @@ static char *output_fields[] = {
 };
 
 r_device nexus = {
-        .name        = "Nexus, FreeTec NC-7345, NX-3980 temperature/humidity sensor",
+        .name        = "Nexus, FreeTec NC-7345, NX-3980, Solight TE82S temperature/humidity sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 1000,
         .long_width  = 2000,


### PR DESCRIPTION
Hi,

I got a Solight TE82S sensor and discovered that it uses the Nexus protocol. So I mentioned this device being compatible with the nexus decoder in the docs.