### PR TITLE
+WS019T doc

### DIFF
--- a/src/devices/cotech_36_7959.c
+++ b/src/devices/cotech_36_7959.c
@@ -13,6 +13,7 @@
 Cotech 36-7959 Weatherstation, 433Mhz.
 
 Also: SwitchDoc Labs Weather FT020T.
+Also: Sainlogic Weather Station WS019T
 
 OOK modulated with Manchester encoding, halfbit-width 500 us.
 Message length is 112 bit, every second time it will transmit two identical messages, packet gap 5400 us.


### PR DESCRIPTION
cotech_36_7959 was found to decode my WS019T Sainlogic Weatherstation correctly in testing:

```
{"time" : "2021-11-13 12:39:11", "model" : "Cotech-367959", "id" : 210, "battery_ok" : 1, "temperature_F" : 68.900, "humidity" : 49, "rain_mm" : 0.000, "wind_dir_deg" : 169, "wind_avg_m_s" : 0.000, "wind_max_m_s" : 0.000, "light_lux" : 69627, "uv" : 251, "mic" : "CRC"}
```

Adding documentation reference.