### PR TITLE
bresser_7in1: Add UV index, add missing decimals in light_klx

### DIFF
--- a/src/devices/bresser_7in1.c
+++ b/src/devices/bresser_7in1.c
@@ -111,8 +111,8 @@ static int bresser_7in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     if (temp_raw > 600)
         temp_c = (temp_raw - 1000) * 0.1f;
     int humidity = (msg[16] >> 4) * 10 + (msg[16] & 0x0f);
-    int lght_raw = (msg[17] >> 4) * 100000 + (msg[17] & 0x0f) * 10000 + (msg[18] >> 4) * 1000 
-	    + (msg[18] & 0x0f) * 100 + (msg[19] >> 4) * 10 + (msg[19] & 0x0f);
+    int lght_raw = (msg[17] >> 4) * 100000 + (msg[17] & 0x0f) * 10000 + (msg[18] >> 4) * 1000
+            + (msg[18] & 0x0f) * 100 + (msg[19] >> 4) * 10 + (msg[19] & 0x0f);
     int uv_raw =   (msg[20] >> 4) * 100 + (msg[20] & 0x0f) * 10 + (msg[21] >> 4);
 
     float light_klx = lght_raw * 0.001f;

--- a/src/devices/bresser_7in1.c
+++ b/src/devices/bresser_7in1.c
@@ -27,7 +27,17 @@ Data layout:
 
     {271}631d05c09e9a18abaabaaaaaaaaa8adacbacff9cafcaaaaaaa000000000000000000
 
