### PR TITLE
Fix bad conf for Fan-11t

### DIFF
--- a/conf/fan-11t.conf
+++ b/conf/fan-11t.conf
@@ -81,7 +81,7 @@
 frequency 302.400M
 
 decoder {
-    Fan-11t,
+    name        = Fan-11t,
     modulation  = OOK_PWM,
     short       = 360,
     long        = 710,


### PR DESCRIPTION
prevent from starting when using this conf, with an error message "Bad flex spec, unknown keyword (Fan-11t)!"