### PR TITLE
add _CRT_NONSTDC_NO_DEPRECATE to avoid the C4996 warning

### DIFF
--- a/vs15/rtl_433.vcxproj
+++ b/vs15/rtl_433.vcxproj
@@ -54,7 +54,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>RTLSDR;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>RTLSDR;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\include\;..\src\;..\..\rtl-sdr\;..\..\libusb\include\libusb-1.0</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>


### PR DESCRIPTION
Add _CRT_NONSTDC_NO_DEPRECATE to avoid the C4996 warning POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name) which is more of an annoyance than anything else.

This fixes warnings discussed in #1866 

Note that I tried various "tricks" to get rid of it only for the few functions that were reported, none worked (`#define`, `inline` methods...)