### PR TITLE
Improve unit tests for bitbuffer with extra assertions

### DIFF
--- a/src/bitbuffer.c
+++ b/src/bitbuffer.c
@@ -413,29 +413,46 @@ int bitbuffer_find_repeated_row(bitbuffer_t *bits, unsigned min_repeats, unsigne
 
 // Unit testing
 #ifdef _TEST
-#include <assert.h>
+
+#define ASSERT(expr) \
+    do { \
+        if (expr) { \
+            ++passed; \
+        } else { \
+            ++failed; \
+            fprintf(stderr, "FAIL: line %d: %s\n", __LINE__, #expr); \
+        } \
+    } while (0)
+
 int main(void)
 {
+    unsigned passed = 0;
+    unsigned failed = 0;
+
     fprintf(stderr, "bitbuffer:: test\n");
 
     bitbuffer_t bits = {0};
 
     fprintf(stderr, "TEST: bitbuffer:: The empty buffer\n");
     bitbuffer_print(&bits);
+    ASSERT(bits.num_rows == 0);
 
     fprintf(stderr, "TEST: bitbuffer:: Add 1 bit\n");
     bitbuffer_add_bit(&bits, 1);
     bitbuffer_print(&bits);
+    ASSERT(bits.num_rows == 1);
 
     fprintf(stderr, "TEST: bitbuffer:: Add 1 new row\n");
     bitbuffer_add_row(&bits);
     bitbuffer_print(&bits);
+    ASSERT(bits.num_rows == 2);
 
     fprintf(stderr, "TEST: bitbuffer:: Fill row\n");
     for (int i = 0; i < BITBUF_COLS * 8; ++i) {
         bitbuffer_add_bit(&bits, i % 2);
     }
     bitbuffer_print(&bits);
+    ASSERT(bits.num_rows == 2);
 
     fprintf(stderr, "TEST: bitbuffer:: Add row and fill 1 column too many\n");
     bitbuffer_add_row(&bits);
@@ -443,6 +460,7 @@ int main(void)
         bitbuffer_add_bit(&bits, i % 2);
     }
     bitbuffer_print(&bits);
+    ASSERT(bits.num_rows == 3);
 
     fprintf(stderr, "TEST: bitbuffer:: invert\n");
     bitbuffer_invert(&bits);
@@ -455,11 +473,12 @@ int main(void)
     bits.bits_per_row[0] = 12;
     bitbuffer_nrzs_decode(&bits);
     bitbuffer_print(&bits);
-    assert(bits.bb[0][0] == 0xB1);
-    assert(bits.bb[0][1] == 0xA0);
+    ASSERT(bits.bb[0][0] == 0xB1);
+    ASSERT(bits.bb[0][1] == 0xA0);
 
     fprintf(stderr, "TEST: bitbuffer:: Clear\n");
     bitbuffer_clear(&bits);
+    ASSERT(bits.num_rows == 0);
     bitbuffer_print(&bits);
 
     fprintf(stderr, "TEST: bitbuffer:: Add 1 row too many\n");
@@ -469,6 +488,8 @@ int main(void)
     bitbuffer_add_bit(&bits, 1);
     bitbuffer_print(&bits);
 
-    return 0;
+    fprintf(stderr, "bitbuffer:: test (%u/%u) passed, (%u) failed.\n", passed, passed + failed, failed);
+
+    return failed > 0 ? 1 : 0;
 }
 #endif /* _TEST */


### PR DESCRIPTION
This should ensure that the bitbuffer tests will actually return non-zero if anything fails. Previously this wasn't the case, because the assert.h header doesn't do anything when building in release mode.

Main discussion point for me: is this how we want to structure unit tests? I tried to use the same sort of method as used in `util.c`, `optparse.c`, but with some slight changes (e.g. I don't think it's very useful to log the amount of passed tests, just relying on the 'failed' count and the return code is enough).