### PR TITLE
Tasmotized Sonoff RF-Bridge decoding support

### DIFF
--- a/include/output_mqtt.h
+++ b/include/output_mqtt.h
@@ -13,9 +13,13 @@
 #define INCLUDE_OUTPUT_MQTT_H_
 
 #include "data.h"
+#include "pulse_detect.h"
 
 struct mg_mgr;
 
 struct data_output *data_output_mqtt_create(struct mg_mgr *mgr, char *param, char const *dev_hint);
+
+const char *input_mqtt_rfraw_config(const char *topic);
+int input_mqtt_rfraw_read(pulse_data_t *data);
 
 #endif /* INCLUDE_OUTPUT_MQTT_H_ */


### PR DESCRIPTION
The [tasmotized Sonoff RF-Bridge](https://tasmota.github.io/docs/devices/Sonoff-RF-Bridge-433/#b1-to-b0-conversion-tools) could be a great tool for RF433 communication. The device contains a small EFM8BB1 MCU for RF433 communication, the firmware of which can be replaced by an open source alternative (Portisch firmware). The MCU is so resourceless, that it can support just a few RF433 protocols. But it has a hidden gem, called bucket sniffing.

The bucket sniffing output is a small pulse description message transmitted via the MQTT protocol. This addition listens for these messages and translates them into the standard PULSE_OOK format and lets the existing decoders do their jobs.