### PR TITLE
burnhardbbq: Relicense under GPLv2+

### DIFF
--- a/src/devices/burnhardbbq.c
+++ b/src/devices/burnhardbbq.c
@@ -4,8 +4,9 @@
     Copyright (C) 2021 Christian Fetzer
 
     This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License version 3 as
-    published by the Free Software Foundation.
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
 */
 /**
 Burnhard BBQ thermometer.


### PR DESCRIPTION
As original author of this code, I relicense the driver under GPLv2+ for easing integration in other projects.

Licensing under GPLv3 only was unintentional, I apparently copied the header from one of the very few another GPLv3 device files.

See: https://github.com/merbanan/rtl_433/pull/1624#issuecomment-770464988