### PR TITLE
Add file meta data as watermark

### DIFF
--- a/include/fileformat.h
+++ b/include/fileformat.h
@@ -117,6 +117,20 @@ void file_info_clear(file_info_t *info);
 /// @return the detected file format, 0 otherwise
 int file_info_parse_filename(file_info_t *info, const char *filename);
 
+/// Detect a watermark from cu8, cs8, cs16, cf32 files and set file info.
+///
+/// @param[in,out] info the file info to parse into
+/// @param buf the IQ sample data, needs to be at least 1024 bytes length
+/// @param verbose the verbosity level for reports to stderr
+/// @return the detected file format, 0 otherwise
+int file_info_get_watermark(file_info_t *info, uint8_t *buf, int verbose);
+
+/// Re-apply overrides from file name to file info.
+///
+/// @param[in,out] info the file info to override
+/// @return the detected file format, 0 otherwise
+int file_info_apply_overrides(file_info_t *info);
+
 /// Check if the format in this file info is supported for reading,
 /// print a warning and exit otherwise.
 ///
@@ -134,5 +148,44 @@ void file_info_check_write(file_info_t *info);
 /// @param info the file info to check
 /// @return a string describing the format
 char const *file_info_string(file_info_t *info);
+
+/// Insert a 128 bit watermark of "SDR:IQcu",rate,freq into the first 128 samples (256 bytes).
+///
+/// @param[in,out] buf the IQ sample data, needs to be at least 256 bytes length
+/// @param sample_rate the sample rate to encode in the watermark
+/// @param center_frequency the center frequency to encode in the watermark
+void watermark_set_cu8(uint8_t *buf, uint32_t sample_rate, uint32_t center_frequency);
+
+/// Insert a 128 bit watermark of "SDR:IQcs",rate,freq into the first 128 samples (256 bytes).
+///
+/// @param[in,out] buf the IQ sample data, needs to be at least 256 bytes length
+/// @param sample_rate the sample rate to encode in the watermark
+/// @param center_frequency the center frequency to encode in the watermark
+void watermark_set_cs8(int8_t *buf, uint32_t sample_rate, uint32_t center_frequency);
+
+/// Insert a 128 bit watermark of "SDR:IQcs",rate,freq into the first 128 samples (512 bytes).
+///
+/// @param[in,out] buf the IQ sample data, needs to be at least 512 bytes length
+/// @param sample_rate the sample rate to encode in the watermark
+/// @param center_frequency the center frequency to encode in the watermark
+void watermark_set_cs16(int16_t *buf, uint32_t sample_rate, uint32_t center_frequency);
+
+/// Insert a 128 bit watermark of "SDR:IQcs",rate,freq into the first 128 samples (1024 bytes).
+///
+/// @param[in,out] buf the IQ sample data, needs to be at least 1024 bytes length
+/// @param sample_rate the sample rate to encode in the watermark
+/// @param center_frequency the center frequency to encode in the watermark
+void watermark_set_cf32(float *buf, uint32_t sample_rate, uint32_t center_frequency);
+
+/// Detect a watermark from cu8, cs8, cs16, cf32 files.
+///
+/// @param buf the IQ sample data, needs to be at least 1024 bytes length
+/// @param[out] format set to the detected format if a watermark is found
+/// @param[out] sample_rate set to the detected sample rate if a watermark is found
+/// @param[out] center_frequency set to the detected center frequency if a watermark is found
+/// @return 1 if a watermark was found, 0 otherwise
+/// @retval 0 no watermark was found
+/// @retval 1 a watermark was found
+int watermark_get(uint8_t *buf, uint32_t *format, uint32_t *sample_rate, uint32_t *center_frequency, int verbose);
 
 #endif /* INCLUDE_FILEFORMAT_H_ */


### PR DESCRIPTION
Here is an idea to add critical file meta data as watermark in first few samples.

It's at the absolute lowest dB (LSB in the stronger of an I/Q pair) and will be invisible (we don't expect data in the first few samples anyway though). Fully compatible with all other applications, as the data is somewhat steganographically hidden.

We should then test files for a watermark, otherwise default to the filename info, and after that override with arguments if present.

Just a demo for now to get feedback.