### PR TITLE
Fix arithmetics overflow warnings with VS2019

### DIFF
--- a/src/baseband.c
+++ b/src/baseband.c
@@ -86,7 +86,7 @@ float magnitude_true_cu8(uint8_t const *iq_buf, uint16_t *y_buf, uint32_t len)
     for (i = 0; i < len; i++) {
         int16_t x = iq_buf[2 * i] - 128;
         int16_t y = iq_buf[2 * i + 1] - 128;
-        y_buf[i]  = (uint16_t)(sqrt(x * x + y * y) * 128.0); // max 181, scaled 23170, fs 16384
+        y_buf[i]  = (uint16_t)(sqrt((double)x * x + (double)y * y) * 128.0); // max 181, scaled 23170, fs 16384
         sum += y_buf[i];
     }
     return len > 0 && sum >= len ? MAG_TO_DB((float)sum / len) : MAG_TO_DB(1);
@@ -117,7 +117,7 @@ float magnitude_true_cs16(int16_t const *iq_buf, uint16_t *y_buf, uint32_t len)
     for (i = 0; i < len; i++) {
         int32_t x = iq_buf[2 * i];
         int32_t y = iq_buf[2 * i + 1];
-        y_buf[i]  = (int)sqrt(x * x + y * y) >> 1; // max 46341, scaled 23170, fs 16384
+        y_buf[i]  = (int)sqrt((double)x * x + (double)y * y) >> 1; // max 46341, scaled 23170, fs 16384
         sum += y_buf[i];
     }
     return len > 0 && sum >= len ? MAG_TO_DB((float)sum / len) : MAG_TO_DB(1);
@@ -126,7 +126,7 @@ float magnitude_true_cs16(int16_t const *iq_buf, uint16_t *y_buf, uint32_t len)
 
 // Fixed-point arithmetic on Q0.15
 #define F_SCALE 15
