### PR TITLE
Added support for LaCrosse Technology View TH2 Thermo/Hygro sensor.

### DIFF
--- a/src/devices/lacrosse_th3.c
+++ b/src/devices/lacrosse_th3.c
@@ -1,5 +1,5 @@
 /** @file
-    LaCrosse Technology View LTV-TH3 Thermo/Hygro Sensor.
+    LaCrosse Technology View LTV-TH3 & LTV-TH2 Thermo/Hygro Sensor.
 
     Copyright (C) 2020 Mike Bruski (AJ9X) <michael.bruski@gmail.com>
 
@@ -9,27 +9,31 @@
     (at your option) any later version.
 */
 /**
-LaCrosse Technology View LTV-TH3 Thermo/Hygro Sensor.
+LaCrosse Technology View LTV-TH3 & LTV-TH2 Thermo/Hygro Sensor.
 
-LaCrosse Color Forecast Station (model S84060?) utilizes the remote
+LaCrosse Color Forecast Station (model S84060) utilizes the remote
 Thermo/Hygro LTV-TH3 and LTV-WR1 multi sensor (wind spd/dir and rain).
+LaCrosse Color Forecast Station (model C84343) utilizes the remote
+Thermo/Hygro LTV-TH2.
 
 Product pages:
 https://www.lacrossetechnology.com/products/S84060
 https://www.lacrossetechnology.com/products/ltv-th3
+https://www.lacrossetechnology.com/products/C84343
+https://www.lacrossetechnology.com/products/ltv-th2
 
 Specifications:
 - Outdoor Temperature Range: -40 C to 60 C
 - Outdoor Humidity Range: 10 to 99 %RH
 - Update Interval: Every 30 Seconds
 
-No internal inspection of the console or sensors was performed so can
-only speculate that the remote sensors utilize a HopeRF CMT2119A ISM
+No internal inspection of the sensors was performed so can only
+speculate that the remote sensors utilize a HopeRF CMT2119A ISM
 transmitter chip which is tuned to 915Mhz.
 
-Again, no inspection of the S84060 console was performed but it
-probably a HopeRF CMT2219A ISM receiver chip.  An application note is
-available that provides further info into the capabilities of the
+Again, no inspection of the S84060 or C84343 console was performed but
+it probably utilizes a HopeRF CMT2219A ISM receiver chip.  An application
+note is available that provides further info into the capabilities of the
 CMT2119A and CMT2219A.
 
 (http://www.cmostek.com/download/CMT2119A_v0.95.pdf)
@@ -38,42 +42,57 @@ CMT2119A and CMT2219A.
 
 Protocol Specification:
 
-Data bits are NRZ encoded with logical 1 and 0 bits 104us in length.
+Data bits are NRZ encoded.  Logical 1 and 0 bits are 104us in
+length for the LTV-TH3 and 107us for the LTV-TH2.
 
 LTV-TH3
     SYN:32h ID:24h ?:4b SEQ:3b ?:1b TEMP:12d HUM:12d CHK:8h END:
 
     CHK is CRC-8 poly 0x31 init 0x00 over 7 bytes following SYN
 
+LTV-TH2
+    SYN:32h ID:24h ?:4b SEQ:3b ?:1b TEMP:12d HUM:12d CHK:8h END:
+
+Sequence# 2 & 6
+    CHK is CRC-8 poly 0x31 init 0x00 over 7 bytes following SYN
+Sequence# 0,1,3,4,5 & 7
+    CHK is CRC-8 poly 0x31 init 0xac over 7 bytes following SYN
+
+
 */
 
 #include "decoder.h"
 
-static int lacrosse_th3_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+static int lacrosse_th_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     uint8_t const preamble_pattern[] = { 0xd2, 0xaa, 0x2d, 0xd4 };
 
     data_t *data;
     uint8_t b[11];
     uint32_t id;
