### PR TITLE
Fix Insteon payload  buffer too small

### DIFF
--- a/src/devices/insteon.c
+++ b/src/devices/insteon.c
@@ -302,9 +302,9 @@ static int parse_insteon_pkt(r_device *decoder, bitbuffer_t *bits, unsigned int 
         cmd_array[cmd_array_len++] = (int)results[j];
     }
 
-    char payload[INSTEON_PACKET_MIN_EXT * 2 + 1] = {0};
+    char payload[INSTEON_PACKET_MAX_EXT * 2 + 2] = {0};
     p                = payload;
-    for (int j = 0; j < min_pkt_len; j++) {
+    for (int j = 0; j < results_len; j++) {
         p += sprintf(p, "%02X", results[j]);
     }
 


### PR DESCRIPTION
used min packet instead of max packet size

this went unnoticed as full packets are rarely received. (there is a lot of padding in the protocal and only 23 or the 32 bytes are needed for extended packets )  