### PR TITLE
Fix warnings about size_t being cast to a narrower type

### DIFF
--- a/include/bitbuffer.h
+++ b/include/bitbuffer.h
@@ -92,7 +92,7 @@ void bitrow_debug(uint8_t const *bitrow, unsigned bit_len);
 /// @param size the size of @p str
 ///
 /// @return the number of characters printed (not including the trailing `\0`).
-int bitrow_snprint(uint8_t const *bitrow, unsigned bit_len, char *str, unsigned size);
+int bitrow_snprint(uint8_t const *bitrow, unsigned bit_len, char *str, size_t size);
 
 /// Parse a string into a bitbuffer.
 ///

--- a/include/bitbuffer.h
+++ b/include/bitbuffer.h
@@ -13,6 +13,7 @@
 #define INCLUDE_BITBUFFER_H_
 
 #include <stdint.h>
+#include <stddef.h>
 
 // NOTE: Wireless mbus protocol needs at least ((256+16*2+3)*12)/8 => 437 bytes
 //       which fits even if RTL_433_REDUCE_STACK_USE is defined because of row spilling

--- a/src/bitbuffer.c
+++ b/src/bitbuffer.c
@@ -392,7 +392,7 @@ void bitrow_debug(uint8_t const *bitrow, unsigned bit_len)
     print_bitrow(bitrow, bit_len, 0, 1);
 }
 
