### PR TITLE
Do not call CloseHandle on invalid handle

### DIFF
--- a/src/compat_alarm.c
+++ b/src/compat_alarm.c
@@ -36,7 +36,6 @@ static void alarm_delete(void)
        return;
     signal(SIGALRM, SIG_IGN);
     DeleteTimerQueueTimer(NULL, alarm_hnd, NULL);
-    CloseHandle(alarm_hnd);
     alarm_hnd = INVALID_HANDLE_VALUE;
 }
 


### PR DESCRIPTION
Under Windows, the alarm handle retrieved by CreateTimerQueueTimer is not a valid handle and must NOT be given to CloseHandle as it raises an exception in Debug mode