### PR TITLE
Change HASS logging to use logging levels

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -636,6 +636,10 @@ def rtl_433_bridge():
     """Run a MQTT Home Assistant auto discovery bridge for rtl_433."""
 
     mqttc = mqtt.Client()
+
+    if args.debug:
+        mqttc.enable_logger()
+
     if args.user is not None:
         mqttc.username_pw_set(args.user, args.password)
     mqttc.on_connect = mqtt_connect

--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -712,4 +712,7 @@ if __name__ == "__main__":
     if not args.password and 'MQTT_PASSWORD' in os.environ:
         args.password = os.environ['MQTT_PASSWORD']
 
+    if not args.user or not args.password:
+        logging.warning("User or password is not set. Check credentials if subscriptions do not return messages.")
+
     run()


### PR DESCRIPTION
This PR:

- Uses the `logging` module instead of prints. This allows for filtering based on logging levels.
- Wires in `--debug` and `--quiet` to trigger `DEBUG` and `WARNING` logs respectively.
- Enables mqttc debug logging when `DEBUG` is set.
- Adds some additional debug log messages I found useful troubleshooting what turned out to be an auth issue (which is added in 23b2df8).
- Fixes allowing both quiet and debug to be specified at the same time.