### PR TITLE
fix warning declaration of function ‘memcmp’

### DIFF
--- a/src/pulse_analyzer.c
+++ b/src/pulse_analyzer.c
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <strings.h>
+#include <string.h>
 
 #define MAX_HIST_BINS 16
 


### PR DESCRIPTION
Fixes warning :

```
[  3%] Building C object src/CMakeFiles/r_433.dir/pulse_analyzer.c.
/root/Projects/rtl_433/src/pulse_analyzer.c: In function ‘pulse_analyzer’:
/root/Projects/rtl_433/src/pulse_analyzer.c:398:29: warning: implicit declaration of function ‘memcmp’ [-Wimplicit-function-declaration]
  398 |                         && !memcmp(&hexstrs[hexstr_cnt - 1].p[5], &hexstr->p[5], hexstr->idx - 5)) {
      |                             ^~~~~~
/root/Projects/rtl_433/src/pulse_analyzer.c:398:94: warning: ‘memcmp’ argument 3 type is ‘unsigned int’ where ‘long unsigned int’ is expected in a call to built-in function declared without prototype [-Wbuiltin-declaration-mismatch]
  398 |                         && !memcmp(&hexstrs[hexstr_cnt - 1].p[5], &hexstr->p[5], hexstr->idx - 5)) {
      |                                                                                  ~~~~~~~~~~~~^~~
<built-in>: note: built-in ‘memcmp’ declared here
```
