### PR TITLE
Roja Flex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,49 +223,49 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [142]  Fine Offset Electronics/ECOWITT WH51 Soil Moisture Sensor
     [143]  Holman Industries iWeather WS5029 weather station (older PWM)
     [144]  TBH weather sensor
-    [145]  Rojaflex
-    [146]  WS2032 weather station
-    [147]  Auriol AFW2A1 temperature/humidity sensor
-    [148]  TFA Drop Rain Gauge 30.3233.01
-    [149]  DSC Security Contact (WS4945)
-    [150]  ERT Standard Consumption Message (SCM)
-    [151]* Klimalogg
-    [152]  Visonic powercode
-    [153]  Eurochron EFTH-800 temperature and humidity sensor
-    [154]  Cotech 36-7959 wireless weather station with USB
-    [155]  Standard Consumption Message Plus (SCMplus)
-    [156]  Fine Offset Electronics WH1080/WH3080 Weather Station (FSK)
-    [157]  Abarth 124 Spider TPMS
-    [158]  Missil ML0757 weather station
-    [159]  Sharp SPC775 weather station
-    [160]  Insteon
-    [161]  ERT Interval Data Message (IDM)
-    [162]  ERT Interval Data Message (IDM) for Net Meters
-    [163]* ThermoPro-TX2 temperature sensor
-    [164]  Acurite 590TX Temperature with optional Humidity
-    [165]  Security+ 2.0 (Keyfob)
-    [166]  TFA Dostmann 30.3221.02 T/H Outdoor Sensor
-    [167]  LaCrosse Technology View LTV-WSDTH01 Breeze Pro Wind Sensor
-    [168]  Somfy RTS
-    [169]  Schrader TPMS SMD3MA4 (Subaru)
-    [170]* Nice Flor-s remote control for gates
-    [171]  LaCrosse Technology View LTV-WR1 Multi Sensor
-    [172]  LaCrosse Technology View LTV-TH Thermo/Hygro Sensor
-    [173]  Bresser Weather Center 6-in-1, 7-in-1 indoor, new 5-in-1, 3-in-1 wind gauge, Froggit WH6000, Ventus C8488A
-    [174]  Bresser Weather Center 7-in-1
-    [175]  EcoDHOME Smart Socket and MCEE Solar monitor
-    [176]  LaCrosse Technology View LTV-R1 Rainfall Gauge
-    [177]  BlueLine Power Monitor
-    [178]  Burnhard BBQ thermometer
-    [179]  Security+ (Keyfob)
-    [180]  Cavius smoke, heat and water detector
-    [181]  Jansite TPMS Model Solar
-    [182]  Amazon Basics Meat Thermometer
-    [183]  TFA Marbella Pool Thermometer
-    [184]  Auriol AHFL temperature/humidity sensor
-    [185]  Auriol AFT 77 B2 temperature sensor
-    [186]  Honeywell CM921 Wireless Programmable Room Thermostat
-    [187]  Hyundai TPMS (VDO)
+    [145]  WS2032 weather station
+    [146]  Auriol AFW2A1 temperature/humidity sensor
+    [147]  TFA Drop Rain Gauge 30.3233.01
+    [148]  DSC Security Contact (WS4945)
+    [149]  ERT Standard Consumption Message (SCM)
+    [150]* Klimalogg
+    [151]  Visonic powercode
+    [152]  Eurochron EFTH-800 temperature and humidity sensor
+    [153]  Cotech 36-7959 wireless weather station with USB
+    [154]  Standard Consumption Message Plus (SCMplus)
+    [155]  Fine Offset Electronics WH1080/WH3080 Weather Station (FSK)
+    [156]  Abarth 124 Spider TPMS
+    [157]  Missil ML0757 weather station
+    [158]  Sharp SPC775 weather station
+    [159]  Insteon
+    [160]  ERT Interval Data Message (IDM)
+    [161]  ERT Interval Data Message (IDM) for Net Meters
+    [162]* ThermoPro-TX2 temperature sensor
+    [163]  Acurite 590TX Temperature with optional Humidity
+    [164]  Security+ 2.0 (Keyfob)
+    [165]  TFA Dostmann 30.3221.02 T/H Outdoor Sensor
+    [166]  LaCrosse Technology View LTV-WSDTH01 Breeze Pro Wind Sensor
+    [167]  Somfy RTS
+    [168]  Schrader TPMS SMD3MA4 (Subaru)
+    [169]* Nice Flor-s remote control for gates
+    [170]  LaCrosse Technology View LTV-WR1 Multi Sensor
+    [171]  LaCrosse Technology View LTV-TH Thermo/Hygro Sensor
+    [172]  Bresser Weather Center 6-in-1, 7-in-1 indoor, new 5-in-1, 3-in-1 wind gauge, Froggit WH6000, Ventus C8488A
+    [173]  Bresser Weather Center 7-in-1
+    [174]  EcoDHOME Smart Socket and MCEE Solar monitor
+    [175]  LaCrosse Technology View LTV-R1 Rainfall Gauge
+    [176]  BlueLine Power Monitor
+    [177]  Burnhard BBQ thermometer
+    [178]  Security+ (Keyfob)
+    [179]  Cavius smoke, heat and water detector
+    [180]  Jansite TPMS Model Solar
+    [181]  Amazon Basics Meat Thermometer
+    [182]  TFA Marbella Pool Thermometer
+    [183]  Auriol AHFL temperature/humidity sensor
+    [184]  Auriol AFT 77 B2 temperature sensor
+    [185]  Honeywell CM921 Wireless Programmable Room Thermostat
+    [186]  Hyundai TPMS (VDO)
+    [187]  Rojaflex
 
 * Disabled by default, use -R n or -G
 

--- a/README.md
+++ b/README.md
@@ -223,48 +223,49 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [142]  Fine Offset Electronics/ECOWITT WH51 Soil Moisture Sensor
     [143]  Holman Industries iWeather WS5029 weather station (older PWM)
     [144]  TBH weather sensor
-    [145]  WS2032 weather station
-    [146]  Auriol AFW2A1 temperature/humidity sensor
-    [147]  TFA Drop Rain Gauge 30.3233.01
-    [148]  DSC Security Contact (WS4945)
-    [149]  ERT Standard Consumption Message (SCM)
-    [150]* Klimalogg
-    [151]  Visonic powercode
-    [152]  Eurochron EFTH-800 temperature and humidity sensor
-    [153]  Cotech 36-7959 wireless weather station with USB
-    [154]  Standard Consumption Message Plus (SCMplus)
-    [155]  Fine Offset Electronics WH1080/WH3080 Weather Station (FSK)
-    [156]  Abarth 124 Spider TPMS
-    [157]  Missil ML0757 weather station
-    [158]  Sharp SPC775 weather station
-    [159]  Insteon
-    [160]  ERT Interval Data Message (IDM)
-    [161]  ERT Interval Data Message (IDM) for Net Meters
-    [162]* ThermoPro-TX2 temperature sensor
-    [163]  Acurite 590TX Temperature with optional Humidity
-    [164]  Security+ 2.0 (Keyfob)
-    [165]  TFA Dostmann 30.3221.02 T/H Outdoor Sensor
-    [166]  LaCrosse Technology View LTV-WSDTH01 Breeze Pro Wind Sensor
-    [167]  Somfy RTS
-    [168]  Schrader TPMS SMD3MA4 (Subaru)
-    [169]* Nice Flor-s remote control for gates
-    [170]  LaCrosse Technology View LTV-WR1 Multi Sensor
-    [171]  LaCrosse Technology View LTV-TH Thermo/Hygro Sensor
-    [172]  Bresser Weather Center 6-in-1, 7-in-1 indoor, new 5-in-1, 3-in-1 wind gauge, Froggit WH6000, Ventus C8488A
-    [173]  Bresser Weather Center 7-in-1
-    [174]  EcoDHOME Smart Socket and MCEE Solar monitor
-    [175]  LaCrosse Technology View LTV-R1 Rainfall Gauge
-    [176]  BlueLine Power Monitor
-    [177]  Burnhard BBQ thermometer
-    [178]  Security+ (Keyfob)
-    [179]  Cavius smoke, heat and water detector
-    [180]  Jansite TPMS Model Solar
-    [181]  Amazon Basics Meat Thermometer
-    [182]  TFA Marbella Pool Thermometer
-    [183]  Auriol AHFL temperature/humidity sensor
-    [184]  Auriol AFT 77 B2 temperature sensor
-    [185]  Honeywell CM921 Wireless Programmable Room Thermostat
-    [186]  Hyundai TPMS (VDO)
+    [145]  Rojaflex
+    [146]  WS2032 weather station
+    [147]  Auriol AFW2A1 temperature/humidity sensor
+    [148]  TFA Drop Rain Gauge 30.3233.01
+    [149]  DSC Security Contact (WS4945)
+    [150]  ERT Standard Consumption Message (SCM)
+    [151]* Klimalogg
+    [152]  Visonic powercode
+    [153]  Eurochron EFTH-800 temperature and humidity sensor
+    [154]  Cotech 36-7959 wireless weather station with USB
+    [155]  Standard Consumption Message Plus (SCMplus)
+    [156]  Fine Offset Electronics WH1080/WH3080 Weather Station (FSK)
+    [157]  Abarth 124 Spider TPMS
+    [158]  Missil ML0757 weather station
+    [159]  Sharp SPC775 weather station
+    [160]  Insteon
+    [161]  ERT Interval Data Message (IDM)
+    [162]  ERT Interval Data Message (IDM) for Net Meters
+    [163]* ThermoPro-TX2 temperature sensor
+    [164]  Acurite 590TX Temperature with optional Humidity
+    [165]  Security+ 2.0 (Keyfob)
+    [166]  TFA Dostmann 30.3221.02 T/H Outdoor Sensor
+    [167]  LaCrosse Technology View LTV-WSDTH01 Breeze Pro Wind Sensor
+    [168]  Somfy RTS
+    [169]  Schrader TPMS SMD3MA4 (Subaru)
+    [170]* Nice Flor-s remote control for gates
+    [171]  LaCrosse Technology View LTV-WR1 Multi Sensor
+    [172]  LaCrosse Technology View LTV-TH Thermo/Hygro Sensor
+    [173]  Bresser Weather Center 6-in-1, 7-in-1 indoor, new 5-in-1, 3-in-1 wind gauge, Froggit WH6000, Ventus C8488A
+    [174]  Bresser Weather Center 7-in-1
+    [175]  EcoDHOME Smart Socket and MCEE Solar monitor
+    [176]  LaCrosse Technology View LTV-R1 Rainfall Gauge
+    [177]  BlueLine Power Monitor
+    [178]  Burnhard BBQ thermometer
+    [179]  Security+ (Keyfob)
+    [180]  Cavius smoke, heat and water detector
+    [181]  Jansite TPMS Model Solar
+    [182]  Amazon Basics Meat Thermometer
+    [183]  TFA Marbella Pool Thermometer
+    [184]  Auriol AHFL temperature/humidity sensor
+    [185]  Auriol AFT 77 B2 temperature sensor
+    [186]  Honeywell CM921 Wireless Programmable Room Thermostat
+    [187]  Hyundai TPMS (VDO)
 
 * Disabled by default, use -R n or -G
 
