### PR TITLE
Fix: make sure fprintf uses an unsigned marker when an unsigned value is given

### DIFF
--- a/src/bitbuffer.c
+++ b/src/bitbuffer.c
@@ -29,7 +29,7 @@ void bitbuffer_add_bit(bitbuffer_t *bits, int bit)
         return;
     }
     if (bits->bits_per_row[bits->num_rows - 1] == UINT16_MAX - 1) {
-        fprintf(stderr, "%s: Warning: row length limit (%d bits) reached\n", __func__, UINT16_MAX);
+        fprintf(stderr, "%s: Warning: row length limit (%u bits) reached\n", __func__, UINT16_MAX);
     }
 
     uint16_t col_index = bits->bits_per_row[bits->num_rows - 1] / 8;
@@ -330,7 +330,7 @@ static void print_bitbuffer(const bitbuffer_t *bits, int always_binary)
             highest_indent = indent_this_row;
     }
 
-    fprintf(stderr, "bitbuffer:: Number of rows: %d \n", bits->num_rows);
+    fprintf(stderr, "bitbuffer:: Number of rows: %u \n", bits->num_rows);
     for (row = 0; row < bits->num_rows; ++row) {
         fprintf(stderr, "[%02u] ", row);
         print_bitrow(bits->bb[row], bits->bits_per_row[row], highest_indent, always_binary);

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -672,7 +672,7 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         bb = bitbuffer->bb[brow];
 
         if (decoder->verbose > 1)
-            fprintf(stderr, "%s: row %d bits %d, bytes %d \n", __func__, brow, bitbuffer->bits_per_row[brow], browlen);
+            fprintf(stderr, "%s: row %u bits %u, bytes %d \n", __func__, brow, bitbuffer->bits_per_row[brow], browlen);
 
         if ((bitbuffer->bits_per_row[brow] < ACURITE_TXR_BITLEN ||
                 bitbuffer->bits_per_row[brow] > ACURITE_5N1_BITLEN + 1)
@@ -1014,7 +1014,7 @@ static int acurite_986_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     for (uint16_t brow = 0; brow < bitbuffer->num_rows; ++brow) {
 
         if (decoder->verbose > 1)
-            fprintf(stderr, "%s: row %d bits %d, bytes %d \n", __func__, brow, bitbuffer->bits_per_row[brow], browlen);
+            fprintf(stderr, "%s: row %u bits %u, bytes %d \n", __func__, brow, bitbuffer->bits_per_row[brow], browlen);
 
         if (bitbuffer->bits_per_row[brow] < 39 ||
             bitbuffer->bits_per_row[brow] > 43 ) {

--- a/src/devices/ambientweather_tx8300.c
+++ b/src/devices/ambientweather_tx8300.c
@@ -67,7 +67,7 @@ static int ambientweather_tx8300_callback(r_device *decoder, bitbuffer_t *bitbuf
     /* length check */
     if (74 != bitbuffer->bits_per_row[0]) {
         if (decoder->verbose > 1)
-            fprintf(stderr, "AmbientWeather-TX8300: wrong size (%i bits)\n", bitbuffer->bits_per_row[0]);
+            fprintf(stderr, "AmbientWeather-TX8300: wrong size (%u bits)\n", bitbuffer->bits_per_row[0]);
         return DECODE_ABORT_LENGTH;
     }
 

--- a/src/devices/ambientweather_wh31e.c
+++ b/src/devices/ambientweather_wh31e.c
@@ -192,7 +192,7 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         if (start_pos == bitbuffer->bits_per_row[row])
             continue; // DECODE_ABORT_EARLY
         if (decoder->verbose)
-            fprintf(stderr, "%s: WH31E/WH31B/WH40 detected, buffer is %d bits length\n", __func__, bitbuffer->bits_per_row[row]);
+            fprintf(stderr, "%s: WH31E/WH31B/WH40 detected, buffer is %u bits length\n", __func__, bitbuffer->bits_per_row[row]);
 
         // remove preamble, keep whole payload
         bitbuffer_extract_bytes(bitbuffer, row, start_pos + 24, b, 18 * 8);

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -909,7 +909,7 @@ static void handle_cmd_rpc(struct mg_connection *nc, struct http_message *hm)
     }
     char *endptr = NULL;
     rpc.val = strtol(val, &endptr, 10);
-    fprintf(stderr, "POST Got %s, arg %s, val %s (%d)\n", cmd, arg, val, rpc.val);
+    fprintf(stderr, "POST Got %s, arg %s, val %s (%u)\n", cmd, arg, val, rpc.val);
 
     rpc_exec(&rpc, ctx->cfg);
 }

--- a/src/output_mqtt.c
+++ b/src/output_mqtt.c
@@ -66,14 +66,14 @@ static void mqtt_client_event(struct mg_connection *nc, int ev, void *ev_data)
     }
     case MG_EV_MQTT_CONNACK:
         if (msg->connack_ret_code != MG_EV_MQTT_CONNACK_ACCEPTED) {
-            fprintf(stderr, "MQTT Connection error: %d\n", msg->connack_ret_code);
+            fprintf(stderr, "MQTT Connection error: %u\n", msg->connack_ret_code);
         }
         else {
             fprintf(stderr, "MQTT Connection established.\n");
         }
         break;
     case MG_EV_MQTT_PUBACK:
-        fprintf(stderr, "MQTT Message publishing acknowledged (msg_id: %d)\n", msg->message_id);
+        fprintf(stderr, "MQTT Message publishing acknowledged (msg_id: %u)\n", msg->message_id);
         break;
     case MG_EV_MQTT_SUBACK:
         fprintf(stderr, "MQTT Subscription acknowledged.\n");

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1411,7 +1411,7 @@ int main(int argc, char **argv) {
             }
             abuf_printf(&p, " ]");
         }
-        fprintf(stderr, "Registered %zu out of %d device decoding protocols%s\n",
+        fprintf(stderr, "Registered %zu out of %u device decoding protocols%s\n",
                 demod->r_devs.len, cfg->num_r_devices, decoders_str);
     }
 


### PR DESCRIPTION
Fixes C6340 as reported in #1866