-#define S_CONST (1 << F_SCALE)
+#define S_CONST ((int)(1 << F_SCALE))
 #define FIX(x) ((int)(x * S_CONST))
 
 /** Something that might look like a IIR lowpass filter.
@@ -212,7 +212,7 @@ void baseband_demod_FM(uint8_t const *x_buf, int16_t *y_buf, unsigned long num_s
             low_pass = 1e6f / low_pass / samp_rate;
         }
         print_logf(LOG_NOTICE, "Baseband", "low pass filter for %u Hz at cutoff %.0f Hz, %.1f us",
-                samp_rate, samp_rate * low_pass, 1e6 / (samp_rate * low_pass));
+                samp_rate, samp_rate * (double)low_pass, 1e6 / (samp_rate * (double)low_pass));
         double ita  = 1.0 / tan(M_PI_2 * low_pass);
         double gain = 1.0 / (1.0 + ita) / 2; // prescaled by div 2
         state->alp_16[0] = FIX(1.0);
@@ -265,7 +265,7 @@ void baseband_demod_FM(uint8_t const *x_buf, int16_t *y_buf, unsigned long num_s
 
 // Fixed-point arithmetic on Q0.31 (actually Q0.30 to counter 64 signed trouble)
 #define F_SCALE32 30
-#define S_CONST32 (1 << F_SCALE32)
+#define S_CONST32 ((int)(1 << F_SCALE32))
 #define FIX32(x) ((int)(x * S_CONST32))
 
 /// for evaluation.
@@ -305,7 +305,7 @@ void baseband_demod_FM_cs16(int16_t const *x_buf, int16_t *y_buf, unsigned long 
             low_pass = 1e6f / low_pass / samp_rate;
         }
         print_logf(LOG_NOTICE, "Baseband", "low pass filter for %u Hz at cutoff %.0f Hz, %.1f us",
-                samp_rate, samp_rate * low_pass, 1e6 / (samp_rate * low_pass));
+                samp_rate, samp_rate * (double)low_pass, 1e6 / (samp_rate * (double)low_pass));
         double ita  = 1.0 / tan(M_PI_2 * low_pass);
         double gain = 1.0 / (1.0 + ita);
         state->alp_32[0] = FIX32(1.0);

--- a/src/pulse_analyzer.c
+++ b/src/pulse_analyzer.c
@@ -256,8 +256,8 @@ void pulse_analyzer(pulse_data_t *data, int package_type, r_device* device)
             data->rssi_db, data->snr_db, data->noise_db);
     fprintf(stderr, "Frequency offsets [F1, F2]:  %6i, %6i\t(%+.1f kHz, %+.1f kHz)\n",
             data->fsk_f1_est, data->fsk_f2_est,
-            (float)data->fsk_f1_est / INT16_MAX * data->sample_rate / 2.0 / 1000.0,
-            (float)data->fsk_f2_est / INT16_MAX * data->sample_rate / 2.0 / 1000.0);
+            ((float)data->fsk_f1_est / INT16_MAX) * (data->sample_rate / 2.0 / 1000.0),
+            ((float)data->fsk_f2_est / INT16_MAX) * (data->sample_rate / 2.0 / 1000.0));
 
     fprintf(stderr, "Guessing modulation: ");
     device->name    = "Analyzer Device",

--- a/src/pulse_analyzer.c
+++ b/src/pulse_analyzer.c
@@ -280,8 +280,8 @@ void pulse_analyzer(pulse_data_t *data, int package_type, r_device* device)
         device->modulation  = OOK_PULSE_PPM; // TODO: there is not FSK_PULSE_PPM
         device->short_width = to_us * hist_gaps.bins[0].mean;
         device->long_width  = to_us * hist_gaps.bins[1].mean;
-        device->gap_limit   = to_us * (hist_gaps.bins[1].max + 1);                        // Set limit above next lower gap
-        device->reset_limit = to_us * (hist_gaps.bins[hist_gaps.bins_count - 1].max + 1); // Set limit above biggest gap
+        device->gap_limit   = to_us * (hist_gaps.bins[1].max + 1.0);                        // Set limit above next lower gap
+        device->reset_limit = to_us * (hist_gaps.bins[hist_gaps.bins_count - 1].max + 1.0); // Set limit above biggest gap
     }
     else if (hist_pulses.bins_count == 2 && hist_gaps.bins_count == 1) {
         fprintf(stderr, "Pulse Width Modulation with fixed gap\n");
@@ -289,7 +289,7 @@ void pulse_analyzer(pulse_data_t *data, int package_type, r_device* device)
         device->short_width = to_us * hist_pulses.bins[0].mean;
         device->long_width  = to_us * hist_pulses.bins[1].mean;
         device->tolerance   = (device->long_width - device->short_width) * 0.4;
-        device->reset_limit = to_us * (hist_gaps.bins[hist_gaps.bins_count - 1].max + 1); // Set limit above biggest gap
+        device->reset_limit = to_us * (hist_gaps.bins[hist_gaps.bins_count - 1].max + 1.0); // Set limit above biggest gap
     }
     else if (hist_pulses.bins_count == 2 && hist_gaps.bins_count == 2 && hist_periods.bins_count == 1) {
         fprintf(stderr, "Pulse Width Modulation with fixed period\n");
@@ -297,23 +297,23 @@ void pulse_analyzer(pulse_data_t *data, int package_type, r_device* device)
         device->short_width = to_us * hist_pulses.bins[0].mean;
         device->long_width  = to_us * hist_pulses.bins[1].mean;
         device->tolerance   = (device->long_width - device->short_width) * 0.4;
-        device->reset_limit = to_us * (hist_gaps.bins[hist_gaps.bins_count - 1].max + 1); // Set limit above biggest gap
+        device->reset_limit = to_us * (hist_gaps.bins[hist_gaps.bins_count - 1].max + 1.0); // Set limit above biggest gap
     }
     else if (hist_pulses.bins_count == 2 && hist_gaps.bins_count == 2 && hist_periods.bins_count == 3) {
         fprintf(stderr, "Manchester coding\n");
         device->modulation  = (package_type == PULSE_DATA_FSK) ? FSK_PULSE_MANCHESTER_ZEROBIT : OOK_PULSE_MANCHESTER_ZEROBIT;
         device->short_width = to_us * MIN(hist_pulses.bins[0].mean, hist_pulses.bins[1].mean); // Assume shortest pulse is half period
         device->long_width  = 0;                                                               // Not used
-        device->reset_limit = to_us * (hist_gaps.bins[hist_gaps.bins_count - 1].max + 1);      // Set limit above biggest gap
+        device->reset_limit = to_us * (hist_gaps.bins[hist_gaps.bins_count - 1].max + 1.0);      // Set limit above biggest gap
     }
     else if (hist_pulses.bins_count == 2 && hist_gaps.bins_count >= 3) {
         fprintf(stderr, "Pulse Width Modulation with multiple packets\n");
         device->modulation  = (package_type == PULSE_DATA_FSK) ? FSK_PULSE_PWM : OOK_PULSE_PWM;
         device->short_width = to_us * hist_pulses.bins[0].mean;
         device->long_width  = to_us * hist_pulses.bins[1].mean;
-        device->gap_limit   = to_us * (hist_gaps.bins[1].max + 1); // Set limit above second gap
+        device->gap_limit   = to_us * (hist_gaps.bins[1].max + 1.0); // Set limit above second gap
         device->tolerance   = (device->long_width - device->short_width) * 0.4;
-        device->reset_limit = to_us * (hist_gaps.bins[hist_gaps.bins_count - 1].max + 1); // Set limit above biggest gap
+        device->reset_limit = to_us * (hist_gaps.bins[hist_gaps.bins_count - 1].max + 1.0); // Set limit above biggest gap
     }
     else if ((hist_pulses.bins_count >= 3 && hist_gaps.bins_count >= 3)
             && (abs(hist_pulses.bins[1].mean - 2*hist_pulses.bins[0].mean) <= hist_pulses.bins[0].mean/8)    // Pulses are multiples of shortest pulse
@@ -337,7 +337,7 @@ void pulse_analyzer(pulse_data_t *data, int package_type, r_device* device)
         device->short_width = to_us * (p1 < p2 ? p1 : p2);                                // Set to shorter pulse width
         device->long_width  = to_us * (p1 < p2 ? p2 : p1);                                // Set to longer pulse width
         device->sync_width  = to_us * hist_pulses.bins[0].mean;                           // Set to lowest count pulse width
-        device->reset_limit = to_us * (hist_gaps.bins[hist_gaps.bins_count - 1].max + 1); // Set limit above biggest gap
+        device->reset_limit = to_us * (hist_gaps.bins[hist_gaps.bins_count - 1].max + 1.0); // Set limit above biggest gap
     }
     else {
         fprintf(stderr, "No clue...\n");


### PR DESCRIPTION
This fixes warnings of this kind, seen via #1866:

> Warning C26451 Arithmetic overflow: Using operator '*' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '*' to avoid overflow (io.2).