@@ -274,7 +275,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
   [-d <RTL-SDR USB device index>] (default: 0)
   [-d :<RTL-SDR USB device serial (can be set with rtl_eeprom -s)>]
 	To set gain for RTL-SDR use -g <gain> to set an overall gain in dB.
-	SoapySDR device driver is available.
+	SoapySDR device driver is not available.
   [-d ""] Open default SoapySDR device
   [-d driver=rtlsdr] Open e.g. specific SoapySDR device
 	To set gain for SoapySDR use -g ELEM=val,ELEM=val,... e.g. -g LNA=20,TIA=8,PGA=2 (for LimeSDR).

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -326,48 +326,49 @@ stop_after_successful_events false
   protocol 142 # Fine Offset Electronics/ECOWITT WH51 Soil Moisture Sensor
   protocol 143 # Holman Industries iWeather WS5029 weather station (older PWM)
   protocol 144 # TBH weather sensor
-  protocol 145 # WS2032 weather station
-  protocol 146 # Auriol AFW2A1 temperature/humidity sensor
-  protocol 147 # TFA Drop Rain Gauge 30.3233.01
-  protocol 148 # DSC Security Contact (WS4945)
-  protocol 149 # ERT Standard Consumption Message (SCM)
-# protocol 150 # Klimalogg
-  protocol 151 # Visonic powercode
-  protocol 152 # Eurochron EFTH-800 temperature and humidity sensor
-  protocol 153 # Cotech 36-7959 wireless weather station with USB
-  protocol 154 # Standard Consumption Message Plus (SCMplus)
-  protocol 155 # Fine Offset Electronics WH1080/WH3080 Weather Station (FSK)
-  protocol 156 # Abarth 124 Spider TPMS
-  protocol 157 # Missil ML0757 weather station
-  protocol 158 # Sharp SPC775 weather station
-  protocol 159 # Insteon
-  protocol 160 # ERT Interval Data Message (IDM)
-  protocol 161 # ERT Interval Data Message (IDM) for Net Meters
-# protocol 162 # ThermoPro-TX2 temperature sensor
-  protocol 163 # Acurite 590TX Temperature with optional Humidity
-  protocol 164 # Security+ 2.0 (Keyfob)
-  protocol 165 # TFA Dostmann 30.3221.02 T/H Outdoor Sensor
-  protocol 166 # LaCrosse Technology View LTV-WSDTH01 Breeze Pro Wind Sensor
-  protocol 167 # Somfy RTS
-  protocol 168 # Schrader TPMS SMD3MA4 (Subaru)
-# protocol 169 # Nice Flor-s remote control for gates
-  protocol 170 # LaCrosse Technology View LTV-WR1 Multi Sensor
-  protocol 171 # LaCrosse Technology View LTV-TH Thermo/Hygro Sensor
-  protocol 172 # Bresser Weather Center 6-in-1, 7-in-1 indoor, new 5-in-1, 3-in-1 wind gauge, Froggit WH6000, Ventus C8488A
-  protocol 173 # Bresser Weather Center 7-in-1
-  protocol 174 # EcoDHOME Smart Socket and MCEE Solar monitor
-  protocol 175 # LaCrosse Technology View LTV-R1 Rainfall Gauge
-  protocol 176 # BlueLine Power Monitor
-  protocol 177 # Burnhard BBQ thermometer
-  protocol 178 # Security+ (Keyfob)
-  protocol 179 # Cavius smoke, heat and water detector
-  protocol 180 # Jansite TPMS Model Solar
-  protocol 181 # Amazon Basics Meat Thermometer
-  protocol 182 # TFA Marbella Pool Thermometer
-  protocol 183 # Auriol AHFL temperature/humidity sensor
-  protocol 184 # Auriol AFT 77 B2 temperature sensor
-  protocol 185 # Honeywell CM921 Wireless Programmable Room Thermostat
-  protocol 186 # Hyundai TPMS (VDO)
+  protocol 145 # Rojaflex
+  protocol 146 # WS2032 weather station
+  protocol 147 # Auriol AFW2A1 temperature/humidity sensor
+  protocol 148 # TFA Drop Rain Gauge 30.3233.01
+  protocol 149 # DSC Security Contact (WS4945)
+  protocol 150 # ERT Standard Consumption Message (SCM)
+# protocol 151 # Klimalogg
+  protocol 152 # Visonic powercode
+  protocol 153 # Eurochron EFTH-800 temperature and humidity sensor
+  protocol 154 # Cotech 36-7959 wireless weather station with USB
+  protocol 155 # Standard Consumption Message Plus (SCMplus)
+  protocol 156 # Fine Offset Electronics WH1080/WH3080 Weather Station (FSK)
+  protocol 157 # Abarth 124 Spider TPMS
+  protocol 158 # Missil ML0757 weather station
+  protocol 159 # Sharp SPC775 weather station
+  protocol 160 # Insteon
+  protocol 161 # ERT Interval Data Message (IDM)
+  protocol 162 # ERT Interval Data Message (IDM) for Net Meters
+# protocol 163 # ThermoPro-TX2 temperature sensor
+  protocol 164 # Acurite 590TX Temperature with optional Humidity
+  protocol 165 # Security+ 2.0 (Keyfob)
+  protocol 166 # TFA Dostmann 30.3221.02 T/H Outdoor Sensor
+  protocol 167 # LaCrosse Technology View LTV-WSDTH01 Breeze Pro Wind Sensor
+  protocol 168 # Somfy RTS
+  protocol 169 # Schrader TPMS SMD3MA4 (Subaru)
+# protocol 170 # Nice Flor-s remote control for gates
+  protocol 171 # LaCrosse Technology View LTV-WR1 Multi Sensor
+  protocol 172 # LaCrosse Technology View LTV-TH Thermo/Hygro Sensor
+  protocol 173 # Bresser Weather Center 6-in-1, 7-in-1 indoor, new 5-in-1, 3-in-1 wind gauge, Froggit WH6000, Ventus C8488A
+  protocol 174 # Bresser Weather Center 7-in-1
+  protocol 175 # EcoDHOME Smart Socket and MCEE Solar monitor
+  protocol 176 # LaCrosse Technology View LTV-R1 Rainfall Gauge
+  protocol 177 # BlueLine Power Monitor
+  protocol 178 # Burnhard BBQ thermometer
+  protocol 179 # Security+ (Keyfob)
+  protocol 180 # Cavius smoke, heat and water detector
+  protocol 181 # Jansite TPMS Model Solar
+  protocol 182 # Amazon Basics Meat Thermometer
+  protocol 183 # TFA Marbella Pool Thermometer
+  protocol 184 # Auriol AHFL temperature/humidity sensor
+  protocol 185 # Auriol AFT 77 B2 temperature sensor
+  protocol 186 # Honeywell CM921 Wireless Programmable Room Thermostat
+  protocol 187 # Hyundai TPMS (VDO)
 
 ## Flex devices (command line option "-X")
 

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -326,49 +326,49 @@ stop_after_successful_events false
   protocol 142 # Fine Offset Electronics/ECOWITT WH51 Soil Moisture Sensor
   protocol 143 # Holman Industries iWeather WS5029 weather station (older PWM)
   protocol 144 # TBH weather sensor
