### PR TITLE
Decode fail return code improvements

### DIFF
--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -176,6 +176,7 @@ static int acurite_th_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     float tempc;
     uint8_t humidity, id, status;
     data_t *data;
+    int result = 0;
 
     for (uint16_t brow = 0; brow < bitbuffer->num_rows; ++brow) {
         if (bitbuffer->bits_per_row[brow] != 40) {

--- a/src/devices/ambient_weather.c
+++ b/src/devices/ambient_weather.c
@@ -101,6 +101,8 @@ static int ambient_weather_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         }
     }
 
+    // TODO: returns 0 when no data is found in the messages.
+    // What would be a better return value? Maybe DECODE_ABORT_SANITY?
     return ret;
 }
 

--- a/src/devices/lacrosse.c
+++ b/src/devices/lacrosse.c
@@ -130,9 +130,12 @@ static int lacrossetx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     uint8_t msg_nybbles[LACROSSE_NYBBLE_CNT];
     data_t *data;
 
+    int result = 0;
+
     for (int row = 0; row < bitbuffer->num_rows; ++row) {
         // break out the message nybbles into separate bytes
         if (lacrossetx_detect(decoder, bb[row], msg_nybbles, bitbuffer->bits_per_row[row]) <= 0) {
+            result = DECODE_ABORT_EARLY;
             continue; // DECODE_ABORT_EARLY
         }
 
@@ -152,6 +155,7 @@ static int lacrossetx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                         "LaCrosse TX Sensor %02x, type: %d: message value mismatch int(%3.1f) != %d?\n",
                         sensor_id, msg_type, msg_value, msg_value_int);
             }
+            result = DECODE_FAIL_SANITY;
             continue; // DECODE_FAIL_SANITY
         }
 
@@ -190,7 +194,10 @@ static int lacrossetx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         }
     }
 
-    return events;
+    if (events)
+      return events;
+
+    return result;
 }
 
 static char *output_fields[] = {

--- a/src/devices/ttx201.c
+++ b/src/devices/ttx201.c
@@ -121,7 +121,7 @@ ttx201_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned 
                         row, bits, MSG_PACKET_BITS);
             }
         }
-        return 0;
+        return DECODE_ABORT_LENGTH;
     }
 
     bitbuffer_extract_bytes(bitbuffer, row, bitpos + MSG_PAD_BITS, b, MSG_PACKET_BITS + MSG_PAD_BITS);
@@ -157,13 +157,13 @@ ttx201_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned 
         if (decoder->verbose > 1)
             fprintf(stderr, "Packet #%u wrong postmark 0x%02x (expected 0x%02x).\n",
                     row, postmark, MSG_PACKET_POSTMARK);
-        return 0;
+        return DECODE_FAIL_SANITY;
     }
 
     if (checksum != checksum_calculated) {
         if (decoder->verbose > 1)
             fprintf(stderr, "Packet #%u checksum error.\n", row);
-        return 0;
+        return DECODE_FAIL_MIC;
     }
 
     device_id = b[1];


### PR DESCRIPTION
Method for finding worst offenders:

- record stats with `./rtl_433 -M stats:2:30 -F json
- put stats into file (result.json)
- run jq over stats with: `jq '.stats[] | select(has("fail_other")) | {(.name): .fail_other}' result.json -c`

(Just documenting this for future reference)

```json
{"LaCrosse TX Temperature / Humidity Sensor":4}
{"Acurite 609TXC Temperature and Humidity Sensor":2}
{"Ambient Weather, TFA 30.3208.02 temperature sensor":28}
{"DSC Security Contact":2}
{"Globaltronics GT-WT-02 Sensor":4}
{"LaCrosse WS-2310 / WS-3600 Weather Station":4}
{"Acurite 592TXR Temp/Humidity, 5n1 Weather Station, 6045 Lightning, 3N1, Atlas":4}
{"Acurite 986 Refrigerator / Freezer Thermometer":2}
{"HT680 Remote control":4}
{"Springfield Temperature and Soil Moisture":2}
{"Oregon Scientific SL109H Remote Thermal Hygro Sensor":2}
{"Acurite 00275rm,00276rm Temp/Humidity with optional probe":892}
{"Oil Ultrasonic STANDARD ASK":31}
{"Ford Car Key":2}
{"Emos TTX201 Temperature Sensor":508}
{"DSC Security Contact (WS4945)":1}
```

I've fixed some of these in the PR (mostly the ones with high numbers).