+
+    {262}10b8b4a5a3ca10aaaaaaaaaaaaaa8bcacbaaaa2aaaaaaaaaaa0000000000000000 [0.08 klx]
+    {220}543bb4a5a3ca10aaaaaaaaaaaaaa8bcacbaaaa28aaaaaaaaaa00000 [0.08 klx]
+    {273}2492b4a5a3ca10aaaaaaaaaaaaaa8bdacbaaaa2daaaaaaaaaa0000000000000000000 [0.08klx]
+
+    {269}9a59b4a5a3da10aaaaaaaaaaaaaa8bdac8afea28a8caaaaaaa000000000000000000 [54.0 klx UV=2.6]
+    {230}fe15b4a5a3da10aaaaaaaaaaaaaa8bdacbba382aacdaaaaaaa00000000 [109.2klx   UV=6.7]
+    {254}2544b4a5a32a10aaaaaaaaaaaaaa8bdac88aaaaabeaaaaaaaa00000000000000 [200.000 klx UV=14
+
     DIGEST:8h8h ID?8h8h WDIR:8h4h 4h 8h WGUST:8h.4h WAVG:8h.4h RAIN:8h8h4h.4h RAIN?:8h TEMP:8h.4hC FLAGS?:4h HUM:8h% LIGHT:8h4h,8h4hKL UV:8h.4h TRAILER:8h8h8h4h
+
 
 Unit of light is kLux (not W/m²).
 
@@ -101,10 +111,11 @@ static int bresser_7in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     if (temp_raw > 600)
         temp_c = (temp_raw - 1000) * 0.1f;
     int humidity = (msg[16] >> 4) * 10 + (msg[16] & 0x0f);
-    int lght_raw = (msg[17] >> 4) * 10000 + (msg[17] & 0x0f) * 1000 + (msg[18] >> 4) * 100 + (msg[18] & 0x0f) * 10 + (msg[19] >> 4) ;
+    int lght_raw = (msg[17] >> 4) * 100000 + (msg[17] & 0x0f) * 10000 + (msg[18] >> 4) * 1000 
+	    + (msg[18] & 0x0f) * 100 + (msg[19] >> 4) * 10 + (msg[19] & 0x0f);
     int uv_raw =   (msg[20] >> 4) * 100 + (msg[20] & 0x0f) * 10 + (msg[21] >> 4);
 
-    float light_klx = lght_raw * 0.01f;
+    float light_klx = lght_raw * 0.001f;
     float uv_index = uv_raw * 0.1f;
 
     /* clang-format off */
@@ -117,7 +128,7 @@ static int bresser_7in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "wind_avg_m_s",     "Wind Speed",   DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wavg_raw * 0.1f,
             "wind_dir_deg",     "Direction",    DATA_INT,    wdir,
             "rain_mm",          "Rain",         DATA_FORMAT, "%.1f mm", DATA_DOUBLE, rain_mm,
-            "light_klx",        "Light",        DATA_FORMAT, "%.2f klx", DATA_DOUBLE, light_klx,
+            "light_klx",        "Light",        DATA_FORMAT, "%.3f klx", DATA_DOUBLE, light_klx,
             "uv",               "UV Index",     DATA_FORMAT, "%.1f", DATA_DOUBLE, uv_index,
             "flags",            "Battery?",     DATA_INT,    flags,
             "mic",              "Integrity",    DATA_STRING, "CRC",


### PR DESCRIPTION
added measured UV index and missing decimals in klux value 
[link to test data](https://triq.net/bitbench?c=%7B271%7D6b65b4a5a39a10aaaaaaaaaaaaaa8bfacdaaaaecaaaaaaaaaa000000000000000000%20%5B0.04%20klx%5D&c=%7B271%7D9ec5b4a5a3ca10aaaaaaaaaaaaaa8bfac8aaaaceaaaaaaaaaa000000000000000000%20%5B0.06%5D&c=&c=%7B233%7D9f6fb4a5a3ca10aaaaaaaaaaaaaa8bfacbaaaad8aaaaaaaaaa000000000%20%5B0.07%5D&c=%7B266%7Da6e8b4a5a3ca10aaaaaaaaaaaaaa8bcacbaaaadeaaaaaaaaaa00000000000000000%20%5B0.07%5D&c=&c=%7B262%7D10b8b4a5a3ca10aaaaaaaaaaaaaa8bcacbaaaa2aaaaaaaaaaa0000000000000000%20%5B0.08%5D&c=%7B220%7D543bb4a5a3ca10aaaaaaaaaaaaaa8bcacbaaaa28aaaaaaaaaa00000%20%5B0.08%5D&c=%7B273%7D2492b4a5a3ca10aaaaaaaaaaaaaa8bdacbaaaa2daaaaaaaaaa0000000000000000000%20%5B0.08%5D&c=&c=&c=%7B212%7D0bc2b4a5a3ca10aaaaaaaaaaaaaa8bfac8aaaa3faaaaaaaaaa000%20%5B0.09%5D&c=%7B216%7D7336b4a5a3ca10aaaaaaaaaaaaaa8bcacbaaaa3daaaaaaaaaa0000%20%5B0.09%5D&c=&c=%7B234%7D740db4a5ad2a18aaaaaaaaaba2aa8bdac8aaaa3daaaaaaaaaa000000000%20%5B0.09%5D&c=%7B274%7D740db4a5ad2a18aaaaaaaaaba2aa8bdac8aaaa3daaaaaaaaaa0000000000000000000%20%5B0.09%5D&c=&c=%7B204%7D9e21b4a5ad2a18aaaaaaaaaba2aa8bdac8aaaba9aaaaaaaaaa0%20%5B0.10%5D&c=%7B264%7D74a9b4a5ad2a18aaaaaaaaaba2aa8bdac8aaabbaaaaaaaaaaa0000000000000000%20%5B0.11%5D&c=%7B241%7D302ab4a5ad2a18aaaaaaaaaba2aa8bdac8aaabb8aaaaaaaaaa00000000000%20%5B0.11%5D&c=&c=%7B259%7D2bb9b4a5ad2a18aaaaaaaaaba2aa8bcac8aaab8aaaaaaaaaaa000000000000000%20%5B0.12%5D&c=%7B224%7Db5c2b4a5ad2a18aaaaaaaaaba2aa8bdac8aaab8caaaaaaaaaa000000%20%5B0.12%5D&c=&c=%7B249%7Dd64cb4a5ad2a18aaaaaaaaaba2aa8bdac8aaab9baaaaaaaaaa0000000000000%20%5B0.13%5D&c=%7B202%7D879fb4a5ad2a18aaaaaaaaaba2aa8bcac8aaab93aaaaaaaaaa0%20%5B0.13%5D&c=%7B225%7D879fb4a5ad2a18aaaaaaaaaba2aa8bcac8aaab93aaaaaaaaaa0000000%20%5B0%2F13%5D&c=&c=&c=&c=&c=&c=&c=&c=%7B264%7Dc9e7b4a5ad2a18aaaaaaaaaba2aa8bdac8aaabe3aaaaaaaaaa0000000000000000%5B0.14%5D&c=%7B271%7Dc9e7b4a5ad2a18aaaaaaaaaba2aa8bdac8aaabe3aaaaaaaaaa000000000000000000%20%5B0.14%5D&c=&c=%7B198%7Dbf39b4a5ad2a18aaaaaaaaaba2aa8bcac8aaabfeaaaaaaaaa8%20%5B0.15%5D&c=&c=%7B224%7D38fcb4a5ad2a18aaaaaaaaaba2aa8bcac8aaabc2aaaaaaaaaa000000%20%5B0.16%5D&c=%7B274%7D38fcb4a5ad2a18aaaaaaaaaba2aa8bcac8aaabc2aaaaaaaaaa0000000000000000000%20%5B0.16%5D&c=&c=%7B252%7Df30eb4a5ad2a18aaaaaaaaaba2aa8bcac8aaabdcaaaaaaaaaa0000000000000%20%5B0.17%5D&c=%7B254%7Df30eb4a5ad2a18aaaaaaaaaba2aa8bcac8aaabdcaaaaaaaaaa00000000000000%20%5B0.17%5D&c=&c=&c=%7B255%7D9c7bb4a5a3da10aaaaaaaaaaaaaa8bdacbab8ab8aaaaaaaaaa00000000000000%20%5B12.01%5D&c=&c=%7B265%7Ddfc7b4a5a3da10aaaaaaaaaaaaaa8bdac8aaccdeaaaaaaaaaa00000000000000000%20%5B6.67%20klx%20UV%3D0%5D&c=%7B269%7D9a59b4a5a3da10aaaaaaaaaaaaaa8bdac8afea28a8caaaaaaa000000000000000000%20%5B54.0%20klx%20UV%3D2.6%5D&c=%7B230%7Dfe15b4a5a3da10aaaaaaaaaaaaaa8bdacbba382aacdaaaaaaa00000000%20%5B109.2klx%20%20%20UV%3D6.7%5D&c=%7B254%7D2544b4a5a32a10aaaaaaaaaaaaaa8bdac88aaaaabeaaaaaaaa00000000000000%20%5B200.000%20klx%20UV%3D14%5D&f=DIGEST%3A8h8h%20ID%3F8h8h%20WDIR%3A8h4h%204h%208h%20WGUST%3A8h.4h%20WAVG%3A8h.4h%20RAIN%3A8h8h4h.4h%20RAIN%3F%3A8h%20TEMP%3A8h.4hC%20FLAGS%3F%3A4h%20HUM%3A8h%25%20LIGHT%3A8h4h%2C8h4hKL%20UV%3A8h.4h%20TRAILER%3A8h8h8h4h&x=a&cw=4)

2nd decimal number in klux is same as visible on the "desk base", changes on 3rd decimal place were consistent with test light movement