-  protocol 145 # Rojaflex
-  protocol 146 # WS2032 weather station
-  protocol 147 # Auriol AFW2A1 temperature/humidity sensor
-  protocol 148 # TFA Drop Rain Gauge 30.3233.01
-  protocol 149 # DSC Security Contact (WS4945)
-  protocol 150 # ERT Standard Consumption Message (SCM)
-# protocol 151 # Klimalogg
-  protocol 152 # Visonic powercode
-  protocol 153 # Eurochron EFTH-800 temperature and humidity sensor
-  protocol 154 # Cotech 36-7959 wireless weather station with USB
-  protocol 155 # Standard Consumption Message Plus (SCMplus)
-  protocol 156 # Fine Offset Electronics WH1080/WH3080 Weather Station (FSK)
-  protocol 157 # Abarth 124 Spider TPMS
-  protocol 158 # Missil ML0757 weather station
-  protocol 159 # Sharp SPC775 weather station
-  protocol 160 # Insteon
-  protocol 161 # ERT Interval Data Message (IDM)
-  protocol 162 # ERT Interval Data Message (IDM) for Net Meters
-# protocol 163 # ThermoPro-TX2 temperature sensor
-  protocol 164 # Acurite 590TX Temperature with optional Humidity
-  protocol 165 # Security+ 2.0 (Keyfob)
-  protocol 166 # TFA Dostmann 30.3221.02 T/H Outdoor Sensor
-  protocol 167 # LaCrosse Technology View LTV-WSDTH01 Breeze Pro Wind Sensor
-  protocol 168 # Somfy RTS
-  protocol 169 # Schrader TPMS SMD3MA4 (Subaru)
-# protocol 170 # Nice Flor-s remote control for gates
-  protocol 171 # LaCrosse Technology View LTV-WR1 Multi Sensor
-  protocol 172 # LaCrosse Technology View LTV-TH Thermo/Hygro Sensor
-  protocol 173 # Bresser Weather Center 6-in-1, 7-in-1 indoor, new 5-in-1, 3-in-1 wind gauge, Froggit WH6000, Ventus C8488A
-  protocol 174 # Bresser Weather Center 7-in-1
-  protocol 175 # EcoDHOME Smart Socket and MCEE Solar monitor
-  protocol 176 # LaCrosse Technology View LTV-R1 Rainfall Gauge
-  protocol 177 # BlueLine Power Monitor
-  protocol 178 # Burnhard BBQ thermometer
-  protocol 179 # Security+ (Keyfob)
-  protocol 180 # Cavius smoke, heat and water detector
-  protocol 181 # Jansite TPMS Model Solar
-  protocol 182 # Amazon Basics Meat Thermometer
-  protocol 183 # TFA Marbella Pool Thermometer
-  protocol 184 # Auriol AHFL temperature/humidity sensor
-  protocol 185 # Auriol AFT 77 B2 temperature sensor
-  protocol 186 # Honeywell CM921 Wireless Programmable Room Thermostat
-  protocol 187 # Hyundai TPMS (VDO)
+  protocol 145 # WS2032 weather station
+  protocol 146 # Auriol AFW2A1 temperature/humidity sensor
+  protocol 147 # TFA Drop Rain Gauge 30.3233.01
+  protocol 148 # DSC Security Contact (WS4945)
+  protocol 149 # ERT Standard Consumption Message (SCM)
+# protocol 150 # Klimalogg
+  protocol 151 # Visonic powercode
+  protocol 152 # Eurochron EFTH-800 temperature and humidity sensor
+  protocol 153 # Cotech 36-7959 wireless weather station with USB
+  protocol 154 # Standard Consumption Message Plus (SCMplus)
+  protocol 155 # Fine Offset Electronics WH1080/WH3080 Weather Station (FSK)
+  protocol 156 # Abarth 124 Spider TPMS
+  protocol 157 # Missil ML0757 weather station
+  protocol 158 # Sharp SPC775 weather station
+  protocol 159 # Insteon
+  protocol 160 # ERT Interval Data Message (IDM)
+  protocol 161 # ERT Interval Data Message (IDM) for Net Meters
+# protocol 162 # ThermoPro-TX2 temperature sensor
+  protocol 163 # Acurite 590TX Temperature with optional Humidity
+  protocol 164 # Security+ 2.0 (Keyfob)
+  protocol 165 # TFA Dostmann 30.3221.02 T/H Outdoor Sensor
+  protocol 166 # LaCrosse Technology View LTV-WSDTH01 Breeze Pro Wind Sensor
+  protocol 167 # Somfy RTS
+  protocol 168 # Schrader TPMS SMD3MA4 (Subaru)
+# protocol 169 # Nice Flor-s remote control for gates
+  protocol 170 # LaCrosse Technology View LTV-WR1 Multi Sensor
+  protocol 171 # LaCrosse Technology View LTV-TH Thermo/Hygro Sensor
+  protocol 172 # Bresser Weather Center 6-in-1, 7-in-1 indoor, new 5-in-1, 3-in-1 wind gauge, Froggit WH6000, Ventus C8488A
+  protocol 173 # Bresser Weather Center 7-in-1
+  protocol 174 # EcoDHOME Smart Socket and MCEE Solar monitor
+  protocol 175 # LaCrosse Technology View LTV-R1 Rainfall Gauge
+  protocol 176 # BlueLine Power Monitor
+  protocol 177 # Burnhard BBQ thermometer
+  protocol 178 # Security+ (Keyfob)
+  protocol 179 # Cavius smoke, heat and water detector
+  protocol 180 # Jansite TPMS Model Solar
+  protocol 181 # Amazon Basics Meat Thermometer
+  protocol 182 # TFA Marbella Pool Thermometer
+  protocol 183 # Auriol AHFL temperature/humidity sensor
+  protocol 184 # Auriol AFT 77 B2 temperature sensor
+  protocol 185 # Honeywell CM921 Wireless Programmable Room Thermostat
+  protocol 186 # Hyundai TPMS (VDO)
+  protocol 187 # Rojaflex
 
 ## Flex devices (command line option "-X")
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -194,7 +194,7 @@
     DECL(auriol_aft77b2) \
     DECL(honeywell_cm921) \
     DECL(tpms_hyundai_vdo) \
-    DECL(rojaflex1)
+    DECL(rojaflex)
 
     /* Add new decoders here. */
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -194,7 +194,7 @@
     DECL(auriol_aft77b2) \
     DECL(honeywell_cm921) \
     DECL(tpms_hyundai_vdo) \
-    DECL(rojaflex)
+    DECL(rojaflex1)
 
     /* Add new decoders here. */
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -152,7 +152,6 @@
     DECL(fineoffset_WH51) \
     DECL(holman_ws5029pwm) \
     DECL(archos_tbh) \
-    DECL(rojaflex) \
     DECL(ws2032) \
     DECL(auriol_afw2a1) \
     DECL(tfa_drop_303233) \
@@ -194,7 +193,8 @@
     DECL(auriol_ahfl) \
     DECL(auriol_aft77b2) \
     DECL(honeywell_cm921) \
-    DECL(tpms_hyundai_vdo)
+    DECL(tpms_hyundai_vdo) \
+    DECL(rojaflex)
 
     /* Add new decoders here. */
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -152,6 +152,7 @@
     DECL(fineoffset_WH51) \
     DECL(holman_ws5029pwm) \
     DECL(archos_tbh) \
+    DECL(rojaflex) \
     DECL(ws2032) \
     DECL(auriol_afw2a1) \
     DECL(tfa_drop_303233) \

--- a/man/man1/rtl_433.1
+++ b/man/man1/rtl_433.1
@@ -151,7 +151,7 @@ RTL\-SDR device driver is available.
 To set gain for RTL\-SDR use \-g <gain> to set an overall gain in dB.
 .RE
 .RS
