### PR TITLE
Field names must be comma separated 

### DIFF
--- a/src/devices/cavius.c
+++ b/src/devices/cavius.c
@@ -125,7 +125,7 @@ static int cavius_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 static char *output_fields[] = {
         "model",
         "id",
-        "battery_ok"
+        "battery_ok",
         "net_id",
         "message",
         "text",

--- a/src/devices/missil_ml0757.c
+++ b/src/devices/missil_ml0757.c
@@ -133,7 +133,7 @@ static int missil_ml0757_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 static char *output_fields[] = {
         "model",
         "id",
-        "battery_ok"
+        "battery_ok",
         "temperature_C",
         "wind_avg_km_h",
         "rain_mm",

--- a/src/devices/secplus_v2.c
+++ b/src/devices/secplus_v2.c
@@ -411,7 +411,7 @@ static char *output_fields[] = {
         // Common fields
         "model",
         "id",
-        "rolling"
+        "rolling",
         "fixed",
         "button_id",
         "remote_id",


### PR DESCRIPTION
If not, it would create a single item with the two strings concatenated