### PR TITLE
Add noise stats, autolevel, and squelch

### DIFF
--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -85,12 +85,32 @@ sample_rate   250k
 # see "decoder" section below.
 
 # as command line option:
-#   [-Y level=<dB level>] Manual detection level used to determine pulses (-1.0 to -30.0) (0=auto)
+#   [-Y auto | classic | minmax] FSK pulse detector mode.
+#pulse_detect auto
+
+# as command line option:
+#   [-Y level=<dB level>] Manual detection level used to determine pulses (-1.0 to -30.0) (0=auto).
 #pulse_detect level=0
 
 # as command line option:
-#   [-Y auto | classic | minmax] FSK pulse detector mode.
-#pulse_detect auto
+#   [-Y minlevel=<dB level>] Manual minimum detection level used to determine pulses (-1.0 to -99.0).
+#pulse_detect minlevel=-12
+
+# as command line option:
+#   [-Y minsnr=<dB level>] Minimum SNR to determine pulses (1.0 to 99.0).
+#pulse_detect minsnr=9
+
+# as command line option:
+#   [-Y autolevel] Set minlevel automatically based on average estimated noise.
+#pulse_detect autolevel
+
+# as command line option:
+#   [-Y squelch] Skip frames below estimated noise level to lower cpu load.
+#pulse_detect squelch
+
+# as command line option:
+#   [-Y ampest | magest] Choose amplitude or magnitude level estimator.
+#pulse_detect magest
 
 # as command line option:
 #   [-n <value>] Specify number of samples to take (each sample is 2 bytes: 1 each of I & Q)
@@ -111,21 +131,25 @@ analyze_pulses false
 #out_block_size
 
 # as command line option:
-#   [-M time[:<options>]|protocol|level|stats|bits] Add various metadata to every output line.
+#   [-M time[:<options>]|protocol|level|noise[:<secs>]|stats|bits] Add various metadata to every output line.
 # Use "time" to add current date and time meta data (preset for live inputs).
 # Use "time:rel" to add sample position meta data (preset for read-file and stdin).
 # Use "time:unix" to show the seconds since unix epoch as time meta data.
 # Use "time:iso" to show the time with ISO-8601 format (YYYY-MM-DD"T"hh:mm:ss).
 # Use "time:off" to remove time meta data.
 # Use "time:usec" to add microseconds to date time meta data.
+# Use "time:tz" to output time with timezone offset.
 # Use "time:utc" to output time in UTC.
 #   (this may also be accomplished by invocation with TZ environment variable set).
 #   "usec" and "utc" can be combined with other options, eg. "time:unix:utc:usec".
 # Use "protocol" / "noprotocol" to output the decoder protocol number meta data.
 # Use "level" to add Modulation, Frequency, RSSI, SNR, and Noise meta data.
+# Use "noise[:secs]" to report estimated noise level at intervals (default: 10 seconds).
 # Use "stats[:[<level>][:<interval>]]" to report statistics (default: 600 seconds).
 #   level 0: no report, 1: report successful devices, 2: report active devices, 3: report all
+# Use "bits" to add bit representation to code outputs (for debug).
 report_meta level
+report_meta noise
 report_meta stats
 report_meta time:usec
 report_meta protocol
@@ -171,6 +195,22 @@ signal_grabber none
 #     Specify host/port for syslog with e.g. -F syslog:127.0.0.1:1514
 # default is "kv", multiple outputs can be used.
 output json
+
+# as command line option:
+#   [-K FILE | PATH | <tag> | <key>=<tag>] Add an expanded token or fixed tag to every output line.
+# If <tag> is "FILE" or "PATH" an expanded token will be added.
+# The <tag> can also be a GPSd URL, e.g.
+#   -K gpsd,lat,lon" (report lat and lon keys from local gpsd)
+#   -K loc=gpsd,lat,lon" (report lat and lon in loc object)
+#   -K gpsd" (full json TPV report, in default "gps" object)
+#   -K foo=gpsd://127.0.0.1:2947" (with key and address)
+#   -K bar=gpsd,nmea" (NMEA deault GPGGA report)
+#   -K rmc=gpsd,nmea,filter='$GPRMC'" (NMEA GPRMC report)
+# Also <tag> can be a generic tcp address, e.g.
+#   -K foo=tcp:localhost:4000" (read lines as TCP client)
+#   -K bar=tcp://127.0.0.1:3000,init='subscribe tags\\r\\n'"
+#   -K baz=tcp://127.0.0.1:5000,filter='a prefix to match'"
+#output_tag mytag
 
 # as command line option:
 #   [-C] native|si|customary Convert units in decoded output.

--- a/include/baseband.h
+++ b/include/baseband.h
@@ -22,15 +22,16 @@
     @param iq_buf input samples (I/Q samples in interleaved uint8)
     @param[out] y_buf output buffer
     @param len number of samples to process
