### PR TITLE
Fix opus_xt300 added sanity check to data values

### DIFF
--- a/src/devices/opus_xt300.c
+++ b/src/devices/opus_xt300.c
@@ -41,7 +41,7 @@ static int opus_xt300_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     data_t *data;
 
     for (row = 0; row < bitbuffer->num_rows; row++) {
-        fprintf(stderr, "%s: bits_per_row %d\n", __func__, bitbuffer->bits_per_row[row]);
+
         if (bitbuffer->bits_per_row[row] != 48) {
             fail_code = DECODE_ABORT_LENGTH;
             continue;


### PR DESCRIPTION

Added sanity checks for Temperature,  Moisture.

Sample with bad values (and  wrong Freq ): 

[opus_xt300_err__915M_2000k.cu8.gz](https://github.com/merbanan/rtl_433/files/5061553/opus_xt300_err__915M_2000k.cu8.gz)

```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
time      : 2020-08-12 00:57:42
model     : Opus-XT300   Channel   : 3             Temperature: 215 C        Moisture  : 255 %         Integrity : CHECKSUM
Modulation: ASK          Freq      : 914.3 MHz
RSSI      : -0.2 dB      SNR       : 28.7 dB       Noise     : -28.9 dB
```