### PR TITLE
Revert Acurite subtype to message_type

### DIFF
--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -544,7 +544,7 @@ static int acurite_atlas_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsig
             "channel",              NULL,           DATA_STRING, &channel_str,
             "sequence_num",         NULL,           DATA_INT,    sequence_num,
             "battery_ok",           NULL,           DATA_INT,    !battery_low,
-            "subtype",              NULL,           DATA_INT,    message_type,
+            "message_type",              NULL,           DATA_INT,    message_type,
             "wind_avg_mi_h",        "Wind Speed",   DATA_FORMAT, "%.1f mi/h", DATA_DOUBLE, wind_speed_mph,
             NULL);
     /* clang-format on */
@@ -789,7 +789,7 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 /* clang-format off */
                 data = data_make(
                         "model",        "",   DATA_STRING,    _X("Acurite-5n1","Acurite 5n1 sensor"),
-                        _X("subtype","message_type"), NULL,   DATA_INT,       message_type,
+                        "message_type", NULL,   DATA_INT,       message_type,
                         _X("id", "sensor_id"),    NULL, DATA_INT,       sensor_id,
                         "channel",      NULL,   DATA_STRING,    &channel_str,
                         "sequence_num",  NULL,   DATA_INT,      sequence_num,
@@ -816,7 +816,7 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 /* clang-format off */
                 data = data_make(
                         "model",        "",   DATA_STRING,    _X("Acurite-5n1","Acurite 5n1 sensor"),
-                        _X("subtype","message_type"), NULL,   DATA_INT,       message_type,
+                        "message_type", NULL,   DATA_INT,       message_type,
                         _X("id", "sensor_id"),    NULL, DATA_INT,  sensor_id,
                         "channel",      NULL,   DATA_STRING,    &channel_str,
                         "sequence_num",  NULL,   DATA_INT,      sequence_num,
@@ -845,7 +845,7 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 /* clang-format off */
                 data = data_make(
                         "model",        "",   DATA_STRING,    _X("Acurite-3n1","Acurite 3n1 sensor"),
-                        _X("subtype","message_type"), NULL,   DATA_INT,       message_type,
+                        "message_type", NULL,   DATA_INT,       message_type,
                         _X("id", "sensor_id"),    NULL,   DATA_FORMAT,    "0x%02X",   DATA_INT,       sensor_id,
                         "channel",      NULL,   DATA_STRING,    &channel_str,
                         "sequence_num",  NULL,   DATA_INT,      sequence_num,
@@ -1336,7 +1336,7 @@ r_device acurite_th = {
  */
 static char *acurite_txr_output_fields[] = {
         "model",
-        "subtype",
+        "subtype",      // TODO: remove this
         "message_type", // TODO: remove this
         "id",
         "sensor_id", // TODO: remove this


### PR DESCRIPTION
Per the discussion in #1510, `subtype` is used incorrectly for Acurite weather stations that send multiple message types. Per @zuckschwerdt `subtype` is intended to be used to identify somewhat distinct sub-devices. Message type isn't used that way for the Acurite 5n1 and Acurite Atlas which send 2 or 3 different message types respectively.

`subtype` is used in the naming of MQTT topics and possibly other output forms. The default topic is made using the following fields from the data.

    rtl_433/[host]/devices[/type][/model][/subtype][/channel][/id]

Identifying the Acurite `message_type` as `subtype` causes there to be 2 or 3 different topic prefixes for the one device. To get all of the wind speed updates, it would be required to subscribe to all 2 or 3 topics under the different subtypes.

This is potentially a breaking change for people who are using Acurite 5n1 or Atlas weather stations and `-F mqtt` output of rtl_33.

Note: I didn't change the use of subtype for the 275 sensor, which looks like it behaves differently depending on whether a probe is attached. I don't have enough info about that device to know what would be right for that device.