+    @return the average level in dB
 */
-void envelope_detect(uint8_t const *iq_buf, uint16_t *y_buf, uint32_t len);
+float envelope_detect(uint8_t const *iq_buf, uint16_t *y_buf, uint32_t len);
 
 // for evaluation
-void envelope_detect_nolut(uint8_t const *iq_buf, uint16_t *y_buf, uint32_t len);
-void magnitude_est_cu8(uint8_t const *iq_buf, uint16_t *y_buf, uint32_t len);
-void magnitude_true_cu8(uint8_t const *iq_buf, uint16_t *y_buf, uint32_t len);
-void magnitude_est_cs16(int16_t const *iq_buf, uint16_t *y_buf, uint32_t len);
-void magnitude_true_cs16(int16_t const *iq_buf, uint16_t *y_buf, uint32_t len);
+float envelope_detect_nolut(uint8_t const *iq_buf, uint16_t *y_buf, uint32_t len);
+float magnitude_est_cu8(uint8_t const *iq_buf, uint16_t *y_buf, uint32_t len);
+float magnitude_true_cu8(uint8_t const *iq_buf, uint16_t *y_buf, uint32_t len);
+float magnitude_est_cs16(int16_t const *iq_buf, uint16_t *y_buf, uint32_t len);
+float magnitude_true_cs16(int16_t const *iq_buf, uint16_t *y_buf, uint32_t len);
 
 #define AMP_TO_DB(x) (10.0f * ((x) > 0 ? log10f(x) : 0) - 42.1442f)  // 10*log10f(16384.0f)
 #define MAG_TO_DB(x) (20.0f * ((x) > 0 ? log10f(x) : 0) - 84.2884f)  // 20*log10f(16384.0f)

--- a/include/optparse.h
+++ b/include/optparse.h
@@ -106,7 +106,7 @@ uint32_t atouint32_metric(char const *str, char const *error_hint);
 ///
 /// @param str character string to parse
 /// @param error_hint prepended to error output
-/// @return parsed number value
+/// @return parsed number value in seconds
 int atoi_time(char const *str, char const *error_hint);
 
 /// Similar to strsep.

