### PR TITLE
Fix mixing SoapySDR allocator

### DIFF
--- a/src/sdr.c
+++ b/src/sdr.c
@@ -590,7 +590,7 @@ static int soapysdr_direct_sampling(SoapySDRDevice *dev, int on)
         fprintf(stderr, "Enabled direct sampling mode, input 2/Q.\n");}
     else if (set_num == 3) {
         fprintf(stderr, "Enabled no-mod direct sampling mode.\n");}
-    free(set_value);
+    SoapySDR_free(set_value);
     return r;
 }
 
@@ -613,7 +613,7 @@ static int soapysdr_offset_tuning(SoapySDRDevice *dev)
     else {
         fprintf(stderr, "Offset tuning mode enabled.\n");
     }
-    free(set_value);
+    SoapySDR_free(set_value);
     return r;
 }
 
@@ -654,7 +654,7 @@ static int soapysdr_auto_gain(SoapySDRDevice *dev, int verbose)
         }
 
     }
-    free(driver);
+    SoapySDR_free(driver);
     // otherwise leave unset, hopefully the driver has good defaults
 
     return r;
@@ -746,7 +746,7 @@ static void soapysdr_show_device_info(SoapySDRDevice *dev)
 
     hwkey = SoapySDRDevice_getHardwareKey(dev);
     fprintf(stderr, "Using device %s: ", hwkey);
-    free(hwkey);
+    SoapySDR_free(hwkey);
 
     args = SoapySDRDevice_getHardwareInfo(dev);
     for (i = 0; i < args.size; ++i) {
@@ -786,7 +786,7 @@ static void soapysdr_show_device_info(SoapySDRDevice *dev)
         fprintf(stderr, "%.0f - %.0f (step %.0f) ", frequencyRanges[i].minimum, frequencyRanges[i].maximum, frequencyRanges[i].step);
     }
     fprintf(stderr, "\n");
-    free(frequencyRanges);
+    SoapySDR_free(frequencyRanges);
 
     rates = SoapySDRDevice_getSampleRateRange(dev, direction, channel, &len);
     fprintf(stderr, "Found %zu sample rate range(s): ", len);
@@ -797,7 +797,7 @@ static void soapysdr_show_device_info(SoapySDRDevice *dev)
             fprintf(stderr, "%.0f - %.0f (step %.0f) ", rates[i].minimum, rates[i].maximum, rates[i].step);
     }
     fprintf(stderr, "\n");
-    free(rates);
+    SoapySDR_free(rates);
 
     bandwidths = SoapySDRDevice_getBandwidthRange(dev, direction, channel, &len);
     fprintf(stderr, "Found %zu bandwidth range(s): ", len);
@@ -805,7 +805,7 @@ static void soapysdr_show_device_info(SoapySDRDevice *dev)
         fprintf(stderr, "%.0f - %.0f (step %.0f) ", bandwidths[i].minimum, bandwidths[i].maximum, bandwidths[i].step);
     }
     fprintf(stderr, "\n");
-    free(bandwidths);
+    SoapySDR_free(bandwidths);
 
     double bandwidth = SoapySDRDevice_getBandwidth(dev, direction, channel);
     fprintf(stderr, "Found current bandwidth %.0f\n", bandwidth);
@@ -820,7 +820,7 @@ static void soapysdr_show_device_info(SoapySDRDevice *dev)
 
     native_stream_format = SoapySDRDevice_getNativeStreamFormat(dev, direction, channel, &fullScale);
     fprintf(stderr, "Found native stream format: %s (full scale: %.1f)\n", native_stream_format, fullScale);
-    free(native_stream_format);
+    SoapySDR_free(native_stream_format);
 }
 
 static int sdr_open_soapy(sdr_dev_t **out_dev, char const *dev_query, int verbose)
@@ -876,7 +876,7 @@ static int sdr_open_soapy(sdr_dev_t **out_dev, char const *dev_query, int verbos
         dev->sample_signed = 1;
         dev->fullScale = 32768.0; // assume max for SOAPY_SDR_CS16
     }
-    free(native_format);
+    SoapySDR_free(native_format);
 
     SoapySDRKwargs args = SoapySDRDevice_getHardwareInfo(dev->soapy_dev);
     size_t info_len     = 2;


### PR DESCRIPTION
Using MSVC debug-mode (`-MDd`) to build `rtl_433.exe` with a Soapy library built for release-mode (`-MD`)
does not work. It will crash inside MSVC's CRT on a call to `free_dbg (ptr_from_soapy)`.

Hence let Soapy free it's own allocated memory using the `SoapySDR_free (ptr_from_soapy)` function.