### PR TITLE
Fix:  buffer length error in devices/honeywell.c 

### DIFF
--- a/src/devices/honeywell.c
+++ b/src/devices/honeywell.c
@@ -80,8 +80,9 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_ABORT_EARLY; // Reduce collisions
 
     if (len > 50) { // DW11
+        // printf("honeywell len = %d %d\n", len, (len >80 ? 80 : len));
         if (decoder->verbose)
-            bitrow_printf(b, len, "%s: ", __func__);
+            bitrow_printf(b, (len >80 ? 80 : len) , "%s: ", __func__);
     }
 
     if (channel == 0x2 || channel == 0x4 || channel == 0xA) {

--- a/src/devices/honeywell.c
+++ b/src/devices/honeywell.c
@@ -80,9 +80,8 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_ABORT_EARLY; // Reduce collisions
 
     if (len > 50) { // DW11
-        // printf("honeywell len = %d %d\n", len, (len >80 ? 80 : len));
         if (decoder->verbose)
-            bitrow_printf(b, (len >80 ? 80 : len) , "%s: ", __func__);
+            bitrow_printf(b, (len > 80 ? 80 : len), "%s: ", __func__);
     }
 
     if (channel == 0x2 || channel == 0x4 || channel == 0xA) {


### PR DESCRIPTION
bitrow_printf can be called with a length that exceeds the buffer length of `b` (80 bits) if called with sufficiently large bitbuffer

closes #1597 