### PR TITLE
Add support for Microchip HCS300 KeeLoq remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [128]  DirecTV RC66RX Remote Control
     [129]* Eurochron temperature and humidity sensor
     [130]  IKEA Sparsnas Energy Meter Monitor
-    [131]  Microchip HCS200 KeeLoq Hopping Encoder based remotes
+    [131]  Microchip HCS200/HCS300 KeeLoq Hopping Encoder based remotes
     [132]  TFA Dostmann 30.3196 T/H outdoor sensor
     [133]  Rubicson 48659 Thermometer
     [134]  Holman Industries iWeather WS5029 weather station (newer PCM)

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -311,7 +311,7 @@ stop_after_successful_events false
   protocol 128 # DirecTV RC66RX Remote Control
 # protocol 129 # Eurochron temperature and humidity sensor
   protocol 130 # IKEA Sparsnas Energy Meter Monitor
-  protocol 131 # Microchip HCS200 KeeLoq Hopping Encoder based remotes
+  protocol 131 # Microchip HCS200/HCS300 KeeLoq Hopping Encoder based remotes
   protocol 132 # TFA Dostmann 30.3196 T/H outdoor sensor
   protocol 133 # Rubicson 48659 Thermometer
   protocol 134 # Holman Industries iWeather WS5029 weather station (newer PCM)


### PR DESCRIPTION
Discussion in #1512

@667bdrm and other current HCS200 users: this is a breaking change.
The output is now `button`: 1,2,3,12,13,14 for the HCS200. And 1-14, 0=Standby, 15=Learn for HCS300.
The raw pin bits are in "button3", "button0", "button1", "button2" with this mapping to the old fields:
- "button1: ON" is now "button: 1, button0: 1
- "button2: ON" is now "button: 2, button1: 1
- "button3: ON" is now "button: 12, button2: 1, button3: 1
- "button4: ON" is now "button: 3, button0: 1, button1: 1
- "misc: ALL_PRESSED" is now "learn: 1"