--- a/include/r_private.h
+++ b/include/r_private.h
@@ -17,7 +17,11 @@
 #include "compat_time.h"
 
 struct dm_state {
+    float auto_level;
+    float squelch_offset;
     float level_limit;
+    float noise_level;
+    float min_level_auto;
     float min_level;
     float min_snr;
     float low_pass;

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -77,6 +77,7 @@ typedef struct r_cfg {
     int verbose_bits;
     conversion_mode_t conversion_mode;
     int report_meta;
+    int report_noise;
     int report_protocol;
     time_mode_t report_time;
     int report_time_hires;

--- a/src/baseband.c
+++ b/src/baseband.c
@@ -32,32 +32,39 @@ static void calc_squares()
 
 // This will give a noisy envelope of OOK/ASK signals.
 // Subtract the bias (-128) and get an envelope estimation.
-void envelope_detect(uint8_t const *iq_buf, uint16_t *y_buf, uint32_t len)
+float envelope_detect(uint8_t const *iq_buf, uint16_t *y_buf, uint32_t len)
 {
     unsigned long i;
+    uint32_t sum = 0;
     for (i = 0; i < len; i++) {
         y_buf[i] = scaled_squares[iq_buf[2 * i ]] + scaled_squares[iq_buf[2 * i + 1]];
+        sum += y_buf[i];
     }
+    return len > 0 && sum >= len ? AMP_TO_DB((float)sum / len) : AMP_TO_DB(1);
 }
 
 /// This will give a noisy envelope of OOK/ASK signals.
 /// Subtracts the bias (-128) and calculates the norm (scaled by 16384).
 /// Using a LUT is slower for O1 and above.
-void envelope_detect_nolut(uint8_t const *iq_buf, uint16_t *y_buf, uint32_t len)
+float envelope_detect_nolut(uint8_t const *iq_buf, uint16_t *y_buf, uint32_t len)
 {
     unsigned long i;
+    uint32_t sum = 0;
     for (i = 0; i < len; i++) {
         int16_t x = 127 - iq_buf[2 * i];
         int16_t y = 127 - iq_buf[2 * i + 1];
         y_buf[i]  = x * x + y * y; // max 32768, fs 16384
+        sum += y_buf[i];
     }
+    return len > 0 && sum >= len ? AMP_TO_DB((float)sum / len) : AMP_TO_DB(1);
 }
 
 /// 122/128, 51/128 Magnitude Estimator for CU8 (SIMD has min/max).
 /// Note that magnitude emphasizes quiet signals / deemphasizes loud signals.
-void magnitude_est_cu8(uint8_t const *iq_buf, uint16_t *y_buf, uint32_t len)
+float magnitude_est_cu8(uint8_t const *iq_buf, uint16_t *y_buf, uint32_t len)
 {
     unsigned long i;
+    uint32_t sum = 0;
     for (i = 0; i < len; i++) {
         uint16_t x = abs(iq_buf[2 * i] - 128);
         uint16_t y = abs(iq_buf[2 * i + 1] - 128);
@@ -65,24 +72,30 @@ void magnitude_est_cu8(uint8_t const *iq_buf, uint16_t *y_buf, uint32_t len)
         uint16_t mx = x > y ? x : y;
         uint16_t mag_est = 122 * mx + 51 * mi;
         y_buf[i] = mag_est; // max 22144, fs 16384
+        sum += y_buf[i];
     }
+    return len > 0 && sum >= len ? MAG_TO_DB((float)sum / len) : MAG_TO_DB(1);
 }
 
 /// True Magnitude for CU8 (sqrt can SIMD but float is slow).
-void magnitude_true_cu8(uint8_t const *iq_buf, uint16_t *y_buf, uint32_t len)
+float magnitude_true_cu8(uint8_t const *iq_buf, uint16_t *y_buf, uint32_t len)
 {
     unsigned long i;
+    uint32_t sum = 0;
     for (i = 0; i < len; i++) {
         int16_t x = iq_buf[2 * i] - 128;
         int16_t y = iq_buf[2 * i + 1] - 128;
         y_buf[i]  = (uint16_t)(sqrt(x * x + y * y) * 128.0); // max 181, scaled 23170, fs 16384
+        sum += y_buf[i];
     }
+    return len > 0 && sum >= len ? MAG_TO_DB((float)sum / len) : MAG_TO_DB(1);
 }
 
 /// 122/128, 51/128 Magnitude Estimator for CS16 (SIMD has min/max).
-void magnitude_est_cs16(int16_t const *iq_buf, uint16_t *y_buf, uint32_t len)
+float magnitude_est_cs16(int16_t const *iq_buf, uint16_t *y_buf, uint32_t len)
 {
     unsigned long i;
+    uint32_t sum = 0;
     for (i = 0; i < len; i++) {
         uint32_t x = abs(iq_buf[2 * i]);
         uint32_t y = abs(iq_buf[2 * i + 1]);
@@ -90,18 +103,23 @@ void magnitude_est_cs16(int16_t const *iq_buf, uint16_t *y_buf, uint32_t len)
         uint32_t mx = x > y ? x : y;
         uint32_t mag_est = 122 * mx + 51 * mi;
         y_buf[i] = mag_est >> 8; // max 5668864, scaled 22144, fs 16384
+        sum += y_buf[i];
     }
+    return len > 0 && sum >= len ? MAG_TO_DB((float)sum / len) : MAG_TO_DB(1);
 }
 
 /// True Magnitude for CS16 (sqrt can SIMD but float is slow).
-void magnitude_true_cs16(int16_t const *iq_buf, uint16_t *y_buf, uint32_t len)
+float magnitude_true_cs16(int16_t const *iq_buf, uint16_t *y_buf, uint32_t len)
 {
     unsigned long i;
+    uint32_t sum = 0;
     for (i = 0; i < len; i++) {
         int32_t x = iq_buf[2 * i];
         int32_t y = iq_buf[2 * i + 1];
         y_buf[i]  = (int)sqrt(x * x + y * y) >> 1; // max 46341, scaled 23170, fs 16384
+        sum += y_buf[i];
     }
+    return len > 0 && sum >= len ? MAG_TO_DB((float)sum / len) : MAG_TO_DB(1);
 }
 
 

--- a/src/term_ctl.c
+++ b/src/term_ctl.c
@@ -377,7 +377,7 @@ int term_help_puts(void *ctx, char const *buf)
             state = 1;
             next_color = 5;
         }
-        else if ((state == 1 || state == 2) && *p == ']' && (p[1] == ' ' || p[1] == '\n' || p[1] == '\0')) {
+        else if ((state == 1 || state == 2) && *p == ']' && ((p[1] == ' ' && p[2] != '|') || p[1] == '\n' || p[1] == '\0')) {
             state = 0;
             set_color = 0;
         }


### PR DESCRIPTION
New features to report noise stats, set the minimum detection level based on noise estimate and squelch below estimated noise level to reduce cpu load.

Not enabled by default, more testing and fine tuning is required.
It is recommended to enable
- `-M noise[:secs]` to report estimated noise level at intervals (default: 10 seconds).
- `-Y autolevel` Set minlevel automatically based on average estimated noise.
- `-Y squelch` Skip frames below estimated noise level to reduce cpu load.
