### PR TITLE
Fix: bitbuffer_clear() was not clearing syncs_before_row

### DIFF
--- a/src/bitbuffer.c
+++ b/src/bitbuffer.c
@@ -18,6 +18,7 @@ void bitbuffer_clear(bitbuffer_t *bits)
 {
     bits->num_rows = 0;
     memset(bits->bits_per_row, 0, BITBUF_ROWS * 2);
+    memset(bits->syncs_before_row, 0, BITBUF_ROWS * sizeof(bits->syncs_before_row[0]));
     memset(bits->bb, 0, BITBUF_ROWS * BITBUF_COLS);
 }
 


### PR DESCRIPTION
This is most useful when allocating a `bitbuffer_t` on heap which requires using `bitbuffer_clear()` to initialize it.