### PR TITLE
Update holman_ws5029.c

### DIFF
--- a/src/devices/holman_ws5029.c
+++ b/src/devices/holman_ws5029.c
@@ -95,7 +95,7 @@ static int holman_ws5029pcm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int temp_raw      = (int16_t)((b[11] << 8) | (b[12] & 0xf0)); // uses sign-extend
     float temp_c      = (temp_raw >> 4) * 0.1f;
     int humidity      = ((b[12] & 0x0f) << 4) | ((b[13] & 0xf0) >> 4);
-    int rain_raw      = ((b[13] & 0x0f) << 12) | b[14];
+    int rain_raw      = ((b[13] & 0x0f) << 8) | b[14]; //should only shift left by 8 bits, not 12 bits.
     float rain_mm     = rain_raw * 0.79f;
     int speed_kmh     = b[15];
     int direction_deg = wind_dir_degr[(b[16] & 0xf0) >> 4];

--- a/src/devices/holman_ws5029.c
+++ b/src/devices/holman_ws5029.c
@@ -95,7 +95,7 @@ static int holman_ws5029pcm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int temp_raw      = (int16_t)((b[11] << 8) | (b[12] & 0xf0)); // uses sign-extend
     float temp_c      = (temp_raw >> 4) * 0.1f;
     int humidity      = ((b[12] & 0x0f) << 4) | ((b[13] & 0xf0) >> 4);
-    int rain_raw      = ((b[13] & 0x0f) << 8) | b[14]; 
+    int rain_raw      = ((b[13] & 0x0f) << 8) | b[14];
     float rain_mm     = rain_raw * 0.79f;
     int speed_kmh     = b[15];
     int direction_deg = wind_dir_degr[(b[16] & 0xf0) >> 4];

--- a/src/devices/holman_ws5029.c
+++ b/src/devices/holman_ws5029.c
@@ -95,7 +95,7 @@ static int holman_ws5029pcm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int temp_raw      = (int16_t)((b[11] << 8) | (b[12] & 0xf0)); // uses sign-extend
     float temp_c      = (temp_raw >> 4) * 0.1f;
     int humidity      = ((b[12] & 0x0f) << 4) | ((b[13] & 0xf0) >> 4);
-    int rain_raw      = ((b[13] & 0x0f) << 8) | b[14]; //should only shift left by 8 bits, not 12 bits.
+    int rain_raw      = ((b[13] & 0x0f) << 8) | b[14]; 
     float rain_mm     = rain_raw * 0.79f;
     int speed_kmh     = b[15];
     int direction_deg = wind_dir_degr[(b[16] & 0xf0) >> 4];


### PR DESCRIPTION
:fix
Line 98 - the most significant 4 bits of the rain should only be shifted left by 8 bits, not by 12 bits as per the original. The incorrect shift by 12 bits, causes it to incorrectly report rainfall of ~3000mm every time the 8th bit overflows.