### PR TITLE
Fix copy paste error in hass-example script.

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -380,7 +380,7 @@ mappings = {
         "config": {
             "device_class": "signal_strength",
             "unit_of_measurement": "dB",
-            "value_template": "{{ valuei|float|round(2) }}"
+            "value_template": "{{ value|float|round(2) }}"
         }
     },
 


### PR DESCRIPTION
I used this script to add sensors to my Homeassistant. However when running with -M level the noise level was not reported right, which is because of this little typo.