### PR TITLE
Add basic logger

### DIFF
--- a/include/decoder.h
+++ b/include/decoder.h
@@ -12,5 +12,7 @@
 #include "data.h"
 #include "util.h"
 #include "decoder_util.h"
+#include "log.h"
+#define LOG_MODULE __func__
 
 #endif /* INCLUDE_DECODER_H_ */

--- a/include/log.h
+++ b/include/log.h
@@ -1,0 +1,48 @@
+/** @file
+    Basic logging, internal.
+
+    Copyright (C) 2021 Christian Zuckschwerdt
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#ifndef INCLUDE_LOG_H_
+#define INCLUDE_LOG_H_
+
+#include "logger.h"
+
+/// Log a format string message of level LOG_TRACE.
+#define log_trace(...) r_logger_logf(LOG_TRACE, LOG_MODULE, __FILE__, __LINE__, __func__, __VA_ARGS__)
+/// Log a format string message of level LOG_DEBUG.
+#define log_debug(...) r_logger_logf(LOG_DEBUG, LOG_MODULE, __FILE__, __LINE__, __func__, __VA_ARGS__)
+/// Log a format string message of level LOG_INFO.
+#define log_info(...) r_logger_logf(LOG_INFO, LOG_MODULE, __FILE__, __LINE__, __func__, __VA_ARGS__)
+/// Log a format string message of unknown level.
+#define log_idk(...) r_logger_logf(LOG_INFO, LOG_MODULE, __FILE__, __LINE__, __func__, __VA_ARGS__)
+/// Log a format string message of level LOG_WARNING.
+#define log_warn(...) r_logger_logf(LOG_WARNING, LOG_MODULE, __FILE__, __LINE__, __func__, __VA_ARGS__)
+/// Log a format string message of level LOG_ERROR.
+#define log_error(...) r_logger_logf(LOG_ERROR, LOG_MODULE, __FILE__, __LINE__, __func__, __VA_ARGS__)
+/// Log a format string message of level LOG_FATAL.
+#define log_fatal(...) r_logger_logf(LOG_FATAL, LOG_MODULE, __FILE__, __LINE__, __func__, __VA_ARGS__)
+
+// Defined in newer <sal.h> for MSVC.
+#ifndef _Printf_format_string_
+#define _Printf_format_string_
+#endif
+
+// shim until fprintf is converted to log_
+#include <stdio.h>
+#define fprintf(...) r_logger_fprintf(LOG_INFO, LOG_MODULE, __FILE__, __LINE__, __func__, __VA_ARGS__)
+
+int r_logger_fprintf(int level, char const *mod, char const *file, int line, char const *func, FILE *stream, _Printf_format_string_ const char *format, ...)
+#if defined(__GNUC__) || defined(__clang__)
+        __attribute__((format(printf, 7, 8)))
+#endif
+        ;
+
+
+#endif /* INCLUDE_LOG_H_ */

--- a/include/logger.h
+++ b/include/logger.h
@@ -1,0 +1,69 @@
+/** @file
+    Basic logging, API.
+
+    Copyright (C) 2021 Christian Zuckschwerdt
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#ifndef INCLUDE_LOGGER_H_
+#define INCLUDE_LOGGER_H_
+
+/// Log levels, copied from and compatible with SoapySDR.
+typedef enum log_level {
+    LOG_FATAL    = 1, //!< A fatal error. The application will most likely terminate. This is the highest priority.
+    LOG_CRITICAL = 2, //!< A critical error. The application might not be able to continue running successfully.
+    LOG_ERROR    = 3, //!< An error. An operation did not complete successfully, but the application as a whole is not affected.
+    LOG_WARNING  = 4, //!< A warning. An operation completed with an unexpected result.
+    LOG_NOTICE   = 5, //!< A notice, which is an information with just a higher priority.
+    LOG_INFO     = 6, //!< An informational message, usually denoting the successful completion of an operation.
+    LOG_DEBUG    = 7, //!< A debugging message.
+    LOG_TRACE    = 8, //!< A tracing message. This is the lowest priority.
+} log_level_t;
+
+typedef void (*r_logger_handler)(log_level_t level, char const *mod, char const *file, int line, char const *func, char const *msg, void *userdata);
+
+/** Set the log handler.
+
+    @param handler the handler to use, NULL to reset to default handler
+    @param userdata user data passed back to the handler
+*/
+void r_logger_set_log_handler(r_logger_handler const handler, void *userdata);
+
+/** Set an auxilary log handler.
+
+    @param handler the handler to use, NULL to disable
+    @param userdata user data passed back to the handler
+*/
+void r_logger_set_aux_handler(r_logger_handler const handler, void *userdata);
+
+/** Log a message string.
+
+    @param level a log level
+    @param mod the module name
+    @param file the file name
+    @param line the line number
+    @param func the function name
+    @param msg the log message
+*/
+void r_logger_log(log_level_t level, char const *mod, char const *file, int line, char const *func, char const *msg);
+
+/** Log a message format string.
+
+    @param level a log level
+    @param mod the module name
+    @param file the file name
+    @param line the line number
+    @param func the function name
+    @param fmt the log message format string
+*/
+void r_logger_logf(log_level_t level, char const *mod, char const *file, int line, char const *func, char const *fmt, ...)
+#if defined(__GNUC__) || defined(__clang__)
+        __attribute__((format(printf, 6, 7)))
+#endif
+        ;
+
+#endif /* INCLUDE_LOGGER_H_ */

