### PR TITLE
Annotations must be the same in the header and source files

### DIFF
--- a/src/abuf.c
+++ b/src/abuf.c
@@ -51,7 +51,7 @@ void abuf_cat(abuf_t *buf, char const *str)
     }
 }
 
-int abuf_printf(abuf_t *buf, char const *restrict format, ...)
+int abuf_printf(abuf_t *buf, _Printf_format_string_ char const *restrict format, ...)
 {
     va_list ap;
     va_start(ap, format);

--- a/src/decoder_util.c
+++ b/src/decoder_util.c
@@ -33,7 +33,7 @@ r_device *create_device(r_device *dev_template)
 
 // variadic print functions
 
-void bitbuffer_printf(const bitbuffer_t *bitbuffer, char const *restrict format, ...)
+void bitbuffer_printf(const bitbuffer_t *bitbuffer, _Printf_format_string_ char const *restrict format, ...)
 {
     va_list ap;
     va_start(ap, format);
@@ -42,7 +42,7 @@ void bitbuffer_printf(const bitbuffer_t *bitbuffer, char const *restrict format,
     bitbuffer_print(bitbuffer);
 }
 
-void bitbuffer_debugf(const bitbuffer_t *bitbuffer, char const *restrict format, ...)
+void bitbuffer_debugf(const bitbuffer_t *bitbuffer, _Printf_format_string_ char const *restrict format, ...)
 {
     va_list ap;
     va_start(ap, format);
@@ -51,7 +51,7 @@ void bitbuffer_debugf(const bitbuffer_t *bitbuffer, char const *restrict format,
     bitbuffer_debug(bitbuffer);
 }
 
-void bitrow_printf(uint8_t const *bitrow, unsigned bit_len, char const *restrict format, ...)
+void bitrow_printf(uint8_t const *bitrow, unsigned bit_len, _Printf_format_string_ char const *restrict format, ...)
 {
     va_list ap;
     va_start(ap, format);
@@ -60,7 +60,7 @@ void bitrow_printf(uint8_t const *bitrow, unsigned bit_len, char const *restrict
     bitrow_print(bitrow, bit_len);
 }
 
-void bitrow_debugf(uint8_t const *bitrow, unsigned bit_len, char const *restrict format, ...)
+void bitrow_debugf(uint8_t const *bitrow, unsigned bit_len, _Printf_format_string_ char const *restrict format, ...)
 {
     va_list ap;
     va_start(ap, format);
@@ -71,7 +71,7 @@ void bitrow_debugf(uint8_t const *bitrow, unsigned bit_len, char const *restrict
 
 // variadic output functions
 
-void decoder_output_messagef(r_device *decoder, char const *restrict format, ...)
+void decoder_output_messagef(r_device *decoder, _Printf_format_string_ char const *restrict format, ...)
 {
     char msg[60]; // fixed length limit
     va_list ap;
@@ -81,7 +81,7 @@ void decoder_output_messagef(r_device *decoder, char const *restrict format, ...
     decoder_output_message(decoder, msg);
 }
 
-void decoder_output_bitbufferf(r_device *decoder, bitbuffer_t const *bitbuffer, char const *restrict format, ...)
+void decoder_output_bitbufferf(r_device *decoder, bitbuffer_t const *bitbuffer, _Printf_format_string_ char const *restrict format, ...)
 {
     char msg[60]; // fixed length limit
     va_list ap;
@@ -91,7 +91,7 @@ void decoder_output_bitbufferf(r_device *decoder, bitbuffer_t const *bitbuffer, 
     decoder_output_bitbuffer(decoder, bitbuffer, msg);
 }
 
-void decoder_output_bitbuffer_arrayf(r_device *decoder, bitbuffer_t const *bitbuffer, char const *restrict format, ...)
+void decoder_output_bitbuffer_arrayf(r_device *decoder, bitbuffer_t const *bitbuffer, _Printf_format_string_ char const *restrict format, ...)
 {
     char msg[60]; // fixed length limit
     va_list ap;
@@ -101,7 +101,7 @@ void decoder_output_bitbuffer_arrayf(r_device *decoder, bitbuffer_t const *bitbu
     decoder_output_bitbuffer_array(decoder, bitbuffer, msg);
 }
 
-void decoder_output_bitrowf(r_device *decoder, uint8_t const *bitrow, unsigned bit_len, char const *restrict format, ...)
+void decoder_output_bitrowf(r_device *decoder, uint8_t const *bitrow, unsigned bit_len, _Printf_format_string_ char const *restrict format, ...)
 {
     char msg[60]; // fixed length limit
     va_list ap;

--- a/src/term_ctl.c
+++ b/src/term_ctl.c
@@ -328,7 +328,7 @@ int term_puts(void *ctx, char const *buf)
     return len;
 }
 
-int term_printf(void *ctx, char const *format, ...)
+int term_printf(void *ctx, _Printf_format_string_ char const *format, ...)
 {
     int len;
     va_list args;
@@ -431,7 +431,7 @@ int term_help_puts(void *ctx, char const *buf)
     return len;
 }
 
-int term_help_printf(char const *format, ...)
+int term_help_printf(_Printf_format_string_ char const *format, ...)
 {
     int len;
     va_list args;


### PR DESCRIPTION
This fixes C28251 warnings as mentioned in #1866 