### PR TITLE
Introduce RTL_433_REDUCE_STACK_USE which, when defined, drastically reduces the size of bitrow_t

### DIFF
--- a/include/bitbuffer.h
+++ b/include/bitbuffer.h
@@ -15,8 +15,14 @@
 #include <stdint.h>
 
 // NOTE: Wireless mbus protocol needs at least ((256+16*2+3)*12)/8 => 437 bytes
+//       but it will not be included if RTL_433_REDUCE_STACK_USE is defined
+#ifdef RTL_433_REDUCE_STACK_USE
+#define BITBUF_COLS 40 // Number of bytes in a column
+#define BITBUF_ROWS 25
+#else
 #define BITBUF_COLS 128 // Number of bytes in a column
 #define BITBUF_ROWS 50
+#endif
 #define BITBUF_MAX_PRINT_BITS 50 // Maximum number of bits to print (in addition to hex values)
 
 typedef uint8_t bitrow_t[BITBUF_COLS];

--- a/include/bitbuffer.h
+++ b/include/bitbuffer.h
@@ -15,7 +15,7 @@
 #include <stdint.h>
 
 // NOTE: Wireless mbus protocol needs at least ((256+16*2+3)*12)/8 => 437 bytes
-//       but it will not be included if RTL_433_REDUCE_STACK_USE is defined
+//       which fits even if RTL_433_REDUCE_STACK_USE is defined because of row spilling
 #ifdef RTL_433_REDUCE_STACK_USE
 #define BITBUF_COLS 40 // Number of bytes in a column
 #define BITBUF_ROWS 25

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -7,16 +7,6 @@
 
 #include "r_device.h"
 
-#ifndef RTL_433_REDUCE_STACK_USE
-#define M_BUS_DEVICES \
-    DECL(m_bus_mode_c_t) \
-    DECL(m_bus_mode_s) \
-    DECL(m_bus_mode_r) \
-    DECL(m_bus_mode_f)
-#else
-#define M_BUS_DEVICES /**/
-#endif
-
 #define DEVICES \
     DECL(silvercrest) \
     DECL(rubicson) \
@@ -121,7 +111,10 @@
     DECL(dish_remote_6_3) \
     DECL(ss_sensor) \
     DECL(sensible_living) \
-    M_BUS_DEVICES \
+    DECL(m_bus_mode_c_t) \
+    DECL(m_bus_mode_s) \
+    DECL(m_bus_mode_r) \
+    DECL(m_bus_mode_f) \
     DECL(wssensor) \
     DECL(wt1024) \
     DECL(tpms_pmv107j) \

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -7,6 +7,16 @@
 
 #include "r_device.h"
 
+#ifndef RTL_433_REDUCE_STACK_USE
+#define M_BUS_DEVICES \
+    DECL(m_bus_mode_c_t) \
+    DECL(m_bus_mode_s) \
+    DECL(m_bus_mode_r) \
+    DECL(m_bus_mode_f)
+#else
+#define M_BUS_DEVICES /**/
+#endif
+
 #define DEVICES \
     DECL(silvercrest) \
     DECL(rubicson) \
@@ -111,10 +121,7 @@
     DECL(dish_remote_6_3) \
     DECL(ss_sensor) \
     DECL(sensible_living) \
-    DECL(m_bus_mode_c_t) \
-    DECL(m_bus_mode_s) \
-    DECL(m_bus_mode_r) \
-    DECL(m_bus_mode_f) \
+    M_BUS_DEVICES \
     DECL(wssensor) \
     DECL(wt1024) \
     DECL(tpms_pmv107j) \

--- a/src/devices/lacrossews.c
+++ b/src/devices/lacrossews.c
@@ -100,7 +100,7 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     float temp_c, wind_dir, wind_spd, rain_mm;
     data_t *data;
 
-    for (row = 0; row < BITBUF_ROWS; row++) {
+    for (row = 0; row < bitbuffer->num_rows; row++) {
         // break out the message nybbles into separate bytes
         if (lacrossews_detect(decoder, bitbuffer->bb[row], msg_nybbles, bitbuffer->bits_per_row[row]) <= 0)
             continue; // DECODE_ABORT_EARLY

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -568,7 +568,7 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
     return 0;
 }
 
-// ceil( (335 + 11) / 8 ) 
+// ceil( (335 + 11) / 8 )
 #define EXPECTED_NUM_BYTES 44
 
 static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer)

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -568,6 +568,9 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
     return 0;
 }
 
+// ceil( (335 + 11) / 8 ) 
+#define EXPECTED_NUM_BYTES 44
+
 static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     uint8_t *b = bitbuffer->bb[0];
@@ -583,7 +586,7 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
         return DECODE_ABORT_EARLY;
     }
 
-    unsigned char msg[44 /* ceil( (335 + 11) / 8 ) */] = {0};
+    unsigned char msg[EXPECTED_NUM_BYTES] = {0};
     int msg_pos = 0;
     int msg_len = 0;
 
@@ -759,7 +762,7 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
     else if (msg[0] == 0x26) { // Owl CM180 readings
         msg[0]    = msg[0] & 0x0f;
         int valid = validate_os_checksum(decoder, msg, 23);
-        for (int k = 0; k < BITBUF_COLS; k++) { // Reverse nibbles
+        for (int k = 0; k < EXPECTED_NUM_BYTES; k++) { // Reverse nibbles
             msg[k] = (msg[k] & 0xF0) >> 4 | (msg[k] & 0x0F) << 4;
         }
         // TODO: should we return if valid == 0?
@@ -791,7 +794,7 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
         msg[0]    = msg[0] & 0x0f;
         // to be done
         // int valid = validate_os_checksum(decoder, msg, 23);
-        for (int k = 0; k < BITBUF_COLS; k++) { // Reverse nibbles
+        for (int k = 0; k < EXPECTED_NUM_BYTES; k++) { // Reverse nibbles
             msg[k] = (msg[k] & 0xF0) >> 4 | (msg[k] & 0x0F) << 4;
         }
         // TODO: should we return if valid == 0?

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -630,7 +630,7 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
         msg_len = bitbuffer->bits_per_row[0] - alt_pos;
     }
 
-    if (msg_len == 0 || msg_len > sizeof(msg) * 8)
+    if (msg_len == 0 || msg_len > (int)sizeof(msg) * 8)
         return DECODE_ABORT_EARLY;
 
     bitbuffer_extract_bytes(bitbuffer, 0, msg_pos, msg, msg_len);

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -583,7 +583,7 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
         return DECODE_ABORT_EARLY;
     }
 
-    unsigned char msg[BITBUF_COLS] = {0};
+    unsigned char msg[44 /* ceil( (335 + 11) / 8 ) */] = {0};
     int msg_pos = 0;
     int msg_len = 0;
 
@@ -627,7 +627,7 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
         msg_len = bitbuffer->bits_per_row[0] - alt_pos;
     }
 
-    if (msg_len == 0)
+    if (msg_len == 0 || msg_len > sizeof(msg) * 8)
         return DECODE_ABORT_EARLY;
 
     bitbuffer_extract_bytes(bitbuffer, 0, msg_pos, msg, msg_len);


### PR DESCRIPTION
This saves a lot of stack space, as explained in #1726 