### PR TITLE
Added kPa value transformation

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -210,8 +210,8 @@ mappings = {
         "config": {
             "device_class": "pressure",
             "name": "Pressure",
-            "unit_of_measurement": "hPa",
-            "value_template": "{{ float(value|float) * 10.0 | round(2) }}"
+            "unit_of_measurement": "kPa",
+            "value_template": "{{ value|float }}"
         }
     },
 

--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -204,6 +204,17 @@ mappings = {
         }
     },
 
+    "pressure_kPa": {
+        "device_type": "sensor",
+        "object_suffix": "P",
+        "config": {
+            "device_class": "pressure",
+            "name": "Pressure",
+            "unit_of_measurement": "hPa",
+            "value_template": "{{ float(value|float) * 10.0 | round(2) }}"
+        }
+    },
+
     "wind_speed_km_h": {
         "device_type": "sensor",
         "object_suffix": "WS",


### PR DESCRIPTION
While running rtl433 for some time now I noticed lots of `TPMS` devices popping up.

Seems like those are "Tire Pressure Monitoring Systems" values reported as `kPa` instead of `hPa`.

Maybe you'd like to include this.