### PR TITLE
Remove oldmodel macro use

### DIFF
--- a/include/decoder.h
+++ b/include/decoder.h
@@ -12,7 +12,4 @@
 #include "util.h"
 #include "decoder_util.h"
 
-/* TODO: temporary allow to change to new style model keys */
-#define _X(n, o) ((0) ? (o) : (n))
-
 #endif /* INCLUDE_DECODER_H_ */

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -144,9 +144,9 @@ static int acurite_rain_896_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",                "",             DATA_STRING, _X("Acurite-Rain","Acurite Rain Gauge"),
+            "model",                "",             DATA_STRING, "Acurite-Rain",
             "id",                   "",             DATA_INT,    id,
-            _X("rain_mm","rain"),   "Total Rain",   DATA_FORMAT, "%.1f mm", DATA_DOUBLE, total_rain,
+            "rain_mm",              "Total Rain",   DATA_FORMAT, "%.1f mm", DATA_DOUBLE, total_rain,
             NULL);
     /* clang-format on */
 
@@ -202,7 +202,7 @@ static int acurite_th_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
         /* clang-format off */
         data = data_make(
-                "model",            "",             DATA_STRING, _X("Acurite-609TXC","Acurite 609TXC Sensor"),
+                "model",            "",             DATA_STRING, "Acurite-609TXC",
                 "id",               "",             DATA_INT,    id,
                 "battery",          "",             DATA_STRING, battery_low ? "LOW" : "OK",
                 "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, tempc,
@@ -402,7 +402,7 @@ static int acurite_6045_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
 
     /* clang-format off */
     data = data_make(
-            "model",            "",                 DATA_STRING, _X("Acurite-6045M","Acurite Lightning 6045M"),
+            "model",            "",                 DATA_STRING, "Acurite-6045M",
             "id",               NULL,               DATA_INT,    sensor_id,
             "channel",          NULL,               DATA_STRING, channel_str,
             "battery",          "battery",          DATA_STRING, battery_low ? "LOW" : "OK",
@@ -736,10 +736,10 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
             /* clang-format off */
             data = data_make(
-                    "model",                "",             DATA_STRING, _X("Acurite-Tower","Acurite tower sensor"),
+                    "model",                "",             DATA_STRING, "Acurite-Tower",
                     "id",                   "",             DATA_INT,    sensor_id,
                     "channel",              NULL,           DATA_STRING, &channel_str,
-                    _X("battery_ok","battery_low"), "",     DATA_INT,    _X(!battery_low,battery_low),
+                    "battery_ok",           "",             DATA_INT,    !battery_low,
                     "temperature_C",        "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, tempc,
                     "humidity",             "Humidity",     DATA_FORMAT, "%u %%", DATA_INT,    humidity,
                     "mic",                  "Integrity",    DATA_STRING, "CHECKSUM",
@@ -788,7 +788,7 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                     "model",                "",             DATA_STRING, "Acurite-515",
                     "id",                   "",             DATA_INT,    sensor_id,
                     "channel",              NULL,           DATA_STRING, &channel_str,
-                    _X("battery_ok","battery_low"), "",     DATA_INT,    _X(!battery_low,battery_low),
+                    "battery_ok",           "",             DATA_INT,    !battery_low,
                     "temperature_F",        "Temperature",  DATA_FORMAT, "%.1f F", DATA_DOUBLE, tempf,
                     "mic",                  "Integrity",    DATA_STRING, "CHECKSUM",
                     NULL);
@@ -843,15 +843,15 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
                 /* clang-format off */
                 data = data_make(
-                        "model",        "",   DATA_STRING,    _X("Acurite-5n1","Acurite 5n1 sensor"),
+                        "model",        "",   DATA_STRING,    "Acurite-5n1",
                         "message_type", NULL,   DATA_INT,       message_type,
-                        _X("id", "sensor_id"),    NULL, DATA_INT,       sensor_id,
+                        "id",           NULL, DATA_INT,       sensor_id,
                         "channel",      NULL,   DATA_STRING,    &channel_str,
                         "sequence_num",  NULL,   DATA_INT,      sequence_num,
                         "battery",      NULL,   DATA_STRING,    battery_low ? "OK" : "LOW",
-                        _X("wind_avg_km_h","wind_speed_kph"),   "wind_speed",   DATA_FORMAT,    "%.1f km/h", DATA_DOUBLE,     wind_speed_kph,
+                        "wind_avg_km_h",   "wind_speed",   DATA_FORMAT,    "%.1f km/h", DATA_DOUBLE,     wind_speed_kph,
                         "wind_dir_deg", NULL,   DATA_FORMAT,    "%.1f", DATA_DOUBLE,    wind_dir,
-                        _X("rain_in","rain_inch"), "Rainfall Accumulation",   DATA_FORMAT, "%.2f in", DATA_DOUBLE, raincounter * 0.01f,
+                        "rain_in",      "Rainfall Accumulation",   DATA_FORMAT, "%.2f in", DATA_DOUBLE, raincounter * 0.01f,
                         "mic",                  "Integrity",    DATA_STRING, "CHECKSUM",
                         NULL);
                 /* clang-format on */
@@ -870,13 +870,13 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
                 /* clang-format off */
                 data = data_make(
-                        "model",        "",   DATA_STRING,    _X("Acurite-5n1","Acurite 5n1 sensor"),
+                        "model",        "",   DATA_STRING,    "Acurite-5n1",
                         "message_type", NULL,   DATA_INT,       message_type,
-                        _X("id", "sensor_id"),    NULL, DATA_INT,  sensor_id,
+                        "id",           NULL, DATA_INT,  sensor_id,
                         "channel",      NULL,   DATA_STRING,    &channel_str,
                         "sequence_num",  NULL,   DATA_INT,      sequence_num,
                         "battery",      NULL,   DATA_STRING,    battery_low ? "OK" : "LOW",
-                        _X("wind_avg_km_h","wind_speed_kph"),   "wind_speed",   DATA_FORMAT,    "%.1f km/h", DATA_DOUBLE,     wind_speed_kph,
+                        "wind_avg_km_h",   "wind_speed",   DATA_FORMAT,    "%.1f km/h", DATA_DOUBLE,     wind_speed_kph,
                         "temperature_F",     "temperature",    DATA_FORMAT,    "%.1f F", DATA_DOUBLE,    tempf,
                         "humidity",     NULL,    DATA_FORMAT,    "%u %%",   DATA_INT,   humidity,
                         "mic",                  "Integrity",    DATA_STRING, "CHECKSUM",
@@ -899,13 +899,13 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
                 /* clang-format off */
                 data = data_make(
-                        "model",        "",   DATA_STRING,    _X("Acurite-3n1","Acurite 3n1 sensor"),
+                        "model",        "",   DATA_STRING,    "Acurite-3n1",
                         "message_type", NULL,   DATA_INT,       message_type,
-                        _X("id", "sensor_id"),    NULL,   DATA_FORMAT,    "0x%02X",   DATA_INT,       sensor_id,
+                        "id",    NULL,   DATA_FORMAT,    "0x%02X",   DATA_INT,       sensor_id,
                         "channel",      NULL,   DATA_STRING,    &channel_str,
                         "sequence_num",  NULL,   DATA_INT,      sequence_num,
                         "battery",      NULL,   DATA_STRING,    battery_low ? "OK" : "LOW",
-                        _X("wind_avg_mi_h","wind_speed_mph"),   "wind_speed",   DATA_FORMAT,    "%.1f mi/h", DATA_DOUBLE,     wind_speed_mph,
+                        "wind_avg_mi_h",   "wind_speed",   DATA_FORMAT,    "%.1f mi/h", DATA_DOUBLE,     wind_speed_mph,
                         "temperature_F",     "temperature",    DATA_FORMAT,    "%.1f F", DATA_DOUBLE,    tempf,
                         "humidity",     NULL,    DATA_FORMAT,    "%u %%",   DATA_INT,   humidity,
                         "mic",                  "Integrity",    DATA_STRING, "CHECKSUM",
@@ -1075,7 +1075,7 @@ static int acurite_986_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
         /* clang-format off */
         data = data_make(
-                "model",            "",             DATA_STRING, _X("Acurite-986","Acurite 986 Sensor"),
+                "model",            "",             DATA_STRING, "Acurite-986",
                 "id",               NULL,           DATA_INT,    sensor_id,
                 "channel",          NULL,           DATA_STRING, channel_str,
                 "battery",          "battery",      DATA_STRING, battery_low ? "LOW" : "OK",
@@ -1141,7 +1141,7 @@ static int acurite_606_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",            "",             DATA_STRING, _X("Acurite-606TX","Acurite 606TX Sensor"),
+            "model",            "",             DATA_STRING, "Acurite-606TX",
             "id",               "",             DATA_INT, sensor_id,
             "battery",          "Battery",      DATA_STRING, battery ? "OK" : "LOW",
             "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
@@ -1319,7 +1319,6 @@ static int acurite_00275rm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 static char *acurite_rain_gauge_output_fields[] = {
         "model",
         "id",
-        "rain", // TODO: remove this
         "rain_mm",
         NULL,
 };
@@ -1364,24 +1363,18 @@ r_device acurite_th = {
  */
 static char *acurite_txr_output_fields[] = {
         "model",
-        "subtype",      // TODO: remove this
         "message_type", // TODO: remove this
         "id",
-        "sensor_id", // TODO: remove this
         "channel",
         "sequence_num",
-        "battery_low", // TODO: remove this
         "battery_ok",
         "battery",
         "temperature_C",
         "temperature_F",
         "humidity",
-        "wind_speed_mph", // TODO: remove this
-        "wind_speed_kph", // TODO: remove this
         "wind_avg_mi_h",
         "wind_avg_km_h",
         "wind_dir_deg",
-        "rain_inch", // TODO: remove this
         "rain_in",
         "rain_mm",
         "storm_dist",
@@ -1487,7 +1480,6 @@ r_device acurite_606 = {
 static char *acurite_00275rm_output_fields[] = {
         "model",
         "subtype",
-        "probe", // TODO: remove this
         "id",
         "battery",
         "temperature_C",
@@ -1495,8 +1487,6 @@ static char *acurite_00275rm_output_fields[] = {
         "water",
         "temperature_1_C",
         "humidity_1",
-        "ptemperature_C",
-        "phumidity",
         "mic",
         NULL,
 };

--- a/src/devices/akhan_100F14.c
+++ b/src/devices/akhan_100F14.c
@@ -51,7 +51,7 @@ static int akhan_rke_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_FAIL_SANITY;
 
     data = data_make(
-            "model",    "",             DATA_STRING, _X("Akhan-100F14","Akhan 100F14 remote keyless entry"),
+            "model",    "",             DATA_STRING, "Akhan-100F14",
             "id",       "ID (20bit)",   DATA_FORMAT, "0x%x", DATA_INT, id,
             "data",     "Data (4bit)",  DATA_STRING, cmd_str,
             NULL);

--- a/src/devices/alecto.c
+++ b/src/devices/alecto.c
@@ -159,14 +159,14 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
             /* clang-format off */
             data = data_make(
-                    "model",          "",           DATA_STRING, _X("AlectoV1-Wind","AlectoV1 Wind Sensor"),
-                    "id",             "House Code", DATA_INT,    sensor_id,
-                    "channel",        "Channel",    DATA_INT,    channel,
-                    "battery",        "Battery",    DATA_STRING, battery_low ? "LOW" : "OK",
-                    _X("wind_avg_m_s","wind_speed"),     "Wind speed", DATA_FORMAT, "%.2f m/s", DATA_DOUBLE, speed * 0.2F,
-                    _X("wind_max_m_s","wind_gust"),      "Wind gust",  DATA_FORMAT, "%.2f m/s", DATA_DOUBLE, gust * 0.2F,
-                    _X("wind_dir_deg","wind_direction"),   "Wind Direction",   DATA_INT, direction,
-                    "mic",           "Integrity",   DATA_STRING,    "CHECKSUM",
+                    "model",            "",                 DATA_STRING, "AlectoV1-Wind",
+                    "id",               "House Code",       DATA_INT,    sensor_id,
+                    "channel",          "Channel",          DATA_INT,    channel,
+                    "battery",          "Battery",          DATA_STRING, battery_low ? "LOW" : "OK",
+                    "wind_avg_m_s",     "Wind speed",       DATA_FORMAT, "%.2f m/s", DATA_DOUBLE, speed * 0.2F,
+                    "wind_max_m_s",     "Wind gust",        DATA_FORMAT, "%.2f m/s", DATA_DOUBLE, gust * 0.2F,
+                    "wind_dir_deg",     "Wind Direction",   DATA_INT,    direction,
+                    "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
                     NULL);
             /* clang-format on */
             decoder_output_data(decoder, data);
@@ -180,12 +180,12 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         /* clang-format off */
         data = data_make(
-                "model",         "",           DATA_STRING, _X("AlectoV1-Rain","AlectoV1 Rain Sensor"),
-                "id",            "House Code", DATA_INT,    sensor_id,
-                "channel",       "Channel",    DATA_INT,    channel,
-                "battery",       "Battery",    DATA_STRING, battery_low ? "LOW" : "OK",
-                _X("rain_mm","rain_total"),    "Total Rain", DATA_FORMAT, "%.02f mm", DATA_DOUBLE, rain_mm,
-                "mic",           "Integrity",  DATA_STRING,    "CHECKSUM",
+                "model",        "",             DATA_STRING, "AlectoV1-Rain",
+                "id",           "House Code",   DATA_INT,    sensor_id,
+                "channel",      "Channel",      DATA_INT,    channel,
+                "battery",      "Battery",      DATA_STRING, battery_low ? "LOW" : "OK",
+                "rain_mm",      "Total Rain",   DATA_FORMAT, "%.02f mm", DATA_DOUBLE, rain_mm,
+                "mic",          "Integrity",    DATA_STRING, "CHECKSUM",
                 NULL);
         /* clang-format on */
         decoder_output_data(decoder, data);
@@ -205,13 +205,13 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         /* clang-format off */
         data = data_make(
-                "model",         "",            DATA_STRING, _X("AlectoV1-Temperature","AlectoV1 Temperature Sensor"),
+                "model",         "",            DATA_STRING, "AlectoV1-Temperature",
                 "id",            "House Code",  DATA_INT,    sensor_id,
                 "channel",       "Channel",     DATA_INT,    channel,
                 "battery",       "Battery",     DATA_STRING, battery_low ? "LOW" : "OK",
                 "temperature_C", "Temperature", DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
                 "humidity",      "Humidity",    DATA_FORMAT, "%u %%",   DATA_INT, humidity,
-                "mic",           "Integrity",   DATA_STRING,    "CHECKSUM",
+                "mic",           "Integrity",   DATA_STRING, "CHECKSUM",
                 NULL);
         /* clang-format on */
         decoder_output_data(decoder, data);
@@ -228,11 +228,7 @@ static char *output_fields[] = {
     "battery",
     "temperature_C",
     "humidity",
-    "rain_total", // TODO: remove this
     "rain_mm",
-    "wind_speed", // TODO: remove this
-    "wind_gust", // TODO: remove this
-    "wind_direction", // TODO: remove this
     "wind_avg_m_s",
     "wind_max_m_s",
     "wind_dir_deg",

--- a/src/devices/ambient_weather.c
+++ b/src/devices/ambient_weather.c
@@ -50,8 +50,8 @@ static int ambient_weather_decode(r_device *decoder, bitbuffer_t *bitbuffer, uns
     humidity = b[4];
 
     data = data_make(
-            "model",          "",             DATA_STRING, _X("Ambientweather-F007TH","Ambient Weather F007TH Thermo-Hygrometer"),
-            _X("id","device"),         "House Code",   DATA_INT,    deviceID,
+            "model",          "",             DATA_STRING, "Ambientweather-F007TH",
+            "id",             "House Code",   DATA_INT,    deviceID,
             "channel",        "Channel",      DATA_INT,    channel,
             "battery",        "Battery",      DATA_STRING, isBatteryLow ? "Low" : "OK",
             "temperature_F",  "Temperature",  DATA_FORMAT, "%.1f F", DATA_DOUBLE, temperature,
@@ -104,7 +104,6 @@ static int ambient_weather_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
 static char *output_fields[] = {
         "model",
-        "device", // TODO: delete this
         "id",
         "channel",
         "battery",

--- a/src/devices/brennenstuhl_rcs_2044.c
+++ b/src/devices/brennenstuhl_rcs_2044.c
@@ -90,7 +90,7 @@ static int brennenstuhl_rcs_2044_process_row(r_device *decoder, bitbuffer_t *bit
         return 0; /* Pressing simultaneously ON and OFF key is not useful either */
 
     data = data_make(
-            "model",    "Model",    DATA_STRING, _X("Brennenstuhl-RCS2044","Brennenstuhl RCS 2044"),
+            "model",    "Model",    DATA_STRING, "Brennenstuhl-RCS2044",
             "id",       "id",       DATA_INT, system_code,
             "key",      "key",      DATA_STRING, key,
             "state",    "state",    DATA_STRING, (on_off == 0x02 ? "ON" : "OFF"),

--- a/src/devices/bresser_3ch.c
+++ b/src/devices/bresser_3ch.c
@@ -85,7 +85,7 @@ static int bresser_3ch_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",         "",            DATA_STRING, _X("Bresser-3CH","Bresser 3CH sensor"),
+            "model",         "",            DATA_STRING, "Bresser-3CH",
             "id",            "Id",          DATA_INT,    id,
             "channel",       "Channel",     DATA_INT,    channel,
             "battery",       "Battery",     DATA_STRING, battery_low ? "LOW": "OK",

--- a/src/devices/bresser_5in1.c
+++ b/src/devices/bresser_5in1.c
@@ -140,8 +140,8 @@ static int bresser_5in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 "model",            "",             DATA_STRING, "Bresser-ProRainGauge",
                 "id",               "",             DATA_INT,    sensor_id,
                 "battery",          "Battery",      DATA_STRING, battery_ok ? "OK": "LOW",
-                "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
-                "rain_mm",          "Rain",         DATA_FORMAT, "%.1f mm",DATA_DOUBLE, rain,
+                "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C",      DATA_DOUBLE, temperature,
+                "rain_mm",          "Rain",         DATA_FORMAT, "%.1f mm",     DATA_DOUBLE, rain,
                 "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
                 NULL);
         /* clang-format on */
@@ -152,12 +152,12 @@ static int bresser_5in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 "model",            "",             DATA_STRING, "Bresser-5in1",
                 "id",               "",             DATA_INT,    sensor_id,
                 "battery",          "Battery",      DATA_STRING, battery_ok ? "OK": "LOW",
-                "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
+                "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C",      DATA_DOUBLE, temperature,
                 "humidity",         "Humidity",     DATA_INT, humidity,
-                _X("wind_max_m_s","wind_gust"),        "Wind Gust",    DATA_FORMAT, "%.1f m/s",DATA_DOUBLE, wind_gust,
-                _X("wind_avg_m_s","wind_speed"),       "Wind Speed",   DATA_FORMAT, "%.1f m/s",DATA_DOUBLE, wind_avg,
-                "wind_dir_deg",     "Direction",    DATA_FORMAT, "%.1f",DATA_DOUBLE, wind_direction_deg,
-                "rain_mm",          "Rain",         DATA_FORMAT, "%.1f mm",DATA_DOUBLE, rain,
+                "wind_max_m_s",     "Wind Gust",    DATA_FORMAT, "%.1f m/s",    DATA_DOUBLE, wind_gust,
+                "wind_avg_m_s",     "Wind Speed",   DATA_FORMAT, "%.1f m/s",    DATA_DOUBLE, wind_avg,
+                "wind_dir_deg",     "Direction",    DATA_FORMAT, "%.1f",        DATA_DOUBLE, wind_direction_deg,
+                "rain_mm",          "Rain",         DATA_FORMAT, "%.1f mm",     DATA_DOUBLE, rain,
                 "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
                 NULL);
         /* clang-format on */
@@ -172,8 +172,6 @@ static char *output_fields[] = {
         "battery",
         "temperature_C",
         "humidity",
-        "wind_gust",  // TODO: delete this
-        "wind_speed", // TODO: delete this
         "wind_max_m_s",
         "wind_avg_m_s",
         "wind_dir_deg",

--- a/src/devices/bt_rain.c
+++ b/src/devices/bt_rain.c
@@ -75,7 +75,7 @@ static int bt_rain_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "battery",          "Battery",          DATA_STRING, battery ? "LOW" : "OK",
             "transmit",         "Transmit",         DATA_STRING, button ? "MANUAL" : "AUTO", // TODO: delete this
             "temperature_C",    "Temperature",      DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp_c,
-            _X("rain_rate_mm_h","rainrate"),         "Rain per hour",    DATA_FORMAT, "%.02f mm/h", DATA_DOUBLE, rainrate,
+            "rain_rate_mm_h",   "Rain per hour",    DATA_FORMAT, "%.02f mm/h", DATA_DOUBLE, rainrate,
             "button",           "Button",       DATA_INT, button,
             NULL);
     /* clang-format on */
@@ -91,7 +91,6 @@ static char *output_fields[] = {
         "battery",
         "transmit", // TODO: delete this
         "temperature_C",
-        "rainrate", // TODO: remove this
         "rain_rate_mm_h",
         "button",
         NULL,

--- a/src/devices/calibeur.c
+++ b/src/devices/calibeur.c
@@ -103,7 +103,7 @@ static int calibeur_rf104_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     humidity = bits;
 
     data = data_make(
-                    "model",         "",            DATA_STRING, _X("Calibeur-RF104","Calibeur RF-104"),
+                    "model",         "",            DATA_STRING, "Calibeur-RF104",
                     "id",            "ID",          DATA_INT, ID,
                     "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
                     "humidity",      "Humidity",    DATA_FORMAT, "%2.0f %%", DATA_DOUBLE, humidity,

--- a/src/devices/cardin.c
+++ b/src/devices/cardin.c
@@ -112,7 +112,7 @@ static int cardin_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         }
 
         data = data_make(
-            "model",      "",                       DATA_STRING, _X("Cardin-S466","Cardin S466"),
+            "model",      "",                       DATA_STRING, "Cardin-S466",
             "dipswitch",  "dipswitch",              DATA_STRING, dip,
             "rbutton",    "right button switches",  DATA_STRING, rbutton[((bb[0][2] & 15) / 3)-1],
             NULL);

--- a/src/devices/chuango.c
+++ b/src/devices/chuango.c
@@ -76,7 +76,7 @@ static int chuango_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     data = data_make(
-            "model",    "",             DATA_STRING, _X("Chuango-Security","Chuango Security Technology"),
+            "model",    "",             DATA_STRING, "Chuango-Security",
             "id",       "ID",           DATA_INT,    id,
             "cmd",      "CMD",          DATA_STRING, cmd_str,
             "cmd_id",   "CMD_ID",       DATA_INT,    cmd,

--- a/src/devices/current_cost.c
+++ b/src/devices/current_cost.c
@@ -73,13 +73,13 @@ static int current_cost_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             watt2 = (b[6] & 0x7F) << 8 | b[7];
         /* clang-format off */
         data = data_make(
-                "model",         "",              DATA_STRING, is_envir ? "CurrentCost-EnviR" : _X("CurrentCost-TX","CurrentCost TX"), //TODO: it may have different CC Model ? any ref ?
-                //"rc",            "Rolling Code",  DATA_INT, rc, //TODO: add rolling code b[1] ? test needed
-                _X("id","dev_id"),       "Device Id",     DATA_FORMAT, "%d", DATA_INT, device_id,
-                _X("power0_W","power0"),       "Power 0",       DATA_FORMAT, "%d W", DATA_INT, watt0,
-                _X("power1_W","power1"),       "Power 1",       DATA_FORMAT, "%d W", DATA_INT, watt1,
-                _X("power2_W","power2"),       "Power 2",       DATA_FORMAT, "%d W", DATA_INT, watt2,
-                //"battery",       "Battery",       DATA_STRING, battery_low ? "LOW" : "OK", //TODO is there some low battery indicator ?
+                "model",        "",              DATA_STRING, is_envir ? "CurrentCost-EnviR" : "CurrentCost-TX", //TODO: it may have different CC Model ? any ref ?
+                //"rc",           "Rolling Code",  DATA_INT, rc, //TODO: add rolling code b[1] ? test needed
+                "id",           "Device Id",     DATA_FORMAT, "%d", DATA_INT, device_id,
+                "power0_W",     "Power 0",       DATA_FORMAT, "%d W", DATA_INT, watt0,
+                "power1_W",     "Power 1",       DATA_FORMAT, "%d W", DATA_INT, watt1,
+                "power2_W",     "Power 2",       DATA_FORMAT, "%d W", DATA_INT, watt2,
+                //"battery",      "Battery",       DATA_STRING, battery_low ? "LOW" : "OK", //TODO is there some low battery indicator ?
                 NULL);
         /* clang-format on */
         decoder_output_data(decoder, data);
@@ -93,11 +93,11 @@ static int current_cost_decode(r_device *decoder, bitbuffer_t *bitbuffer)
        uint32_t c_impulse = (unsigned)b[4] << 24 | b[5] <<16 | b[6] <<8 | b[7];
        /* clang-format off */
        data = data_make(
-               "model",        "",              DATA_STRING, is_envir ? "CurrentCost-EnviRCounter" :_X("CurrentCost-Counter","CurrentCost Counter"), //TODO: it may have different CC Model ? any ref ?
-               _X("subtype","sensor_type"),  "Sensor Id",     DATA_FORMAT, "%d", DATA_INT, sensor_type, //Could "friendly name" this?
-               _X("id","dev_id"),       "Device Id",     DATA_FORMAT, "%d", DATA_INT, device_id,
-               //"counter",      "Counter",       DATA_FORMAT, "%d", DATA_INT, c_impulse,
-               "power0",       "Counter",       DATA_FORMAT, "%d", DATA_INT, c_impulse,
+               "model",         "",              DATA_STRING, is_envir ? "CurrentCost-EnviRCounter" : "CurrentCost-Counter", //TODO: it may have different CC Model ? any ref ?
+               "subtype",       "Sensor Id",     DATA_FORMAT, "%d", DATA_INT, sensor_type, //Could "friendly name" this?
+               "id",            "Device Id",     DATA_FORMAT, "%d", DATA_INT, device_id,
+               //"counter",       "Counter",       DATA_FORMAT, "%d", DATA_INT, c_impulse,
+               "power0",        "Counter",       DATA_FORMAT, "%d", DATA_INT, c_impulse,
                NULL);
        /* clang-format on */
        decoder_output_data(decoder, data);
@@ -109,13 +109,8 @@ static int current_cost_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
 static char *output_fields[] = {
         "model",
-        "dev_id", // TODO: delete this
         "id",
-        "sensor_type", // TODO: delete this
         "subtype",
-        "power0", // TODO: delete this
-        "power1", // TODO: delete this
-        "power2", // TODO: delete this
         "power0_W",
         "power1_W",
         "power2_W",

--- a/src/devices/danfoss.c
+++ b/src/devices/danfoss.c
@@ -144,7 +144,7 @@ static int danfoss_cfr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         // Output data
         data = data_make(
-            "model",        "",     DATA_STRING,    _X("Danfoss-CFR","Danfoss CFR Thermostat"),
+            "model",        "",     DATA_STRING,    "Danfoss-CFR",
             "id",       "ID",       DATA_INT,   id,
             "temperature_C",    "Temperature",  DATA_FORMAT,    "%.2f C", DATA_DOUBLE, temp_meas,
             "setpoint_C",   "Setpoint", DATA_FORMAT,    "%.2f C", DATA_DOUBLE, temp_setp,

--- a/src/devices/digitech_xc0324.c
+++ b/src/devices/digitech_xc0324.c
@@ -118,7 +118,7 @@ static int decode_xc0324_message(r_device *decoder, bitbuffer_t *bitbuffer,
     // from (simulated) deciphering stage output (decoder->verbose > 0)
     if (!decoder->verbose) { // production output
         *data = data_make(
-                "model",            "Device Type",      DATA_STRING, _X("Digitech-XC0324","Digitech XC0324"),
+                "model",            "Device Type",      DATA_STRING, "Digitech-XC0324",
                 "id",               "ID",               DATA_STRING, id,
                 "temperature_C",    "Temperature C",    DATA_FORMAT, "%.1f", DATA_DOUBLE, temperature,
                 "flags",            "Constant ?",       DATA_INT,    flags,

--- a/src/devices/dish_remote_6_3.c
+++ b/src/devices/dish_remote_6_3.c
@@ -126,7 +126,7 @@ static int dish_remote_6_3_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     button_string = button_map[button];
 
     data = data_make(
-            "model", "", DATA_STRING, _X("Dish-RC63","Dish remote 6.3"),
+            "model", "", DATA_STRING, "Dish-RC63",
             "button", "", DATA_STRING, button_string,
             NULL);
 

--- a/src/devices/dsc.c
+++ b/src/devices/dsc.c
@@ -212,12 +212,12 @@ static int dsc_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         /* clang-format off */
         data = data_make(
-                "model",        "",             DATA_STRING, _X("DSC-Security","DSC Contact"),
+                "model",        "",             DATA_STRING, "DSC-Security",
                 "id",           "",             DATA_INT,    esn,
                 "closed",       "",             DATA_INT,    s_closed, // @todo make bool
                 "event",        "",             DATA_INT,    s_event, // @todo make bool
                 "tamper",       "",             DATA_INT,    s_tamper, // @todo make bool
-                _X("battery_ok","battery_low"), "", DATA_INT, _X(!s_battery_low,s_battery_low),
+                "battery_ok",   "",             DATA_INT,    !s_battery_low,
                 "xactivity",    "",             DATA_INT,    s_xactivity, // @todo make bool
 
                 // Note: the following may change or be removed

--- a/src/devices/efergy_e2_classic.c
+++ b/src/devices/efergy_e2_classic.c
@@ -93,7 +93,7 @@ static int efergy_e2_classic_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",    "",                 DATA_STRING, _X("Efergy-e2CT","Efergy e2 CT"),
+            "model",    "",                 DATA_STRING, "Efergy-e2CT",
             "id",       "Transmitter ID",   DATA_INT,    address,
             "battery",  "Battery",          DATA_STRING, battery ? "OK" : "LOW",
             "current",  "Current",          DATA_FORMAT, "%.2f A", DATA_DOUBLE, current_adc,

--- a/src/devices/efergy_optical.c
+++ b/src/devices/efergy_optical.c
@@ -116,12 +116,12 @@ static int efergy_optical_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         /* clang-format off */
         data = data_make(
-                "model",    "Model",        DATA_STRING, _X("Efergy-Optical","Efergy Optical"),
-                "id",       "",             DATA_INT,   id,
-                "pulses", "Pulse-rate",     DATA_INT, imp_kwh[i],
-                "pulsecount", "Pulse-count", DATA_INT, pulsecount,
-                _X("energy_kWh","energy"),   "Energy",       DATA_FORMAT, "%.03f kWh", DATA_DOUBLE, energy,
-                "mic",       "Integrity",   DATA_STRING, "CRC",
+                "model",        "Model",        DATA_STRING, "Efergy-Optical",
+                "id",           "",             DATA_INT,   id,
+                "pulses",       "Pulse-rate",   DATA_INT, imp_kwh[i],
+                "pulsecount",   "Pulse-count",  DATA_INT, pulsecount,
+                "energy_kWh",   "Energy",       DATA_FORMAT, "%.03f kWh", DATA_DOUBLE, energy,
+                "mic",          "Integrity",    DATA_STRING, "CRC",
                 NULL);
         /* clang-format on */
         decoder_output_data(decoder, data);
@@ -134,7 +134,6 @@ static char *output_fields[] = {
         "id",
         "pulses",
         "pulsecount",
-        "energy", // TODO: remove this
         "energy_kWh",
         "mic",
         NULL,

--- a/src/devices/emontx.c
+++ b/src/devices/emontx.c
@@ -110,13 +110,13 @@ static int emontx_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         /* clang-format off */
         data = data_make(
-                "model",        "",             DATA_STRING, _X("emonTx-Energy","emonTx"),
+                "model",        "",             DATA_STRING, "emonTx-Energy",
                 "node",         "",             DATA_FORMAT, "%02x", DATA_INT, pkt.p.node & 0x1f,
                 "ct1",          "",             DATA_FORMAT, "%d", DATA_INT, (int16_t)words[0],
                 "ct2",          "",             DATA_FORMAT, "%d", DATA_INT, (int16_t)words[1],
                 "ct3",          "",             DATA_FORMAT, "%d", DATA_INT, (int16_t)words[2],
                 "ct4",          "",             DATA_FORMAT, "%d", DATA_INT, (int16_t)words[3],
-                _X("batt_Vrms","Vrms/batt"), "", DATA_FORMAT, "%.2f", DATA_DOUBLE, vrms,
+                "batt_Vrms",    "",             DATA_FORMAT, "%.2f", DATA_DOUBLE, vrms,
                 "pulse",        "",             DATA_FORMAT, "%u", DATA_INT, words[11] | ((uint32_t)words[12] << 16),
                 // Slightly horrid... a value of 300.0°C means 'no reading'. So omit them completely.
                 "temp1_C",      "",             DATA_COND, words[5] != 3000, DATA_FORMAT, "%.1f", DATA_DOUBLE, words[5] * 0.1f,
@@ -141,7 +141,6 @@ static char *output_fields[] = {
         "ct2",
         "ct3",
         "ct4",
-        "Vrms/batt", // TODO: delete this
         "batt_Vrms",
         "temp1_C",
         "temp2_C",

--- a/src/devices/esperanza_ews.c
+++ b/src/devices/esperanza_ews.c
@@ -84,7 +84,7 @@ static int esperanza_ews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     int humidity  = ((b[3] & 0x0f) << 4) | ((b[3] & 0xf0) >> 4);
 
     data = data_make(
-            "model",            "",             DATA_STRING, _X("Esperanza-EWS","Esperanza EWS"),
+            "model",            "",             DATA_STRING, "Esperanza-EWS",
             "id",               "ID",           DATA_INT, device_id,
             "channel",          "Channel",      DATA_INT, channel,
             "temperature_F",    "Temperature",  DATA_FORMAT, "%.02f F", DATA_DOUBLE, temp_f,

--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -78,24 +78,24 @@ static int fineoffset_WH2_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (bitbuffer->bits_per_row[0] == 48 &&
             bb[0][0] == 0xFF) { // WH2
         bitbuffer_extract_bytes(bitbuffer, 0, 8, b, 40);
-        model = _X("Fineoffset-WH2","Fine Offset Electronics, WH2 Temperature/Humidity sensor");
+        model = "Fineoffset-WH2";
 
     } else if (bitbuffer->bits_per_row[0] == 55 &&
             bb[0][0] == 0xFE) { // WH2A
         bitbuffer_extract_bytes(bitbuffer, 0, 7, b, 48);
-        model = _X("Fineoffset-WH2A","Fine Offset WH2A sensor");
+        model = "Fineoffset-WH2A";
 
     } else if (bitbuffer->bits_per_row[0] == 47 &&
             bb[0][0] == 0xFE) { // WH5
         bitbuffer_extract_bytes(bitbuffer, 0, 7, b, 40);
-        model = _X("Fineoffset-WH5","Fine Offset WH5 sensor");
+        model = "Fineoffset-WH5";
         if (decoder->decode_ctx) // don't care for the actual value
             model = "Rosenborg-66796";
 
     } else if (bitbuffer->bits_per_row[0] == 49 &&
             bb[0][0] == 0xFF && (bb[0][1]&0x80) == 0x80) { // Telldus
         bitbuffer_extract_bytes(bitbuffer, 0, 9, b, 40);
-        model = _X("Fineoffset-TelldusProove","Telldus/Proove thermometer");
+        model = "Fineoffset-TelldusProove";
 
     } else
         return DECODE_ABORT_LENGTH;
@@ -307,15 +307,15 @@ static int fineoffset_WH24_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",            "",                 DATA_STRING, type == MODEL_WH24 ? _X("Fineoffset-WH24","Fine Offset WH24") : _X("Fineoffset-WH65B","Fine Offset WH65B"),
+            "model",            "",                 DATA_STRING, type == MODEL_WH24 ? "Fineoffset-WH24" : "Fineoffset-WH65B",
             "id",               "ID",               DATA_INT, id,
             "battery",          "Battery",          DATA_STRING, low_battery ? "LOW" : "OK",
             "temperature_C",    "Temperature",      DATA_COND, temp_raw != 0x7ff, DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
             "humidity",         "Humidity",         DATA_COND, humidity != 0xff, DATA_FORMAT, "%u %%", DATA_INT, humidity,
             "wind_dir_deg",     "Wind direction",   DATA_COND, wind_dir != 0x1ff, DATA_INT, wind_dir,
-            _X("wind_avg_m_s","wind_speed_ms"),    "Wind speed",       DATA_COND, wind_speed_raw != 0x1ff, DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wind_speed_ms,
-            _X("wind_max_m_s","gust_speed_ms"),    "Gust speed",       DATA_COND, gust_speed_raw != 0xff, DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, gust_speed_ms,
-            _X("rain_mm","rainfall_mm"),           "Rainfall",         DATA_FORMAT, "%.1f mm", DATA_DOUBLE, rainfall_mm,
+            "wind_avg_m_s",     "Wind speed",       DATA_COND, wind_speed_raw != 0x1ff, DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wind_speed_ms,
+            "wind_max_m_s",     "Gust speed",       DATA_COND, gust_speed_raw != 0xff, DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, gust_speed_ms,
+            "rain_mm",          "Rainfall",         DATA_FORMAT, "%.1f mm", DATA_DOUBLE, rainfall_mm,
             "uv",               "UV",               DATA_COND, uv_raw != 0xffff, DATA_INT, uv_raw,
             "uvi",              "UVI",              DATA_COND, uv_raw != 0xffff, DATA_INT, uv_index,
             "light_lux",        "Light",            DATA_COND, light_raw != 0xffffff, DATA_FORMAT, "%.1f lux", DATA_DOUBLE, light_lux,
@@ -439,9 +439,9 @@ static int fineoffset_WH0290_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",            "",             DATA_STRING, _X("Fineoffset-WH0290","Fine Offset Electronics, WH0290"),
+            "model",            "",             DATA_STRING, "Fineoffset-WH0290",
             "id",               "ID",           DATA_INT,    id,
-            "battery_ok",          "Battery Level",  DATA_FORMAT, "%.1f", DATA_DOUBLE, battery_ok,
+            "battery_ok",       "Battery Level",  DATA_FORMAT, "%.1f", DATA_DOUBLE, battery_ok,
             "pm2_5_ug_m3",      "2.5um Fine Particulate Matter",  DATA_FORMAT, "%i ug/m3", DATA_INT, pm25/10,
             "estimated_pm10_0_ug_m3",     "Estimate of 10um Coarse Particulate Matter",  DATA_FORMAT, "%i ug/m3", DATA_INT, pm100/10,
             "family",           "FAMILY",       DATA_INT,    family,
@@ -558,7 +558,7 @@ static int fineoffset_WH25_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     data = data_make(
             "model",            "",             DATA_COND, type == 31, DATA_STRING, "Fineoffset-WH32",
             "model",            "",             DATA_COND, type == 32, DATA_STRING, "Fineoffset-WH32B",
-            "model",            "",             DATA_COND, type == 25, DATA_STRING, _X("Fineoffset-WH25","Fine Offset Electronics, WH25"),
+            "model",            "",             DATA_COND, type == 25, DATA_STRING, "Fineoffset-WH25",
             "id",               "ID",           DATA_INT,    id,
             "battery",          "Battery",      DATA_STRING, low_battery ? "LOW" : "OK",
             "temperature_C",    "Temperature",  DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
@@ -968,11 +968,11 @@ static int fineoffset_WH0530_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",            "",             DATA_STRING, _X("Fineoffset-WH0530","Fine Offset Electronics, WH0530 Temperature/Rain sensor"),
+            "model",            "",             DATA_STRING, "Fineoffset-WH0530",
             "id",               "ID",           DATA_INT, id,
             "battery",          "Battery",      DATA_STRING, battery_low ? "LOW" : "OK",
             "temperature_C",    "Temperature",  DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
-            _X("rain_mm","rain"),             "Rain",         DATA_FORMAT, "%.01f mm", DATA_DOUBLE, rainfall,
+            "rain_mm",          "Rain",         DATA_FORMAT, "%.01f mm", DATA_DOUBLE, rainfall,
             "mic",              "Integrity",    DATA_STRING, "CRC",
             NULL);
     /* clang-format on */
@@ -999,11 +999,8 @@ static char *output_fields_WH25[] = {
     "pressure_hPa",
     // WH24
     "wind_dir_deg",
-    "wind_speed_ms", // TODO: delete this
-    "gust_speed_ms", // TODO: delete this
     "wind_avg_m_s",
     "wind_max_m_s",
-    "rainfall_mm", //TODO: remove this
     "rain_mm",
     "uv",
     "uvi",
@@ -1032,7 +1029,6 @@ static char *output_fields_WH0530[] = {
     "id",
     "battery",
     "temperature_C",
-    "rain", //TODO: remove this
     "rain_mm",
     "radio_clock",
     "mic",

--- a/src/devices/fineoffset_wh1050.c
+++ b/src/devices/fineoffset_wh1050.c
@@ -104,14 +104,14 @@ static int fineoffset_wh1050_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",            "",                 DATA_STRING, _X("Fineoffset-WH1050","Fine Offset WH1050 weather station"),
+            "model",            "",                 DATA_STRING, "Fineoffset-WH1050",
             "id",               "StationID",        DATA_FORMAT, "%04X",    DATA_INT,    device_id,
             "battery",          "Battery",          DATA_STRING, battery_low ? "LOW" : "OK",
             "temperature_C",    "Temperature",      DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
             "humidity",         "Humidity",         DATA_FORMAT, "%u %%",   DATA_INT,    humidity,
-            _X("wind_avg_km_h","speed"),   "Wind avg speed",   DATA_FORMAT, "%.02f",   DATA_DOUBLE, speed,
-            _X("wind_max_km_h","gust"),   "Wind gust",        DATA_FORMAT, "%.02f",   DATA_DOUBLE, gust,
-            _X("rain_mm","rain"),             "Total rainfall",   DATA_FORMAT, "%.01f",   DATA_DOUBLE, rain,
+            "wind_avg_km_h",    "Wind avg speed",   DATA_FORMAT, "%.02f",   DATA_DOUBLE, speed,
+            "wind_max_km_h",    "Wind gust",        DATA_FORMAT, "%.02f",   DATA_DOUBLE, gust,
+            "rain_mm",          "Total rainfall",   DATA_FORMAT, "%.01f",   DATA_DOUBLE, rain,
             "mic",              "Integrity",        DATA_STRING, "CRC",
             NULL);
     /* clang-format on */
@@ -126,11 +126,8 @@ static char *output_fields[] = {
     "battery",
     "temperature_C",
     "humidity",
-    "speed", // TODO: remove this
-    "gust", // TODO: remove this
     "wind_avg_km_h",
     "wind_max_km_h",
-    "rain", // TODO: delete this
     "rain_mm",
     "mic",
     NULL,

--- a/src/devices/fineoffset_wh1080.c
+++ b/src/devices/fineoffset_wh1080.c
@@ -262,16 +262,16 @@ static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer,
     if (msg_type == 0) {
         /* clang-format off */
         data = data_make(
-                "model",            "",                 DATA_STRING,    _X("Fineoffset-WHx080","Fine Offset Electronics WH1080/WH3080 Weather Station"),
-                _X("subtype","msg_type"), "Msg type",         DATA_INT,       msg_type,
+                "model",            "",                 DATA_STRING,    "Fineoffset-WHx080",
+                "subtype",          "Msg type",         DATA_INT,       msg_type,
                 "id",               "Station ID",       DATA_INT,       device_id,
                 "battery",          "Battery",          DATA_STRING,    battery_low ? "LOW" : "OK",
                 "temperature_C",    "Temperature",      DATA_FORMAT,    "%.01f C",  DATA_DOUBLE,    temperature,
                 "humidity",         "Humidity",         DATA_FORMAT,    "%u %%",    DATA_INT,       humidity,
-                _X("wind_dir_deg","direction_deg"),     "Wind Direction",    DATA_INT, direction_deg,
-                _X("wind_avg_km_h","speed"),   "Wind avg speed",   DATA_FORMAT,    "%.02f",    DATA_DOUBLE,    speed,
-                _X("wind_max_km_h","gust"),   "Wind gust",        DATA_FORMAT,    "%.02f",    DATA_DOUBLE,    gust,
-                _X("rain_mm","rain"),             "Total rainfall",   DATA_FORMAT,    "%3.1f",    DATA_DOUBLE,    rain,
+                "wind_dir_deg",     "Wind Direction",   DATA_INT, direction_deg,
+                "wind_avg_km_h",    "Wind avg speed",   DATA_FORMAT,    "%.02f",    DATA_DOUBLE,    speed,
+                "wind_max_km_h",    "Wind gust",        DATA_FORMAT,    "%.02f",    DATA_DOUBLE,    gust,
+                "rain_mm",          "Total rainfall",   DATA_FORMAT,    "%3.1f",    DATA_DOUBLE,    rain,
                 "mic",              "Integrity",        DATA_STRING,    "CRC",
                 NULL);
         /* clang-format on */
@@ -283,8 +283,8 @@ static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer,
 
         /* clang-format off */
         data = data_make(
-                "model",            "",                 DATA_STRING,    _X("Fineoffset-WHx080","Fine Offset Electronics WH1080/WH3080 Weather Station"),
-                _X("subtype","msg_type"), "Msg type",         DATA_INT,       msg_type,
+                "model",            "",                 DATA_STRING,    "Fineoffset-WHx080",
+                "subtype",          "Msg type",         DATA_INT,       msg_type,
                 "id",               "Station ID",       DATA_INT,       device_id,
                 "signal",           "Signal Type",      DATA_STRING,    signal_type_str,
                 "radio_clock",      "Radio Clock",      DATA_STRING,    clock_str,
@@ -295,8 +295,8 @@ static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer,
     else {
         /* clang-format off */
         data = data_make(
-                "model",            "",                 DATA_STRING,    _X("Fineoffset-WHx080","Fine Offset Electronics WH3080 Weather Station"),
-                _X("subtype","msg_type"), "Msg type",         DATA_INT,       msg_type,
+                "model",            "",                 DATA_STRING,    "Fineoffset-WHx080",
+                "subtype",          "Msg type",         DATA_INT,       msg_type,
                 "uv_sensor_id",     "UV Sensor ID",     DATA_INT,       uv_sensor_id,
                 "uv_status",        "Sensor Status",    DATA_STRING,    uv_status_ok ? "OK" : "ERROR",
                 "uv_index",         "UV Index",         DATA_INT,       uv_index,
@@ -335,15 +335,10 @@ static char *output_fields[] = {
         "battery",
         "temperature_C",
         "humidity",
-        "direction_deg", // TODO: remove this
         "wind_dir_deg",
-        "speed", // TODO: remove this
-        "gust",  // TODO: remove this
         "wind_avg_km_h",
         "wind_max_km_h",
-        "rain", // TODO: remove this
         "rain_mm",
-        "msg_type", // TODO: remove this
         "signal",
         "radio_clock",
         "sensor_code",

--- a/src/devices/fordremote.c
+++ b/src/devices/fordremote.c
@@ -50,13 +50,14 @@ static int fordremote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         device_id = (bytes[0]<<16) | (bytes[1]<<8) | bytes[2];
         code = bytes[7];
 
-        /* Get time now */
+        /* clang-format off */
         data = data_make(
-                "model",    "model",    DATA_STRING, _X("Ford-CarRemote","Ford Car Remote"),
-                "id",       "device-id",    DATA_INT, device_id,
-                "code",     "data",     DATA_INT, code,
+                "model",    "model",        DATA_STRING, "Ford-CarRemote",
+                "id",       "device-id",    DATA_INT,    device_id,
+                "code",     "data",         DATA_INT,    code,
                 NULL);
         decoder_output_data(decoder, data);
+        /* clang-format on */
 
         found++;
     }

--- a/src/devices/ft004b.c
+++ b/src/devices/ft004b.c
@@ -55,10 +55,12 @@ ft004b_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     int temp_raw = ((msg[4] & 0x7) << 8) | msg[3];
     temperature = (temp_raw * 0.05f) - 40.0f;
 
+    /* clang-format off */
     data = data_make(
-            "model", "", DATA_STRING, _X("FT-004B","FT-004-B Temperature Sensor"),
-            "temperature_C", "Temperature", DATA_FORMAT, "%.1f", DATA_DOUBLE, temperature,
+            "model",            "",             DATA_STRING, "FT-004B",
+            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f", DATA_DOUBLE, temperature,
             NULL);
+    /* clang-format on */
     decoder_output_data(decoder, data);
 
     return 1;

--- a/src/devices/ge_coloreffects.c
+++ b/src/devices/ge_coloreffects.c
@@ -113,11 +113,13 @@ static int ge_coloreffects_decode(r_device *decoder, bitbuffer_t *bitbuffer, uns
     }
 
     // Format data
+    /* clang-format off */
     data = data_make(
-        "model",         "",     DATA_STRING, _X("GE-ColorEffects","GE Color Effects Remote"),
-        "id",            "",     DATA_FORMAT, "0x%x", DATA_INT, device_id,
-        "command",       "",     DATA_STRING, cmd,
-        NULL);
+            "model",        "",     DATA_STRING, "GE-ColorEffects",
+            "id",           "",     DATA_FORMAT, "0x%x", DATA_INT, device_id,
+            "command",      "",     DATA_STRING, cmd,
+            NULL);
+    /* clang-format on */
 
     decoder_output_data(decoder, data);
     return 1;

--- a/src/devices/generic_motion.c
+++ b/src/devices/generic_motion.c
@@ -49,10 +49,12 @@ static int generic_motion_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         code = (b[0] << 12) | (b[1] << 4) | (b[2] >> 4);
         sprintf(code_str, "%05x", code);
 
+        /* clang-format off */
         data = data_make(
-                "model",    "",  DATA_STRING, _X("Generic-Motion","Generic motion sensor"),
+                "model",    "",  DATA_STRING, "Generic-Motion",
                 "code",     "",  DATA_STRING, code_str,
                 NULL);
+        /* clang-format on */
 
         decoder_output_data(decoder, data);
         return 1;

--- a/src/devices/generic_remote.c
+++ b/src/devices/generic_remote.c
@@ -58,12 +58,14 @@ static int generic_remote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     }
     *p = '\0';
 
+    /* clang-format off */
     data = data_make(
-            "model",        "",             DATA_STRING, _X("Generic-Remote","Generic Remote"),
+            "model",        "",             DATA_STRING, "Generic-Remote",
             "id",           "House Code",   DATA_INT, id_16b,
             "cmd",          "Command",      DATA_INT, cmd_8b,
             "tristate",     "Tri-State",    DATA_STRING, tristate,
             NULL);
+    /* clang-format on */
 
     decoder_output_data(decoder, data);
 

--- a/src/devices/generic_temperature_sensor.c
+++ b/src/devices/generic_temperature_sensor.c
@@ -49,7 +49,7 @@ static int generic_temperature_sensor_callback(r_device *decoder, bitbuffer_t *b
 
     /* clang-format off */
     data = data_make(
-            "model",        "",             DATA_STRING,    _X("Generic-Temperature","Generic temperature sensor 1"),
+            "model",        "",             DATA_STRING,    "Generic-Temperature",
             "id",           "Id",           DATA_INT,   device,
             "battery",          "Battery?",     DATA_INT,                   battery,
             "temperature_C",    "Temperature",      DATA_FORMAT,    "%.02f C",  DATA_DOUBLE,    temp_f,

--- a/src/devices/hideki.c
+++ b/src/devices/hideki.c
@@ -134,9 +134,9 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         humidity = ((packet[6] & 0xF0) >> 4) * 10 + (packet[6] & 0x0F);
         /* clang-format off */
         data = data_make(
-                "model",            "",                 DATA_STRING, _X("Hideki-TS04","HIDEKI TS04 sensor"),
-                _X("id","rc"),               "Rolling Code",     DATA_INT, rc,
-                "channel",          "Channel",          DATA_INT, channel,
+                "model",            "",                 DATA_STRING, "Hideki-TS04",
+                "id",               "Rolling Code",     DATA_INT,    rc,
+                "channel",          "Channel",          DATA_INT,    channel,
                 "battery",          "Battery",          DATA_STRING, battery_ok ? "OK": "LOW",
                 "temperature_C",    "Temperature",      DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp/10.f,
                 "humidity",         "Humidity",         DATA_FORMAT, "%u %%", DATA_INT, humidity,
@@ -156,15 +156,15 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         /* clang-format off */
         data = data_make(
-                "model",            "",                 DATA_STRING, _X("Hideki-Wind","HIDEKI Wind sensor"),
-                _X("id","rc"),               "Rolling Code",     DATA_INT, rc,
-                "channel",          "Channel",          DATA_INT, channel,
+                "model",            "",                 DATA_STRING, "Hideki-Wind",
+                "id",               "Rolling Code",     DATA_INT,    rc,
+                "channel",          "Channel",          DATA_INT,    channel,
                 "battery",          "Battery",          DATA_STRING, battery_ok ? "OK": "LOW",
                 "temperature_C",    "Temperature",      DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp * 0.1f,
-                _X("wind_avg_mi_h","wind_speed_mph"),   "Wind Speed",       DATA_FORMAT, "%.02f mi/h", DATA_DOUBLE, wind_speed * 0.1f,
-                _X("wind_max_mi_h","gust_speed_mph"),   "Gust Speed",       DATA_FORMAT, "%.02f mi/h", DATA_DOUBLE, gust_speed * 0.1f,
-                "wind_approach",    "Wind Approach",    DATA_INT, wind_approach,
-                _X("wind_dir_deg","wind_direction"),   "Wind Direction",   DATA_FORMAT, "%.01f", DATA_DOUBLE, wind_direction * 0.1f,
+                "wind_avg_mi_h",    "Wind Speed",       DATA_FORMAT, "%.02f mi/h", DATA_DOUBLE, wind_speed * 0.1f,
+                "wind_max_mi_h",    "Gust Speed",       DATA_FORMAT, "%.02f mi/h", DATA_DOUBLE, gust_speed * 0.1f,
+                "wind_approach",    "Wind Approach",    DATA_INT,    wind_approach,
+                "wind_dir_deg",     "Wind Direction",   DATA_FORMAT, "%.01f", DATA_DOUBLE, wind_direction * 0.1f,
                 "mic",              "Integrity",        DATA_STRING, "CRC",
                 NULL);
         /* clang-format on */
@@ -174,9 +174,9 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (sensortype == HIDEKI_TEMP) {
         /* clang-format off */
         data = data_make(
-                "model",            "",                 DATA_STRING, _X("Hideki-Temperature","HIDEKI Temperature sensor"),
-                _X("id","rc"),               "Rolling Code",     DATA_INT, rc,
-                "channel",          "Channel",          DATA_INT, channel,
+                "model",            "",                 DATA_STRING, "Hideki-Temperature",
+                "id",               "Rolling Code",     DATA_INT,    rc,
+                "channel",          "Channel",          DATA_INT,    channel,
                 "battery",          "Battery",          DATA_STRING, battery_ok ? "OK": "LOW",
                 "temperature_C",    "Temperature",      DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp * 0.1f,
                 "mic",              "Integrity",        DATA_STRING, "CRC",
@@ -191,9 +191,9 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         /* clang-format off */
         data = data_make(
-                "model",            "",                 DATA_STRING, _X("Hideki-Rain","HIDEKI Rain sensor"),
-                _X("id","rc"),               "Rolling Code",     DATA_INT, rc,
-                "channel",          "Channel",          DATA_INT, channel,
+                "model",            "",                 DATA_STRING, "Hideki-Rain",
+                "id",               "Rolling Code",     DATA_INT,    rc,
+                "channel",          "Channel",          DATA_INT,    channel,
                 "battery",          "Battery",          DATA_STRING, battery_ok ? "OK": "LOW",
                 "rain_mm",          "Rain",             DATA_FORMAT, "%.01f mm", DATA_DOUBLE, rain_units * 0.7f,
                 "mic",              "Integrity",        DATA_STRING, "CRC",
@@ -208,18 +208,14 @@ static int hideki_ts04_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
 static char *output_fields[] = {
         "model",
-        "rc", // TODO: delete this
         "id",
         "channel",
         "battery",
         "temperature_C",
         "humidity",
-        "wind_speed_mph", // TODO: remove this
-        "gust_speed_mph", // TODO: remove this
         "wind_avg_mi_h",
         "wind_max_mi_h",
         "wind_approach",
-        "wind_direction", // TODO: remove this
         "wind_dir_deg",
         "rain_mm",
         "mic",

--- a/src/devices/holman_ws5029.c
+++ b/src/devices/holman_ws5029.c
@@ -108,7 +108,7 @@ static int holman_ws5029pcm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "humidity",         "Humidity",         DATA_FORMAT, "%u %%",    DATA_INT,    humidity,
             "rain_mm",          "Total rainfall",   DATA_FORMAT, "%.01f mm", DATA_DOUBLE, rain_mm,
             "wind_avg_km_h",    "Wind avg speed",   DATA_FORMAT, "%u km/h",  DATA_INT,    speed_kmh,
-            _X("wind_dir_deg","direction_deg"),     "Wind Direction",    DATA_INT, direction_deg,
+            "wind_dir_deg",     "Wind Direction",   DATA_INT, direction_deg,
             NULL);
     /* clang-format on */
 
@@ -124,8 +124,7 @@ static char *output_fields[] = {
         "battery_ok",
         "rain_mm",
         "wind_avg_km_h",
-        "direction_deg", // TODO: remove this
-        "wind_dir_deg", // TODO: remove this
+        "wind_dir_deg",
         "mic",
         NULL,
 };
@@ -200,7 +199,7 @@ static int holman_ws5029pwm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "humidity",         "Humidity",         DATA_FORMAT, "%u %%",    DATA_INT,    humidity,
             "rain_mm",          "Total rainfall",   DATA_FORMAT, "%.01f mm", DATA_DOUBLE, rain_mm,
             "wind_avg_km_h",    "Wind avg speed",   DATA_FORMAT, "%u km/h",  DATA_INT,    speed_kmh,
-            _X("wind_dir_deg","direction_deg"),     "Wind Direction",    DATA_INT, (int)(wind_dir * 22.5),
+            "wind_dir_deg",     "Wind Direction",   DATA_INT, (int)(wind_dir * 22.5),
             "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
             NULL);
     /* clang-format on */

--- a/src/devices/hondaremote.c
+++ b/src/devices/hondaremote.c
@@ -47,11 +47,13 @@ static int hondaremote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         code = get_command_codes(b);
         device_id = b[44]<<8 | b[45];
 
+        /* clang-format off */
         data = data_make(
-                "model",        "",     DATA_STRING, _X("Honda-CarRemote","Honda Remote"),
-                _X("id","device id"),    "",    DATA_INT, device_id,
-                "code",         "",    DATA_STRING, code,
+                "model",        "",     DATA_STRING, "Honda-CarRemote",
+                "id",           "",     DATA_INT, device_id,
+                "code",         "",     DATA_STRING, code,
                 NULL);
+        /* clang-format on */
 
         decoder_output_data(decoder, data);
         return 1;
@@ -61,7 +63,6 @@ static int hondaremote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
 static char *output_fields[] = {
         "model",
-        "device_id", // TODO: delete this
         "id",
         "code",
         NULL,

--- a/src/devices/honeywell.c
+++ b/src/devices/honeywell.c
@@ -105,7 +105,7 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",        "", DATA_STRING, _X("Honeywell-Security","Honeywell Door/Window Sensor"),
+            "model",        "", DATA_STRING, "Honeywell-Security",
             "id",           "", DATA_FORMAT, "%05x", DATA_INT, device_id,
             "channel",      "", DATA_INT,    channel,
             "event",        "", DATA_FORMAT, "%02x", DATA_INT, event,

--- a/src/devices/honeywell_wdb.c
+++ b/src/devices/honeywell_wdb.c
@@ -103,8 +103,8 @@ static int honeywell_wdb_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",         "",            DATA_STRING, _X("Honeywell-ActivLink","Honeywell Wireless Doorbell"),
-            _X("subtype","class"),         "Class",       DATA_FORMAT, "%s",   DATA_STRING, class,
+            "model",         "",            DATA_STRING, "Honeywell-ActivLink",
+            "subtype",       "Class",       DATA_FORMAT, "%s",   DATA_STRING, class,
             "id",            "Id",          DATA_FORMAT, "%x",   DATA_INT,    device,
             "battery",       "Battery",     DATA_STRING, battery ? "LOW" : "OK",
             "alert",         "Alert",       DATA_FORMAT, "%s",   DATA_STRING, alert,
@@ -121,7 +121,6 @@ static int honeywell_wdb_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 static char *output_fields[] = {
         "model",
         "subtype",
-        "class", // TODO: remove this
         "id",
         "battery",
         "alert",

--- a/src/devices/ht680.c
+++ b/src/devices/ht680.c
@@ -63,8 +63,8 @@ static int ht680_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         /* clang-format off */
         data = data_make(
-                "model",    "",                 DATA_STRING, _X("HT680-Remote","HT680 Remote control"),
-                _X("id","address"),  "Address",          DATA_FORMAT, "0x%06X", DATA_INT, address,
+                "model",    "",                 DATA_STRING, "HT680-Remote",
+                "id",       "Address",          DATA_FORMAT, "0x%06X", DATA_INT, address,
                 "button1",  "Button 1",         DATA_STRING, button1 == 3 ? "PRESSED" : "",
                 "button2",  "Button 2",         DATA_STRING, button2 == 3 ? "PRESSED" : "",
                 "button3",  "Button 3",         DATA_STRING, button3 == 3 ? "PRESSED" : "",
@@ -82,7 +82,6 @@ static int ht680_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 static char *output_fields[] = {
         "model",
         "id",
-        "address", // TODO: remove this
         "button1",
         "button2",
         "button3",

--- a/src/devices/ibis_beacon.c
+++ b/src/devices/ibis_beacon.c
@@ -66,14 +66,15 @@ static int ibis_beacon_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         sprintf(&code_str[i*2], "%02x", msg[i]);
     }
 
-    /* Get time now */
+    /* clang-format off */
     data = data_make(
-        "model",    "",             DATA_STRING,    _X("IBIS-Beacon","IBIS beacon"),
-        "id",       "Vehicle No.",  DATA_INT,       id,
-        "counter",  "Counter",      DATA_INT,       counter,
-        "code",     "Code data",    DATA_STRING,    code_str,
-        "mic",      "Integrity",    DATA_STRING,    "CRC",
-        NULL);
+            "model",    "",             DATA_STRING,    "IBIS-Beacon",
+            "id",       "Vehicle No.",  DATA_INT,       id,
+            "counter",  "Counter",      DATA_INT,       counter,
+            "code",     "Code data",    DATA_STRING,    code_str,
+            "mic",      "Integrity",    DATA_STRING,    "CRC",
+            NULL);
+    /* clang-format on */
 
     decoder_output_data(decoder, data);
     return 1;

--- a/src/devices/infactory.c
+++ b/src/devices/infactory.c
@@ -90,7 +90,7 @@ static int infactory_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",            "",             DATA_STRING, _X("inFactory-TH","inFactory sensor"),
+            "model",            "",             DATA_STRING, "inFactory-TH",
             "id",               "ID",           DATA_INT, id,
             "channel",          "Channel",      DATA_INT, channel,
             "battery_ok",       "Battery OK",   DATA_INT, !battery_low,

--- a/src/devices/inovalley-kw9015b.c
+++ b/src/devices/inovalley-kw9015b.c
@@ -57,7 +57,7 @@ static int kw9015b_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",            "",             DATA_STRING, _X("Inovalley-kw9015b","Inovalley kw9015b"),
+            "model",            "",             DATA_STRING, "Inovalley-kw9015b",
             "id",               "",             DATA_INT,    device,
             "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
             "rain",             "Rain Count",   DATA_INT,    rain, // TODO: remove this

--- a/src/devices/interlogix.c
+++ b/src/devices/interlogix.c
@@ -199,8 +199,8 @@ static int interlogix_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",       "Model",         DATA_STRING, _X("Interlogix-Security","Interlogix"),
-            _X("subtype","device_type"),     "Device Type",   DATA_STRING, device_type,
+            "model",       "Model",         DATA_STRING, "Interlogix-Security",
+            "subtype",     "Device Type",   DATA_STRING, device_type,
             "id",          "ID",            DATA_STRING, device_serial,
             "battery",     "Battery",       DATA_STRING, low_battery,
             "switch1",     "Switch1 State", DATA_STRING, f1_latch_state,
@@ -220,7 +220,6 @@ static char *output_fields[] = {
         "model",
         "subtype",
         "id",
-        "device_type", // TODO: delete this
         "raw_message",
         "battery",
         "switch1",

--- a/src/devices/intertechno.c
+++ b/src/devices/intertechno.c
@@ -53,13 +53,15 @@ static int intertechno_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     master = (b[7] & 0xf0) >> 4;
     command = b[6] & 0x07;
 
+    /* clang-format off */
     data = data_make(
-        "model",            "",     DATA_STRING,    _X("Intertechno-Remote","Intertechno"),
-        "id",               "",     DATA_STRING,    id_str,
-        "slave",            "",     DATA_INT,       slave,
-        "master",           "",     DATA_INT,       master,
-        "command",          "",     DATA_INT,       command,
-        NULL);
+            "model",            "",     DATA_STRING,    "Intertechno-Remote",
+            "id",               "",     DATA_STRING,    id_str,
+            "slave",            "",     DATA_INT,       slave,
+            "master",           "",     DATA_INT,       master,
+            "command",          "",     DATA_INT,       command,
+            NULL);
+    /* clang-format on */
 
     decoder_output_data(decoder, data);
     return 1;

--- a/src/devices/kedsum.c
+++ b/src/devices/kedsum.c
@@ -76,8 +76,9 @@ static int kedsum_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     int flags = (b[1] & 0xc0) | (b[4] >> 4);
 
+    /* clang-format off */
     data = data_make(
-            "model",            "",             DATA_STRING, _X("Kedsum-TH","Kedsum Temperature & Humidity Sensor"),
+            "model",            "",             DATA_STRING, "Kedsum-TH",
             "id",               "ID",           DATA_INT, id,
             "channel",          "Channel",      DATA_INT, channel,
             "battery",          "Battery",      DATA_STRING, battery_str,
@@ -86,6 +87,7 @@ static int kedsum_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             "humidity",         "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, humidity,
             "mic",              "Integrity",    DATA_STRING, "CRC",
             NULL);
+    /* clang-format on */
 
     decoder_output_data(decoder, data);
     return 1;

--- a/src/devices/kerui.c
+++ b/src/devices/kerui.c
@@ -36,8 +36,6 @@ static int kerui_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     int id;
     int cmd;
     char *cmd_str;
-    char *field_name;
-    int field_value;
 
     int r = bitbuffer_find_repeated_row(bitbuffer, 9, 25); // expected are 25 packets, require 9
     if (r < 0)
@@ -63,25 +61,32 @@ static int kerui_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     id = (b[0] << 12) | (b[1] << 4) | (b[2] >> 4);
     cmd = b[2] & 0x0F;
     switch (cmd) {
-        case 0xa: cmd_str = "motion";  field_name = "motion";     field_value = 1; break;
-        case 0xe: cmd_str = "open";    field_name = "opened";     field_value = 1; break;
-        case 0x7: cmd_str = "close";   field_name = "opened";     field_value = 0; break;
-        case 0xb: cmd_str = "tamper";  field_name = "tamper";     field_value = 1; break;
-        case 0x5: cmd_str = "water";   field_name = "water";     field_value = 1; break;
-        case 0xf: cmd_str = "battery"; field_name = "battery_ok"; field_value = 0; break;
+        case 0xa: cmd_str = "motion"; break;
+        case 0xe: cmd_str = "open"; break;
+        case 0x7: cmd_str = "close"; break;
+        case 0xb: cmd_str = "tamper"; break;
+        case 0x5: cmd_str = "water"; break;
+        case 0xf: cmd_str = "battery"; break;
         default:  cmd_str = NULL; break;
     }
 
     if (!cmd_str)
         return DECODE_ABORT_EARLY;
 
+    /* clang-format off */
     data = data_make(
-            "model",    "",               DATA_STRING, _X("Kerui-Security","Kerui Security"),
-            "id",       "ID (20bit)",     DATA_FORMAT, "0x%x", DATA_INT, id,
-            "cmd",      "Command (4bit)", DATA_FORMAT, "0x%x", DATA_INT, cmd,
-            field_name, "",               DATA_INT,    field_value,
-            "state",    "State",          DATA_STRING, cmd_str,
+            "model",        "",                 DATA_STRING, "Kerui-Security",
+            "id",           "ID (20bit)",       DATA_FORMAT, "0x%x", DATA_INT, id,
+            "cmd",          "Command (4bit)",   DATA_FORMAT, "0x%x", DATA_INT, cmd,
+            "motion",       "",                 DATA_COND, cmd == 0xa, DATA_INT, 1,
+            "opened",       "",                 DATA_COND, cmd == 0xe, DATA_INT, 1,
+            "opened",       "",                 DATA_COND, cmd == 0x7, DATA_INT, 0,
+            "tamper",       "",                 DATA_COND, cmd == 0xb, DATA_INT, 1,
+            "water",        "",                 DATA_COND, cmd == 0x5, DATA_INT, 1,
+            "battery_ok",   "",                 DATA_COND, cmd == 0xf, DATA_INT, 0,
+            "state",        "State",            DATA_STRING, cmd_str,
             NULL);
+    /* clang-format on */
 
     decoder_output_data(decoder, data);
     return 1;

--- a/src/devices/lacrosse.c
+++ b/src/devices/lacrosse.c
@@ -159,7 +159,7 @@ static int lacrossetx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             float temp_c = msg_value - 50.0;
             /* clang-format off */
             data = data_make(
-                    "model",            "",             DATA_STRING, _X("LaCrosse-TX","LaCrosse TX Sensor"),
+                    "model",            "",             DATA_STRING, "LaCrosse-TX",
                     "id",               "",             DATA_INT,    sensor_id,
                     "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
                     "mic",              "Integrity",    DATA_STRING, "PARITY",
@@ -171,7 +171,7 @@ static int lacrossetx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         else if (msg_type == 0x0E) {
             /* clang-format off */
             data = data_make(
-                    "model",            "",             DATA_STRING, _X("LaCrosse-TX","LaCrosse TX Sensor"),
+                    "model",            "",             DATA_STRING, "LaCrosse-TX",
                     "id",               "",             DATA_INT,    sensor_id,
                     "humidity",         "Humidity",     DATA_FORMAT, "%.1f %%", DATA_DOUBLE, msg_value,
                     "mic",              "Integrity",    DATA_STRING, "PARITY",

--- a/src/devices/lacrosse_tx141x.c
+++ b/src/devices/lacrosse_tx141x.c
@@ -256,7 +256,7 @@ static int lacrosse_tx141x_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     if (device == LACROSSE_TX141B) {
         /* clang-format off */
         data = data_make(
-                "model",         "",              DATA_STRING, _X("LaCrosse-TX141B","LaCrosse TX141B sensor"),
+                "model",         "",              DATA_STRING, "LaCrosse-TX141B",
                 "id",            "Sensor ID",     DATA_FORMAT, "%02x", DATA_INT, id,
                 "temperature_C", "Temperature",   DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
                 "battery",       "Battery",       DATA_STRING, battery_low ? "LOW" : "OK",
@@ -266,7 +266,7 @@ static int lacrosse_tx141x_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     } else if (device == LACROSSE_TX141) {
         /* clang-format off */
         data = data_make(
-                "model",         "",              DATA_STRING, _X("LaCrosse-TX141Bv2","LaCrosse TX141-Bv2 sensor"),
+                "model",         "",              DATA_STRING, "LaCrosse-TX141Bv2",
                 "id",            "Sensor ID",     DATA_FORMAT, "%02x", DATA_INT, id,
                 "channel",       "Channel",       DATA_FORMAT, "%02x", DATA_INT, channel,
                 "temperature_C", "Temperature",   DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
@@ -294,7 +294,7 @@ static int lacrosse_tx141x_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         }
         /* clang-format off */
         data = data_make(
-                "model",         "",              DATA_STRING, _X("LaCrosse-TX141THBv2","LaCrosse TX141TH-Bv2 sensor"),
+                "model",         "",              DATA_STRING, "LaCrosse-TX141THBv2",
                 "id",            "Sensor ID",     DATA_FORMAT, "%02x", DATA_INT, id,
                 "channel",       "Channel",       DATA_FORMAT, "%02x", DATA_INT, channel,
                 "battery",       "Battery",       DATA_STRING, battery_low ? "LOW" : "OK",

--- a/src/devices/lacrosse_tx35.c
+++ b/src/devices/lacrosse_tx35.c
@@ -134,24 +134,24 @@ static int lacrosse_it(r_device *decoder, bitbuffer_t *bitbuffer, int device29or
                 sensor_id += 0x40;      // Change ID to distinguish between the main and probe channels
             /* clang-format off */
             data = data_make(
-                    "model", "", DATA_STRING, (device29or35 == 29 ? _X("LaCrosse-TX29IT","TX29-IT") : _X("LaCrosse-TX35DTHIT","TX35DTH-IT")),
-                    "id", "", DATA_INT, sensor_id,
-                    "battery", "Battery", DATA_STRING, battery_low ? "LOW" : "OK",
-                    "newbattery", "NewBattery", DATA_INT, newbatt,
-                    "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-                    "mic", "Integrity", DATA_STRING, "CRC",
+                    "model",            "",             DATA_STRING, (device29or35 == 29 ? "LaCrosse-TX29IT" : "LaCrosse-TX35DTHIT"),
+                    "id",               "",             DATA_INT,    sensor_id,
+                    "battery",          "Battery",      DATA_STRING, battery_low ? "LOW" : "OK",
+                    "newbattery",       "NewBattery",   DATA_INT,    newbatt,
+                    "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
+                    "mic",              "Integrity",    DATA_STRING, "CRC",
                     NULL);
             /* clang-format on */
         } else {
             /* clang-format off */
             data = data_make(
-                    "model", "", DATA_STRING, (device29or35 == 29 ? _X("LaCrosse-TX29IT","TX29-IT") : _X("LaCrosse-TX35DTHIT","TX35DTH-IT")),
-                    "id", "", DATA_INT, sensor_id,
-                    "battery", "Battery", DATA_STRING, battery_low ? "LOW" : "OK",
-                    "newbattery", "NewBattery", DATA_INT, newbatt,
-                    "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-                    "humidity", "Humidity", DATA_FORMAT, "%u %%", DATA_INT, humidity,
-                    "mic", "Integrity", DATA_STRING, "CRC",
+                    "model",            "",             DATA_STRING, (device29or35 == 29 ? "LaCrosse-TX29IT" : "LaCrosse-TX35DTHIT"),
+                    "id",               "",             DATA_INT,    sensor_id,
+                    "battery",          "Battery",      DATA_STRING, battery_low ? "LOW" : "OK",
+                    "newbattery",       "NewBattery",   DATA_INT,    newbatt,
+                    "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
+                    "humidity",         "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, humidity,
+                    "mic",              "Integrity",    DATA_STRING, "CRC",
                     NULL);
             /* clang-format on */
         }

--- a/src/devices/lacrossews.c
+++ b/src/devices/lacrossews.c
@@ -98,7 +98,6 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     // uint8_t msg_data, msg_unknown, msg_checksum;
     int msg_value_bcd, msg_value_bcd2, msg_value_bin;
     float temp_c, wind_dir, wind_spd, rain_mm;
-    char *wind_key, *wind_label;
     data_t *data;
 
     for (row = 0; row < BITBUF_ROWS; row++) {
@@ -126,7 +125,7 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
             /* clang-format off */
             data = data_make(
-                    "model",            "",             DATA_STRING, ws_id == 0x6 ? "LaCrosse-WS3600" : _X("LaCrosse-WS2310", "LaCrosse WS"),
+                    "model",            "",             DATA_STRING, ws_id == 0x6 ? "LaCrosse-WS3600" : "LaCrosse-WS2310",
                     "id",               "",             DATA_INT,    sensor_id,
                     "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
                     NULL);
@@ -146,7 +145,7 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
             /* clang-format off */
             data = data_make(
-                    "model",            "",             DATA_STRING, ws_id == 0x6 ? "LaCrosse-WS3600" : _X("LaCrosse-WS2310", "LaCrosse WS"),
+                    "model",            "",             DATA_STRING, ws_id == 0x6 ? "LaCrosse-WS3600" : "LaCrosse-WS2310",
                     "id",               "",             DATA_INT,    sensor_id,
                     "humidity",         "Humidity",     DATA_INT,    msg_value_bcd2,
                     NULL);
@@ -161,9 +160,9 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
             /* clang-format off */
             data = data_make(
-                    "model",            "",             DATA_STRING, ws_id == 0x6 ? "LaCrosse-WS3600" : _X("LaCrosse-WS2310", "LaCrosse WS"),
+                    "model",            "",             DATA_STRING, ws_id == 0x6 ? "LaCrosse-WS3600" : "LaCrosse-WS2310",
                     "id",               "",             DATA_INT,    sensor_id,
-                    _X("rain_mm", "rainfall_mm"), "Rainfall", DATA_FORMAT, "%3.2f mm", DATA_DOUBLE, rain_mm,
+                    "rain_mm",          "Rainfall",     DATA_FORMAT, "%3.2f mm", DATA_DOUBLE, rain_mm,
                     NULL);
             /* clang-format on */
 
@@ -184,15 +183,13 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                 break;
             }
 
-            wind_key   = msg_type == 3 ? _X("wind_avg_m_s", "wind_speed_ms") : _X("wind_max_m_s", "gust_speed_ms");
-            wind_label = msg_type == 3 ? "Wind speed" : "Gust speed";
-
             /* clang-format off */
             data = data_make(
-                    "model",            "",             DATA_STRING, ws_id == 0x6 ? "LaCrosse-WS3600" : _X("LaCrosse-WS2310", "LaCrosse WS"),
+                    "model",            "",             DATA_STRING, ws_id == 0x6 ? "LaCrosse-WS3600" : "LaCrosse-WS2310",
                     "id",               "",             DATA_INT,    sensor_id,
-                    wind_key,           wind_label,     DATA_FORMAT, "%3.1f m/s", DATA_DOUBLE, wind_spd,
-                    _X("wind_dir_deg", "wind_direction"), "Direction", DATA_DOUBLE, wind_dir, NULL);
+                    "wind_avg_m_s",     "Wind speed",   DATA_COND,   msg_type == 3, DATA_FORMAT, "%3.1f m/s", DATA_DOUBLE, wind_spd,
+                    "wind_max_m_s",     "Gust speed",   DATA_COND,   msg_type != 3, DATA_FORMAT, "%3.1f m/s", DATA_DOUBLE, wind_spd,
+                    "wind_dir_deg",     "Direction",    DATA_DOUBLE, wind_dir, NULL);
             /* clang-format on */
 
             decoder_output_data(decoder, data);
@@ -217,13 +214,9 @@ static char *output_fields[] = {
         "id",
         "temperature_C",
         "humidity",
-        "rainfall_mm", // TODO: delete this
         "rain_mm",
-        "wind_speed_ms", // TODO: delete this
-        "gust_speed_ms", // TODO: delete this
         "wind_avg_m_s",
         "wind_max_m_s",
-        "wind_direction", // TODO: delete this
         "wind_dir_deg",
         NULL,
 };

--- a/src/devices/lightwave_rf.c
+++ b/src/devices/lightwave_rf.c
@@ -125,13 +125,15 @@ static int lightwave_rf_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         fprintf(stderr, "  Row 0 = Input, Row 1 = Zero bit stuffing, Row 2 = Stripped delimiters, Row 3 = Decoded nibbles\n");
     }
 
+    /* clang-format off */
     data = data_make(
-            "model",        "", DATA_STRING, _X("Lightwave-RF","LightwaveRF"),
+            "model",        "", DATA_STRING, "Lightwave-RF",
             "id",           "", DATA_FORMAT, "%06x", DATA_INT, id,
-            "subunit",      "", DATA_INT, subunit,
-            "command",      "", DATA_INT, command,
-            "parameter",    "", DATA_INT, parameter,
+            "subunit",      "", DATA_INT,    subunit,
+            "command",      "", DATA_INT,    command,
+            "parameter",    "", DATA_INT,    parameter,
             NULL);
+    /* clang-format on */
 
     decoder_output_data(decoder, data);
 

--- a/src/devices/m_bus.c
+++ b/src/devices/m_bus.c
@@ -892,7 +892,7 @@ static void m_bus_output_data(r_device *decoder, const m_bus_data_t *out, const 
         NULL);
     } else {
         data = data_make(
-        "model",    "",             DATA_STRING,    _X("Wireless-MBus","Wireless M-Bus"),
+        "model",    "",             DATA_STRING,    "Wireless-MBus",
         "mode",     "Mode",         DATA_STRING,    mode,
         "M",        "Manufacturer", DATA_STRING,    block1->M_str,
         "id",       "ID",           DATA_INT,       block1->A_ID,

--- a/src/devices/maverick_et73.c
+++ b/src/devices/maverick_et73.c
@@ -81,8 +81,8 @@ static int maverick_et73_sensor_callback(r_device *decoder, bitbuffer_t *bitbuff
 
     /* clang-format off */
     data = data_make(
-            "model",            "",                 DATA_STRING, _X("Maverick-ET73","Maverick ET73"),
-            _X("id","rid"),              "Random Id",        DATA_INT, device,
+            "model",            "",                 DATA_STRING, "Maverick-ET73",
+            "id",               "Random Id",        DATA_INT, device,
             "temperature_1_C",  "Temperature 1",    DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp1_c,
             "temperature_2_C",  "Temperature 2",    DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp2_c,
             NULL);
@@ -94,7 +94,6 @@ static int maverick_et73_sensor_callback(r_device *decoder, bitbuffer_t *bitbuff
 
 static char *output_fields[] = {
         "model",
-        "rid", // TODO: delete this
         "id",
         "temperature_1_C",
         "temperature_2_C",

--- a/src/devices/maverick_et73x.c
+++ b/src/devices/maverick_et73x.c
@@ -90,15 +90,17 @@ static int maverick_et73x_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         fprintf(stderr, "%s: pre %03x, flags %0x, t1 %d, t2 %d, digest %04x, chk_data %02x%02x%02x, digest xor'ed: %04x\n",
                 __func__, pre, flags, temp1, temp2, digest, chk[0], chk[1], chk[2], id);
 
+    /* clang-format off */
     data = data_make(
             "model",            "",                     DATA_STRING, "Maverick-ET73x",
-            "id",               "Session_ID",           DATA_INT, id,
+            "id",               "Session_ID",           DATA_INT,    id,
             "status",           "Status",               DATA_STRING, status,
-            _X("temperature_1_C","temperature1_C"),  "TemperatureSensor1",   DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp1_c,
-            _X("temperature_2_C","temperature2_C"),  "TemperatureSensor2",   DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp2_c,
+            "temperature_1_C",  "TemperatureSensor1",   DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp1_c,
+            "temperature_2_C",  "TemperatureSensor2",   DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp2_c,
             NULL);
-    decoder_output_data(decoder, data);
+    /* clang-format on */
 
+    decoder_output_data(decoder, data);
     return 1;
 }
 
@@ -106,8 +108,6 @@ static char *output_fields[] = {
         "model",
         "id",
         "status",
-        "temperature1_C", // TODO: remove this
-        "temperature2_C", // TODO: remove this
         "temperature_1_C",
         "temperature_2_C",
         "mic",

--- a/src/devices/mebus.c
+++ b/src/devices/mebus.c
@@ -43,19 +43,20 @@ static int mebus433_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         // Always 0b1111?
         unknown2 = (bb[1][3] & 0xf0) >> 4;
 
+        /* clang-format off */
         data = data_make(
-                "model",         "",            DATA_STRING, _X("Mebus-433","Mebus/433"),
-                "id",            "Address",     DATA_INT, address,
-                "channel",       "Channel",     DATA_INT, channel,
-                "battery",       "Battery",     DATA_STRING, battery ? "OK" : "LOW",
-                "unknown1",      "Unknown 1",   DATA_INT, unknown1,
-                "unknown2",      "Unknown 2",   DATA_INT, unknown2,
-                "temperature_C", "Temperature", DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp * 0.1f,
-                "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, hum,
+                "model",            "",             DATA_STRING, "Mebus-433",
+                "id",               "Address",      DATA_INT,    address,
+                "channel",          "Channel",      DATA_INT,    channel,
+                "battery",          "Battery",      DATA_STRING, battery ? "OK" : "LOW",
+                "unknown1",         "Unknown 1",    DATA_INT,    unknown1,
+                "unknown2",         "Unknown 2",    DATA_INT,    unknown2,
+                "temperature_C",    "Temperature",  DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp * 0.1f,
+                "humidity",         "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, hum,
                 NULL);
+        /* clang-format on */
+
         decoder_output_data(decoder, data);
-
-
         return 1;
     }
     return DECODE_ABORT_EARLY;

--- a/src/devices/newkaku.c
+++ b/src/devices/newkaku.c
@@ -60,7 +60,7 @@ static int newkaku_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",        "",             DATA_STRING, _X("KlikAanKlikUit-Switch","KlikAanKlikUit Wireless Switch"),
+            "model",        "",             DATA_STRING, "KlikAanKlikUit-Switch",
             "id",           "",             DATA_INT,    id,
             "unit",         "Unit",         DATA_INT,    unit,
             "group_call",   "Group Call",   DATA_STRING, group_cmd ? "Yes" : "No",

--- a/src/devices/nexa.c
+++ b/src/devices/nexa.c
@@ -56,7 +56,7 @@ static int nexa_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",         "",            DATA_STRING, _X("Nexa-Security","Nexa"),
+            "model",         "",            DATA_STRING, "Nexa-Security",
             "id",            "House Code",  DATA_INT,    id,
             "channel",       "Channel",     DATA_INT,    channel,
             "state",         "State",       DATA_STRING, on_bit ? "ON" : "OFF",

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -77,9 +77,9 @@ static int nexus_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (humidity == 0x00) { // Thermo
         /* clang-format off */
         data = data_make(
-                "model",         "",            DATA_STRING, _X("Nexus-T","Nexus Temperature"),
-                "id",            "House Code",  DATA_INT, id,
-                "channel",       "Channel",     DATA_INT, channel,
+                "model",         "",            DATA_STRING, "Nexus-T",
+                "id",            "House Code",  DATA_INT,    id,
+                "channel",       "Channel",     DATA_INT,    channel,
                 "battery",       "Battery",     DATA_STRING, battery ? "OK" : "LOW",
                 "temperature_C", "Temperature", DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
                 NULL);
@@ -88,9 +88,9 @@ static int nexus_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     else { // Thermo/Hygro
         /* clang-format off */
         data = data_make(
-                "model",         "",            DATA_STRING, _X("Nexus-TH","Nexus Temperature/Humidity"),
-                "id",            "House Code",  DATA_INT, id,
-                "channel",       "Channel",     DATA_INT, channel,
+                "model",         "",            DATA_STRING, "Nexus-TH",
+                "id",            "House Code",  DATA_INT,    id,
+                "channel",       "Channel",     DATA_INT,    channel,
                 "battery",       "Battery",     DATA_STRING, battery ? "OK" : "LOW",
                 "temperature_C", "Temperature", DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_c,
                 "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, humidity,

--- a/src/devices/oil_standard.c
+++ b/src/devices/oil_standard.c
@@ -87,16 +87,18 @@ static int oil_standard_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
         // A depth reading of zero indicates no reading.
         depth = ((b[2] & 0x02) << 7) | b[3];
 
+    /* clang-format off */
     data = data_make(
-            "model", "", DATA_STRING, _X("Oil-SonicStd","Oil Ultrasonic STANDARD"),
-            "id", "", DATA_FORMAT, "%04x", DATA_INT, unit_id,
-            "flags", "", DATA_FORMAT, "%02x", DATA_INT, flags,
-            "alarm", "", DATA_INT, alarm,
-            "binding_countdown", "", DATA_INT, binding_countdown,
-            "depth_cm", "", DATA_INT, depth,
+            "model",                "", DATA_STRING, "Oil-SonicStd",
+            "id",                   "", DATA_FORMAT, "%04x", DATA_INT, unit_id,
+            "flags",                "", DATA_FORMAT, "%02x", DATA_INT, flags,
+            "alarm",                "", DATA_INT,    alarm,
+            "binding_countdown",    "", DATA_INT,    binding_countdown,
+            "depth_cm",             "", DATA_INT,    depth,
             NULL);
-    decoder_output_data(decoder, data);
+    /* clang-format on */
 
+    decoder_output_data(decoder, data);
     return 1;
 }
 

--- a/src/devices/oil_watchman.c
+++ b/src/devices/oil_watchman.c
@@ -83,13 +83,13 @@ static int oil_watchman_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         /* clang-format off */
         data = data_make(
-                "model", "", DATA_STRING, _X("Oil-SonicSmart","Oil Watchman"),
-                "id", "", DATA_FORMAT, "%06x", DATA_INT, unit_id,
-                "flags", "", DATA_FORMAT, "%02x", DATA_INT, flags,
-                "maybetemp", "", DATA_INT, maybetemp,
-                "temperature_C", "", DATA_DOUBLE, temperature,
-                "binding_countdown", "", DATA_INT, binding_countdown,
-                _X("depth_cm","depth"), "", DATA_INT, depth,
+                "model",                "", DATA_STRING, "Oil-SonicSmart",
+                "id",                   "", DATA_FORMAT, "%06x", DATA_INT, unit_id,
+                "flags",                "", DATA_FORMAT, "%02x", DATA_INT, flags,
+                "maybetemp",            "", DATA_INT,    maybetemp,
+                "temperature_C",        "", DATA_DOUBLE, temperature,
+                "binding_countdown",    "", DATA_INT,    binding_countdown,
+                "depth_cm",             "", DATA_INT,    depth,
                 NULL);
         /* clang-format on */
 
@@ -106,7 +106,6 @@ static char *output_fields[] = {
         "maybetemp",
         "temperature_C",
         "binding_countdown",
-        "depth", // TODO: remove this
         "depth_cm",
         NULL,
 };

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -266,7 +266,7 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
             return 0;
         /* clang-format off */
         data = data_make(
-                "model",                 "",                        DATA_STRING, (sensor_id == ID_THGR122N) ? _X("Oregon-THGR122N","THGR122N"): _X("Oregon-THGR968","THGR968"),
+                "model",                 "",                        DATA_STRING, (sensor_id == ID_THGR122N) ? "Oregon-THGR122N" : "Oregon-THGR968",
                 "id",                        "House Code",    DATA_INT,        get_os_rollingcode(msg),
                 "channel",             "Channel",         DATA_INT,        get_os_channel(msg, sensor_id),
                 "battery",             "Battery",         DATA_STRING, get_os_battery(msg) ? "LOW" : "OK",
@@ -285,13 +285,13 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         float gustWindspeed = (msg[5] & 0x0f) / 10.0F + ((msg[6] >> 4) & 0x0f) * 1.0F + (msg[6] & 0x0f) / 10.0F;
         /* clang-format off */
         data = data_make(
-                "model",            "",                     DATA_STRING, _X("Oregon-WGR968","WGR968"),
+                "model",            "",                     DATA_STRING, "Oregon-WGR968",
                 "id",                 "House Code", DATA_INT,        get_os_rollingcode(msg),
                 "channel",        "Channel",        DATA_INT,        get_os_channel(msg, sensor_id),
                 "battery",        "Battery",        DATA_STRING, get_os_battery(msg) ? "LOW" : "OK",
-                _X("wind_max_m_s","gust"), "Gust",             DATA_FORMAT, "%2.1f m/s",DATA_DOUBLE, gustWindspeed,
-                _X("wind_avg_m_s","average"), "Average",        DATA_FORMAT, "%2.1f m/s",DATA_DOUBLE, avgWindspeed,
-                _X("wind_dir_deg","direction"),    "Direction",    DATA_FORMAT, "%3.1f degrees",DATA_DOUBLE, quadrant,
+                "wind_max_m_s", "Gust",             DATA_FORMAT, "%2.1f m/s",DATA_DOUBLE, gustWindspeed,
+                "wind_avg_m_s", "Average",        DATA_FORMAT, "%2.1f m/s",DATA_DOUBLE, avgWindspeed,
+                "wind_dir_deg",    "Direction",    DATA_FORMAT, "%3.1f degrees",DATA_DOUBLE, quadrant,
                 NULL);
         /* clang-format on */
         decoder_output_data(decoder, data);
@@ -316,7 +316,7 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         // fprintf(stderr, " (%s) Pressure: %dmbar (%s)\n", comfort_str, ((msg[7] & 0x0f) | (msg[8] & 0xf0))+856, forecast_str);
         /* clang-format off */
         data = data_make(
-                "model",            "",                             DATA_STRING, _X("Oregon-BHTR968","BHTR968"),
+                "model",            "",                             DATA_STRING, "Oregon-BHTR968",
                 "id",                 "House Code",         DATA_INT,        get_os_rollingcode(msg),
                 "channel",        "Channel",                DATA_INT,        get_os_channel(msg, sensor_id),
                 "battery",        "Battery",                DATA_STRING, get_os_battery(msg) ? "LOW" : "OK",
@@ -335,12 +335,12 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         float total_rain = ((msg[7] & 0xf) * 10000 + (msg[7] >> 4) * 1000 + (msg[6] & 0xf) * 100 + (msg[6] >> 4) * 10 + (msg[5] & 0xf)) / 10.0F;
         /* clang-format off */
         data = data_make(
-                "model",            "",                     DATA_STRING, _X("Oregon-RGR968","RGR968"),
+                "model",            "",                     DATA_STRING, "Oregon-RGR968",
                 "id",                 "House Code", DATA_INT,        get_os_rollingcode(msg),
                 "channel",        "Channel",        DATA_INT,        get_os_channel(msg, sensor_id),
                 "battery",        "Battery",        DATA_STRING, get_os_battery(msg) ? "LOW" : "OK",
-                _X("rain_rate_mm_h","rain_rate"),    "Rain Rate",    DATA_FORMAT, "%.02f mm/h", DATA_DOUBLE, rain_rate,
-                _X("rain_mm","total_rain"), "Total Rain", DATA_FORMAT, "%.02f mm", DATA_DOUBLE, total_rain,
+                "rain_rate_mm_h",    "Rain Rate",    DATA_FORMAT, "%.02f mm/h", DATA_DOUBLE, rain_rate,
+                "rain_mm", "Total Rain", DATA_FORMAT, "%.02f mm", DATA_DOUBLE, total_rain,
                 NULL);
         /* clang-format on */
         decoder_output_data(decoder, data);
@@ -352,7 +352,7 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         float temp_c = get_os_temperature(msg);
         /* clang-format off */
         data = data_make(
-                "model",                 "",                        DATA_STRING, _X("Oregon-THR228N","THR228N"),
+                "model",                 "",                        DATA_STRING, "Oregon-THR228N",
                 "id",                        "House Code",    DATA_INT,        get_os_rollingcode(msg),
                 "channel",             "Channel",         DATA_INT,        get_os_channel(msg, sensor_id),
                 "battery",             "Battery",         DATA_STRING, get_os_battery(msg) ? "LOW" : "OK",
@@ -368,7 +368,7 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         float temp_c = get_os_temperature(msg);
         /* clang-format off */
         data = data_make(
-                "model",                 "",                        DATA_STRING, _X("Oregon-THN132N","THN132N"),
+                "model",                 "",                        DATA_STRING, "Oregon-THN132N",
                 "id",                        "House Code",    DATA_INT,        get_os_rollingcode(msg),
                 "channel",             "Channel",         DATA_INT,        get_os_channel(msg, sensor_id),
                 "battery",             "Battery",         DATA_STRING, get_os_battery(msg) ? "LOW" : "OK",
@@ -384,7 +384,7 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         float temp_c = get_os_temperature(msg);
         /* clang-format off */
         data = data_make(
-                "model",                 "",                        DATA_STRING, _X("Oregon-RTGN129","RTGN129"),
+                "model",                 "",                        DATA_STRING, "Oregon-RTGN129",
                 "id",                        "House Code",    DATA_INT,        get_os_rollingcode(msg),
                 "channel",             "Channel",         DATA_INT,        get_os_channel(msg, sensor_id), // 1 to 5
                 "battery",             "Battery",         DATA_STRING, get_os_battery(msg) ? "LOW" : "OK",
@@ -444,7 +444,7 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
             float temp_c = get_os_temperature(msg);
             /* clang-format off */
             data = data_make(
-                    "model",                 "",                        DATA_STRING, _X("Oregon-RTGN318","RTGN318"),
+                    "model",                 "",                        DATA_STRING, "Oregon-RTGN318",
                     "id",                        "House Code",    DATA_INT,        get_os_rollingcode(msg),
                     "channel",             "Channel",         DATA_INT,        get_os_channel(msg, sensor_id), // 1 to 5
                     "battery",             "Battery",         DATA_STRING, get_os_battery(msg) ? "LOW" : "OK",
@@ -465,7 +465,7 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
             float temp_c = get_os_temperature(msg);
             /* clang-format off */
             data = data_make(
-                    "model",                 "",                        DATA_STRING, (sensor_id == ID_THN129) ? _X("Oregon-THN129","THN129") : "Oregon-RTHN129",
+                    "model",                 "",                        DATA_STRING, (sensor_id == ID_THN129) ? "Oregon-THN129" : "Oregon-RTHN129",
                     "id",                        "House Code",    DATA_INT,        get_os_rollingcode(msg),
                     "channel",             "Channel",         DATA_INT,        get_os_channel(msg, sensor_id), // 1 to 5
                     "battery",             "Battery",         DATA_STRING, get_os_battery(msg) ? "LOW" : "OK",
@@ -489,7 +489,7 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         float pressure = ((msg[7] & 0x0f) | (msg[8] & 0xf0)) * 2 + (msg[8] & 0x01) + 600;
         /* clang-format off */
         data = data_make(
-                "model",                 "",                        DATA_STRING, _X("Oregon-BTHGN129","BTHGN129"),
+                "model",                 "",                        DATA_STRING, "Oregon-BTHGN129",
                 "id",                        "House Code",    DATA_INT,        get_os_rollingcode(msg),
                 "channel",             "Channel",         DATA_INT,        get_os_channel(msg, sensor_id), // 1 to 5
                 "battery",             "Battery",         DATA_STRING, get_os_battery(msg) ? "LOW" : "OK",
@@ -507,7 +507,7 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         int uvidx = get_os_uv(msg);
         /* clang-format off */
         data = data_make(
-                "model",                    "",                     DATA_STRING, _X("Oregon-UVR128","Oregon Scientific UVR128"),
+                "model",                    "",                     DATA_STRING, "Oregon-UVR128",
                 "id",                         "House Code", DATA_INT,        get_os_rollingcode(msg),
                 "uv",                         "UV Index",     DATA_FORMAT, "%u", DATA_INT, uvidx,
                 "battery",                "Battery",        DATA_STRING, get_os_battery(msg)?"LOW":"OK",
@@ -620,7 +620,7 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
         int humidity = get_os_humidity(msg);
         /* clang-format off */
         data = data_make(
-                "model",                    "",                     DATA_STRING, _X("Oregon-THGR810","THGR810"),
+                "model",                    "",                     DATA_STRING, "Oregon-THGR810",
                 "id",                         "House Code", DATA_INT,        get_os_rollingcode(msg),
                 "channel",                "Channel",        DATA_INT,        get_os_channel(msg, sensor_id),
                 "battery",                "Battery",        DATA_STRING, get_os_battery(msg)?"LOW":"OK",
@@ -637,7 +637,7 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
         float temp_c = get_os_temperature(msg);
         /* clang-format off */
         data = data_make(
-                "model",                    "",                     DATA_STRING, _X("Oregon-THN802","THN802"),
+                "model",                    "",                     DATA_STRING, "Oregon-THN802",
                 "id",                         "House Code", DATA_INT,        get_os_rollingcode(msg),
                 "channel",                "Channel",        DATA_INT,        get_os_channel(msg, sensor_id),
                 "battery",                "Battery",        DATA_STRING, get_os_battery(msg)?"LOW":"OK",
@@ -653,7 +653,7 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
         int uvidx = get_os_uv(msg);
         /* clang-format off */
         data = data_make(
-                "model",                    "",                     DATA_STRING, _X("Oregon-UV800","UV800"),
+                "model",                    "",                     DATA_STRING, "Oregon-UV800",
                 "id",                         "House Code", DATA_INT,        get_os_rollingcode(msg),
                 "channel",                "Channel",        DATA_INT,        get_os_channel(msg, sensor_id),
                 "battery",                "Battery",        DATA_STRING, get_os_battery(msg)?"LOW":"OK",
@@ -670,12 +670,12 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
         float total_rain = get_os_total_rain(msg);
         /* clang-format off */
         data = data_make(
-                "model",            "",                     DATA_STRING, _X("Oregon-PCR800","PCR800"),
+                "model",            "",                     DATA_STRING, "Oregon-PCR800",
                 "id",                 "House Code", DATA_INT,        get_os_rollingcode(msg),
                 "channel",        "Channel",        DATA_INT,        get_os_channel(msg, sensor_id),
                 "battery",        "Battery",        DATA_STRING, get_os_battery(msg)?"LOW":"OK",
-                _X("rain_rate_in_h","rain_rate"),    "Rain Rate",    DATA_FORMAT, "%3.1f in/h", DATA_DOUBLE, rain_rate,
-                _X("rain_in","rain_total"), "Total Rain", DATA_FORMAT, "%3.1f in", DATA_DOUBLE, total_rain,
+                "rain_rate_in_h",    "Rain Rate",    DATA_FORMAT, "%3.1f in/h", DATA_DOUBLE, rain_rate,
+                "rain_in", "Total Rain", DATA_FORMAT, "%3.1f in", DATA_DOUBLE, total_rain,
                 NULL);
         /* clang-format on */
         decoder_output_data(decoder, data);
@@ -688,12 +688,12 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
         float total_rain = get_os_total_rain(msg);
         /* clang-format off */
         data = data_make(
-                "model",            "",                     DATA_STRING, _X("Oregon-PCR800a","PCR800a"),
+                "model",            "",                     DATA_STRING, "Oregon-PCR800a",
                 "id",                 "House Code", DATA_INT,        get_os_rollingcode(msg),
                 "channel",        "Channel",        DATA_INT,        get_os_channel(msg, sensor_id),
                 "battery",        "Battery",        DATA_STRING, get_os_battery(msg)?"LOW":"OK",
-                _X("rain_rate_in_h","rain_rate"),    "Rain Rate",    DATA_FORMAT, "%3.1f in/h", DATA_DOUBLE, rain_rate,
-                _X("rain_in","rain_total"), "Total Rain", DATA_FORMAT, "%3.1f in", DATA_DOUBLE, total_rain,
+                "rain_rate_in_h",    "Rain Rate",    DATA_FORMAT, "%3.1f in/h", DATA_DOUBLE, rain_rate,
+                "rain_in", "Total Rain", DATA_FORMAT, "%3.1f in", DATA_DOUBLE, total_rain,
                 NULL);
         /* clang-format on */
         decoder_output_data(decoder, data);
@@ -707,13 +707,13 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
         float quadrant = (0x0f&(msg[4]>>4))*22.5F;
         /* clang-format off */
         data = data_make(
-                "model",            "",                     DATA_STRING,    _X("Oregon-WGR800","WGR800"),
+                "model",            "",                     DATA_STRING,    "Oregon-WGR800",
                 "id",                 "House Code", DATA_INT,         get_os_rollingcode(msg),
                 "channel",        "Channel",        DATA_INT,         get_os_channel(msg, sensor_id),
                 "battery",        "Battery",        DATA_STRING,    get_os_battery(msg)?"LOW":"OK",
-                _X("wind_max_m_s","gust"),             "Gust",             DATA_FORMAT,    "%2.1f m/s",DATA_DOUBLE, gustWindspeed,
-                _X("wind_avg_m_s","average"),        "Average",        DATA_FORMAT,    "%2.1f m/s",DATA_DOUBLE, avgWindspeed,
-                _X("wind_dir_deg","direction"),    "Direction",    DATA_FORMAT,    "%3.1f degrees",DATA_DOUBLE, quadrant,
+                "wind_max_m_s",             "Gust",             DATA_FORMAT,    "%2.1f m/s",DATA_DOUBLE, gustWindspeed,
+                "wind_avg_m_s",        "Average",        DATA_FORMAT,    "%2.1f m/s",DATA_DOUBLE, avgWindspeed,
+                "wind_dir_deg",    "Direction",    DATA_FORMAT,    "%3.1f degrees",DATA_DOUBLE, quadrant,
                 NULL);
         /* clang-format on */
         decoder_output_data(decoder, data);
@@ -727,7 +727,7 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
         unsigned short int ipower = (rawAmp /(0.27*230)*1000);
         /* clang-format off */
         data = data_make(
-                "model",    "",                     DATA_STRING,    _X("Oregon-CM160","CM160"),
+                "model",    "",                     DATA_STRING,    "Oregon-CM160",
                 "id",         "House Code", DATA_INT, msg[1]&0x0F,
                 "power_W", "Power",         DATA_FORMAT,    "%d W", DATA_INT, ipower,
                 NULL);
@@ -753,7 +753,7 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
         if (valid == 0) {
             /* clang-format off */
             data = data_make(
-                    "model",            "",                 DATA_STRING, _X("Oregon-CM180","CM180"),
+                    "model",            "",                 DATA_STRING, "Oregon-CM180",
                     "id",               "House Code",       DATA_INT,    id,
                     "battery",          "Battery",          DATA_STRING, batt_low ? "LOW" : "OK",
                     "power_W",          "Power",            DATA_FORMAT, "%d W",DATA_INT, ipower,
@@ -791,7 +791,7 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
         if (valid == 0) {
             /* clang-format off */
             data = data_make(
-                    "model",            "",                 DATA_STRING, _X("Oregon-CM180i","CM180i"),
+                    "model",            "",                 DATA_STRING, "Oregon-CM180i",
                     "id",               "House Code",       DATA_INT,    id,
                     "battery",          "Battery",          DATA_STRING, batt_low ? "LOW" : "OK",
                     "power1_W",         "Power1",           DATA_FORMAT, "%d W",DATA_INT, ipower1,

--- a/src/devices/oregon_scientific_sl109h.c
+++ b/src/devices/oregon_scientific_sl109h.c
@@ -91,7 +91,7 @@ static int oregon_scientific_sl109h_callback(r_device *decoder, bitbuffer_t *bit
 
         /* clang-format off */
         data = data_make(
-                "model",            "Model",                                DATA_STRING, _X("Oregon-SL109H","Oregon Scientific SL109H"),
+                "model",            "Model",                                DATA_STRING, "Oregon-SL109H",
                 "id",               "Id",                                   DATA_INT,    id,
                 "channel",          "Channel",                              DATA_INT,    channel,
                 "temperature_C",    "Celsius",      DATA_FORMAT, "%.1f C",  DATA_DOUBLE, temp_c,

--- a/src/devices/oregon_scientific_v1.c
+++ b/src/devices/oregon_scientific_v1.c
@@ -81,14 +81,15 @@ static int oregon_scientific_v1_callback(r_device *decoder, bitbuffer_t *bitbuff
 
         /* clang-format off */
         data = data_make(
-                "model",        "",             DATA_STRING,    _X("Oregon-v1","OSv1 Temperature Sensor"),
-                _X("id","sid"),         "SID",          DATA_INT,       sid,
-                "channel",      "Channel",      DATA_INT,       channel,
-                "battery",      "Battery",      DATA_STRING,    battery ? "LOW" : "OK",
-                "temperature_C","Temperature",  DATA_FORMAT,    "%.01f C",              DATA_DOUBLE,    tempC,
-                "mic",          "Integrity",    DATA_STRING,    "CHECKSUM",
+                "model",            "",             DATA_STRING,    "Oregon-v1",
+                "id",               "SID",          DATA_INT,       sid,
+                "channel",          "Channel",      DATA_INT,       channel,
+                "battery",          "Battery",      DATA_STRING,    battery ? "LOW" : "OK",
+                "temperature_C",    "Temperature",  DATA_FORMAT,    "%.01f C",              DATA_DOUBLE,    tempC,
+                "mic",              "Integrity",    DATA_STRING,    "CHECKSUM",
                 NULL);
         /* clang-format on */
+
         decoder_output_data(decoder, data);
         ret++;
     }
@@ -97,7 +98,6 @@ static int oregon_scientific_v1_callback(r_device *decoder, bitbuffer_t *bitbuff
 
 static char *output_fields[] = {
     "model",
-    "sid", // TODO: delete this
     "id",
     "channel",
     "battery",

--- a/src/devices/philips_aj3650.c
+++ b/src/devices/philips_aj3650.c
@@ -137,7 +137,7 @@ static int philips_aj3650_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",         "",            DATA_STRING, _X("Philips-Temperature","Philips outdoor temperature sensor"),
+            "model",         "",            DATA_STRING, "Philips-Temperature",
             "channel",       "Channel",     DATA_INT,    channel,
             "battery",       "Battery",     DATA_STRING, battery_status ? "LOW" : "OK",
             "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,

--- a/src/devices/prologue.c
+++ b/src/devices/prologue.c
@@ -78,14 +78,14 @@ static int prologue_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",         "",            DATA_STRING, _X("Prologue-TH","Prologue sensor"),
-            _X("subtype","id"),       "",            DATA_INT, type,
-            _X("id","rid"),            "",            DATA_INT, id,
-            "channel",       "Channel",     DATA_INT, channel,
+            "model",         "",            DATA_STRING, "Prologue-TH",
+            "subtype",       "",            DATA_INT,    type,
+            "id",            "",            DATA_INT,    id,
+            "channel",       "Channel",     DATA_INT,    channel,
             "battery",       "Battery",     DATA_STRING, battery ? "OK" : "LOW",
             "temperature_C", "Temperature", DATA_FORMAT, "%.02f C", DATA_DOUBLE, temp_raw * 0.1,
-            "humidity",      "Humidity",    DATA_COND, humidity != 0xcc, DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "button",        "Button",      DATA_INT, button,
+            "humidity",      "Humidity",    DATA_COND,   humidity != 0xcc, DATA_FORMAT, "%u %%", DATA_INT, humidity,
+            "button",        "Button",      DATA_INT,    button,
             NULL);
     /* clang-format on */
 
@@ -97,7 +97,6 @@ static char *output_fields[] = {
         "model",
         "subtype",
         "id",
-        "rid", // TODO: delete this
         "channel",
         "battery",
         "temperature_C",

--- a/src/devices/proove.c
+++ b/src/devices/proove.c
@@ -80,7 +80,7 @@ static int proove_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",         "",            DATA_STRING, _X("Proove-Security","Proove"),
+            "model",         "",            DATA_STRING, "Proove-Security",
             "id",            "House Code",  DATA_INT,    id,
             "channel",       "Channel",     DATA_INT,    channel,
             "state",         "State",       DATA_STRING, on_bit ? "ON" : "OFF",

--- a/src/devices/quhwa.c
+++ b/src/devices/quhwa.c
@@ -47,7 +47,7 @@ static int quhwa_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data_t *data = data_make(
-            "model",  "",    DATA_STRING, _X("Quhwa-Doorbell","Quhwa doorbell"),
+            "model",  "",    DATA_STRING, "Quhwa-Doorbell",
             "id",     "ID",  DATA_INT, id,
             NULL);
     /* clang-format on */

--- a/src/devices/radiohead_ask.c
+++ b/src/devices/radiohead_ask.c
@@ -172,7 +172,7 @@ static int radiohead_ask_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     }
     /* clang-format off */
     data = data_make(
-            "model",        "",             DATA_STRING, _X("RadioHead-ASK","RadioHead ASK"),
+            "model",        "",             DATA_STRING, "RadioHead-ASK",
             "len",          "Data len",     DATA_INT, data_len,
             "to",           "To",           DATA_INT, header_to,
             "from",         "From",         DATA_INT, header_from,
@@ -211,14 +211,14 @@ static int sensible_living_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",            "",                 DATA_STRING,  _X("SensibleLiving-Moisture","Sensible Living Plant Moisture"),
+            "model",            "",                 DATA_STRING,  "SensibleLiving-Moisture",
             "house_id",         "House ID",         DATA_INT,     house_id,
             "module_id",        "Module ID",        DATA_INT,     module_id,
             "sensor_type",      "Sensor Type",      DATA_INT,     sensor_type,
             "sensor_count",     "Sensor Count",     DATA_INT,     sensor_count,
             "alarms",           "Alarms",           DATA_INT,     alarms,
             "sensor_value",     "Sensor Value",     DATA_INT,     sensor_value,
-            _X("battery_mV","battery_voltage"),       "Battery Voltage",  DATA_INT,     _X(battery_voltage * 10, battery_voltage),
+            "battery_mV",       "Battery Voltage",  DATA_INT,     battery_voltage * 10,
             "mic",              "Integrity",        DATA_STRING,  "CRC",
             NULL);
     /* clang-format on */
@@ -247,7 +247,6 @@ static char *sensible_living_output_fields[] = {
     "sensor_count",
     "alarms",
     "sensor_value",
-    "battery_voltage", // TODO: remove this
     "battery_mV",
     "mic",
     NULL,

--- a/src/devices/rubicson.c
+++ b/src/devices/rubicson.c
@@ -75,7 +75,7 @@ static int rubicson_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",            "",             DATA_STRING, _X("Rubicson-Temperature","Rubicson Temperature Sensor"),
+            "model",            "",             DATA_STRING, "Rubicson-Temperature",
             "id",               "House Code",   DATA_INT,    id,
             "channel",          "Channel",      DATA_INT,    channel,
             "battery",          "Battery",      DATA_STRING, battery ? "OK" : "LOW",

--- a/src/devices/rubicson_48659.c
+++ b/src/devices/rubicson_48659.c
@@ -177,7 +177,7 @@ static int rubicson_48659_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",         "",            DATA_STRING, _X("Rubicson-48659","Rubicson 48659"),
+            "model",         "",            DATA_STRING, "Rubicson-48659",
             "id",            "Id",          DATA_INT,    id,
             "temperature_F", "Temperature", DATA_FORMAT, "%.1f F", DATA_DOUBLE, temp_f,
             "mic",           "Integrity",   DATA_STRING, "CHECKSUM",

--- a/src/devices/s3318p.c
+++ b/src/devices/s3318p.c
@@ -99,7 +99,7 @@ static int s3318p_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",            "",             DATA_STRING, _X("Conrad-S3318P","S3318P Temperature & Humidity Sensor"),
+            "model",            "",             DATA_STRING, "Conrad-S3318P",
             "id",               "ID",           DATA_INT, id,
             "channel",          "Channel",      DATA_INT, channel,
             "battery",          "Battery",      DATA_STRING, battery_low ? "LOW" : "OK",

--- a/src/devices/silvercrest.c
+++ b/src/devices/silvercrest.c
@@ -31,11 +31,12 @@ static int silvercrest_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         if ((b[3]&0xF) != cmd_lu_tab[cmd])
             return DECODE_ABORT_EARLY;
 
-
+        /* clang-format off */
         data = data_make(
-            "model", "", DATA_STRING, _X("Silvercrest-Remote","Silvercrest Remote Control"),
-            "button", "", DATA_INT, cmd,
-            NULL);
+                "model",    "", DATA_STRING, "Silvercrest-Remote",
+                "button",   "", DATA_INT,    cmd,
+                NULL);
+        /* clang-format on */
 
         decoder_output_data(decoder, data);
 

--- a/src/devices/simplisafe.c
+++ b/src/devices/simplisafe.c
@@ -73,16 +73,17 @@ ss_sensor_parser(r_device *decoder, bitbuffer_t *bitbuffer, int row)
         strcpy(extradata,"Alarm Off");
     }
 
+    /* clang-format off */
     data = data_make(
-            "model",        "",             DATA_STRING, _X("SimpliSafe-Sensor","SimpliSafe Sensor"),
-            _X("id","device"),       "Device ID",    DATA_STRING, id,
-            "seq",          "Sequence",     DATA_INT, seq,
-            "state",        "State",        DATA_INT, state,
+            "model",        "",             DATA_STRING, "SimpliSafe-Sensor",
+            "id",           "Device ID",    DATA_STRING, id,
+            "seq",          "Sequence",     DATA_INT,    seq,
+            "state",        "State",        DATA_INT,    state,
             "extradata",    "Extra Data",   DATA_STRING, extradata,
-            NULL
-    );
-    decoder_output_data(decoder, data);
+            NULL);
+    /* clang-format on */
 
+    decoder_output_data(decoder, data);
     return 1;
 }
 
@@ -108,15 +109,16 @@ ss_pinentry_parser(r_device *decoder, bitbuffer_t *bitbuffer, int row)
 
     sprintf(extradata, "Disarm Pin: %x%x%x%x", digits[0], digits[1], digits[2], digits[3]);
 
+    /* clang-format off */
     data = data_make(
-            "model",        "",             DATA_STRING, _X("SimpliSafe-Keypad","SimpliSafe Keypad"),
-            _X("id","device"),       "Device ID",    DATA_STRING, id,
-            "seq",          "Sequence",     DATA_INT, b[9],
+            "model",        "",             DATA_STRING, "SimpliSafe-Keypad",
+            "id",           "Device ID",    DATA_STRING, id,
+            "seq",          "Sequence",     DATA_INT,    b[9],
             "extradata",    "Extra Data",   DATA_STRING, extradata,
-            NULL
-    );
-    decoder_output_data(decoder, data);
+            NULL);
+    /* clang-format on */
 
+    decoder_output_data(decoder, data);
     return 1;
 }
 
@@ -144,15 +146,16 @@ ss_keypad_commands(r_device *decoder, bitbuffer_t *bitbuffer, int row)
 
     ss_get_id(id, b);
 
+    /* clang-format off */
     data = data_make(
-            "model",        "",             DATA_STRING, _X("SimpliSafe-Keypad","SimpliSafe Keypad"),
-            _X("id","device"),       "Device ID",    DATA_STRING, id,
-            "seq",          "Sequence",     DATA_INT, b[9],
+            "model",        "",             DATA_STRING, "SimpliSafe-Keypad",
+            "id",           "Device ID",    DATA_STRING, id,
+            "seq",          "Sequence",     DATA_INT,    b[9],
             "extradata",    "Extra Data",   DATA_STRING, extradata,
-            NULL
-    );
-    decoder_output_data(decoder, data);
+            NULL);
+    /* clang-format on */
 
+    decoder_output_data(decoder, data);
     return 1;
 }
 
@@ -190,7 +193,6 @@ ss_sensor_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
 static char *sensor_output_fields[] = {
     "model",
-    "device", // TODO: delete this
     "id",
     "seq",
     "state",

--- a/src/devices/smoke_gs558.c
+++ b/src/devices/smoke_gs558.c
@@ -103,13 +103,15 @@ static int smoke_gs558_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     sprintf(code_str, "%02x%02x%02x", b[2], b[1], b[0]);
 
+    /* clang-format off */
     data = data_make(
-        "model",         "",            DATA_STRING, _X("Smoke-GS558","Smoke detector GS 558"),
-        "id"   ,         "",            DATA_INT, id,
-        "unit",          "",            DATA_INT, unit,
-        "learn",         "",            DATA_INT, learn > 1,
-        "code",          "Raw Code",    DATA_STRING, code_str,
-        NULL);
+            "model",        "",             DATA_STRING, "Smoke-GS558",
+            "id"   ,        "",             DATA_INT, id,
+            "unit",         "",             DATA_INT, unit,
+            "learn",        "",             DATA_INT, learn > 1,
+            "code",         "Raw Code",     DATA_STRING, code_str,
+            NULL);
+    /* clang-format on */
     decoder_output_data(decoder, data);
 
     return 1;

--- a/src/devices/solight_te44.c
+++ b/src/devices/solight_te44.c
@@ -70,7 +70,7 @@ static int solight_te44_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",            "",             DATA_STRING, _X("Solight-TE44","Solight TE44"),
+            "model",            "",             DATA_STRING, "Solight-TE44",
             "id",               "Id",           DATA_INT,    id,
             "channel",          "Channel",      DATA_INT,    channel + 1,
 //            "battery",          "Battery",      DATA_STRING, battery ? "OK" : "LOW",

--- a/src/devices/springfield.c
+++ b/src/devices/springfield.c
@@ -77,8 +77,8 @@ static int springfield_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
         /* clang-format off */
         data = data_make(
-                "model",            "",             DATA_STRING, _X("Springfield-Soil","Springfield Temperature & Moisture"),
-                _X("id","sid"),              "SID",          DATA_INT,    sid,
+                "model",            "",             DATA_STRING, "Springfield-Soil",
+                "id",               "SID",          DATA_INT,    sid,
                 "channel",          "Channel",      DATA_INT,    channel,
                 "battery",          "Battery",      DATA_STRING, battery ? "LOW" : "OK",
                 "transmit",         "Transmit",     DATA_STRING, button ? "MANUAL" : "AUTO", // TODO: delete this
@@ -98,7 +98,6 @@ static int springfield_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
 static char *output_fields[] = {
         "model",
-        "sid", // TODO: delete this
         "id",
         "channel",
         "battery",

--- a/src/devices/tfa_pool_thermometer.c
+++ b/src/devices/tfa_pool_thermometer.c
@@ -66,7 +66,7 @@ static int tfa_pool_thermometer_decode(r_device *decoder, bitbuffer_t *bitbuffer
 
     /* clang-format off */
     data = data_make(
-            "model",            "",                 DATA_STRING,    _X("TFA-Pool","TFA pool temperature sensor"),
+            "model",            "",                 DATA_STRING,    "TFA-Pool",
             "id",               "Id",               DATA_INT,       device,
             "channel",          "Channel",          DATA_INT,       channel,
             "battery_ok",       "Battery",          DATA_INT,       battery,

--- a/src/devices/tfa_twin_plus_30.3049.c
+++ b/src/devices/tfa_twin_plus_30.3049.c
@@ -91,7 +91,7 @@ static int tfa_twin_plus_303049_callback(r_device *decoder, bitbuffer_t *bitbuff
     float tempC = (negative_sign ? -( (1<<9) - temp ) : temp ) * 0.1F;
 
     data = data_make(
-            "model",         "",            DATA_STRING, _X("TFA-TwinPlus","TFA-Twin-Plus-30.3049"),
+            "model",         "",            DATA_STRING, "TFA-TwinPlus",
             "id",            "Id",          DATA_INT, sensor_id,
             "channel",       "Channel",     DATA_INT, channel,
             "battery",       "Battery",     DATA_STRING, battery_low ? "LOW" : "OK",

--- a/src/devices/thermopro_tp11.c
+++ b/src/devices/thermopro_tp11.c
@@ -61,7 +61,7 @@ static int thermopro_tp11_sensor_callback(r_device *decoder, bitbuffer_t *bitbuf
 
     /* clang-format off */
     data = data_make(
-            "model",         "",            DATA_STRING, _X("Thermopro-TP11","Thermopro TP11 Thermometer"),
+            "model",         "",            DATA_STRING, "Thermopro-TP11",
             "id",            "Id",          DATA_INT,    device,
             "temperature_C", "Temperature", DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp_c,
             "mic",           "Integrity",   DATA_STRING, "CRC",

--- a/src/devices/thermopro_tp12.c
+++ b/src/devices/thermopro_tp12.c
@@ -91,7 +91,7 @@ static int thermopro_tp12_sensor_callback(r_device *decoder, bitbuffer_t *bitbuf
     temp2_c = (temp2_raw - 200) * 0.1f;
 
     data = data_make(
-            "model",            "",            DATA_STRING, _X("Thermopro-TP12","Thermopro TP12 Thermometer"),
+            "model",            "",            DATA_STRING, "Thermopro-TP12",
             "id",               "Id",          DATA_INT,    device,
             "temperature_1_C",  "Temperature 1 (Food)", DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp1_c,
             "temperature_2_C",  "Temperature 2 (Barbecue)", DATA_FORMAT, "%.01f C", DATA_DOUBLE, temp2_c,

--- a/src/devices/ttx201.c
+++ b/src/devices/ttx201.c
@@ -173,7 +173,7 @@ ttx201_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned 
     temperature_c = (temperature >> 4) * 0.1f;
 
     data = data_make(
-            "model",         "",            DATA_STRING, _X("Emos-TTX201","Emos TTX201"),
+            "model",         "",            DATA_STRING, "Emos-TTX201",
             "id",            "House Code",  DATA_INT,    device_id,
             "channel",       "Channel",     DATA_INT,    channel,
             "battery",       "Battery",     DATA_STRING, battery_low ? "LOW" : "OK",

--- a/src/devices/vaillant_vrt340f.c
+++ b/src/devices/vaillant_vrt340f.c
@@ -164,14 +164,16 @@ vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         uint8_t water_preheated = get_water_preheated(bb[0]); // 1=Pre-heat, 0=no pre-heated water
         uint8_t isBatteryLow = get_battery_status(bb[0]);
 
+        /* clang-format off */
         data = data_make(
-                "model",   "", DATA_STRING, _X("Vaillant-VRT340f","Vaillant VRT340f Central Heating Thermostat"),
-                _X("id","device"),  "Device ID", DATA_FORMAT, "0x%04X", DATA_INT, deviceID,
-                "heating", "Heating Mode", DATA_STRING, (heating_mode==0)?"OFF":((heating_mode==1)?"ON (2-point)":"ON (analogue)"),
-                "heating_temp", "Heating Water Temp.", DATA_FORMAT, "%d", DATA_INT, (int16_t)target_temperature,
-                "water",   "Pre-heated Water", DATA_STRING, water_preheated ? "ON" : "off",
-                "battery", "Battery", DATA_STRING, isBatteryLow ? "Low" : "OK",
+                "model",        "",                     DATA_STRING, "Vaillant-VRT340f",
+                "id",           "Device ID",            DATA_FORMAT, "0x%04X", DATA_INT, deviceID,
+                "heating",      "Heating Mode",         DATA_STRING, (heating_mode==0)?"OFF":((heating_mode==1)?"ON (2-point)":"ON (analogue)"),
+                "heating_temp", "Heating Water Temp.",  DATA_FORMAT, "%d", DATA_INT, (int16_t)target_temperature,
+                "water",        "Pre-heated Water",     DATA_STRING, water_preheated ? "ON" : "off",
+                "battery",      "Battery",              DATA_STRING, isBatteryLow ? "Low" : "OK",
                 NULL);
+        /* clang-format on */
         decoder_output_data(decoder, data);
 
         return 1;
@@ -187,10 +189,12 @@ vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         // Device ID starts at bit 12:
         uint16_t deviceID = get_device_id(bb[0], 11);
 
+        /* clang-format off */
         data = data_make(
-                "model",   "", DATA_STRING, _X("Vaillant-VRT340f","Vaillant VRT340f Central Heating Thermostat (RF Detection)"),
-                _X("id","device"),  "Device ID", DATA_INT, deviceID,
+                "model",    "",             DATA_STRING, "Vaillant-VRT340f",
+                "id",       "Device ID",    DATA_INT, deviceID,
                 NULL);
+        /* clang-format on */
         decoder_output_data(decoder, data);
 
         return 1;
@@ -201,7 +205,6 @@ vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
 static char *output_fields[] = {
     "model",
-    "device", // TODO: delete this
     "id",
     "heating",
     "heating_temp",

--- a/src/devices/waveman.c
+++ b/src/devices/waveman.c
@@ -65,13 +65,15 @@ static int waveman_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     id_str[0] = 'A' + nb[0];
     id_str[1] = '\0';
 
+    /* clang-format off */
     data = data_make(
-        "model",    "",     DATA_STRING,    _X("Waveman-Switch","Waveman Switch Transmitter"),
-        "id",       "",     DATA_STRING,    id_str,
-        "channel",  "",     DATA_INT,       (nb[1] >> 2) + 1,
-        "button",   "",     DATA_INT,       (nb[1] & 3) + 1,
-        "state",    "",     DATA_STRING,    (nb[2] == 0xe) ? "on" : "off",
-        NULL);
+            "model",    "",     DATA_STRING,    "Waveman-Switch",
+            "id",       "",     DATA_STRING,    id_str,
+            "channel",  "",     DATA_INT,       (nb[1] >> 2) + 1,
+            "button",   "",     DATA_INT,       (nb[1] & 3) + 1,
+            "state",    "",     DATA_STRING,    (nb[2] == 0xe) ? "on" : "off",
+            NULL);
+    /* clang-format on */
     decoder_output_data(decoder, data);
 
     return 1;

--- a/src/devices/ws2032.c
+++ b/src/devices/ws2032.c
@@ -87,7 +87,7 @@ static int fineoffset_ws2032_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "battery_ok",       "Battery",                                  DATA_INT,    !battery_low,
             "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C",  DATA_DOUBLE, temperature,
             "humidity",         "Humidity",         DATA_FORMAT, "%u %%",   DATA_INT,    humidity,
-            _X("wind_dir_deg","direction_deg"),     "Wind Direction",       DATA_FORMAT, "%.1f",   DATA_DOUBLE, dir,
+            "wind_dir_deg",     "Wind Direction",   DATA_FORMAT, "%.1f",    DATA_DOUBLE, dir,
             "wind_avg_km_h",    "Wind avg speed",   DATA_FORMAT, "%.1f",    DATA_DOUBLE, speed,
             "wind_max_km_h",    "Wind gust",        DATA_FORMAT, "%.1f",    DATA_DOUBLE, gust,
             "rain",             "Rain tips",                                DATA_INT,    rain_raw,
@@ -106,7 +106,6 @@ static char *output_fields[] = {
         "battery_ok",
         "temperature_C",
         "humidity",
-        "direction_deg", // TODO: remove this
         "wind_dir_deg",
         "wind_avg_km_h",
         "wind_max_km_h",

--- a/src/devices/wssensor.c
+++ b/src/devices/wssensor.c
@@ -84,7 +84,7 @@ static int wssensor_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",         "",            DATA_STRING, _X("Hyundai-WS","WS Temperature Sensor"),
+            "model",         "",            DATA_STRING, "Hyundai-WS",
             "id",            "House Code",  DATA_INT, sensor_id,
             "channel",       "Channel",     DATA_INT, channel,
             "battery",       "Battery",     DATA_STRING, battery_status ? "OK" : "LOW",

--- a/src/devices/wt0124.c
+++ b/src/devices/wt0124.c
@@ -72,14 +72,16 @@ static int wt1024_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         bitbuffer_print(bitbuffer);
     }
 
+    /* clang-format off */
     data = data_make(
-            "model", "", DATA_STRING, _X("WT0124-Pool","WT0124 Pool Thermometer"),
-            _X("id","rid"),    "Random ID", DATA_INT,    sensor_rid,
-            "channel",       "Channel",     DATA_INT,    channel,
-            "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "mic",      "Integrity",      DATA_STRING, "CHECKSUM",
-            "data",  "Data", DATA_INT,    value,
+            "model",            "",             DATA_STRING, "WT0124-Pool",
+            "id",               "Random ID",    DATA_INT,    sensor_rid,
+            "channel",          "Channel",      DATA_INT,    channel,
+            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
+            "data",             "Data",         DATA_INT,    value,
+            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
             NULL);
+    /* clang-format on */
 
     decoder_output_data(decoder, data);
 
@@ -96,12 +98,11 @@ static int wt1024_callback(r_device *decoder, bitbuffer_t *bitbuffer)
  */
 static char *output_fields[] = {
         "model",
-        "rid", // TODO: delete this
         "id",
         "channel",
         "temperature_C",
-        "mic",
         "data",
+        "mic",
         NULL,
 };
 

--- a/src/devices/wt450.c
+++ b/src/devices/wt450.c
@@ -104,7 +104,7 @@ static int wt450_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",            "",             DATA_STRING, _X("WT450-TH","WT450 sensor"),
+            "model",            "",             DATA_STRING, "WT450-TH",
             "id",               "House Code",   DATA_INT,    house_code,
             "channel",          "Channel",      DATA_INT,    channel,
             "battery",          "Battery",      DATA_STRING, battery_low ? "LOW" : "OK",

--- a/src/devices/x10_rf.c
+++ b/src/devices/x10_rf.c
@@ -140,12 +140,12 @@ static int x10_rf_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",                   "", DATA_STRING, "X10-RF",
-            _X("id", "deviceid"),      "", DATA_INT,    bDeviceCode,
-            _X("channel", "houseid"),  "", DATA_STRING, housecode,
-            "state",              "State", DATA_STRING, event_str,
-            "data",                "Data", DATA_FORMAT, "%08x", DATA_INT, code,
-            "mic",           "Integrity",  DATA_STRING, "PARITY",
+            "model",        "",             DATA_STRING, "X10-RF",
+            "id",           "",             DATA_INT,    bDeviceCode,
+            "channel",      "",             DATA_STRING, housecode,
+            "state",        "State",        DATA_STRING, event_str,
+            "data",         "Data",         DATA_FORMAT, "%08x", DATA_INT, code,
+            "mic",          "Integrity",    DATA_STRING, "PARITY",
             NULL);
     /* clang-format on */
 
@@ -158,8 +158,6 @@ static char *output_fields[] = {
         "model",
         "channel",
         "id",
-        "houseid",  // TODO: remove ??
-        "deviceid", // TODO: remove ??
         "state",
         "data",
         "mic",

--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -176,7 +176,7 @@ static int x10_sec_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     /* build and handle data set for normal output */
     /* clang-format off */
     data = data_make(
-            "model",        "",             DATA_STRING, _X("X10-Security","X10 Security"),
+            "model",        "",             DATA_STRING, "X10-Security",
             "id",           "Device ID",    DATA_STRING, x10_id_str,
             "code",         "Code",         DATA_STRING, x10_code_str,
             "event",        "Event",        DATA_STRING, event_str,


### PR DESCRIPTION
This removes the deprecated "oldmodel" workaround macro `_X()`.

Regression checks pass, but if anyone can spare some time then please review.