### PR TITLE
Fix 5n1 battery

### DIFF
--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -904,7 +904,7 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                         "id",    NULL,   DATA_FORMAT,    "0x%02X",   DATA_INT,       sensor_id,
                         "channel",      NULL,   DATA_STRING,    &channel_str,
                         "sequence_num",  NULL,   DATA_INT,      sequence_num,
-                        "battery_ok",       "Battery",      DATA_INT,    !!battery_low, // NOTE: is this really flipped?
+                        "battery_ok",       "Battery",      DATA_INT,    !battery_low,
                         "wind_avg_mi_h",   "wind_speed",   DATA_FORMAT,    "%.1f mi/h", DATA_DOUBLE,     wind_speed_mph,
                         "temperature_F",     "temperature",    DATA_FORMAT,    "%.1f F", DATA_DOUBLE,    tempf,
                         "humidity",     NULL,    DATA_FORMAT,    "%u %%",   DATA_INT,   humidity,

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -823,7 +823,7 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             //  1101 xxxx  = channel A 2nd copy
             //  1110 xxxx  = channel A 3rd copy
             sequence_num = (bb[0] & 0x30) >> 4;
-            battery_low = (bb[2] & 0x40) >> 6;
+            battery_low = (bb[2] & 0x40) == 0;
 
             // Only for 5N1, range: 0 to 159 kph
             // raw number is cup rotations per 4 seconds


### PR DESCRIPTION
Commit ef2d37cf51e3264d11cde9149ef87de2f0a4d37a reversed the battery on indicator on the Acurite 5n1/3n1. This fixes it.