-    int flags, seq, offset, chk;
+    int flags, seq, offset, chk3, chk2, model;
     int raw_temp, humidity;
     float temp_c;
 
+    // bit length is specified as 104us for the TH3 (~256 bits per packet)
+    // but the TH2 bit length is actually 107us leading the bitbuffer to
+    // report the packet length as ~286 bits long.  We'll use this fact
+    // to indentify which of the two models actually sent the data.
     if (bitbuffer->bits_per_row[0] < 156) {
         if (decoder->verbose) {
             fprintf(stderr, "%s: Packet too short: %d bits\n", __func__, bitbuffer->bits_per_row[0]);
         }
         return DECODE_ABORT_LENGTH;
-    } else if (bitbuffer->bits_per_row[0] > 256) {
+    } else if (bitbuffer->bits_per_row[0] > 290) {
         if (decoder->verbose) {
-            fprintf(stderr, "%s: Packet too long: %d bits\n", __func__, bitbuffer->bits_per_row[0]);
-        }
+           fprintf(stderr, "%s: Packet too long: %d bits\n", __func__, bitbuffer->bits_per_row[0]);
+           bitbuffer_debug(bitbuffer);         }
         return DECODE_ABORT_LENGTH;
     } else {
         if (decoder->verbose) {
            fprintf(stderr, "%s: packet length: %d\n", __func__, bitbuffer->bits_per_row[0]);
         }
+        model = (bitbuffer->bits_per_row[0] < 280) ? 3 : 2;         
     }
 
     offset = bitbuffer_search(bitbuffer, 0, 0,
@@ -89,8 +108,11 @@ static int lacrosse_th3_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     offset += sizeof(preamble_pattern) * 8;
     bitbuffer_extract_bytes(bitbuffer, 0, offset, b, 8 * 8);
 
-    chk = crc8(b, 8, 0x31, 0x00);
-    if (chk) {
+    // failing the CRC checks indicates the packet is corrupt <OR>
+    // this is not a LTV-TH3 or LTV-TH2 sensor
+    chk3 = crc8(b, 8, 0x31, 0x00);
+    chk2 = crc8(b, 8, 0x31, 0xac);
+    if (!(chk3 || chk2)) {
         if (decoder->verbose) {
            fprintf(stderr, "%s: CRC failed!\n", __func__);
         }
@@ -110,8 +132,9 @@ static int lacrosse_th3_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     // base and/or scale adjustments
     temp_c = (raw_temp - 400) * 0.1f;
 
-    /* clang-format off */
-    data = data_make(
+    if (model == 3) {
+       /* clang-format off */
+       data = data_make(
             "model",            "",                 DATA_STRING, "LaCrosse-TH3",
             "id",               "Sensor ID",        DATA_FORMAT, "%06x", DATA_INT, id,
             "seq",              "Sequence",         DATA_INT,     seq,
@@ -120,7 +143,20 @@ static int lacrosse_th3_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "humidity",         "Humidity",         DATA_FORMAT, "%u %%", DATA_INT, humidity,
             "mic",              "Integrity",        DATA_STRING, "CRC",
             NULL);
-    /* clang-format on */
+       /* clang-format on */
+    } else {
+       /* clang-format off */
+       data = data_make(
+            "model",            "",                 DATA_STRING, "LaCrosse-TH2",
+            "id",               "Sensor ID",        DATA_FORMAT, "%06x", DATA_INT, id,
+            "seq",              "Sequence",         DATA_INT,     seq,
+            "flags",            "unknown",          DATA_INT,     flags,
+            "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C",  DATA_DOUBLE, temp_c,
+            "humidity",         "Humidity",         DATA_FORMAT, "%u %%", DATA_INT, humidity,
+            "mic",              "Integrity",        DATA_STRING, "CRC",
+            NULL);
+       /* clang-format on */
+    }
 
     decoder_output_data(decoder, data);
     return 1;
@@ -137,13 +173,15 @@ static char *output_fields[] = {
         NULL,
 };
 
-// flex decoder m=FSK_PCM, s=104, l=104, r=9600
+// flex decoder n=TH3, m=FSK_PCM, s=104, l=104, r=9600
+// flex decoder n=TH2, m=FSK_PCM, s=107, l=107, r=5900
+// TH3 parameters should be good enough for both sensors
 r_device lacrosse_th3 = {
-        .name        = "LaCrosse Technology View LTV-TH3 Thermo/Hygro Sensor",
+        .name        = "LaCrosse Technology View LTV-TH Thermo/Hygro Sensor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 104,
         .long_width  = 104,
         .reset_limit = 9600,
-        .decode_fn   = &lacrosse_th3_decode,
+        .decode_fn   = &lacrosse_th_decode,
         .fields      = output_fields,
 };

--- a/src/devices/lacrosse_th3.c
+++ b/src/devices/lacrosse_th3.c
@@ -92,7 +92,7 @@ static int lacrosse_th_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         if (decoder->verbose) {
            fprintf(stderr, "%s: packet length: %d\n", __func__, bitbuffer->bits_per_row[0]);
         }
-        model = (bitbuffer->bits_per_row[0] < 280) ? 3 : 2;         
+        model = (bitbuffer->bits_per_row[0] < 280) ? 3 : 2;
     }
 
     offset = bitbuffer_search(bitbuffer, 0, 0,

--- a/src/devices/lacrosse_th3.c
+++ b/src/devices/lacrosse_th3.c
@@ -132,31 +132,17 @@ static int lacrosse_th_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     // base and/or scale adjustments
     temp_c = (raw_temp - 400) * 0.1f;
 
-    if (model == 3) {
-       /* clang-format off */
-       data = data_make(
-            "model",            "",                 DATA_STRING, "LaCrosse-TH3",
-            "id",               "Sensor ID",        DATA_FORMAT, "%06x", DATA_INT, id,
-            "seq",              "Sequence",         DATA_INT,     seq,
-            "flags",            "unknown",          DATA_INT,     flags,
-            "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C",  DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",         DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
-       /* clang-format on */
-    } else {
-       /* clang-format off */
-       data = data_make(
-            "model",            "",                 DATA_STRING, "LaCrosse-TH2",
-            "id",               "Sensor ID",        DATA_FORMAT, "%06x", DATA_INT, id,
-            "seq",              "Sequence",         DATA_INT,     seq,
-            "flags",            "unknown",          DATA_INT,     flags,
-            "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C",  DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",         DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
-       /* clang-format on */
-    }
+    /* clang-format off */
+    data = data_make(
+         "model",            "",                 DATA_FORMAT, "LaCrosse-TH%u", DATA_INT, model,
+         "id",               "Sensor ID",        DATA_FORMAT, "%06x", DATA_INT, id,
+         "seq",              "Sequence",         DATA_INT,     seq,
+         "flags",            "unknown",          DATA_INT,     flags,
+         "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C",  DATA_DOUBLE, temp_c,
+         "humidity",         "Humidity",         DATA_FORMAT, "%u %%", DATA_INT, humidity,
+         "mic",              "Integrity",        DATA_STRING, "CRC",
+         NULL);
+    /* clang-format on */
 
     decoder_output_data(decoder, data);
     return 1;


### PR DESCRIPTION
Modified src/devices/lacrosse_th3.c to support LTV-TH2.

TH2 differs from the TH3 in the following ways:
   pulse width is 107us (TH3 is 104us) so bitbuffer reports bit_per_row to be ~289 instead of ~256
   CRC for packets with sequence # 0,1,3,4,5 and 7 is CRC-8 poly 0x31 init 0xac
   CRC for packets with sequence # 2 and 6 is CRC-8 poly 0x31 init 0x00 (same as TH3 for all sequence numbers)

Output reflects correct device model number.