### PR TITLE
Added OpenSSL development library to build guide

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -38,23 +38,33 @@ Depending on your system, you may need to install the following libraries.
 
 Debian:
 
-    sudo apt-get install libtool libusb-1.0-0-dev librtlsdr-dev libssl-dev rtl-sdr build-essential cmake pkg-config
+* If you require TLS connections, install `libssl-dev`.
+
+````
+sudo apt-get install libtool libusb-1.0-0-dev librtlsdr-dev rtl-sdr build-essential cmake pkg-config
+````
+
 
 Centos/Fedora/RHEL with EPEL repo using cmake:
 
   * If `dnf` doesn't exist, use `yum`.
+  * If you require TLS connections, install `openssl-devel`.
 
 ````
-sudo dnf install libtool libusbx-devel openssl-devel rtl-sdr-devel rtl-sdr cmake
+sudo dnf install libtool libusbx-devel rtl-sdr-devel rtl-sdr cmake
 ````
 
 Mac OS X with MacPorts:
 
-    sudo port install openssl rtl-sdr cmake
+* If you require TLS connections, install `openssl` from either MacPorts or Homebrew.
+
+````
+sudo port install rtl-sdr cmake
+````
 
 Mac OS X with Homebrew:
 
-    brew install rtl-sdr openssl cmake pkg-config
+    brew install rtl-sdr cmake pkg-config
 
 ### CMake
 


### PR DESCRIPTION
I ran into this issue a few minutes ago, hopefully this will help someone else.
```
-- Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the system variable OPENSSL_ROOT_DIR (missing: OPENSSL_CRYPTO_LIBRARY OPENSSL_INCLUDE_DIR) 

-- OpenSSL development files not found, TLS won't be possible.
```