--- a/include/sdr.h
+++ b/include/sdr.h
@@ -204,4 +204,8 @@ int sdr_start(sdr_dev_t *dev, sdr_event_cb_t cb, void *ctx, uint32_t buf_num, ui
 */
 int sdr_stop(sdr_dev_t *dev);
 
+/** Redirect SoapySDR library logging.
+*/
+void sdr_redirect_logging(void);
+
 #endif /* INCLUDE_SDR_H_ */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(r_433 STATIC
     http_server.c
     jsmn.c
     list.c
+    logger.c
     mongoose.c
     optparse.c
     output_file.c

--- a/src/am_analyze.c
+++ b/src/am_analyze.c
@@ -19,6 +19,9 @@
 
 #include "am_analyze.h"
 
+#include "log.h"
+#define LOG_MODULE "am_analyze"
+
 #define FRAME_END_MIN 50000 /* minimum sample count to detect frame end */
 #define FRAME_PAD 10000 /* number of samples to pad both frame start and end */
 

--- a/src/confparse.c
+++ b/src/confparse.c
@@ -34,6 +34,9 @@
 #include <unistd.h>
 #endif
 
+#include "log.h"
+#define LOG_MODULE "confparse"
+
 static off_t fsize(const char *path)
 {
     struct stat st;

--- a/src/data_tag.c
+++ b/src/data_tag.c
@@ -22,6 +22,9 @@
 #include "fileformat.h"
 #include "fatal.h"
 
+#include "log.h"
+#define LOG_MODULE "tag"
+
 typedef struct gpsd_client {
     struct mg_connect_opts connect_opts;
     struct mg_connection *conn;

--- a/src/logger.c
+++ b/src/logger.c
@@ -1,0 +1,112 @@
+/** @file
+    Basic logging.
+
+    Copyright (C) 2021 Christian W. Zuckschwerdt <zany@triq.net>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <logger.h>
+
+static r_logger_handler logger_handler = NULL;
+static void *logger_handler_userdata   = NULL;
+static r_logger_handler aux_handler    = NULL;
+static void *aux_handler_userdata      = NULL;
+
+// shim until fprintf is converted to log_
+#undef fprintf
+
+static void default_handler(log_level_t level, char const *mod, char const *file, int line, char const *func, char const *msg)
+{
+    (void)file;
+    (void)line;
+    if (msg && msg[strlen(msg) - 1] == '\n') {
+        fprintf(stderr, "%s(%d) %s: %s", mod, level, func, msg);
+    }
+    else {
+        fprintf(stderr, "%s(%d) %s: %s\n", mod, level, func, msg);
+    }
+}
+
+void r_logger_set_log_handler(r_logger_handler const handler, void *userdata)
+{
+    logger_handler = handler;
+    logger_handler_userdata = userdata;
+}
+
+void r_logger_set_aux_handler(r_logger_handler const handler, void *userdata)
+{
+    aux_handler = handler;
+    aux_handler_userdata = userdata;
+}
+
+void r_logger_log(log_level_t level, char const *mod, char const *file, int line, char const *func, char const *msg)
+{
+    if (logger_handler) {
+        logger_handler(level, mod, file, line, func, msg, logger_handler_userdata);
+    }
+    else {
+        default_handler(level, mod, file, line, func, msg);
+    }
+    if (aux_handler) {
+        aux_handler(level, mod, file, line, func, msg, aux_handler_userdata);
+    }
+}
+
+void r_logger_logf(log_level_t level, char const *mod, char const *file, int line, char const *func, char const *fmt, ...)
+{
+    char msg[4096];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(msg, sizeof(msg), fmt, ap);
+    va_end(ap);
+    r_logger_log(level, mod, file, line, func, msg);
+}
+
+int r_logger_fprintf(log_level_t level, char const *mod, char const *file, int line, char const *func, FILE *stream, const char *format, ...)
+{
+    if (stream != stderr) {
+        va_list ap;
+        va_start(ap, format);
+        int r = vfprintf(stream, format, ap);
+        va_end(ap);
+        return r;
+    }
+
+    int r;
+    if (!logger_handler) {
+        va_list ap;
+        va_start(ap, format);
+        r = vfprintf(stream, format, ap);
+        va_end(ap);
+    }
+    if (logger_handler || aux_handler) {
+        char msg[4096];
+        va_list ap;
+        va_start(ap, format);
+        r = vsnprintf(msg, sizeof(msg), format, ap);
+        va_end(ap);
+
+        // cap length to match fprintf return
+        r = r >= (int)sizeof(msg) ? (int)sizeof(msg) - 1 : r;
+        // strip trailing newline from typical fprintf
+        if (r > 0 && msg[r - 1] == '\n') {
+            msg[r - 1] = '\0';
+        }
+
+        if (logger_handler) {
+            logger_handler(level, mod, file, line, func, msg, logger_handler_userdata);
+        }
+        if (aux_handler) {
+            aux_handler(level, mod, file, line, func, msg, aux_handler_userdata);
+        }
+
+    }
+    return r;
+}

--- a/src/output_influx.c
+++ b/src/output_influx.c
@@ -25,6 +25,9 @@
 
 #include "mongoose.h"
 
+#include "log.h"
+#define LOG_MODULE "influx"
+
 /* InfluxDB client abstraction / printer */
 
 typedef struct {

--- a/src/output_mqtt.c
+++ b/src/output_mqtt.c
@@ -22,6 +22,9 @@
 
 #include "mongoose.h"
 
+#include "log.h"
+#define LOG_MODULE "mqtt"
+
 /* MQTT client abstraction */
 
 typedef struct mqtt_client {

--- a/src/pulse_analyzer.c
+++ b/src/pulse_analyzer.c
@@ -17,6 +17,9 @@
 #include <string.h>
 #include <limits.h>
 
+#include "log.h"
+#define LOG_MODULE "analyzer"
+
 #define MAX_HIST_BINS 16
 
 /// Histogram data for single bin

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -19,6 +19,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "log.h"
+#define LOG_MODULE "detect_ook"
+
 // OOK adaptive level estimator constants
 #define OOK_MAX_HIGH_LEVEL  DB_TO_AMP(0)   // Maximum estimate for high level (-0 dB)
 #define OOK_MAX_LOW_LEVEL   DB_TO_AMP(-15) // Maximum estimate for low level

--- a/src/pulse_detect_fsk.c
+++ b/src/pulse_detect_fsk.c
@@ -18,6 +18,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "log.h"
+#define LOG_MODULE "detect_fsk"
+
 // FSK adaptive frequency estimator constants
 #define FSK_DEFAULT_FM_DELTA 6000       // Default estimate for frequency delta
 #define FSK_EST_SLOW        64          // Constant for slowness of FSK estimators

--- a/src/pulse_slicer.c
+++ b/src/pulse_slicer.c
@@ -20,6 +20,9 @@
 #include <math.h>
 #include <limits.h>
 
+#include "log.h"
+#define LOG_MODULE "slicer"
+
 static int account_event(r_device *device, bitbuffer_t *bits, char const *demod_name)
 {
     // run decoder

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -40,6 +40,8 @@
 #include "compat_time.h"
 #include "fatal.h"
 #include "http_server.h"
+#include "log.h"
+#define LOG_MODULE "r_api"
 
 #ifdef _WIN32
 #include <io.h>

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -84,6 +84,9 @@
 #endif
 #endif
 
+#include "log.h"
+#define LOG_MODULE "main"
+
 // STDERR_FILENO is not defined in at least MSVC
 #ifndef STDERR_FILENO
 #define STDERR_FILENO 2
@@ -1370,6 +1373,7 @@ int main(int argc, char **argv) {
     r_cfg_t *cfg = &g_cfg;
 
     print_version(); // always print the version info
+    sdr_redirect_logging();
 
     r_init_cfg(cfg);
 

--- a/src/samp_grab.c
+++ b/src/samp_grab.c
@@ -27,6 +27,9 @@
 #include "samp_grab.h"
 #include "fatal.h"
 
+#include "log.h"
+#define LOG_MODULE "grabber"
+
 samp_grab_t *samp_grab_create(unsigned size)
 {
     samp_grab_t *g;

--- a/src/sdr.c
+++ b/src/sdr.c
@@ -72,6 +72,9 @@ int __attribute__((weak)) rtlsdr_set_bias_tee(rtlsdr_dev_t *dev, int on);
     #define closesocket(x)  close(x)
 #endif
 
+#include "log.h"
+#define LOG_MODULE "sdr"
+
 #define GAIN_STR_MAX_SIZE 64
 
 struct sdr_dev {
@@ -1644,4 +1647,18 @@ int sdr_stop(sdr_dev_t *dev)
 #endif
 
     return -1;
+}
+
+#ifdef SOAPYSDR
+static void soapysdr_log_handler(const SoapySDRLogLevel level, const char *message)
+{
+    r_logger_logf((log_level_t)level, "SoapySDR", NULL, 0, NULL, "%s", message);
+}
+#endif
+
+void sdr_redirect_logging()
+{
+#ifdef SOAPYSDR
+    SoapySDR_registerLogHandler(soapysdr_log_handler);
+#endif
 }


### PR DESCRIPTION
Adds basic structured logging.
- allows (e.g. HTTP output) to capture log messages
- allows library use and different apps with custom log handling
- allows coloring of logs (`key: value`), highlighting of errors, ...
- `fprintf`'s are re-defined to use logging for now, until calls are converted