-SoapySDR device driver is available.
+SoapySDR device driver is not available.
 .RE
 .TP
 [ \fB\-d\fI ""\fP ]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(r_433 STATIC
     devices/ambientweather_tx8300.c
     devices/ambientweather_wh31e.c
     devices/archos_tbh.c
+    devices/rojaflex.c
     devices/auriol_aft77b2.c
     devices/auriol_afw2a1.c
     devices/auriol_ahfl.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,7 +43,6 @@ add_library(r_433 STATIC
     devices/ambientweather_tx8300.c
     devices/ambientweather_wh31e.c
     devices/archos_tbh.c
-    devices/rojaflex.c
     devices/auriol_aft77b2.c
     devices/auriol_afw2a1.c
     devices/auriol_ahfl.c
@@ -149,6 +148,7 @@ add_library(r_433 STATIC
     devices/quhwa.c
     devices/radiohead_ask.c
     devices/rftech.c
+    devices/rojaflex.c
     devices/rubicson.c
     devices/rubicson_48659.c
     devices/s3318p.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -147,6 +147,7 @@ rtl_433_SOURCES      = abuf.c \
                        devices/quhwa.c \
                        devices/radiohead_ask.c \
                        devices/rftech.c \
+                       devices/rojaflex.c \
                        devices/rubicson.c \
                        devices/rubicson_48659.c \
                        devices/s3318p.c \

--- a/src/devices/rojaflex.c
+++ b/src/devices/rojaflex.c
@@ -227,7 +227,6 @@ static int rojaflex_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     {
         char tokenString[7] = "";
         char id[10]         = "";
-        char *integrity     = (dataframe_bitcount == DATAFRAME_BITCOUNT_INCL_CRC) ? "CRC-16/CMS" : "CRC-16/CMS missing";
         char *deviceType    = "unknown";
         sprintf(tokenString, "0x%02x%02x", msg[MESSAGE_TOKEN_OFFSET], msg[MESSAGE_TOKEN_OFFSET + 1]);
         sprintf(id, "0x%02x%02x%02x%01x", msg[ID_OFFSET], msg[ID_OFFSET + 1], msg[ID_OFFSET + 2], (msg[ID_OFFSET + 3] >> 4));
@@ -254,7 +253,7 @@ static int rojaflex_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                     "token",        "Msg Token", DATA_STRING, tokenString,
                     "commandtype",  "Command ",  DATA_STRING, getCommandString(&msg[0]),
                     "commandvalue", "Value",     DATA_INT,    msg[COMMAND_VALUE_OFFSET],
-                    "mic",          "Integrity", DATA_STRING, integrity,
+                    "mic",          "Integrity", DATA_STRING, (dataframe_bitcount == DATAFRAME_BITCOUNT_INCL_CRC) ? "CRC" : "",
                     NULL);
         /* clang-format on */
 

--- a/src/devices/rojaflex.c
+++ b/src/devices/rojaflex.c
@@ -201,7 +201,7 @@ static int rojaflex_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                     "token",        "Msg Token", DATA_STRING, tokenString,
                     "commandtype",  "Command ",  DATA_STRING, getCommandString(&msg[0]),
                     "commandvalue", "Value",     DATA_INT,    msg[COMMAND_VALUE_OFFSET],
-                    "mic",          "Integrity", DATA_STRING, (dataframe_bitcount == DATAFRAME_BITCOUNT_INCL_CRC) ? "CRC" : "",
+                    "mic",      "Integrity",     DATA_COND, dataframe_bitcount == DATAFRAME_BITCOUNT_INCL_CRC, DATA_FORMAT, "%s", DATA_STRING, "CRC",
                     NULL);
         /* clang-format on */
 

--- a/src/devices/rojaflex.c
+++ b/src/devices/rojaflex.c
@@ -226,9 +226,11 @@ static int rojaflex_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         uint8_t msg_new[19];
         uint16_t sum = 0;
 
-        fprintf(stderr, "\n");
-        fprintf(stderr, "%s: Signal cloner\n", __func__);
-        fprintf(stderr, "%s: \n", __func__);
+        if (decoder->verbose > 1) {
+            fprintf(stderr, "\n");
+            fprintf(stderr, "%s: Signal cloner\n", __func__);
+            fprintf(stderr, "%s: \n", __func__);
+        }
 
         do {
             for (uint8_t i = 0; i < sizeof(remote_commands); ++i) {
@@ -280,10 +282,14 @@ static int rojaflex_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 /*
                 // Print final command
                 */
-                bitrow_printf(&msg_new[0], sizeof(msg_new) * 8, "%s: CH:%01x Command:0x%02x: ", __func__, channel, command);
+                if (decoder->verbose > 1) {
+                    bitrow_printf(&msg_new[0], sizeof(msg_new) * 8, "%s: CH:%01x Command:0x%02x: ", __func__, channel, command);
+                }
             }
 
-            fprintf(stderr, "\n");
+            if (decoder->verbose > 1) {    
+                fprintf(stderr, "\n");
+            }
             ++channel;
         } while ((channel <= 0xF) && GENERATE_COMMANDS_FOR_ALL_CHANNELS);
     }

--- a/src/devices/rojaflex.c
+++ b/src/devices/rojaflex.c
@@ -1,0 +1,371 @@
+/** @file
+    Rojaflex shutter and remote devices.
+
+    Copyright (c) 2021 Sebastian Hofmann <sebastian.hofmann+rtl433@posteo.de>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+ */
+
+#include "decoder.h"
+
+/**
+Frequency: 433.92MH
+.modulation  = FSK_PULSE_PCM,
+.short_width = 100,
+.long_width  = 100,
+.reset_limit = 102400,
+*/
+
+/**
+Signal documentation
+
+Default signal layout
+0xaaaaaaaa d391d391 SS KKKKKK ?CDDDD TTTT CCCC
+
+4 Bytes Preamble
+4 Bytes Sync Word
+1 Byte  Size       "S" is always "0x08"
+3 Bytes Key        "Seems to be the static ID for the Homeinstallation"
+3 Bytes Data       "See docu below"
+2 Bytes Token      "It seems to be a message token which is used for the shutter answer."
+2 Bytes CRC-16/CMS "Seems optional, because this is missing from commands via bridge P2D."
+19 Byte Summe      "Only 17 Bytes without CRC (from bridge)"
+
+Data documentation
+0xFF     - Size always "0x8"
+0xFFFFFF - Home ID, I assume that differs per installation, but is static then
+0xF      - Unknown (is static 0x2) - Not sure if it is also the HomeID
+0xF      - Radio channel: 1-15 single channels (one shutter is registert to one channel), 0 means all
+0xFF     - Command ID    (0x0a = stop, 0x1a = up,0x8a = down, 0xea = Request)
+0xFF     - Command Value (in status from shutter this is the percent value. 0% for open 100% for close)
+
+Message Token documentation
+See generator function, no clue how to calculate it dynamic
+
+To get raw data:
+./rtl_433 -f 433920000 -X n=rojaflex,m=FSK_PCM,s=100,l=100,r=102400
+*/
+
+
+// Message Defines
+#define MESSAGE_BYTECOUNT_INCL_CRC 19 //Including CRC which is optional
+#define MESSAGE_BITCOUNT_INCL_CRC  152
+#define PREAMBLE_OFFSET   0
+#define PREAMBLE_BITCOUNT 64
+#define LENGTH_OFFSET     8
+#define LENGTH_BITCOUNT   8
+#define HOMEID_OFFSET     9
+#define HOMEID_BITCOUNT   28
+#define RADIO_CHANNEL_OFFSET   12 // Mask 0x0F
+#define UNKNOWN_CHANNEL_OFFSET 12 // Mask 0xF0
+#define COMMAND_ID_OFFSET      13
+#define COMMAND_ID_BITCOUNT    8
+#define COMMAND_VALUE_OFFSET   14
+#define COMMAND_VALUE_BITCOUNT 8
+#define MESSAGE_TOKEN_OFFSET   15
+#define MESSAGE_TOKEN_BITCOUNT 16
+#define MESSAGE_CRC_OFFSET     17
+#define MESSAGE_CRC_BITCOUNT   16
+
+//Command Defindes
+#define COMMAND_ID_STOP     0x0a
+#define COMMAND_ID_UP       0x1a
+#define COMMAND_ID_DOWN     0x8a
+#define COMMAND_ID_SAVE_UNSAVE_POS 0x9a
+#define COMMAND_ID_GO_SAVED_POS    0xda
+#define COMMAND_ID_REQUESTSTATUS   0xea
+
+#if 0
+static char* getDeviceTypeString( uint8_t * msg, unsigned int msg_bitcount)
+{
+    if( (msg[COMMAND_ID_OFFSET] & 0xF) == 0x5 ) {
+        return "RojaFlex Shutter";
+    } else if ( (msg[COMMAND_ID_OFFSET] & 0xF) == 0xa ) {
+        // Rojaflex Bridge clones a remote signal but does not send an CRC!?!?
+        // So we can detect if it a real remote or a bridge on the message length.
+        if( msg_bitcount == MESSAGE_BITCOUNT_INCL_CRC ) {
+            return "RojaFlex Remote";
+        } else {
+            return "RojaFlex Bridge";
+        }
+    }
+    return "Unknown";
+}
+#endif
+
+// Calcualte message token in static way
+// It seems to be a more dynamic formular ... but I did not find it until now.
+static uint16_t calcMessageToken( uint8_t command, uint8_t channel )
+{
+    uint16_t token = 0;
+    uint8_t  magic_static_value = 0;
+
+    // Calculate some magic static value because I do not know the dynamic way.
+    switch( command )
+    {
+        case COMMAND_ID_STOP: magic_static_value = 0x85; break;
+        case COMMAND_ID_UP:   magic_static_value = 0xa5; break;
+        case COMMAND_ID_DOWN: magic_static_value = 0x85; break;
+        case COMMAND_ID_SAVE_UNSAVE_POS: magic_static_value = 0xa5; break;
+        case COMMAND_ID_GO_SAVED_POS:    magic_static_value = 0x25; break;
+        case COMMAND_ID_REQUESTSTATUS:   magic_static_value = 0x5D; break;
+        default:
+            return 0xFFFF;
+    }
+
+    switch( command )
+    {
+        case COMMAND_ID_STOP:
+        case COMMAND_ID_UP:
+        case COMMAND_ID_DOWN:
+        case COMMAND_ID_SAVE_UNSAVE_POS:
+        case COMMAND_ID_GO_SAVED_POS:
+            token = command << 8;
+            break;
+        case COMMAND_ID_REQUESTSTATUS:
+            // I do not know why not also the command
+            token = 0x02 << 8;
+            break;
+    }
+
+    token = token + magic_static_value + channel;
+
+    return token;
+}
+
+// Done
+static char* getCommandString( uint8_t * msg )
+{
+    switch( msg[COMMAND_ID_OFFSET] )
+    {
+    case COMMAND_ID_STOP:
+        return "0x0a - Stop     ";
+    case COMMAND_ID_UP:
+        return "0x1a - Up       ";
+    case COMMAND_ID_DOWN:
+        return "0x8a - Down     ";
+    case COMMAND_ID_SAVE_UNSAVE_POS:
+        // 5 x Stop on remote set inclined pos.
+        // Command is complete identical for set and unset
+        // - If nothing is saved it will set.
+        // - If something is saved and the position is identical it will reset.
+        //   The P2D bridge is beeping in that case.
+        return "0x9a - Save/Unsave position";
+    case COMMAND_ID_GO_SAVED_POS:
+        // Hold Stop for 5 seconds to drive to saved pos.
+        return "0xda - Go saved position";
+    case COMMAND_ID_REQUESTSTATUS:
+       // I am not sure if that is true.     
+       // I know that the remote is sending the message and not the shutter.
+       // I know that the bridge is not sending this message after e.g.0x1a.
+       // I know that the shutter sends a Position status right after this message.
+       // After the normal 0x1a command from a bridge, the position status
+       // will be send wenn the stutter is completely up but not before.
+       // So I think this is a "Request Shutter Status Now".
+        return "0xea - Request Status    ";     
+    case 0x85: //  0%
+        return "0x85 - Pos. Status -   0%";
+    case 0x95: // 20%
+        return "0x95 - Pos. Status -  20%";
+    case 0xA5: // 40%
+        return "0xA5 - Pos. Status -  40%";
+    case 0xB5: // 60%
+        return "0xB5 - Pos. Status -  60%";
+    case 0xC5: // 80%
+        return "0xC5 - Pos. Status -  80%";
+    case 0xD5: //100%
+        return "0xD5 - Pos. Status - 100%";      
+    }
+    return "unknown";
+}
+
+static int rojaflex_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    uint8_t const message_preamble[] = {
+            0xaa, 0xaa, 0xaa, 0xaa, // preamble
+            0xd3, 0x91, 0xd3, 0x91  // sync word
+    };
+
+    data_t *data;
+    uint8_t msg[MESSAGE_BYTECOUNT_INCL_CRC];
+    uint8_t msg_bitcount = 0;
+  
+    if (bitbuffer->num_rows != 1) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    int row = 0;
+    // Validate message and reject it as fast as possible : check for preamble
+    unsigned start_pos = bitbuffer_search(bitbuffer, row, 0, message_preamble, sizeof (message_preamble) * 8);
+
+    if (start_pos < bitbuffer->bits_per_row[row]) {
+        // Save bitcount of total message including preamble
+        msg_bitcount = (bitbuffer->bits_per_row[row] - start_pos) & 0xFE;
+    } else {
+        return DECODE_ABORT_EARLY; // no preamble detected
+    }
+    
+    if ( msg_bitcount < (MESSAGE_BITCOUNT_INCL_CRC - MESSAGE_CRC_BITCOUNT) || (msg_bitcount > MESSAGE_BITCOUNT_INCL_CRC) ) { 
+        // check min and max length
+        return DECODE_ABORT_LENGTH;
+    }
+
+    //Extract raw line
+    bitbuffer_extract_bytes(bitbuffer, row, start_pos, msg, sizeof (msg) * 8);
+    if ( decoder->verbose > 1 ) {
+        bitrow_printf(msg, msg_bitcount, "%s: rawdata: ", __func__ );
+    }
+
+    // Check CRC if available
+    if( msg_bitcount == MESSAGE_BITCOUNT_INCL_CRC )
+    {
+        // Thanks to: ./reveng -w 16 -s $msg1 $msg2 $msg3
+        // width=16  poly=0x8005  init=0xffff  refin=false  refout=false  xorout=0x0000  check=0xaee7  residue=0x0000  name="CRC-16/CMS"
+        uint16_t crc_message = (msg[MESSAGE_CRC_OFFSET] << 8 | msg[MESSAGE_CRC_OFFSET + 1]);
+        uint16_t crc_calc    = crc16( &msg[LENGTH_OFFSET], 9, 0x8005, 0xffff);
+
+        if( crc_message != crc_calc )
+        {
+            if (decoder->verbose)
+                fprintf(stderr, "%s: CRC invalid message:%04x != calc:%04x\n", __func__, crc_message, crc_calc);
+
+            return DECODE_FAIL_MIC;
+        };    
+    } 
+    
+    // Build the default terminal output
+    {
+        char tokenString[7] = "";
+        char homeID[10]     = "";
+        char * integrity    =  (msg_bitcount == MESSAGE_BITCOUNT_INCL_CRC) ? "CRC-16/CMS" : "CRC-16/CMS missing";
+        char * deviceType   = "unknown";
+        sprintf(tokenString, "0x%02x%02x",msg[MESSAGE_TOKEN_OFFSET], msg[MESSAGE_TOKEN_OFFSET+1]);
+        sprintf(homeID, "0x%02x%02x%02x%01x",msg[HOMEID_OFFSET], msg[HOMEID_OFFSET+1],msg[HOMEID_OFFSET+2], (msg[HOMEID_OFFSET+3] >> 4));
+
+        if((msg[COMMAND_ID_OFFSET] & 0xF) == 0x5) {
+            deviceType = "RojaFlex Shutter";
+        } else if( (msg[COMMAND_ID_OFFSET] & 0xF) == 0xa ) {
+            // Rojaflex Bridge clones a remote signal but does not send an CRC!?!?
+            // So we can detect if it a real remote or a bridge on the message length.
+            if( msg_bitcount == MESSAGE_BITCOUNT_INCL_CRC ) {
+                deviceType = "RojaFlex Remote";
+            } else {
+                deviceType = "RojaFlex Bridge";
+            }
+        }
+
+        /* clang-format off */
+        data = data_make(
+                    "model",        "Model",     DATA_STRING, deviceType,
+                    "radiochannel", "Radio CH.", DATA_INT,    msg[RADIO_CHANNEL_OFFSET] & 0xF,
+                    "homeid",       "Home ID",   DATA_STRING, homeID,
+                    "token",        "Msg Token", DATA_STRING, tokenString,
+                    "commandtype",  "Command ",  DATA_STRING, getCommandString(&msg[0]),
+                    "commandvalue", "Value",     DATA_INT,    msg[COMMAND_VALUE_OFFSET],
+                    "mic",          "Integrity", DATA_STRING, integrity,
+                    NULL);
+        /* clang-format on */
+        
+        decoder_output_data(decoder, data);
+    }
+
+// You can use this defines to clone / generate all commands for other bridges
+#define GENERATE_COMMANDS_FOR_CURRENT_CHANNEL 0
+#define GENERATE_COMMANDS_FOR_ALL_CHANNELS    0
+
+    if( GENERATE_COMMANDS_FOR_CURRENT_CHANNEL || GENERATE_COMMANDS_FOR_ALL_CHANNELS  )
+    {
+        uint8_t const remote_commands[] = {
+            COMMAND_ID_STOP,
+            COMMAND_ID_UP,
+            COMMAND_ID_DOWN,
+            COMMAND_ID_SAVE_UNSAVE_POS,
+            COMMAND_ID_GO_SAVED_POS,
+            COMMAND_ID_REQUESTSTATUS
+        };
+
+        uint8_t channel = GENERATE_COMMANDS_FOR_CURRENT_CHANNEL ? msg[RADIO_CHANNEL_OFFSET] & 0xF : 0;
+        uint8_t command = 0;   // Test
+        uint8_t msg_new[MESSAGE_BYTECOUNT_INCL_CRC];
+
+        fprintf(stderr, "\n" );
+        fprintf(stderr, "%s: Signal cloner\n", __func__ );
+        fprintf(stderr, "%s: \n", __func__ );
+    
+        do
+        {
+            for(uint8_t i = 0; i < sizeof(remote_commands); ++i )
+            {
+                command = remote_commands[i];
+                
+                // Clone message preamble
+                for(uint8_t j = 0; j < sizeof(message_preamble); ++j ) {
+                    msg_new[j] = message_preamble[j] ;
+                }
+                // Set length
+                msg_new[LENGTH_OFFSET] = 0x8;
+                
+                // Clone homeid from received message
+                msg_new[HOMEID_OFFSET + 0] = msg[HOMEID_OFFSET + 0];
+                msg_new[HOMEID_OFFSET + 1] = msg[HOMEID_OFFSET + 1];
+                msg_new[HOMEID_OFFSET + 2] = msg[HOMEID_OFFSET + 2];
+
+                // Clone 4bit homeID + radio channel
+                msg_new[HOMEID_OFFSET + 3] = msg[HOMEID_OFFSET + 3] & 0xF0 + channel;
+
+                // Set command id + command value
+                msg_new[COMMAND_ID_OFFSET]    = command;
+                msg_new[COMMAND_VALUE_OFFSET] = (command == COMMAND_ID_REQUESTSTATUS) ? 0x0 : 0x1; //Only the pos request has a zero!?
+
+                // Generate message token
+                uint16_t token_calc = calcMessageToken( command, channel);
+                msg_new[MESSAGE_TOKEN_OFFSET + 0] = token_calc >> 8;
+                msg_new[MESSAGE_TOKEN_OFFSET + 1] = token_calc & 0xFF;
+
+                // Generate CRC
+                // Thanks to: ./reveng -w 16 -s $msg1 $msg2 $msg3
+                // width=16  poly=0x8005  init=0xffff  refin=false  refout=false  xorout=0x0000  check=0xaee7  residue=0x0000  name="CRC-16/CMS"
+                uint16_t crc_calc    = crc16( &msg_new[LENGTH_OFFSET], 9, 0x8005, 0xffff);
+                msg_new[MESSAGE_CRC_OFFSET + 0] = crc_calc >> 8;
+                msg_new[MESSAGE_CRC_OFFSET + 1] = crc_calc & 0xFF;
+            
+                /*
+                // Print final command
+                */
+                bitrow_printf(&msg_new[0], msg_bitcount, "%s: CH:%01x Command:0x%02x: ", __func__, channel, command);
+            }
+
+            fprintf(stderr, "\n" );
+            ++channel;
+        }
+        while( channel <= 0xF && GENERATE_COMMANDS_FOR_ALL_CHANNELS );
+    }
+
+    return 1;
+}
+
+static char *output_fields[] = {
+        "model",
+        "radiochannel",
+        "homeid",
+        "token",
+        "commandtype",
+        "commandvalue",
+        "mic",
+        NULL,
+};
+
+r_device rojaflex = {
+        .name        = "Rojaflex",
+        .modulation  = FSK_PULSE_PCM,
+        .short_width = 100,
+        .long_width  = 100,
+        .reset_limit = 102400,
+        .sync_width  = 0,
+        .decode_fn   = &rojaflex_decode,
+        .disabled    = 0,
+        .fields      = output_fields,
+};

