### PR TITLE
Enable more warnings and prevent or suppress current ones

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,6 @@ if(("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" MATCHES 
     ADD_DEFINITIONS(-Wextra)
     ADD_DEFINITIONS(-Wsign-compare)
     ADD_DEFINITIONS(-Wno-unused)
-    ADD_DEFINITIONS(-Wno-unused-parameter)
     ADD_DEFINITIONS(-Wno-missing-field-initializers)
     ADD_DEFINITIONS(-std=c99)
     ADD_DEFINITIONS(-pedantic)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,6 @@ if(("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" MATCHES 
     ADD_DEFINITIONS(-Wall)
     ADD_DEFINITIONS(-Wextra)
     ADD_DEFINITIONS(-Wsign-compare)
-    ADD_DEFINITIONS(-Wno-unused)
     ADD_DEFINITIONS(-Wno-missing-field-initializers)
     ADD_DEFINITIONS(-std=c99)
     ADD_DEFINITIONS(-pedantic)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,6 @@ if(("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" MATCHES 
     ADD_DEFINITIONS(-Wall)
     ADD_DEFINITIONS(-Wextra)
     ADD_DEFINITIONS(-Wsign-compare)
-    ADD_DEFINITIONS(-Wno-missing-field-initializers)
     ADD_DEFINITIONS(-std=c99)
     ADD_DEFINITIONS(-pedantic)
     # for strdup, setenv, use either

--- a/include/r_util.h
+++ b/include/r_util.h
@@ -27,6 +27,14 @@
 // buffer to hold localized timestamp "YYYY-MM-DD HH:MM:SS.000000+0000"
 #define LOCAL_TIME_BUFLEN 32
 
+// Macro to prevent unused variables (passed into a function)
+// from generating a warning.
+#define UNUSED(x) (void)(x)
+// Macro to signal that that variable might not be used.
+// Useful when a variable is used only in an ifdef block that may or
+// may not be enabled.
+#define POSSIBLY_UNUSED(x) (void)(x)
+
 /** Get current time with usec precision.
 
     @param tv output for current time

--- a/src/baseband.c
+++ b/src/baseband.c
@@ -16,6 +16,8 @@
 #include <string.h>
 #include <math.h>
 
+#include "r_util.h"
+
 static uint16_t scaled_squares[256];
 
 /// precalculate lookup table for envelope detection.
@@ -257,6 +259,7 @@ static int32_t atan2_int32(int32_t y, int32_t x)
 /// for evaluation.
 void baseband_demod_FM_cs16(int16_t const *x_buf, int16_t *y_buf, unsigned long num_samples, demodfm_state_t *state, unsigned fpdm)
 {
+    UNUSED(fpdm);
     ///  [b,a] = butter(1, 0.1) -> 3x tau (95%) ~10 samples
     //static int const alp[2] = {FIX32(1.00000), FIX32(0.72654)};
     //static int const blp[2] = {FIX32(0.13673), FIX32(0.13673)};

--- a/src/data.c
+++ b/src/data.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <limits.h>
+
 // gethostname() needs _XOPEN_SOURCE 500 on unistd.h
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 500
@@ -58,6 +59,7 @@
 #include "term_ctl.h"
 #include "abuf.h"
 #include "fatal.h"
+#include "r_util.h"
 
 #include "data.h"
 
@@ -474,6 +476,7 @@ static void print_json_array(data_output_t *output, data_array_t *array, char co
 
 static void print_json_data(data_output_t *output, data_t *data, char const *format)
 {
+    UNUSED(format);
     bool separator = false;
     fputc('{', output->file);
     while (data) {
@@ -490,6 +493,7 @@ static void print_json_data(data_output_t *output, data_t *data, char const *for
 
 static void print_json_string(data_output_t *output, const char *str, char const *format)
 {
+    UNUSED(format);
     fprintf(output->file, "\"");
     while (*str) {
         if (*str == '"' || *str == '\\')
@@ -502,11 +506,13 @@ static void print_json_string(data_output_t *output, const char *str, char const
 
 static void print_json_double(data_output_t *output, double data, char const *format)
 {
+    UNUSED(format);
     fprintf(output->file, "%.3f", data);
 }
 
 static void print_json_int(data_output_t *output, int data, char const *format)
 {
+    UNUSED(format);
     fprintf(output->file, "%d", data);
 }
 
@@ -588,6 +594,7 @@ typedef struct {
 
 static void print_kv_data(data_output_t *output, data_t *data, char const *format)
 {
+    UNUSED(format);
     data_output_kv_t *kv = (data_output_kv_t *)output;
 
     int color = kv->color;
@@ -737,6 +744,7 @@ typedef struct {
 
 static void print_csv_data(data_output_t *output, data_t *data, char const *format)
 {
+    UNUSED(format);
     data_output_csv_t *csv = (data_output_csv_t *)output;
 
     const char **fields = csv->fields;
@@ -782,6 +790,7 @@ static void print_csv_array(data_output_t *output, data_array_t *array, char con
 
 static void print_csv_string(data_output_t *output, const char *str, char const *format)
 {
+    UNUSED(format);
     data_output_csv_t *csv = (data_output_csv_t *)output;
 
     while (*str) {
@@ -879,11 +888,13 @@ alloc_error:
 
 static void print_csv_double(data_output_t *output, double data, char const *format)
 {
+    UNUSED(format);
     fprintf(output->file, "%.3f", data);
 }
 
 static void print_csv_int(data_output_t *output, int data, char const *format)
 {
+    UNUSED(format);
     fprintf(output->file, "%d", data);
 }
 
@@ -937,6 +948,7 @@ static void format_jsons_array(data_output_t *output, data_array_t *array, char 
 
 static void format_jsons_object(data_output_t *output, data_t *data, char const *format)
 {
+    UNUSED(format);
     data_print_jsons_t *jsons = (data_print_jsons_t *)output;
 
     bool separator = false;
@@ -955,6 +967,7 @@ static void format_jsons_object(data_output_t *output, data_t *data, char const 
 
 static void format_jsons_string(data_output_t *output, const char *str, char const *format)
 {
+    UNUSED(format);
     data_print_jsons_t *jsons = (data_print_jsons_t *)output;
 
     char *buf   = jsons->msg.tail;
@@ -986,6 +999,7 @@ static void format_jsons_string(data_output_t *output, const char *str, char con
 
 static void format_jsons_double(data_output_t *output, double data, char const *format)
 {
+    UNUSED(format);
     data_print_jsons_t *jsons = (data_print_jsons_t *)output;
     // use scientific notation for very big/small values
     if (data > 1e7 || data < 1e-4) {
@@ -1004,6 +1018,7 @@ static void format_jsons_double(data_output_t *output, double data, char const *
 
 static void format_jsons_int(data_output_t *output, int data, char const *format)
 {
+    UNUSED(format);
     data_print_jsons_t *jsons = (data_print_jsons_t *)output;
     abuf_printf(&jsons->msg, "%d", data);
 }
@@ -1108,6 +1123,7 @@ typedef struct {
 
 static void print_syslog_data(data_output_t *output, data_t *data, char const *format)
 {
+    UNUSED(format);
     data_output_syslog_t *syslog = (data_output_syslog_t *)output;
 
     // we expect a normal message around 500 bytes

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -339,7 +339,8 @@ Notes:
 static int acurite_6045_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row)
 {
     float tempf;
-    uint8_t humidity, message_type, l_status;
+    uint8_t humidity;
+    // uint8_t message_type, l_status;
     char channel, channel_str[2];
     char raw_str[31], *rawp;
     uint16_t sensor_id;
@@ -360,7 +361,7 @@ static int acurite_6045_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     battery_low = (bb[2] & 0x40) == 0;
     humidity = (bb[3] & 0x7f); // 1-99 %rH, same as TXR
     active = (bb[4] & 0x40) == 0x40;    // Sensor is actively listening for strikes
-    message_type = bb[2] & 0x3f;
+    //message_type = bb[2] & 0x3f;
 
     // 12 bits of temperature after removing parity and status bits.
     // Message native format appears to be in 1/10 of a degree Fahrenheit
@@ -373,7 +374,7 @@ static int acurite_6045_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     strike_count = ((bb[6] & 0x7f) << 1) | ((bb[7] & 0x40) >> 6);
     strike_distance = bb[7] & 0x1f;
     rfi_detect = (bb[7] & 0x20) == 0x20;
-    l_status = (bb[7] & 0x60) >> 5;
+    //l_status = (bb[7] & 0x60) >> 5;
 
     /*
      * 2018-04-21 rct - There are still a number of unknown bits in the
@@ -648,7 +649,8 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int browlen, valid = 0;
     uint8_t *bb;
     float tempc, tempf, wind_dir, wind_speed_kph, wind_speed_mph;
-    uint8_t humidity, sensor_status, sequence_num, message_type;
+    uint8_t humidity, sequence_num, message_type;
+    // uint8_t sensor_status;
     char channel;
     char channel_str[2];
     uint16_t sensor_id;
@@ -715,7 +717,7 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             // Tower sensor ID is the last 14 bits of byte 0 and 1
             // CCII IIII | IIII IIII
             sensor_id = ((bb[0] & 0x3f) << 8) | bb[1];
-            sensor_status = bb[2]; // TODO:, uses parity? & 0x07f
+            //sensor_status = bb[2]; // TODO:, uses parity? & 0x07f
             humidity = (bb[3] & 0x7f); // 1-99 %rH
             // temperature encoding used by "tower" sensors 592txr
             // 14 bits available after removing both parity bits.

--- a/src/devices/ambientweather_wh31e.c
+++ b/src/devices/ambientweather_wh31e.c
@@ -193,8 +193,9 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
         // remove preamble, keep whole payload
         bitbuffer_extract_bytes(bitbuffer, row, start_pos + 24, b, 18 * 8);
+        msg_type = b[0];
 
-        if (b[0] == 0x30) {
+        if (msg_type == 0x30) {
             // WH31E
             uint8_t c_crc = crc8(b, 6, 0x31, 0x00);
             if (c_crc) {
@@ -209,7 +210,6 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 continue; // DECODE_FAIL_MIC
             }
 
-            msg_type   = b[0]; // fixed 0x30
             id         = b[1];
             battery_ok = (b[2] >> 7);
             channel    = ((b[2] & 0x70) >> 4) + 1;
@@ -234,7 +234,7 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             events++;
         }
 
-        else if (b[0] == 0x52) {
+        else if (msg_type == 0x52) {
             // WH31E (others?) RCC
             uint8_t c_crc = crc8(b, 10, 0x31, 0x00);
             if (c_crc) {
@@ -249,7 +249,6 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 continue; // DECODE_FAIL_MIC
             }
 
-            msg_type   = b[0]; // fixed 0x52
             id         = b[1];
             int unknown = b[2];
             int year    = ((b[3] & 0xF0) >> 4) * 10 + (b[3] & 0x0F) + 2000;
@@ -276,7 +275,7 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             events++;
         }
 
-        else if (b[0] == 0x40) {
+        else if (msg_type == 0x40) {
             // WH40
             uint8_t c_crc = crc8(b, 8, 0x31, 0x00);
             if (c_crc) {
@@ -291,7 +290,6 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 continue; // DECODE_FAIL_MIC
             }
 
-            msg_type   = b[0]; // fixed 0x40
             id         = (b[2] << 8) | b[3];
             battery_ok = (b[4] >> 7);
             channel    = ((b[4] & 0x70) >> 4) + 1;
@@ -313,7 +311,7 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             events++;
         }
 
-        else if (b[0] == 0x68) {
+        else if (msg_type == 0x68) {
             // WS68
             uint8_t c_crc = crc8(b, 15, 0x31, 0x00);
             if (c_crc) {
@@ -328,7 +326,6 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 continue; // DECODE_FAIL_MIC
             }
 
-            msg_type   = b[0]; // fixed 0x68
             id         = (b[2] << 8) | b[3];
             int lux    = (b[4] << 8) | b[5];
             int batt   = b[6];
@@ -358,7 +355,7 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
         else {
             if (decoder->verbose)
-                fprintf(stderr, "%s: unknown message type %02x (expected 0x30/0x40/0x68)\n", __func__, b[0]);
+                fprintf(stderr, "%s: unknown message type %02x (expected 0x30/0x40/0x68)\n", __func__, msg_type);
         }
     }
     return events;

--- a/src/devices/bresser_3ch.c
+++ b/src/devices/bresser_3ch.c
@@ -40,7 +40,8 @@ static int bresser_3ch_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     data_t *data;
     uint8_t *b;
 
-    int id, status, battery_low, test, channel, temp_raw, humidity;
+    int id, battery_low, channel, temp_raw, humidity;
+    // int status, test;
     float temp_f;
 
     int r = bitbuffer_find_repeated_row(bitbuffer, 3, 40);
@@ -63,9 +64,9 @@ static int bresser_3ch_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     id = b[0];
-    status = b[1];
+    //status = b[1];
     battery_low = (b[1] & 0x80) >> 7;
-    test = (b[1] & 0x40) >> 6;
+    //test = (b[1] & 0x40) >> 6;
     channel = (b[1] & 0x30) >> 4;
 
     temp_raw = ((b[1] & 0x0F) << 8) + b[2];

--- a/src/devices/dsc.c
+++ b/src/devices/dsc.c
@@ -106,7 +106,7 @@ static int dsc_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     int valid_cnt = 0;
     uint8_t bytes[5];
     uint8_t status, crc;
-    int subtype;
+    //int subtype;
     uint32_t esn;
     char status_str[3];
     char esn_str[7];
@@ -164,7 +164,7 @@ static int dsc_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         }
 
         status = bytes[0];
-        subtype = bytes[1] >> 4;  // @todo needed for detecing keyfob
+        //subtype = bytes[1] >> 4;  // @todo needed for detecing keyfob
         esn = (bytes[1] << 16) | (bytes[2] << 8) | bytes[3];
         crc = bytes[4];
 

--- a/src/devices/elv.c
+++ b/src/devices/elv.c
@@ -31,7 +31,7 @@ static int em1000_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     uint8_t bytes=0;
     uint8_t bit=18; // preamble
     uint8_t bb_p[14];
-    char* types[] = {"EM 1000-S", "EM 1000-?", "EM 1000-GZ"};
+    //char* types[] = {"EM 1000-S", "EM 1000-?", "EM 1000-GZ"};
     uint8_t checksum_calculated = 0;
     uint8_t i;
     uint8_t stopbit;
@@ -71,7 +71,7 @@ static int em1000_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 //for (i = 0; i < bytes; i++) fprintf(stderr, "%02X ", dec[i]); fprintf(stderr, "\n");
 
     // based on 15_CUL_EM.pm
-    char *subtype = dec[0] >= 1 && dec[0] <= 3 ? types[dec[0] - 1] : "?";
+    //char *subtype = dec[0] >= 1 && dec[0] <= 3 ? types[dec[0] - 1] : "?";
     int code      = dec[1];
     int seqno     = dec[2];
     int total     = dec[3] | dec[4] << 8;

--- a/src/devices/idm.c
+++ b/src/devices/idm.c
@@ -110,7 +110,7 @@ static int idm_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     char TamperCounters_str[16];
     uint16_t AsynchronousCounters;
     // char AsynchronousCounters_str[8];
-    uint64_t PowerOutageFlags = 0; // 6 bytes
+    //uint64_t PowerOutageFlags = 0; // 6 bytes
     char PowerOutageFlags_str[16];
     uint32_t LastConsumptionCount;
     uint32_t DifferentialConsumptionIntervals[47] = {0}; // 47 intervals of 9-bit unsigned integers
@@ -374,17 +374,17 @@ static int netidm_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     uint8_t ModuleProgrammingState;
     // char  ModuleProgrammingState_str[5];
 
-    uint8_t Unknown_field_1[13];
+    //uint8_t Unknown_field_1[13];
     char Unknown_field_1_str[32];
 
     uint32_t LastGenerationCount = 0;
-    char LastGenerationCount_str[16];
+    //char LastGenerationCount_str[16];
 
-    uint8_t Unknown_field_2[3];
+    //uint8_t Unknown_field_2[3];
     char Unknown_field_2_str[9];
 
     uint32_t LastConsumptionCount;
-    char LastConsumptionCount_str[16];
+    //char LastConsumptionCount_str[16];
 
     // uint64_t TamperCounters = 0;  // 6 bytes
     char TamperCounters_str[16];

--- a/src/devices/idm.c
+++ b/src/devices/idm.c
@@ -96,7 +96,7 @@ static int idm_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     char PacketTypeID_str[5];
     uint8_t PacketLength;
     // char    PacketLength_str[5];
-    uint8_t HammingCode;
+    //uint8_t HammingCode;
     // char    HammingCode_str[5];
     uint8_t ApplicationVersion;
     // char    ApplicationVersion_str[5];
@@ -193,7 +193,7 @@ static int idm_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     PacketLength = b[3];
     // snprintf(PacketLength_str, sizeof(PacketLength_str), "0x%02X", PacketLength);
 
-    HammingCode = b[4];
+    //HammingCode = b[4];
     // snprintf(HammingCode_str, sizeof(HammingCode_str), "0x%02X", HammingCode);
 
     ApplicationVersion = b[5];
@@ -363,7 +363,7 @@ static int netidm_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     char PacketTypeID_str[5];
     uint8_t PacketLength;
     // char    PacketLength_str[5];
-    uint8_t HammingCode;
+    //uint8_t HammingCode;
     // char    HammingCode_str[5];
     uint8_t ApplicationVersion;
     // char    ApplicationVersion_str[5];
@@ -470,7 +470,7 @@ static int netidm_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     PacketLength = b[3];
     // snprintf(PacketLength_str, sizeof(PacketLength_str), "0x%02X", PacketLength);
 
-    HammingCode = b[4];
+    //HammingCode = b[4];
     // snprintf(HammingCode_str, sizeof(HammingCode_str), "0x%02X", HammingCode);
 
     ApplicationVersion = b[5];

--- a/src/devices/ikea_sparsnas.c
+++ b/src/devices/ikea_sparsnas.c
@@ -255,14 +255,14 @@ static int ikea_sparsnas_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     uint16_t effect = (decrypted[11] <<  8 | decrypted[12]);
     uint32_t pulses = ((unsigned)decrypted[13] << 24 | decrypted[14] << 16 | decrypted[15] << 8 | decrypted[16]);
     uint8_t battery =  decrypted[17];
-    float watt = effect * 24.;
+    //float watt = effect * 24.;
     uint8_t mode = decrypted[4]^0x0f;
 
-    if (mode == 1) {     //Note that mode cycles between 0-3 when you first put in the batteries in
-      watt = ((3600000.0 / ikea_sparsnas_pulses_per_kwh) * 1024.0) / effect;
-    } else if (mode == 0 ) { // special mode for low power usage
-      watt = effect * 0.24 / ikea_sparsnas_pulses_per_kwh;
-    }
+    //if (mode == 1) {     //Note that mode cycles between 0-3 when you first put in the batteries in
+    //  watt = ((3600000.0 / ikea_sparsnas_pulses_per_kwh) * 1024.0) / effect;
+    //} else if (mode == 0 ) { // special mode for low power usage
+    //  watt = effect * 0.24 / ikea_sparsnas_pulses_per_kwh;
+    //}
     float cumulative_kWh = ((float)pulses) / ((float)ikea_sparsnas_pulses_per_kwh);
 
     data_t *data;

--- a/src/devices/lacrosse_wr1.c
+++ b/src/devices/lacrosse_wr1.c
@@ -59,7 +59,8 @@ static int lacrosse_wr1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     uint32_t id;
     int flags, seq, offset, chk;
     int raw_wind, direction, raw_rain1, raw_rain2;
-    float speed_kmh, rain_mm;
+    float speed_kmh;
+    // float rain_mm;
 
     if (bitbuffer->bits_per_row[0] < 120) {
         if (decoder->verbose) {
@@ -112,7 +113,7 @@ static int lacrosse_wr1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // base and/or scale adjustments
     speed_kmh = raw_wind * 0.1f;
-    rain_mm   = 0.0;  // dummy until we know what raw_rain1 and raw_rain2 mean
+    //rain_mm   = 0.0;  // dummy until we know what raw_rain1 and raw_rain2 mean
 
     /* clang-format off */
     data = data_make(

--- a/src/devices/lacrossews.c
+++ b/src/devices/lacrossews.c
@@ -94,7 +94,8 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     int row;
     int events = 0;
     uint8_t msg_nybbles[(LACROSSE_WS_BITLEN / 4)];
-    uint8_t ws_id, msg_type, sensor_id, msg_data, msg_unknown, msg_checksum;
+    uint8_t ws_id, msg_type, sensor_id;
+    // uint8_t msg_data, msg_unknown, msg_checksum;
     int msg_value_bcd, msg_value_bcd2, msg_value_bin;
     float temp_c, wind_dir, wind_spd, rain_mm;
     char *wind_key, *wind_label;
@@ -108,12 +109,12 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         ws_id          = (msg_nybbles[0] << 4) + msg_nybbles[1];
         msg_type       = ((msg_nybbles[2] >> 1) & 0x4) + (msg_nybbles[2] & 0x3);
         sensor_id      = (msg_nybbles[3] << 4) + msg_nybbles[4];
-        msg_data       = (msg_nybbles[5] << 1) + (msg_nybbles[6] >> 3);
-        msg_unknown    = msg_nybbles[6] & 0x01;
+        //msg_data       = (msg_nybbles[5] << 1) + (msg_nybbles[6] >> 3);
+        //msg_unknown    = msg_nybbles[6] & 0x01;
         msg_value_bcd  = msg_nybbles[7] * 100 + msg_nybbles[8] * 10 + msg_nybbles[9];
         msg_value_bcd2 = msg_nybbles[7] * 10 + msg_nybbles[8];
         msg_value_bin  = (msg_nybbles[7] * 256 + msg_nybbles[8] * 16 + msg_nybbles[9]);
-        msg_checksum   = msg_nybbles[12];
+        //msg_checksum   = msg_nybbles[12];
 
         switch (msg_type) {
 

--- a/src/devices/m_bus.c
+++ b/src/devices/m_bus.c
@@ -346,7 +346,7 @@ static void parse_payload(data_t *data, const m_bus_block1_t *block1, const m_bu
     return;
 }
 
-static int parse_block2(r_device *decoder, const m_bus_data_t *in, m_bus_block1_t *block1)
+static int parse_block2(const m_bus_data_t *in, m_bus_block1_t *block1)
 {
     m_bus_block2_t *b2 = &block1->block2;
     const uint8_t *b = in->data+BLOCK1A_SIZE;
@@ -418,7 +418,7 @@ static int m_bus_decode_format_a(r_device *decoder, const m_bus_data_t *in, m_bu
         memcpy(out_ptr, in_ptr, block_size);
     }
 
-    parse_block2(decoder, in, block1);
+    parse_block2(in, block1);
 
     return 1;
 }

--- a/src/devices/m_bus.c
+++ b/src/devices/m_bus.c
@@ -693,7 +693,6 @@ static int m_bus_mode_f_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 static int m_bus_mode_s_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     static const uint8_t PREAMBLE_S[]  = {0x54, 0x76, 0x96};  // Mode S Preamble
-    unsigned int start_pos;
     bitbuffer_t packet_bits = {0};
     m_bus_data_t    data_in     = {0};  // Data from Physical layer decoded to bytes
     m_bus_data_t    data_out    = {0};  // Data from Data Link layer
@@ -706,7 +705,7 @@ static int m_bus_mode_s_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // Find a Mode S data package
     unsigned bit_offset = bitbuffer_search(bitbuffer, 0, 0, PREAMBLE_S, sizeof(PREAMBLE_S)*8);
-    start_pos = bitbuffer_manchester_decode(bitbuffer, 0, bit_offset+sizeof(PREAMBLE_S)*8, &packet_bits, 800);
+    bitbuffer_manchester_decode(bitbuffer, 0, bit_offset+sizeof(PREAMBLE_S)*8, &packet_bits, 800);
     data_in.length = (bitbuffer->bits_per_row[0]);
     bitbuffer_extract_bytes(&packet_bits, 0, 0, data_in.data, data_in.length);
 

--- a/src/devices/m_bus.c
+++ b/src/devices/m_bus.c
@@ -282,9 +282,10 @@ static void parse_payload(data_t *data, const m_bus_block1_t *block1, const m_bu
     uint8_t vife_cnt = 0;
     uint8_t vif_uam = 0;
     uint8_t vif_linear = 0;
-    uint8_t vife = 0;
-    uint8_t exponent = 0;
-    int cnt = 0, consumed;
+    //uint8_t vife = 0;
+    //uint8_t exponent = 0;
+    //int cnt = 0, consumed;
+    int consumed;
 
     /* Align offset pointer, there might be 2 0x2F bytes */
     if (b[off] == 0x2F) off++;
@@ -646,9 +647,9 @@ static int m_bus_mode_f_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 //  static const uint8_t PREAMBLE_FA[] = {0x55, 0xF6, 0x8D};  // Mode F, format A Preamble
 //  static const uint8_t PREAMBLE_FB[] = {0x55, 0xF6, 0x72};  // Mode F, format B Preamble
 
-    m_bus_data_t    data_in     = {0};  // Data from Physical layer decoded to bytes
-    m_bus_data_t    data_out    = {0};  // Data from Data Link layer
-    m_bus_block1_t  block1      = {0};  // Block1 fields from Data Link layer
+    //m_bus_data_t    data_in     = {0};  // Data from Physical layer decoded to bytes
+    //m_bus_data_t    data_out    = {0};  // Data from Data Link layer
+    //m_bus_block1_t  block1      = {0};  // Block1 fields from Data Link layer
 
     // Validate package length
     if (bitbuffer->bits_per_row[0] < (32+13*8) || bitbuffer->bits_per_row[0] > (64+256*8)) {  // Min/Max (Preamble + payload)

--- a/src/devices/oregon_scientific_v1.c
+++ b/src/devices/oregon_scientific_v1.c
@@ -31,9 +31,11 @@ static int oregon_scientific_v1_callback(r_device *decoder, bitbuffer_t *bitbuff
     int cs;
     int i;
     int nibble[OSV1_BITS/4];
-    int sid, channel, uk1;
+    int sid, channel;
+    // int uk1;
     float tempC;
-    int battery, uk2, sign, uk3, checksum;
+    int battery, sign, checksum;
+    // int uk2, uk3;
     data_t *data;
 
     for (row = 0; row < bitbuffer->num_rows; row++) {
@@ -67,12 +69,12 @@ static int oregon_scientific_v1_callback(r_device *decoder, bitbuffer_t *bitbuff
 
         sid      = nibble[0];
         channel  = ((nibble[1] >> 2) & 0x03) + 1;
-        uk1      = (nibble[1] >> 0) & 0x03; /* unknown.  Seen change every 60 minutes */
+        //uk1      = (nibble[1] >> 0) & 0x03; /* unknown.  Seen change every 60 minutes */
         tempC    =  nibble[2] * 0.1 + nibble[3] + nibble[4] * 10.;
         battery  = (nibble[5] >> 3) & 0x01;
-        uk2      = (nibble[5] >> 2) & 0x01; /* unknown.  Always zero? */
+        //uk2      = (nibble[5] >> 2) & 0x01; /* unknown.  Always zero? */
         sign     = (nibble[5] >> 1) & 0x01;
-        uk3      = (nibble[5] >> 0) & 0x01; /* unknown.  Always zero? */
+        //uk3      = (nibble[5] >> 0) & 0x01; /* unknown.  Always zero? */
 
         if (sign)
             tempC = -tempC;

--- a/src/devices/proove.c
+++ b/src/devices/proove.c
@@ -61,7 +61,7 @@ static int proove_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     bitbuffer_t databits = {0};
     // note: not manchester encoded but actually ternary
-    unsigned pos = bitbuffer_manchester_decode(bitbuffer, 0, 0, &databits, 80);
+    bitbuffer_manchester_decode(bitbuffer, 0, 0, &databits, 80);
 
     /* Reject codes when Manchester decoding fails */
     /* 32 bits or 36 bits with dimmer value */

--- a/src/devices/secplus_v2.c
+++ b/src/devices/secplus_v2.c
@@ -259,11 +259,11 @@ static int secplus_v2_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     bitbuffer_t bits = {0};
     // int i            = 0;
 
-    bitbuffer_t bits_1    = {0};
+    //bitbuffer_t bits_1    = {0};
     bitbuffer_t fixed_1   = {0};
     uint8_t rolling_1[16] = {0};
 
-    bitbuffer_t bits_2    = {0};
+    //bitbuffer_t bits_2    = {0};
     bitbuffer_t fixed_2   = {0};
     uint8_t rolling_2[16] = {0};
 

--- a/src/devices/secplus_v2.c
+++ b/src/devices/secplus_v2.c
@@ -255,7 +255,6 @@ unsigned _preamble_len           = 28;
 static int secplus_v2_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     unsigned search_index = 0;
-    unsigned next_pos     = 0;
     bitbuffer_t bits = {0};
     // int i            = 0;
 
@@ -279,7 +278,7 @@ static int secplus_v2_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         }
 
         bitbuffer_clear(&bits);
-        next_pos = bitbuffer_manchester_decode(bitbuffer, row, search_index + 26, &bits, 80);
+        bitbuffer_manchester_decode(bitbuffer, row, search_index + 26, &bits, 80);
         search_index += 20;
         if (bits.bits_per_row[0] < 42) {
             continue; // DECODE_ABORT_LENGTH;

--- a/src/devices/solight_te44.c
+++ b/src/devices/solight_te44.c
@@ -43,7 +43,8 @@ static int solight_te44_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
     uint8_t *b;
-    int id, battery, channel, temp_raw;
+    int id, channel, temp_raw;
+    // int battery;
     float temp_c;
 
     int r = bitbuffer_find_repeated_row(bitbuffer, 3, 36);
@@ -62,7 +63,7 @@ static int solight_te44_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_ABORT_EARLY;
 
     id       = b[0];
-    battery  = (b[1] & 0x80);
+    //battery  = (b[1] & 0x80);
     channel  = ((b[1] & 0x30) >> 4);
     temp_raw = (int16_t)((b[1] << 12) | (b[2] << 4)); // sign-extend
     temp_c   = (temp_raw >> 4) * 0.1f;
@@ -86,7 +87,7 @@ static char *output_fields[] = {
         "model",
         "id",
         "channel",
-        "battery",
+        //"battery",
         "temperature_C",
         "mic",
         NULL,

--- a/src/devices/springfield.c
+++ b/src/devices/springfield.c
@@ -37,7 +37,8 @@ static int springfield_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     uint8_t *b;
     int sid, battery, button, channel, temp;
     float temp_c;
-    int moisture, uk1;
+    int moisture;
+    // int uk1;
     data_t *data;
     unsigned tmpData;
     unsigned savData = 0;
@@ -65,7 +66,7 @@ static int springfield_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         temp     = (int16_t)(((b[1] & 0x0f) << 12) | (b[2] << 4)); // sign extend
         temp_c   = (temp >> 4) * 0.1f;
         moisture = b[3] >> 4;
-        uk1      = b[4] >> 4; /* unknown. */
+        //uk1      = b[4] >> 4; /* unknown. */
 
         /* clang-format off */
         data = data_make(

--- a/src/devices/tpms_abarth124.c
+++ b/src/devices/tpms_abarth124.c
@@ -39,7 +39,6 @@ Data layout (nibbles):
 static int tpms_abarth124_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    unsigned int start_pos;
     bitbuffer_t packet_bits = {0};
     uint8_t *b;
     char id_str[4 * 2 + 1];
@@ -50,7 +49,7 @@ static int tpms_abarth124_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsi
     int checksum;
 
 
-    start_pos = bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 72);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 72);
 
     // make sure we decoded the expected number of bits
     if (packet_bits.bits_per_row[0] < 72) {

--- a/src/devices/tpms_elantra2012.c
+++ b/src/devices/tpms_elantra2012.c
@@ -52,7 +52,6 @@ Preamble is 111 0001 0101 0101 (0x7155).
 static int tpms_elantra2012_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    unsigned start_pos;
     bitbuffer_t packet_bits = {0};
     uint8_t *b;
     uint32_t id;
@@ -63,7 +62,7 @@ static int tpms_elantra2012_decode(r_device *decoder, bitbuffer_t *bitbuffer, un
     int temperature_c;
     int triggered, battery_low, storage;
 
-    start_pos = bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 64);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 64);
     // require 64 data bits
     if (packet_bits.bits_per_row[0] < 64) {
         return DECODE_ABORT_LENGTH;

--- a/src/devices/tpms_ford.c
+++ b/src/devices/tpms_ford.c
@@ -28,7 +28,6 @@ Packet nibbles:
 static int tpms_ford_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    unsigned int start_pos;
     bitbuffer_t packet_bits = {0};
     uint8_t *b;
     unsigned id;
@@ -36,7 +35,7 @@ static int tpms_ford_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned 
     int code;
     char code_str[7];
 
-    start_pos = bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 160);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 160);
 
     // require 64 data bits
     if (packet_bits.bits_per_row[0] < 64) {

--- a/src/devices/tpms_renault.c
+++ b/src/devices/tpms_renault.c
@@ -29,7 +29,6 @@ Packet nibbles:
 static int tpms_renault_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    unsigned int start_pos;
     bitbuffer_t packet_bits = {0};
     uint8_t *b;
     int flags;
@@ -40,7 +39,7 @@ static int tpms_renault_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     double pressure_kpa;
     char code_str[5];
 
-    start_pos = bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 160);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 160);
     // require 72 data bits
     if (packet_bits.bits_per_row[0] < 72) {
         return 0;

--- a/src/output_influx.c
+++ b/src/output_influx.c
@@ -16,6 +16,7 @@
 #include "optparse.h"
 #include "util.h"
 #include "fatal.h"
+#include "r_util.h"
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -181,6 +182,8 @@ static void mbuf_remove_part(struct mbuf *a, char *pos, size_t len)
 
 static void print_influx_array(data_output_t *output, data_array_t *array, char const *format)
 {
+    UNUSED(array);
+    UNUSED(format);
     influx_client_t *influx = (influx_client_t *)output;
     struct mbuf *buf = &influx->databufs[influx->databufidxfill];
     mbuf_snprintf(buf, "\"array\""); // TODO
@@ -195,6 +198,7 @@ static void print_influx_data_escaped(data_output_t *output, data_t *data, char 
 
 static void print_influx_string_escaped(data_output_t *output, char const *str, char const *format)
 {
+    UNUSED(format);
     influx_client_t *influx = (influx_client_t *)output;
     struct mbuf *databuf = &influx->databufs[influx->databufidxfill];
     size_t size = databuf->size - databuf->len;
@@ -225,6 +229,7 @@ static void print_influx_string_escaped(data_output_t *output, char const *str, 
 
 static void print_influx_string(data_output_t *output, char const *str, char const *format)
 {
+    UNUSED(format);
     influx_client_t *influx = (influx_client_t *)output;
     struct mbuf *buf = &influx->databufs[influx->databufidxfill];
     mbuf_snprintf(buf, "%s", str);
@@ -233,6 +238,7 @@ static void print_influx_string(data_output_t *output, char const *str, char con
 // Generate InfluxDB line protocol
 static void print_influx_data(data_output_t *output, data_t *data, char const *format)
 {
+    UNUSED(format);
     influx_client_t *influx = (influx_client_t *)output;
     char *str;
     char *end;
@@ -351,6 +357,7 @@ static void print_influx_data(data_output_t *output, data_t *data, char const *f
 
 static void print_influx_double(data_output_t *output, double data, char const *format)
 {
+    UNUSED(format);
     influx_client_t *influx = (influx_client_t *)output;
     struct mbuf *buf = &influx->databufs[influx->databufidxfill];
     mbuf_snprintf(buf, "%f", data);
@@ -358,6 +365,7 @@ static void print_influx_double(data_output_t *output, double data, char const *
 
 static void print_influx_int(data_output_t *output, int data, char const *format)
 {
+    UNUSED(format);
     influx_client_t *influx = (influx_client_t *)output;
     struct mbuf *buf = &influx->databufs[influx->databufidxfill];
     mbuf_snprintf(buf, "%d", data);

--- a/src/output_mqtt.c
+++ b/src/output_mqtt.c
@@ -386,7 +386,7 @@ static void print_mqtt_double(data_output_t *output, double data, char const *fo
     char str[20];
     // use scientific notation for very big/small values
     if (data > 1e7 || data < 1e-4) {
-        int ret = snprintf(str, 20, "%g", data);
+        snprintf(str, 20, "%g", data);
     }
     else {
         int ret = snprintf(str, 20, "%.5f", data);
@@ -403,7 +403,7 @@ static void print_mqtt_double(data_output_t *output, double data, char const *fo
 static void print_mqtt_int(data_output_t *output, int data, char const *format)
 {
     char str[20];
-    int ret = snprintf(str, 20, "%d", data);
+    snprintf(str, 20, "%d", data);
     print_mqtt_string(output, str, format);
 }
 

--- a/src/output_mqtt.c
+++ b/src/output_mqtt.c
@@ -14,6 +14,7 @@
 #include "optparse.h"
 #include "util.h"
 #include "fatal.h"
+#include "r_util.h"
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -304,6 +305,7 @@ static char *expand_topic(char *topic, char const *format, data_t *data, char co
 // <prefix>[/type][/model][/subtype][/channel][/id]/battery: "OK"|"LOW"
 static void print_mqtt_data(data_output_t *output, data_t *data, char const *format)
 {
+    UNUSED(format);
     data_output_mqtt_t *mqtt = (data_output_mqtt_t *)output;
 
     char *orig = mqtt->topic + strlen(mqtt->topic); // save current topic
@@ -374,6 +376,7 @@ static void print_mqtt_data(data_output_t *output, data_t *data, char const *for
 
 static void print_mqtt_string(data_output_t *output, char const *str, char const *format)
 {
+    UNUSED(format);
     data_output_mqtt_t *mqtt = (data_output_mqtt_t *)output;
     mqtt_client_publish(mqtt->mqc, mqtt->topic, str);
 }

--- a/src/pulse_analyzer.c
+++ b/src/pulse_analyzer.c
@@ -340,7 +340,7 @@ void pulse_analyzer(pulse_data_t *data, int package_type)
     if (hist_timings.bins_count <= 8) {
         // if there is no 3rd gap length output one long B1 code
         if (hist_gaps.bins_count <= 2) {
-            hexstr_t hexstr = {{0}};
+            hexstr_t hexstr = {.p = {0}};
             hexstr_push_byte(&hexstr, 0xaa);
             hexstr_push_byte(&hexstr, 0xb1);
             hexstr_push_byte(&hexstr, hist_timings.bins_count);
@@ -366,7 +366,7 @@ void pulse_analyzer(pulse_data_t *data, int package_type)
             // pick last gap length but a most the 4th
             int limit_bin = MIN(3, hist_gaps.bins_count - 1);
             int limit = hist_gaps.bins[limit_bin].min;
-            hexstr_t hexstrs[HEXSTR_MAX_COUNT] = {{{0}}};
+            hexstr_t hexstrs[HEXSTR_MAX_COUNT] = {{.p = {0}}};
             unsigned hexstr_cnt = 0;
             unsigned i = 0;
             while (i < data->num_pulses && hexstr_cnt < HEXSTR_MAX_COUNT) {

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -915,7 +915,7 @@ void add_syslog_output(r_cfg_t *cfg, char *param)
 
 void add_null_output(r_cfg_t *cfg, char *param)
 {
-    (void)param;
+    UNUSED(param);
     list_push(&cfg->output_handler, NULL);
 }
 

--- a/src/sdr.c
+++ b/src/sdr.c
@@ -159,6 +159,7 @@ struct rtl_tcp_info {
 
 static int rtltcp_open(sdr_dev_t **out_dev, int *sample_size, char *dev_query, int verbose)
 {
+    UNUSED(verbose);
     char *host = "localhost";
     char *port = "1234";
 
@@ -268,6 +269,7 @@ static int rtltcp_close(SOCKET sock)
 
 static int rtltcp_read_loop(sdr_dev_t *dev, sdr_event_cb_t cb, void *ctx, uint32_t buf_num, uint32_t buf_len)
 {
+    UNUSED(buf_num);
     if (dev->buffer_size != buf_len) {
         free(dev->buffer);
         dev->buffer = malloc(buf_len);
@@ -1229,6 +1231,8 @@ int sdr_set_tuner_gain(sdr_dev_t *dev, char const *gain_str, int verbose)
 
 int sdr_set_antenna(sdr_dev_t *dev, char const *antenna_str, int verbose)
 {
+    POSSIBLY_UNUSED(dev);
+    POSSIBLY_UNUSED(verbose);
     int r = -1;
 
     if (!antenna_str)
@@ -1315,6 +1319,8 @@ uint32_t sdr_get_sample_rate(sdr_dev_t *dev)
 
 int sdr_apply_settings(sdr_dev_t *dev, char const *sdr_settings, int verbose)
 {
+    POSSIBLY_UNUSED(dev);
+    POSSIBLY_UNUSED(verbose);
     int r = -1;
 
     if (!sdr_settings || !*sdr_settings)
@@ -1363,6 +1369,7 @@ int sdr_apply_settings(sdr_dev_t *dev, char const *sdr_settings, int verbose)
 
 int sdr_activate(sdr_dev_t *dev)
 {
+    POSSIBLY_UNUSED(dev);
 #ifdef SOAPYSDR
     if (dev->soapy_dev) {
         if (SoapySDRDevice_activateStream(dev->soapy_dev, dev->soapy_stream, 0, 0, 0) != 0) {
@@ -1377,6 +1384,7 @@ int sdr_activate(sdr_dev_t *dev)
 
 int sdr_deactivate(sdr_dev_t *dev)
 {
+    POSSIBLY_UNUSED(dev);
 #ifdef SOAPYSDR
     if (dev->soapy_dev) {
         SoapySDRDevice_deactivateStream(dev->soapy_dev, dev->soapy_stream, 0, 0);
@@ -1389,6 +1397,7 @@ int sdr_deactivate(sdr_dev_t *dev)
 
 int sdr_reset(sdr_dev_t *dev, int verbose)
 {
+    POSSIBLY_UNUSED(dev);
     int r = 0;
 
 #ifdef RTLSDR

--- a/src/term_ctl.c
+++ b/src/term_ctl.c
@@ -222,7 +222,7 @@ void term_ring_bell(void *ctx)
 {
 #ifdef _WIN32
     Beep(800, 20);
-    (void) ctx;
+    UNUSED(ctx);
 #else
     FILE *fp = (FILE *)ctx;
     fprintf(fp, "\a");


### PR DESCRIPTION
I think it would be good to enable unused variable warnings, to prevent people accidentally sending in patches where they forgot to use a variable.

In some cases (especially with the formatting architecture) it's unavoidable that a format parameter is taken. In those cases I've suppressed the warning with an UNUSED macro.
