### PR TITLE
cosmetics: Fix typo in Hass MQTT Discovery Script for Noise

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -395,7 +395,7 @@ mappings = {
         "config": {
             "device_class": "signal_strength",
             "unit_of_measurement": "dB",
-            "value_template": "{{ valuei|float|round(2) }}"
+            "value_template": "{{ value|float|round(2) }}"
         }
     },
 


### PR DESCRIPTION
Fix typo in Hass MQTT Discovery Script for Noise, remove an erronious `i` that is causing all `-noise` sensors to appear as `unknown`