### PR TITLE
Fix: setting mqtt retain flag for hass example

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -538,7 +538,7 @@ def publish_config(mqttc, topic, model, instance, mapping):
     if args.debug:
         print(path,":",json.dumps(config))
 
-    mqttc.publish(path, json.dumps(config), args.retain)
+    mqttc.publish(path, json.dumps(config), retain=args.retain)
 
     return True
 


### PR DESCRIPTION
I used this script as a reference to add sensors to my Home assistant. However they were not persisted across hass restarts. With this fix they are not retained. (python 3.8.7 and paho-mqtt 1.5.1). 