-int bitrow_snprint(uint8_t const *bitrow, unsigned bit_len, char *str, unsigned size)
+int bitrow_snprint(uint8_t const *bitrow, unsigned bit_len, char *str, size_t size)
 {
     if (bit_len == 0 && size > 0) {
         str[0] = '\0';

--- a/src/confparse.c
+++ b/src/confparse.c
@@ -75,7 +75,7 @@ char *readconf(char const *path)
 
     size_t n_read = fread(conf, sizeof(char), file_size, fp);
     fclose(fp);
-    if (n_read != file_size) {
+    if (n_read != (size_t)file_size) {
         fprintf(stderr, "Failed to read \"%s\"\n", path);
         free(conf);
         return NULL;

--- a/src/confparse.c
+++ b/src/confparse.c
@@ -73,7 +73,7 @@ char *readconf(char const *path)
         return NULL;
     }
 
-    off_t n_read = fread(conf, sizeof(char), file_size, fp);
+    size_t n_read = fread(conf, sizeof(char), file_size, fp);
     fclose(fp);
     if (n_read != file_size) {
         fprintf(stderr, "Failed to read \"%s\"\n", path);

--- a/src/data_tag.c
+++ b/src/data_tag.c
@@ -63,7 +63,7 @@ static void gpsd_client_event(struct mg_connection *nc, int ev, void *ev_data)
             // Success
             fprintf(stderr, "GPSd Connected...\n");
             if (ctx->init_str && *ctx->init_str) {
-                mg_send(nc, ctx->init_str, strlen(ctx->init_str));
+                mg_send(nc, ctx->init_str, (int)strlen(ctx->init_str));
             }
         }
         else {

--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -618,7 +618,7 @@ r_device *flex_create_device(char *spec)
             params->name = strdup(val);
             if (!params->name)
                 FATAL_STRDUP("flex_create_device()");
-            int name_size = strlen(val) + 27;
+            size_t name_size = strlen(val) + 27;
             char* flex_name = malloc(name_size);
             if (!flex_name)
                 FATAL_MALLOC("flex_create_device()");

--- a/src/devices/honeywell_cm921.c
+++ b/src/devices/honeywell_cm921.c
@@ -54,7 +54,7 @@ static data_t *add_hex_string(data_t *data, const char *name, const uint8_t *buf
 {
     if (buf && buf_sz > 0) {
         char tstr[256];
-        bitrow_snprint(buf, buf_sz * 8, tstr, sizeof (tstr));
+        bitrow_snprint(buf, (unsigned int)buf_sz * 8, tstr, sizeof (tstr));
         data = data_append(data, name, "", DATA_STRING, tstr, NULL);
     }
     return data;

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -315,7 +315,7 @@ static data_t *protocols_data(r_cfg_t *cfg)
     }
 
     data_t *data = data_make(
-            "protocols", "", DATA_ARRAY, data_array(devs.len, DATA_DATA, devs.elems),
+            "protocols", "", DATA_ARRAY, data_array((int)devs.len, DATA_DATA, devs.elems),
             NULL);
     list_free_elems(&devs, NULL);
     return data;
@@ -1091,7 +1091,7 @@ static void http_broadcast_send(struct http_server_context *ctx, char const *msg
             mg_set_timer(nc, mg_time() + KEEP_ALIVE); // reset keep alive timer
         }
         else if (cctx && !cctx->is_chunked) {
-            mg_send(nc, msg, len);
+            mg_send(nc, msg, (int)len);
             mg_send(nc, "\r\n", 2);
             mg_set_timer(nc, mg_time() + KEEP_ALIVE); // reset keep alive timer
         }

--- a/src/output_mqtt.c
+++ b/src/output_mqtt.c
@@ -498,9 +498,9 @@ struct data_output *data_output_mqtt_create(struct mg_mgr *mgr, char *param, cha
     //fprintf(stderr, "Hostname: %s\n", hostname);
 
     // generate a short deterministic client_id to identify this input device on restart
-    uint16_t host_crc = crc16((uint8_t *)mqtt->hostname, strlen(mqtt->hostname), 0x1021, 0xffff);
-    uint16_t devq_crc = crc16((uint8_t *)dev_hint, dev_hint ? strlen(dev_hint) : 0, 0x1021, 0xffff);
-    uint16_t parm_crc = crc16((uint8_t *)param, param ? strlen(param) : 0, 0x1021, 0xffff);
+    uint16_t host_crc = crc16((uint8_t *)mqtt->hostname, (unsigned int)strlen(mqtt->hostname), 0x1021, 0xffff);
+    uint16_t devq_crc = crc16((uint8_t *)dev_hint, dev_hint ? (unsigned int)strlen(dev_hint) : 0, 0x1021, 0xffff);
+    uint16_t parm_crc = crc16((uint8_t *)param, param ? (unsigned int)strlen(param) : 0, 0x1021, 0xffff);
     char client_id[21];
     /// MQTT 3.1.1 specifies that the broker MUST accept clients id's between 1 and 23 characters
     snprintf(client_id, sizeof(client_id), "rtl_433-%04x%04x%04x", host_crc, devq_crc, parm_crc);

--- a/src/output_rtltcp.c
+++ b/src/output_rtltcp.c
@@ -391,7 +391,7 @@ static int rtltcp_server_start(rtltcp_server_t *srv, char const *host, char cons
             srv->sock = sock;
             memset(&srv->addr, 0, sizeof(srv->addr));
             memcpy(&srv->addr, res->ai_addr, res->ai_addrlen);
-            srv->addr_len = res->ai_addrlen;
+            srv->addr_len = (socklen_t)res->ai_addrlen;
             break; // success
         }
     }

--- a/src/output_rtltcp.c
+++ b/src/output_rtltcp.c
@@ -116,7 +116,12 @@ static ssize_t send_all(int sockfd, void const *buf, size_t len, int flags)
 {
     size_t sent = 0;
     while (sent < len) {
-        ssize_t ret = send(sockfd, (uint8_t *)buf + sent, len - sent, flags);
+        ssize_t ret = send(sockfd, (uint8_t *)buf + sent,
+#ifdef _WIN32
+            (int)
+#endif
+            (len - sent), flags);
+
         if (ret < 0)
             return ret;
         sent += (size_t)ret;

--- a/src/output_udp.c
+++ b/src/output_udp.c
@@ -107,7 +107,7 @@ static int datagram_client_open(datagram_client_t *client, const char *host, con
             client->sock = sock;
             memset(&client->addr, 0, sizeof(client->addr));
             memcpy(&client->addr, res->ai_addr, res->ai_addrlen);
-            client->addr_len = res->ai_addrlen;
+            client->addr_len = (socklen_t)res->ai_addrlen;
             break; // success
         }
     }

--- a/src/output_udp.c
+++ b/src/output_udp.c
@@ -140,7 +140,11 @@ static void datagram_client_close(datagram_client_t *client)
 
 static void datagram_client_send(datagram_client_t *client, const char *message, size_t message_len)
 {
-    int r =  sendto(client->sock, message, message_len, 0, (struct sockaddr *)&client->addr, client->addr_len);
+    int r =  sendto(client->sock, message,
+#ifdef _WIN32
+        (int)
+#endif
+        message_len, 0, (struct sockaddr *)&client->addr, client->addr_len);
     if (r == -1) {
         perror("sendto");
     }

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -476,7 +476,7 @@ char const **determine_csv_fields(r_cfg_t *cfg, char const *const *well_known, i
     convert_csv_fields(cfg, (char const **)field_list.elems);
 
     if (num_fields)
-        *num_fields = field_list.len;
+        *num_fields = (int)field_list.len;
     return (char const **)field_list.elems;
 }
 
@@ -963,7 +963,7 @@ data_t *create_report_data(r_cfg_t *cfg, int level)
             "enabled",          "", DATA_INT, r_devs->len,
             "since",            "", DATA_STRING, since_str,
             "frames",           "", DATA_DATA, data,
-            "stats",            "", DATA_ARRAY, data_array(dev_data_list.len, DATA_DATA, dev_data_list.elems),
+            "stats",            "", DATA_ARRAY, data_array((int)dev_data_list.len, DATA_DATA, dev_data_list.elems),
             NULL);
 
     list_free_elems(&dev_data_list, NULL);

--- a/src/r_util.c
+++ b/src/r_util.c
@@ -146,8 +146,8 @@ float inhg2hpa(float inhg)
 
 bool str_endswith(char const *restrict str, char const *restrict suffix)
 {
-    int str_len = strlen(str);
-    int suffix_len = strlen(suffix);
+    size_t str_len = strlen(str);
+    size_t suffix_len = strlen(suffix);
 
     return (str_len >= suffix_len) &&
            (0 == strcmp(str + (str_len - suffix_len), suffix));
@@ -162,8 +162,8 @@ char *str_replace(char const *orig, char const *rep, char const *with)
     char *result;  // the return string
     char const *ins; // the next insert point
     char *tmp;     // varies
-    int len_rep;   // length of rep (the string to remove)
-    int len_with;  // length of with (the string to replace rep with)
+    size_t len_rep;  // length of rep (the string to remove)
+    size_t len_with; // length of with (the string to replace rep with)
     int len_front; // distance between rep and end of last rep
     int count;     // number of replacements
 

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1877,7 +1877,7 @@ int main(int argc, char **argv) {
 
             // default case for file-inputs
             int n_blocks = 0;
-            unsigned long n_read;
+            size_t n_read;
             delay_timer_t delay_timer;
             delay_timer_init(&delay_timer);
             do {
@@ -1915,7 +1915,7 @@ int main(int argc, char **argv) {
                 if (n_read == 0) break;  // sdr_callback() will Segmentation Fault with len=0
                 demod->sample_file_pos = ((float)n_blocks * DEFAULT_BUF_LENGTH + n_read) / cfg->samp_rate / demod->sample_size;
                 n_blocks++; // this assumes n_read == DEFAULT_BUF_LENGTH
-                sdr_callback(test_mode_buf, n_read, cfg);
+                sdr_callback(test_mode_buf, (uint32_t)n_read, cfg);
             } while (n_read != 0 && !cfg->exit_async);
 
             // Call a last time with cleared samples to ensure EOP detection

--- a/src/sdr.c
+++ b/src/sdr.c
@@ -174,7 +174,7 @@ static int rtltcp_open(sdr_dev_t **out_dev, char const *dev_query, int verbose)
     for (res = res0; res; res = res->ai_next) {
         sock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
         if (sock >= 0) {
-            ret = connect(sock, res->ai_addr, res->ai_addrlen);
+            ret = connect(sock, res->ai_addr, (int)res->ai_addrlen);
             if (ret == -1) {
                 perror("connect");
                 sock = INVALID_SOCKET;


### PR DESCRIPTION
This fixes a few C4267 warning as reported in #1866 because the x64 target defines `size_t` as a 64 bit unsigned integer.