### PR TITLE
docs: Extended kernel module fix and added blacklist tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,8 +476,13 @@ If you see this error:
 
 then
 
-    sudo rmmod dvb_usb_rtl28xxu rtl2832
+    sudo rmmod rtl2832_sdr dvb_usb_rtl28xxu rtl2832
 
+or add
+
+    blacklist dvb_usb_rtl28xxu
+
+to /etc/modprobe.d/blacklist.conf
 
 ## Releases
 


### PR DESCRIPTION
Used `rtl_433` previously without the need to `rmmod` first.
Suddenly the kernel modules were being loaded when DVB plug was connected.
Blacklisting works like a charm.
(Ubuntu 18.04.6 LTS)
`Bus 003 Device 002: ID 0bda:2838 Realtek Semiconductor Corp. RTL2838 DVB-T`
