### PR TITLE
update value template in rtl_433_mqtt_hass.py for `battery_ok` to allow for float and double battery values

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -172,7 +172,7 @@ mappings = {
             "device_class": "battery",
             "name": "Battery",
             "unit_of_measurement": "%",
-            "value_template": "{{ float(value|int) * 99 + 1 }}",
+            "value_template": "{{ float(value) * 99 + 1 }}",
             "state_class": "measurement"
         }
     },


### PR DESCRIPTION
This was spurred by the fact that I am working tonight on finally having my Govee leak sensors report events in Homeassistant (thanks to the excellent work in #1653, thanks everyone), and relying on [rtl_433_mqtt_hass.py](https://github.com/merbanan/rtl_433/blob/master/examples/rtl_433_mqtt_hass.py) to get me there.

The battery value was being reported as 1% due to the fact that `0.79` was being converted to int (0), then float (0.0), then multiplied by 99, adding 1. For devices reporting binary values of 0 and 1 for OK, this is still functional. For devices reporting integer values from 0-100, this will break down.

Architecturally, it may be a halfway decent solution to start reporting `battery_level` (float) and `battery_ok` (binary) as two distinct output fields for device drivers, but that's probably a different discussion altogether.