### PR TITLE
Remove additional invalid "weather" device class (#1548)

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -214,7 +214,6 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "WS",
         "config": {
-            "device_class": "weather",
             "name": "Wind Speed",
             "unit_of_measurement": "km/h",
             "value_template": "{{ value|float }}"
@@ -225,7 +224,6 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "WS",
         "config": {
-            "device_class": "weather",
             "name": "Wind Speed",
             "unit_of_measurement": "mi/h",
             "value_template": "{{ value|float }}"
@@ -410,7 +408,6 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "lux",
         "config": {
-            "device_class": "weather",
             "name": "Outside Luminancee",
             "unit_of_measurement": "lux",
             "value_template": "{{ value|int }}"
@@ -421,7 +418,6 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "uv",
         "config": {
-            "device_class": "weather",
             "name": "UV Index",
             "unit_of_measurement": "UV Index",
             "value_template": "{{ value|int }}"

--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -404,6 +404,15 @@ mappings = {
         }
     },
 
+    "lux": {
+        "device_type": "sensor",
+        "object_suffix": "lux",
+        "config": {
+            "name": "Outside Luminancee",
+            "unit_of_measurement": "lux",
+            "value_template": "{{ value|int }}"
+        }
+    },
     "light_lux": {
         "device_type": "sensor",
         "object_suffix": "lux",
@@ -417,6 +426,15 @@ mappings = {
     "uv": {
         "device_type": "sensor",
         "object_suffix": "uv",
+        "config": {
+            "name": "UV Index",
+            "unit_of_measurement": "UV Index",
+            "value_template": "{{ value|int }}"
+        }
+    },
+    "uvi": {
+        "device_type": "sensor",
+        "object_suffix": "uvi",
         "config": {
             "name": "UV Index",
             "unit_of_measurement": "UV Index",
@@ -452,6 +470,7 @@ mappings = {
             "value_template": "{{ value|int }}"
         }
     },
+
 }
 
 

--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -404,7 +404,7 @@ mappings = {
         }
     },
 
-    "lux": {
+    "light_lux": {
         "device_type": "sensor",
         "object_suffix": "lux",
         "config": {


### PR DESCRIPTION
The previous merged commit does not remove all the invalid "weather" device class items from the templates.