### PR TITLE
Added output format option to flex getters

### DIFF
--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -71,6 +71,7 @@ struct flex_get {
     unsigned long mask;
     const char *name;
     struct flex_map map[GETTER_MAP_SLOTS];
+    const char *format;
 };
 
 #define GETTER_SLOTS 8
@@ -126,9 +127,15 @@ static void render_getters(data_t *data, uint8_t *bits, struct flex_params *para
             }
         }
         if (!getter->map[m].val) {
-            data_append(data,
+            if(getter->format) {
+                data_append(data,
+                    getter->name, "", DATA_FORMAT, getter->format, DATA_INT, val,
+                    NULL);
+            } else {
+                data_append(data,
                     getter->name, "", DATA_INT, val,
                     NULL);
+            }
         }
     }
 }
@@ -473,6 +480,9 @@ static void parse_getter(const char *arg, struct flex_get *getter)
         else if (*arg == '{' || (*arg >= '0' && *arg <= '9')) {
             getter->bit_count = parse_bits(arg, bitrow);
             getter->mask = extract_number(bitrow, 0, getter->bit_count);
+        }
+        else if (*arg == '%') {
+            getter->format = strdup(arg);
         }
         else {
             getter->name = strdup(arg);

--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -127,7 +127,7 @@ static void render_getters(data_t *data, uint8_t *bits, struct flex_params *para
             }
         }
         if (!getter->map[m].val) {
-            if(getter->format) {
+            if (getter->format) {
                 data_append(data,
                     getter->name, "", DATA_FORMAT, getter->format, DATA_INT, val,
                     NULL);
@@ -483,6 +483,8 @@ static void parse_getter(const char *arg, struct flex_get *getter)
         }
         else if (*arg == '%') {
             getter->format = strdup(arg);
+            if (!getter->name)
+                FATAL_STRDUP("parse_getter()");
         }
         else {
             getter->name = strdup(arg);

--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -483,7 +483,7 @@ static void parse_getter(const char *arg, struct flex_get *getter)
         }
         else if (*arg == '%') {
             getter->format = strdup(arg);
-            if (!getter->name)
+            if (!getter->format)
                 FATAL_STRDUP("parse_getter()");
         }
         else {


### PR DESCRIPTION
Added an option to specify an output format for flex getters, e.g. like so:

-X "(...),get=@2:{32}:code:%x"

to get the value in hexadecimal instead of the default int. (When showing values as integers I sometimes got big negative numbers, which were ugly at best.)
