### PR TITLE
Fix irregular model names

### DIFF
--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -242,7 +242,7 @@ static int flex_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         /* clang-format off */
         data = data_make(
-                "model", "", DATA_STRING, params->name, // "User-defined model"
+                "model", "", DATA_STRING, params->name, // "User-defined"
                 "count", "", DATA_INT, match_count,
                 "num_rows", "", DATA_INT, bitbuffer->num_rows,
                 "len", "", DATA_INT, bitbuffer->bits_per_row[r],
@@ -260,7 +260,7 @@ static int flex_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (params->count_only) {
         /* clang-format off */
         data = data_make(
-                "model", "", DATA_STRING, params->name, // "User-defined model"
+                "model", "", DATA_STRING, params->name, // "User-defined"
                 "count", "", DATA_INT, match_count,
                 NULL);
         /* clang-format on */
@@ -291,7 +291,7 @@ static int flex_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     }
     /* clang-format off */
     data = data_make(
-            "model", "", DATA_STRING, params->name, // "User-defined model"
+            "model", "", DATA_STRING, params->name, // "User-defined"
             "count", "", DATA_INT, match_count,
             "num_rows", "", DATA_INT, bitbuffer->num_rows,
             "rows", "", DATA_ARRAY, data_array(bitbuffer->num_rows, DATA_DATA, row_data),

--- a/src/devices/inkbird_ith20r.c
+++ b/src/devices/inkbird_ith20r.c
@@ -128,7 +128,7 @@ static int inkbird_ith20r_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",            "",             DATA_STRING, "Inkbird ITH-20R",
+            "model",            "",             DATA_STRING, "Inkbird-ITH20R",
             "id",               "",             DATA_INT,    sensor_id,
             "battery",          "Battery",      DATA_INT,    battery,
             "sensor_num",       "",             DATA_INT,    sensor_num,

--- a/src/devices/klimalogg.c
+++ b/src/devices/klimalogg.c
@@ -76,7 +76,7 @@ static int klimalogg_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data_t *data = data_make(
-            "model",            "",                 DATA_STRING, "Klimalogg Pro",
+            "model",            "",                 DATA_STRING, "Klimalogg-Pro",
             "id",               "Id",               DATA_FORMAT, "%04x", DATA_INT, id,
             "battery_ok",       "Battery",          DATA_INT,    !battery_low,
             "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C",      DATA_DOUBLE, temperature,

--- a/src/devices/lacrosse_ws7000.c
+++ b/src/devices/lacrosse_ws7000.c
@@ -100,7 +100,7 @@ static int lacrosse_ws7000_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
         /* clang-format off */
         data = data_make(
-                "model",            "",                 DATA_STRING, "LaCrosse-WS7000-27/28",
+                "model",            "",                 DATA_STRING, "LaCrosse-WS700027",
                 "id",               "",                 DATA_INT,    id,
                 "channel",          "",                 DATA_INT,    addr,
                 "temperature_C",    "Temperature",      DATA_DOUBLE, temperature,
@@ -119,7 +119,7 @@ static int lacrosse_ws7000_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
         /* clang-format off */
         data = data_make(
-                "model",            "",                 DATA_STRING, "LaCrosse-WS7000-22/25",
+                "model",            "",                 DATA_STRING, "LaCrosse-WS700022",
                 "id",               "",                 DATA_INT,    id,
                 "channel",          "",                 DATA_INT,    addr,
                 "temperature_C",    "Temperature",      DATA_DOUBLE, temperature,
@@ -137,7 +137,7 @@ static int lacrosse_ws7000_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
         /* clang-format off */
         data = data_make(
-                "model",            "",                 DATA_STRING, "LaCrosse-WS7000-16",
+                "model",            "",                 DATA_STRING, "LaCrosse-WS700016",
                 "id",               "",                 DATA_INT,    id,
                 "channel",          "",                 DATA_INT,    addr,
                 "rain_mm",          "Rain counter",     DATA_DOUBLE, rain * 0.3,
@@ -156,7 +156,7 @@ static int lacrosse_ws7000_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
         /* clang-format off */
         data = data_make(
-                "model",            "",                 DATA_STRING, "LaCrosse-WS7000-15",
+                "model",            "",                 DATA_STRING, "LaCrosse-WS700015",
                 "id",               "",                 DATA_INT,    id,
                 "channel",          "",                 DATA_INT,    addr,
                 "wind_avg_km_h",    "Wind speed",       DATA_DOUBLE, speed,
@@ -178,7 +178,7 @@ static int lacrosse_ws7000_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
         /* clang-format off */
         data = data_make(
-                "model",            "",                 DATA_STRING, "LaCrosse-WS7000-20",
+                "model",            "",                 DATA_STRING, "LaCrosse-WS700020",
                 "id",               "",                 DATA_INT,    id,
                 "channel",          "",                 DATA_INT,    addr,
                 "temperature_C",    "Temperature",      DATA_DOUBLE, temperature,
@@ -201,7 +201,7 @@ static int lacrosse_ws7000_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
         /* clang-format off */
         data = data_make(
-                "model",            "",                 DATA_STRING, "LaCrosse-WS2500-19",
+                "model",            "",                 DATA_STRING, "LaCrosse-WS250019",
                 "id",               "",                 DATA_INT,    id,
                 "channel",          "",                 DATA_INT,    addr,
                 "light_lux",        "Brightness",       DATA_INT,    brightness,

--- a/src/devices/new_template.c
+++ b/src/devices/new_template.c
@@ -242,7 +242,7 @@ static int new_template_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model", "", DATA_STRING, "New Template",
+            "model", "", DATA_STRING, "New-Template",
             "id",    "", DATA_INT,    sensor_id,
             "data",  "", DATA_INT,    value,
             "mic",   "", DATA_STRING, "CHECKSUM", // CRC, CHECKSUM, or PARITY

--- a/src/devices/scmplus.c
+++ b/src/devices/scmplus.c
@@ -156,7 +156,7 @@ static int scmplus_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",            "",                 DATA_STRING, "SCM+", // TODO: bad name for e.g. MQTT
+            "model",            "",                 DATA_STRING, "SCMplus",
             "id",               "",                 DATA_INT,    endpoint_id,
             "ProtocolID",       "Protocol_ID",      DATA_STRING, protocol_id_str, // TODO: this should be int
             "EndpointType",     "Endpoint_Type",    DATA_STRING, endpoint_type_str, // TODO: this should be int

--- a/src/devices/secplus_v1.c
+++ b/src/devices/secplus_v1.c
@@ -371,7 +371,7 @@ static int secplus_v1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     // fprintf(stderr,  "# Security+:  rolling=2320615320  fixed=1846948897  (id1=2 id0=0 switch=1 remote_id=68405514 button=left)\n");
     /* clang-format off */
     data_t *data = data_make(
-            "model",        "",             DATA_STRING, "Secplus_v1",
+            "model",        "",             DATA_STRING, "Secplus-v1",
             "id",           "",             DATA_INT,    id,
             "id0",          "ID_0",         DATA_INT,    id0,
             "id1",          "ID_1",         DATA_INT,    id1,

--- a/src/devices/tpms_abarth124.c
+++ b/src/devices/tpms_abarth124.c
@@ -74,7 +74,7 @@ static int tpms_abarth124_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsi
 
     /* clang-format off */
     data = data_make(
-            "model",            "",             DATA_STRING, "Abarth 124 Spider",
+            "model",            "",             DATA_STRING, "Abarth-124Spider",
             "type",             "",             DATA_STRING, "TPMS",
             "id",               "",             DATA_STRING, id_str,
             "flags",            "",             DATA_STRING, flags,

--- a/src/devices/tpms_jansite_solar.c
+++ b/src/devices/tpms_jansite_solar.c
@@ -82,7 +82,7 @@ static int tpms_jansite_solar_decode(r_device *decoder, bitbuffer_t *bitbuffer, 
 
     /* clang-format off */
     data = data_make(
-            "model",            "",             DATA_STRING, "Jansite Solar",
+            "model",            "",             DATA_STRING, "Jansite-Solar",
             "type",             "",             DATA_STRING, "TPMS",
             "id",               "",             DATA_STRING, id_str,
             "flags",            "",             DATA_INT, flags,

--- a/tests/symbolizer.py
+++ b/tests/symbolizer.py
@@ -237,6 +237,8 @@ def process_source(path, name):
                 if not fName:
                     err(f"::error file={name},line={i + 1}::No func")
                 for model in models:
+                    if not re.match(r'^[A-Za-z][0-9A-Za-z"]+(-[0-9A-Za-z"]+)?$', model):
+                        log(f"::error file={name},line={i + 1}::Bad model name \"{model}\"")
                     if model in links and links[model]["func"] != fName:
                         log(f"::notice file={name},line={i + 1}::Reused model")
                     elif model in links:


### PR DESCRIPTION
Fixes the last irregular model names that slipped though. Also adds a strict model name check.

**This is a breaking change**

- `Inkbird ITH-20R` -> `Inkbird-ITH20R`
- `LaCrosse-WS7000-27/28` -> `LaCrosse-WS700027`
- `LaCrosse-WS7000-22/25` -> `LaCrosse-WS700022`
- `LaCrosse-WS7000-16` -> `LaCrosse-WS700016`
- `LaCrosse-WS7000-15` -> `LaCrosse-WS700015`
- `LaCrosse-WS7000-20` -> `LaCrosse-WS700020`
- `LaCrosse-WS2500-19` -> `LaCrosse-WS250019`
- `Abarth 124 Spider` -> `Abarth-124Spider`
- `Jansite Solar` -> `Jansite-Solar`
- `Klimalogg Pro` -> `Klimalogg-Pro`
- `Secplus_v1` -> `Secplus-v1`
- `SCM+` -> `SCMplus`

Not great that we missed this before, but we do want to guarantee consumers a simple and safe key for use in e.g. filenames and MQTT.