### PR TITLE
Fix: add required definitions for ESP32 build

### DIFF
--- a/include/r_util.h
+++ b/include/r_util.h
@@ -17,8 +17,8 @@
 #include <time.h>
 #include "compat_time.h"
 
-#if defined _MSC_VER // Microsoft Visual Studio
-    // MSC has something like C99 restrict as __restrict
+#if defined _MSC_VER || defined ESP32 // Microsoft Visual Studio or ESP32
+    // MSC and ESP32 have something like C99 restrict as __restrict
     #ifndef restrict
     #define restrict  __restrict
     #endif


### PR DESCRIPTION
The introduction of `_POSIX_HOST_NAME_MAX ` fixes a compilation error while the `#include`, the other `#ifdef` and the changes in `data_output_syslog_create` allow compiling without any warnings even if that function is not linked into the final image on `ESP32` because there is no syslog.