### PR TITLE
fineoffset: Add explanation of supposed PM10 value, and call it estimated

### DIFF
--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -331,19 +331,51 @@ static int fineoffset_WH24_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 Fine Offset Electronics WH0290 Wireless Air Quality Monitor
 Also: Ambient Weather PM25
 Also: Misol PM25
-Also: EcoWitt WH41
+Also: EcoWitt WH0290, EcoWitt WH41
 
-The sensor sends a package each ~10m. The bits are PCM modulated with Frequency Shift Keying.
+The sensor sends a data burst every 10 minutes.  The bits are PCM
+modulated with Frequency Shift Keying.
 
+Ecowitt advertises this device as a PM2.5 sensor.  It contains a
+Honeywell PM2.5 sensor:
 
-PM10 readings might be bogus:
+  https://sensing.honeywell.com/honeywell-sensing-particulate-hpm-series-datasheet-32322550.pdf
 
-2 PM1.0 in μg/m3, PM4.0 in μg/m3, and PM10 in μg/m3 are calculated from PM 2.5 readings.
-Source:
-https://sensing.honeywell.com/honeywell-sensing-particulate-hpm-series-datasheet-32322550.pdf
+However, the Honeywell datasheet says that it also has a PM10 output
+which is "calculated from" the PM2.5 reading.  While there is an
+accuracy spec for PM2.5, there is no specification of an kind from
+PM10.  The datasheet does not explain the calculation, and does not
+give references to papers in the scientific literature.
 
-So the PM2.5 is a proper read reading and PM10 is as suspected simply derived/calculated from the PM2.5 value.
+Note that PM2.5 is the mass of particles <= 2.5 microns in 1 m^3 of
+air, and PM10 is the mass of particles <= 10 microns.  Therefore the
+difference in those measurements is the mass of particles > 2.5
+microns and <= 10 microns, sometimes called PM2.5-10.  By definition
+these particles are not included in the PM2.5 measurement, so
+"calculating" doesn't make sense.  Rather, this appears an assumption
+about correlation, meaning how much mass of larger particles is likely
+to be present based on the mass of the smaller particles.
 
+The serial stream from the sensor has fields for PM2.5 and PM10 and
+these fields have been verified to appear in the transmitted signal by
+cross-comparing the internal serial lines and data received via
+rtl_433.
+
+The Ecowitt displays show only PM2.5, and Ecowitt confirmed that the
+second field is the PM10 output of the sensor but said the value is
+not accurate so they have not adopted it.
+
+By observation of an Ecowitt WH41, the formula is pm10 = pm2.5 +
+increment(pm2.5), where the increment is by ranges from the following
+table (with gaps when no samples have been observed).  It is left as
+future work to compare with an actual PM10 sensor.
+
+0 to 24		| 1
+25 to 106	| 2
+109 to 185	| 3
+190 to 222	| 4
+311		| 5
+390		| 6
 
 
 Data layout:

--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -443,7 +443,7 @@ static int fineoffset_WH0290_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             "id",               "ID",           DATA_INT,    id,
             "battery_ok",          "Battery Level",  DATA_FORMAT, "%.1f", DATA_DOUBLE, battery_ok,
             "pm2_5_ug_m3",      "2.5um Fine Particulate Matter",  DATA_FORMAT, "%i ug/m3", DATA_INT, pm25/10,
-            "pm10_0_ug_m3",     "10um Coarse Particulate Matter",  DATA_FORMAT, "%i ug/m3", DATA_INT, pm100/10,
+            "estimated_pm10_0_ug_m3",     "Estimate of 10um Coarse Particulate Matter",  DATA_FORMAT, "%i ug/m3", DATA_INT, pm100/10,
             "family",           "FAMILY",       DATA_INT,    family,
             "unknown1",         "UNKNOWN1",     DATA_INT,    unknown1,
             "mic",              "Integrity",    DATA_STRING, "CRC",
@@ -1010,7 +1010,7 @@ static char *output_fields_WH25[] = {
     "light_lux",
     //WH0290
     "pm2_5_ug_m3",
-    "pm10_0_ug_m3",
+    "estimated_pm10_0_ug_m3",
     "mic",
     NULL,
 };


### PR DESCRIPTION
After discussion in https://github.com/merbanan/rtl_433/issues/1640
this commit adjusts the comment about the WH0290 particulate sensor,
mostly surrounding the nature of the field labeled PM10.

The measurement of the sensor serial port was done by @peteakalad, and
the determination of the pm2.5/pm10 conversion was done by @gdt.

Following consensus from #1640, change description to call it "estimated", as a compromise betwen calculated and alleged.