### PR TITLE
Removed invalid "weather" device_class

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -118,7 +118,6 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "WS",
         "config": {
-            "device_class": "weather",
             "name": "Wind Speed",
             "unit_of_measurement": "km/h",
             "value_template": "{{ value|float }}"
@@ -139,7 +138,6 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "WS",
         "config": {
-            "device_class": "weather",
             "name": "Wind Speed",
             "unit_of_measurement": "km/h",
             "value_template": "{{ float(value|float) * 3.6 }}"
@@ -150,7 +148,6 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "GS",
         "config": {
-            "device_class": "weather",
             "name": "Gust Speed",
             "unit_of_measurement": "km/h",
             "value_template": "{{ value|float }}"
@@ -171,7 +168,6 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "GS",
         "config": {
-            "device_class": "weather",
             "name": "Gust Speed",
             "unit_of_measurement": "km/h",
             "value_template": "{{ float(value|float) * 3.6 }}"
@@ -182,7 +178,6 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "WD",
         "config": {
-            "device_class": "weather",
             "name": "Wind Direction",
             "unit_of_measurement": "°",
             "value_template": "{{ value|float }}"
@@ -193,7 +188,6 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "RT",
         "config": {
-            "device_class": "weather",
             "name": "Rain Total",
             "unit_of_measurement": "mm",
             "value_template": "{{ value|float }}"
@@ -204,7 +198,6 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "RR",
         "config": {
-            "device_class": "weather",
             "name": "Rain Rate",
             "unit_of_measurement": "mm/h",
             "value_template": "{{ value|float }}"


### PR DESCRIPTION
HASS does not have a device_class of "weather" and thus will fail to autodiscover any entities with that set: voluptuous.error.MultipleInvalid: value is not allowed for dictionary value @ data['device_class'] 
Please see related comment in PR #1390 and https://www.home-assistant.io/docs/configuration/customizing-devices/#device-class