### PR TITLE
Change 'mic' from field to tag in InfluxDB

### DIFF
--- a/src/output_influx.c
+++ b/src/output_influx.c
@@ -301,7 +301,8 @@ static void print_influx_data(data_output_t *output, data_t *data, char const *f
         else if (!strcmp(data->key, "type")
                 || !strcmp(data->key, "subtype")
                 || !strcmp(data->key, "id")
-                || !strcmp(data->key, "channel")) {
+                || !strcmp(data->key, "channel")
+                || !strcmp(data->key, "mic")) {
             str = mbuf_snprintf(buf, ",%s=", data->key);
             str++;
             end = &buf->buf[buf->len - 1];
@@ -329,7 +330,8 @@ static void print_influx_data(data_output_t *output, data_t *data, char const *f
         else if (!strcmp(data->key, "type")
                 || !strcmp(data->key, "subtype")
                 || !strcmp(data->key, "id")
-                || !strcmp(data->key, "channel")) {
+                || !strcmp(data->key, "channel")
+                || !strcmp(data->key, "mic")) {
             // skip
         }
         else {


### PR DESCRIPTION
I added 'mic' in the list of key/value pairs to include as a tag instead of a metric. This is my first PR on GitHub so I apologize if I'm missing anything or not doing this correctly.


https://docs.influxdata.com/influxdb/v1.8/concepts/glossary/#tag

> Tag 
The key-value pair in the InfluxDB data structure that records metadata. Tags are an optional part of the data structure, but they are useful for storing commonly-queried metadata; tags are indexed so queries on tags are performant. Query tip: Compare tags to fields; fields are not indexed

https://docs.influxdata.com/influxdb/v1.8/concepts/glossary/#field
>Field
The key-value pair in an InfluxDB data structure that records metadata and the actual data value. Fields are required in InfluxDB data structures and they are not indexed - queries on field values scan all points that match the specified time range and, as a result, are not performant relative to tags. Query tip: Compare fields to tags; tags are indexed.