### PR TITLE
fix runtime error 'left shift of 229 by 24 places cannot be represent…

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -26,7 +26,7 @@ uint32_t reverse32(uint32_t x)
 {
     uint32_t ret;
     uint8_t* xp = (uint8_t*)&x;
-    ret = reverse8(xp[0]) << 24 | reverse8(xp[1]) << 16 | reverse8(xp[2]) << 8 | reverse8(xp[3]);
+    ret = (uint32_t) reverse8(xp[0]) << 24 | reverse8(xp[1]) << 16 | reverse8(xp[2]) << 8 | reverse8(xp[3]);
     return ret;
 }
 


### PR DESCRIPTION
Fix the runtime error :
/home/shipley/Projects/rtl_433/src/util.c:29:27: runtime error: left shift of 229 by 24 places cannot be represented in type 'int'