### PR TITLE
Add EcoWitt WH31B support by modifying WH31E

### DIFF
--- a/src/devices/ambientweather_wh31e.c
+++ b/src/devices/ambientweather_wh31e.c
@@ -198,7 +198,7 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         bitbuffer_extract_bytes(bitbuffer, row, start_pos + 24, b, 18 * 8);
         msg_type = b[0];
 
-        if (b[0] == wh31e_type_code || b[0] == wh31b_type_code) {
+        if (msg_type == wh31e_type_code || msg_type == wh31b_type_code) {
             uint8_t c_crc = crc8(b, 6, 0x31, 0x00);
             if (c_crc) {
                 if (decoder->verbose)
@@ -211,7 +211,7 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                     fprintf(stderr, "%s: WH31E/WH31B (%d) bad SUM\n", __func__, msg_type);
                 continue; // DECODE_FAIL_MIC
             }
-            
+
             id         = b[1];
             battery_ok = (b[2] >> 7);
             channel    = ((b[2] & 0x70) >> 4) + 1;

--- a/src/devices/ambientweather_wh31e.c
+++ b/src/devices/ambientweather_wh31e.c
@@ -181,7 +181,7 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     float temp_c;
     char extra[11];
     char long_identifier[20];
-    char short_identifier[4];
+    char short_identifier[5];
     const wh31e_type_code = 0x30;
     const wh31b_type_code = 0x37;
 

--- a/src/devices/ambientweather_wh31e.c
+++ b/src/devices/ambientweather_wh31e.c
@@ -199,15 +199,19 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         msg_type = b[0];
 
         if (b[0] == wh31e_type_code || b[0] == wh31b_type_code) {
-
             uint8_t c_crc = crc8(b, 6, 0x31, 0x00);
-            uint8_t c_sum = add_bytes(b, 6) - b[6];
-            if (c_crc || c_sum) {
+            if (c_crc) {
                 if (decoder->verbose)
-                    fprintf(stderr, "%s: checksum or crc error. (%d) \n", __func__, msg_type);
+                    fprintf(stderr, "%s: WH31E/WH31B (%s) bad CRC\n", __func__, msg_type);
                 continue; // DECODE_FAIL_MIC
             }
-
+            uint8_t c_sum = add_bytes(b, 6) - b[6];
+            if (c_sum) {
+                if (decoder->verbose)
+                    fprintf(stderr, "%s: WH31E/WH31B (%s) bad SUM\n", __func__, msg_type);
+                continue; // DECODE_FAIL_MIC
+            }
+            
             id         = b[1];
             battery_ok = (b[2] >> 7);
             channel    = ((b[2] & 0x70) >> 4) + 1;

--- a/src/devices/ambientweather_wh31e.c
+++ b/src/devices/ambientweather_wh31e.c
@@ -180,8 +180,8 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int humidity, rain_raw;
     float temp_c;
     char extra[11];
-    uint8_t const wh31e_type_code = 0x30;
-    uint8_t const wh31b_type_code = 0x37;
+    uint8_t const wh31e_type_code = 0x30; // 48
+    uint8_t const wh31b_type_code = 0x37; // 55
 
     uint8_t const preamble[] = {0xaa, 0x2d, 0xd4}; // (partial) preamble and sync word
 
@@ -202,13 +202,13 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             uint8_t c_crc = crc8(b, 6, 0x31, 0x00);
             if (c_crc) {
                 if (decoder->verbose)
-                    fprintf(stderr, "%s: WH31E/WH31B (%s) bad CRC\n", __func__, msg_type);
+                    fprintf(stderr, "%s: WH31E/WH31B (%d) bad CRC\n", __func__, msg_type);
                 continue; // DECODE_FAIL_MIC
             }
             uint8_t c_sum = add_bytes(b, 6) - b[6];
             if (c_sum) {
                 if (decoder->verbose)
-                    fprintf(stderr, "%s: WH31E/WH31B (%s) bad SUM\n", __func__, msg_type);
+                    fprintf(stderr, "%s: WH31E/WH31B (%d) bad SUM\n", __func__, msg_type);
                 continue; // DECODE_FAIL_MIC
             }
             


### PR DESCRIPTION
Added samples here: https://github.com/merbanan/rtl_433_tests/pull/394 , https://github.com/bitfliq/rtl_433_tests/tree/EcoWitt-WH31B .  

This code worked for extracting data from WH31B - but I was unable to verify that it did not break the other devices.

Thanks for all of your hard work on this fantastic project.