--- a/src/devices/rojaflex.c
+++ b/src/devices/rojaflex.c
@@ -78,24 +78,6 @@ To get raw data:
 #define COMMAND_ID_GO_SAVED_POS    0xda
 #define COMMAND_ID_REQUESTSTATUS   0xea
 
-#if 0
-static char* getDeviceTypeString( uint8_t * msg, unsigned int msg_bitcount)
-{
-    if( (msg[COMMAND_ID_OFFSET] & 0xF) == 0x5 ) {
-        return "RojaFlex Shutter";
-    } else if ( (msg[COMMAND_ID_OFFSET] & 0xF) == 0xa ) {
-        // Rojaflex Bridge clones a remote signal but does not send an CRC!?!?
-        // So we can detect if it a real remote or a bridge on the message length.
-        if( msg_bitcount == MESSAGE_BITCOUNT_INCL_CRC ) {
-            return "RojaFlex Remote";
-        } else {
-            return "RojaFlex Bridge";
-        }
-    }
-    return "Unknown";
-}
-#endif
-
 // Calcualte message token in static way
 // It seems to be a more dynamic formular ... but I did not find it until now.
 static uint16_t calcMessageToken( uint8_t command, uint8_t channel )

--- a/src/devices/rojaflex.c
+++ b/src/devices/rojaflex.c
@@ -233,24 +233,24 @@ static int rojaflex_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         sprintf(id, "0x%02x%02x%02x%01x", msg[ID_OFFSET], msg[ID_OFFSET + 1], msg[ID_OFFSET + 2], (msg[ID_OFFSET + 3] >> 4));
 
         if ((msg[COMMAND_ID_OFFSET] & 0xF) == 0x5) {
-            deviceType = "RojaFlex Shutter";
+            deviceType = "RojaFlex-Shutter";
         }
         else if ((msg[COMMAND_ID_OFFSET] & 0xF) == 0xa) {
             // Rojaflex Bridge clones a remote signal but does not send an CRC!?!?
             // So we can detect if it a real remote or a bridge on the message length.
             if (dataframe_bitcount == DATAFRAME_BITCOUNT_INCL_CRC) {
-                deviceType = "RojaFlex Remote";
+                deviceType = "RojaFlex-Remote";
             }
             else {
-                deviceType = "RojaFlex Bridge";
+                deviceType = "RojaFlex-Bridge";
             }
         }
 
         /* clang-format off */
         data = data_make(
                     "model",        "Model",     DATA_STRING, deviceType,
-                    "channel",      "Channel",   DATA_INT,    msg[CHANNEL_OFFSET] & 0xF,
                     "id",           "ID",        DATA_STRING, id,
+                    "channel",      "Channel",   DATA_INT,    msg[CHANNEL_OFFSET] & 0xF,
                     "token",        "Msg Token", DATA_STRING, tokenString,
                     "commandtype",  "Command ",  DATA_STRING, getCommandString(&msg[0]),
                     "commandvalue", "Value",     DATA_INT,    msg[COMMAND_VALUE_OFFSET],
@@ -339,8 +339,8 @@ static int rojaflex_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
 static char *output_fields[] = {
         "model",
-        "channel",
         "id",
+        "channel",
         "token",
         "commandtype",
         "commandvalue",

--- a/src/devices/rojaflex.c
+++ b/src/devices/rojaflex.c
@@ -25,12 +25,13 @@ Signal documentation
 Default signal layout
 0xaaaaaaaa d391d391 SS KKKKKK ?CDDDD TTTT CCCC
 
-4 Bytes Preamble
-4 Bytes Sync Word
+4 Bytes Preamble   "0xaaaaaaaa"
+4 Bytes Sync Word  "9391d391"
 1 Byte  Size       "S" is always "0x08"
 3 Bytes ID         "Seems to be the static ID for the Homeinstallation"
 3 Bytes Data       "See docu below"
-2 Bytes Token      "It seems to be a message token which is used for the shutter answer."
+1 Bytes Token I    "It seems to be an internal message token which is used for the shutter answer."
+1 Bytes Token II   "Is the sum of 3 Bytes ID + 3 Bytes Data + 1 Byte token"
 2 Bytes CRC-16/CMS "Seems optional, because this is missing from commands via bridge P2D."
 19 Byte Summe      "Only 17 Bytes without CRC (from bridge)"
 
@@ -41,9 +42,6 @@ Data documentation
 0xF      - Channel: 1-15 single channels (one shutter is registert to one channel), 0 means all
 0xFF     - Command ID    (0x0a = stop, 0x1a = up,0x8a = down, 0xea = Request)
 0xFF     - Command Value (in status from shutter this is the percent value. 0% for open 100% for close)
-
-Message Token documentation
-See generator function, no clue how to calculate it dynamic
 
 To get raw data:
 ./rtl_433 -f 433920000 -X n=rojaflex,m=FSK_PCM,s=100,l=100,r=102400

--- a/src/devices/rojaflex.c
+++ b/src/devices/rojaflex.c
@@ -49,68 +49,77 @@ To get raw data:
 ./rtl_433 -f 433920000 -X n=rojaflex,m=FSK_PCM,s=100,l=100,r=102400
 */
 
-
 // Message Defines
 #define MESSAGE_BYTECOUNT_INCL_CRC 19 //Including CRC which is optional
-#define MESSAGE_BITCOUNT_INCL_CRC  152
-#define PREAMBLE_OFFSET   0
+#define MESSAGE_BITCOUNT_INCL_CRC 152
+#define PREAMBLE_OFFSET 0
 #define PREAMBLE_BITCOUNT 64
-#define LENGTH_OFFSET     8
-#define LENGTH_BITCOUNT   8
-#define ID_OFFSET         9 // HomeID which I assume is static for one Remote Device
-#define ID_BITCOUNT       28
-#define CHANNEL_OFFSET    12 // Mask 0x0F
+#define LENGTH_OFFSET 8
+#define LENGTH_BITCOUNT 8
+#define ID_OFFSET 9 // HomeID which I assume is static for one Remote Device
+#define ID_BITCOUNT 28
+#define CHANNEL_OFFSET 12         // Mask 0x0F
 #define UNKNOWN_CHANNEL_OFFSET 12 // Mask 0xF0
-#define COMMAND_ID_OFFSET      13
-#define COMMAND_ID_BITCOUNT    8
-#define COMMAND_VALUE_OFFSET   14
+#define COMMAND_ID_OFFSET 13
+#define COMMAND_ID_BITCOUNT 8
+#define COMMAND_VALUE_OFFSET 14
 #define COMMAND_VALUE_BITCOUNT 8
-#define MESSAGE_TOKEN_OFFSET   15
+#define MESSAGE_TOKEN_OFFSET 15
 #define MESSAGE_TOKEN_BITCOUNT 16
-#define MESSAGE_CRC_OFFSET     17
-#define MESSAGE_CRC_BITCOUNT   16
+#define MESSAGE_CRC_OFFSET 17
+#define MESSAGE_CRC_BITCOUNT 16
 
 //Command Defindes
-#define COMMAND_ID_STOP     0x0a
-#define COMMAND_ID_UP       0x1a
-#define COMMAND_ID_DOWN     0x8a
+#define COMMAND_ID_STOP 0x0a
+#define COMMAND_ID_UP 0x1a
+#define COMMAND_ID_DOWN 0x8a
 #define COMMAND_ID_SAVE_UNSAVE_POS 0x9a
-#define COMMAND_ID_GO_SAVED_POS    0xda
-#define COMMAND_ID_REQUESTSTATUS   0xea
+#define COMMAND_ID_GO_SAVED_POS 0xda
+#define COMMAND_ID_REQUESTSTATUS 0xea
 
 // Calcualte message token in static way
 // It seems to be a more dynamic formular ... but I did not find it until now.
-static uint16_t calcMessageToken( uint8_t command, uint8_t channel )
+static uint16_t calcMessageToken(uint8_t command, uint8_t channel)
 {
-    uint16_t token = 0;
-    uint8_t  magic_static_value = 0;
+    uint16_t token             = 0;
+    uint8_t magic_static_value = 0;
 
     // Calculate some magic static value because I do not know the dynamic way.
-    switch( command )
-    {
-        case COMMAND_ID_STOP: magic_static_value = 0x85; break;
-        case COMMAND_ID_UP:   magic_static_value = 0xa5; break;
-        case COMMAND_ID_DOWN: magic_static_value = 0x85; break;
-        case COMMAND_ID_SAVE_UNSAVE_POS: magic_static_value = 0xa5; break;
-        case COMMAND_ID_GO_SAVED_POS:    magic_static_value = 0x25; break;
-        case COMMAND_ID_REQUESTSTATUS:   magic_static_value = 0x5D; break;
-        default:
-            return 0xFFFF;
+    switch (command) {
+    case COMMAND_ID_STOP:
+        magic_static_value = 0x85;
+        break;
+    case COMMAND_ID_UP:
+        magic_static_value = 0xa5;
+        break;
+    case COMMAND_ID_DOWN:
+        magic_static_value = 0x85;
+        break;
+    case COMMAND_ID_SAVE_UNSAVE_POS:
+        magic_static_value = 0xa5;
+        break;
+    case COMMAND_ID_GO_SAVED_POS:
+        magic_static_value = 0x25;
+        break;
+    case COMMAND_ID_REQUESTSTATUS:
+        magic_static_value = 0x5D;
+        break;
+    default:
+        return 0xFFFF;
     }
 
-    switch( command )
-    {
-        case COMMAND_ID_STOP:
-        case COMMAND_ID_UP:
-        case COMMAND_ID_DOWN:
-        case COMMAND_ID_SAVE_UNSAVE_POS:
-        case COMMAND_ID_GO_SAVED_POS:
-            token = command << 8;
-            break;
-        case COMMAND_ID_REQUESTSTATUS:
-            // I do not know why not also the command
-            token = 0x02 << 8;
-            break;
+    switch (command) {
+    case COMMAND_ID_STOP:
+    case COMMAND_ID_UP:
+    case COMMAND_ID_DOWN:
+    case COMMAND_ID_SAVE_UNSAVE_POS:
+    case COMMAND_ID_GO_SAVED_POS:
+        token = command << 8;
+        break;
+    case COMMAND_ID_REQUESTSTATUS:
+        // I do not know why not also the command
+        token = 0x02 << 8;
+        break;
     }
 
     token = token + magic_static_value + channel;
@@ -119,10 +128,9 @@ static uint16_t calcMessageToken( uint8_t command, uint8_t channel )
 }
 
 // Done
-static char* getCommandString( uint8_t * msg )
+static char *getCommandString(uint8_t *msg)
 {
-    switch( msg[COMMAND_ID_OFFSET] )
-    {
+    switch (msg[COMMAND_ID_OFFSET]) {
     case COMMAND_ID_STOP:
         return "0x0a - Stop     ";
     case COMMAND_ID_UP:
@@ -140,14 +148,14 @@ static char* getCommandString( uint8_t * msg )
         // Hold Stop for 5 seconds to drive to saved pos.
         return "0xda - Go saved position";
     case COMMAND_ID_REQUESTSTATUS:
-       // I am not sure if that is true.     
-       // I know that the remote is sending the message and not the shutter.
-       // I know that the bridge is not sending this message after e.g.0x1a.
-       // I know that the shutter sends a Position status right after this message.
-       // After the normal 0x1a command from a bridge, the position status
-       // will be send wenn the stutter is completely up but not before.
-       // So I think this is a "Request Shutter Status Now".
-        return "0xea - Request Status    ";     
+        // I am not sure if that is true.
+        // I know that the remote is sending the message and not the shutter.
+        // I know that the bridge is not sending this message after e.g.0x1a.
+        // I know that the shutter sends a Position status right after this message.
+        // After the normal 0x1a command from a bridge, the position status
+        // will be send wenn the stutter is completely up but not before.
+        // So I think this is a "Request Shutter Status Now".
+        return "0xea - Request Status    ";
     case 0x85: //  0%
         return "0x85 - Pos. Status -   0%";
     case 0x95: // 20%
@@ -159,7 +167,7 @@ static char* getCommandString( uint8_t * msg )
     case 0xC5: // 80%
         return "0xC5 - Pos. Status -  80%";
     case 0xD5: //100%
-        return "0xD5 - Pos. Status - 100%";      
+        return "0xD5 - Pos. Status - 100%";
     }
     return "unknown";
 }
@@ -174,67 +182,68 @@ static int rojaflex_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     data_t *data;
     uint8_t msg[MESSAGE_BYTECOUNT_INCL_CRC];
     uint8_t msg_bitcount = 0;
-  
+
     if (bitbuffer->num_rows != 1) {
         return DECODE_ABORT_EARLY;
     }
 
     int row = 0;
     // Validate message and reject it as fast as possible : check for preamble
-    unsigned start_pos = bitbuffer_search(bitbuffer, row, 0, message_preamble, sizeof (message_preamble) * 8);
+    unsigned start_pos = bitbuffer_search(bitbuffer, row, 0, message_preamble, sizeof(message_preamble) * 8);
 
     if (start_pos < bitbuffer->bits_per_row[row]) {
         // Save bitcount of total message including preamble
         msg_bitcount = (bitbuffer->bits_per_row[row] - start_pos) & 0xFE;
-    } else {
+    }
+    else {
         return DECODE_ABORT_EARLY; // no preamble detected
     }
-    
-    if ( msg_bitcount < (MESSAGE_BITCOUNT_INCL_CRC - MESSAGE_CRC_BITCOUNT) || (msg_bitcount > MESSAGE_BITCOUNT_INCL_CRC) ) { 
+
+    if (msg_bitcount < (MESSAGE_BITCOUNT_INCL_CRC - MESSAGE_CRC_BITCOUNT) || (msg_bitcount > MESSAGE_BITCOUNT_INCL_CRC)) {
         // check min and max length
         return DECODE_ABORT_LENGTH;
     }
 
     //Extract raw line
-    bitbuffer_extract_bytes(bitbuffer, row, start_pos, msg, sizeof (msg) * 8);
-    if ( decoder->verbose > 1 ) {
-        bitrow_printf(msg, msg_bitcount, "%s: rawdata: ", __func__ );
+    bitbuffer_extract_bytes(bitbuffer, row, start_pos, msg, sizeof(msg) * 8);
+    if (decoder->verbose > 1) {
+        bitrow_printf(msg, msg_bitcount, "%s: rawdata: ", __func__);
     }
 
     // Check CRC if available
-    if( msg_bitcount == MESSAGE_BITCOUNT_INCL_CRC )
-    {
+    if (msg_bitcount == MESSAGE_BITCOUNT_INCL_CRC) {
         // Thanks to: ./reveng -w 16 -s $msg1 $msg2 $msg3
         // width=16  poly=0x8005  init=0xffff  refin=false  refout=false  xorout=0x0000  check=0xaee7  residue=0x0000  name="CRC-16/CMS"
         uint16_t crc_message = (msg[MESSAGE_CRC_OFFSET] << 8 | msg[MESSAGE_CRC_OFFSET + 1]);
-        uint16_t crc_calc    = crc16( &msg[LENGTH_OFFSET], 9, 0x8005, 0xffff);
+        uint16_t crc_calc    = crc16(&msg[LENGTH_OFFSET], 9, 0x8005, 0xffff);
 
-        if( crc_message != crc_calc )
-        {
+        if (crc_message != crc_calc) {
             if (decoder->verbose)
                 fprintf(stderr, "%s: CRC invalid message:%04x != calc:%04x\n", __func__, crc_message, crc_calc);
 
             return DECODE_FAIL_MIC;
-        };    
-    } 
-    
+        };
+    }
+
     // Build the default terminal output
     {
         char tokenString[7] = "";
-        char id[10]     = "";
-        char * integrity    =  (msg_bitcount == MESSAGE_BITCOUNT_INCL_CRC) ? "CRC-16/CMS" : "CRC-16/CMS missing";
-        char * deviceType   = "unknown";
-        sprintf(tokenString, "0x%02x%02x",msg[MESSAGE_TOKEN_OFFSET], msg[MESSAGE_TOKEN_OFFSET+1]);
-        sprintf(id, "0x%02x%02x%02x%01x",msg[ID_OFFSET], msg[ID_OFFSET+1],msg[ID_OFFSET+2], (msg[ID_OFFSET+3] >> 4));
+        char id[10]         = "";
+        char *integrity     = (msg_bitcount == MESSAGE_BITCOUNT_INCL_CRC) ? "CRC-16/CMS" : "CRC-16/CMS missing";
+        char *deviceType    = "unknown";
+        sprintf(tokenString, "0x%02x%02x", msg[MESSAGE_TOKEN_OFFSET], msg[MESSAGE_TOKEN_OFFSET + 1]);
+        sprintf(id, "0x%02x%02x%02x%01x", msg[ID_OFFSET], msg[ID_OFFSET + 1], msg[ID_OFFSET + 2], (msg[ID_OFFSET + 3] >> 4));
 
-        if((msg[COMMAND_ID_OFFSET] & 0xF) == 0x5) {
+        if ((msg[COMMAND_ID_OFFSET] & 0xF) == 0x5) {
             deviceType = "RojaFlex Shutter";
-        } else if( (msg[COMMAND_ID_OFFSET] & 0xF) == 0xa ) {
+        }
+        else if ((msg[COMMAND_ID_OFFSET] & 0xF) == 0xa) {
             // Rojaflex Bridge clones a remote signal but does not send an CRC!?!?
             // So we can detect if it a real remote or a bridge on the message length.
-            if( msg_bitcount == MESSAGE_BITCOUNT_INCL_CRC ) {
+            if (msg_bitcount == MESSAGE_BITCOUNT_INCL_CRC) {
                 deviceType = "RojaFlex Remote";
-            } else {
+            }
+            else {
                 deviceType = "RojaFlex Bridge";
             }
         }
@@ -250,46 +259,42 @@ static int rojaflex_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                     "mic",          "Integrity", DATA_STRING, integrity,
                     NULL);
         /* clang-format on */
-        
+
         decoder_output_data(decoder, data);
     }
 
 // You can use this defines to clone / generate all commands for other bridges
 #define GENERATE_COMMANDS_FOR_CURRENT_CHANNEL 0
-#define GENERATE_COMMANDS_FOR_ALL_CHANNELS    0
+#define GENERATE_COMMANDS_FOR_ALL_CHANNELS 0
 
-    if( GENERATE_COMMANDS_FOR_CURRENT_CHANNEL || GENERATE_COMMANDS_FOR_ALL_CHANNELS  )
-    {
+    if (GENERATE_COMMANDS_FOR_CURRENT_CHANNEL || GENERATE_COMMANDS_FOR_ALL_CHANNELS) {
         uint8_t const remote_commands[] = {
-            COMMAND_ID_STOP,
-            COMMAND_ID_UP,
-            COMMAND_ID_DOWN,
-            COMMAND_ID_SAVE_UNSAVE_POS,
-            COMMAND_ID_GO_SAVED_POS,
-            COMMAND_ID_REQUESTSTATUS
-        };
+                COMMAND_ID_STOP,
+                COMMAND_ID_UP,
+                COMMAND_ID_DOWN,
+                COMMAND_ID_SAVE_UNSAVE_POS,
+                COMMAND_ID_GO_SAVED_POS,
+                COMMAND_ID_REQUESTSTATUS};
 
         uint8_t channel = GENERATE_COMMANDS_FOR_CURRENT_CHANNEL ? msg[CHANNEL_OFFSET] & 0xF : 0;
-        uint8_t command = 0;   // Test
+        uint8_t command = 0; // Test
         uint8_t msg_new[MESSAGE_BYTECOUNT_INCL_CRC];
 
-        fprintf(stderr, "\n" );
-        fprintf(stderr, "%s: Signal cloner\n", __func__ );
-        fprintf(stderr, "%s: \n", __func__ );
-    
-        do
-        {
-            for(uint8_t i = 0; i < sizeof(remote_commands); ++i )
-            {
+        fprintf(stderr, "\n");
+        fprintf(stderr, "%s: Signal cloner\n", __func__);
+        fprintf(stderr, "%s: \n", __func__);
+
+        do {
+            for (uint8_t i = 0; i < sizeof(remote_commands); ++i) {
                 command = remote_commands[i];
-                
+
                 // Clone message preamble
-                for(uint8_t j = 0; j < sizeof(message_preamble); ++j ) {
-                    msg_new[j] = message_preamble[j] ;
+                for (uint8_t j = 0; j < sizeof(message_preamble); ++j) {
+                    msg_new[j] = message_preamble[j];
                 }
                 // Set length
                 msg_new[LENGTH_OFFSET] = 0x8;
-                
+
                 // Clone ID from received message
                 msg_new[ID_OFFSET + 0] = msg[ID_OFFSET + 0];
                 msg_new[ID_OFFSET + 1] = msg[ID_OFFSET + 1];
@@ -303,27 +308,26 @@ static int rojaflex_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 msg_new[COMMAND_VALUE_OFFSET] = (command == COMMAND_ID_REQUESTSTATUS) ? 0x0 : 0x1; //Only the pos request has a zero!?
 
                 // Generate message token
-                uint16_t token_calc = calcMessageToken( command, channel);
+                uint16_t token_calc               = calcMessageToken(command, channel);
                 msg_new[MESSAGE_TOKEN_OFFSET + 0] = token_calc >> 8;
                 msg_new[MESSAGE_TOKEN_OFFSET + 1] = token_calc & 0xFF;
 
                 // Generate CRC
                 // Thanks to: ./reveng -w 16 -s $msg1 $msg2 $msg3
                 // width=16  poly=0x8005  init=0xffff  refin=false  refout=false  xorout=0x0000  check=0xaee7  residue=0x0000  name="CRC-16/CMS"
-                uint16_t crc_calc    = crc16( &msg_new[LENGTH_OFFSET], 9, 0x8005, 0xffff);
+                uint16_t crc_calc               = crc16(&msg_new[LENGTH_OFFSET], 9, 0x8005, 0xffff);
                 msg_new[MESSAGE_CRC_OFFSET + 0] = crc_calc >> 8;
                 msg_new[MESSAGE_CRC_OFFSET + 1] = crc_calc & 0xFF;
-            
+
                 /*
                 // Print final command
                 */
                 bitrow_printf(&msg_new[0], msg_bitcount, "%s: CH:%01x Command:0x%02x: ", __func__, channel, command);
             }
 
-            fprintf(stderr, "\n" );
+            fprintf(stderr, "\n");
             ++channel;
-        }
-        while( channel <= 0xF && GENERATE_COMMANDS_FOR_ALL_CHANNELS );
+        } while (channel <= 0xF && GENERATE_COMMANDS_FOR_ALL_CHANNELS);
     }
 
     return 1;

--- a/src/devices/rojaflex.c
+++ b/src/devices/rojaflex.c
@@ -50,7 +50,7 @@ To get raw data:
 */
 
 // Message Defines
-#define DATAFRAME_BITCOUNT_INCL_CRC  88
+#define DATAFRAME_BITCOUNT_INCL_CRC 88
 #define DATAFRAME_BYTECOUNT_INCL_CRC 11 //Including CRC but no pramble
 #define LENGTH_OFFSET 0
 #define LENGTH_BITCOUNT 8
@@ -174,7 +174,7 @@ static int rojaflex_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     uint8_t const message_preamble[] = {
             /*0xaa, 0xaa,*/ 0xaa, 0xaa, // preamble
-            0xd3, 0x91, 0xd3, 0x91  // sync word
+            0xd3, 0x91, 0xd3, 0x91      // sync word
     };
 
     data_t *data;
@@ -312,14 +312,14 @@ static int rojaflex_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 msg_new[8 + COMMAND_VALUE_OFFSET] = 0x1;
 
                 // Generate message token
-                uint16_t token_calc               = calcMessageToken(command, channel);
+                uint16_t token_calc                   = calcMessageToken(command, channel);
                 msg_new[8 + MESSAGE_TOKEN_OFFSET + 0] = token_calc >> 8;
                 msg_new[8 + MESSAGE_TOKEN_OFFSET + 1] = token_calc & 0xFF;
 
                 // Generate CRC
                 // Thanks to: ./reveng -w 16 -s $msg1 $msg2 $msg3
                 // width=16  poly=0x8005  init=0xffff  refin=false  refout=false  xorout=0x0000  check=0xaee7  residue=0x0000  name="CRC-16/CMS"
-                uint16_t crc_calc               = crc16(&msg_new[8 + LENGTH_OFFSET], 9, 0x8005, 0xffff);
+                uint16_t crc_calc                   = crc16(&msg_new[8 + LENGTH_OFFSET], 9, 0x8005, 0xffff);
                 msg_new[8 + MESSAGE_CRC_OFFSET + 0] = crc_calc >> 8;
                 msg_new[8 + MESSAGE_CRC_OFFSET + 1] = crc_calc & 0xFF;
 

--- a/src/devices/rojaflex.c
+++ b/src/devices/rojaflex.c
@@ -304,7 +304,7 @@ static int rojaflex_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 msg_new[8 + ID_OFFSET + 2] = msg[ID_OFFSET + 2];
 
                 // Clone 4bit ID + Channel
-                msg_new[8 + ID_OFFSET + 3] = msg[ID_OFFSET + 3] & 0xF0 + channel;
+                msg_new[8 + ID_OFFSET + 3] = (msg[ID_OFFSET + 3] & 0xF0) + channel;
 
                 // Set command id + command value
                 msg_new[8 + COMMAND_ID_OFFSET]    = command;
@@ -330,7 +330,7 @@ static int rojaflex_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
             fprintf(stderr, "\n");
             ++channel;
-        } while (channel <= 0xF && GENERATE_COMMANDS_FOR_ALL_CHANNELS);
+        } while ((channel <= 0xF) && GENERATE_COMMANDS_FOR_ALL_CHANNELS);
     }
 
     return 1;

--- a/vs15/rtl_433.vcxproj
+++ b/vs15/rtl_433.vcxproj
@@ -276,6 +276,7 @@ COPY ..\..\libusb\MS64\dll\libusb*.dll $(TargetDir)</Command>
     <ClCompile Include="..\src\devices\quhwa.c" />
     <ClCompile Include="..\src\devices\radiohead_ask.c" />
     <ClCompile Include="..\src\devices\rftech.c" />
+    <ClCompile Include="..\src\devices\rojaflex.c" />
     <ClCompile Include="..\src\devices\rubicson.c" />
     <ClCompile Include="..\src\devices\rubicson_48659.c" />
     <ClCompile Include="..\src\devices\s3318p.c" />

--- a/vs15/rtl_433.vcxproj.filters
+++ b/vs15/rtl_433.vcxproj.filters
@@ -565,6 +565,9 @@
     <ClCompile Include="..\src\devices\rftech.c">
       <Filter>Source Files\devices</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\devices\rojaflex.c">
+      <Filter>Source Files\devices</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\devices\rubicson.c">
       <Filter>Source Files\devices</Filter>
     </ClCompile>


### PR DESCRIPTION
Supported Device:
- Remote
- Window Shutter

Extra feature:
- Signal Cloner / Generator
   Could be activated in source.
   Take a real message, extract HOMEID and generate all possible command for all 15 channels:
   This is helpful if you what use an own bridge and you need the commands.
   
Review Feedback:

> - Copyright line missing?
> - Decoder doc should be just Markdown (no leading // ), first line the device name.
> - data_make() should be wrapped with /* clang-format off/on */

done

> - those short functions are preferred to be inline code (nothing in the decoder is reuseable...)

done. Two big functions are still there. Which is think helps.

> preamble is best shortened to match truncated start, i.e. 0xaa 0xaa 0xd3...

Not done, because this will change all offsets, and in my tests this works great.
I understand the idea behind this point. Maybe I can rewrite it in a second round with
changed offsets.

> - you would usually check for the required minimum (bit)length, then truncate -- we don't mind if there is garbage at the end.

Question: I only read 19 bytes (which is the message) what should I truncate?


