### PR TITLE
Add decoder priority stages

### DIFF
--- a/include/r_device.h
+++ b/include/r_device.h
@@ -53,7 +53,8 @@ typedef struct r_device {
     float tolerance;
     int (*decode_fn)(struct r_device *decoder, struct bitbuffer *bitbuffer);
     struct r_device *(*create_fn)(char *args);
-    unsigned disabled;
+    unsigned priority; ///< Run later and only if no previous events were produced
+    unsigned disabled; ///< 0: default enabled, 1: default disabled, 2: disabled, 3: disabled and hidden
     char **fields; ///< List of fields this decoder produces; required for CSV output. NULL-terminated.
 
     /* public for each decoder */

--- a/src/devices/alecto.c
+++ b/src/devices/alecto.c
@@ -75,10 +75,8 @@ Format for Winddirection & Windgust:
 
 #include "decoder.h"
 
-// NOTE: this is used in prologue.c, springfield.c, and thermopro_tx2.c
-int alecto_checksum(uint8_t *b);
 // return 1 if the checksum passes and 0 if it fails
-int alecto_checksum(uint8_t *b)
+static int alecto_checksum(uint8_t *b)
 {
     int csum = 0;
     for (int i = 0; i < 4; i++) {

--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -338,6 +338,7 @@ static void help()
             "\treset=<reset> (or: r=<reset>)\n"
             "\tgap=<gap> (or: g=<gap>)\n"
             "\ttolerance=<tolerance> (or: t=<tolerance>)\n"
+            "\tpriority=<n> : run decoder only as fallback\n"
             "where:\n"
             "<name> can be any descriptive name tag you need in the output\n"
             "<modulation> is one of:\n"
@@ -573,6 +574,8 @@ r_device *flex_create_device(char *spec)
             dev->reset_limit = atoi(val);
         else if (!strcasecmp(key, "t") || !strcasecmp(key, "tolerance"))
             dev->tolerance = atoi(val);
+        else if (!strcasecmp(key, "prio") || !strcasecmp(key, "priority"))
+            dev->priority = atoi(val);
 
         else if (!strcasecmp(key, "bits>"))
             params->min_bits = val ? atoi(val) : 0;

--- a/src/devices/prologue.c
+++ b/src/devices/prologue.c
@@ -31,8 +31,6 @@ The data is grouped in 9 nibbles
 
 #include "decoder.h"
 
-extern int alecto_checksum(uint8_t *b);
-
 static int prologue_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     uint8_t *b;
@@ -59,10 +57,6 @@ static int prologue_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     b = bitbuffer->bb[r];
 
     if ((b[0] & 0xF0) != 0x90 && (b[0] & 0xF0) != 0x50)
-        return DECODE_FAIL_SANITY;
-
-    // Check for Alecto collision, if the checksum is correct it's not Prologue/ThermoPro-TX2
-    if (alecto_checksum(b))
         return DECODE_FAIL_SANITY;
 
     // Prologue/ThermoPro-TX2 sensor
@@ -112,6 +106,6 @@ r_device prologue = {
         .gap_limit   = 7000,
         .reset_limit = 10000,
         .decode_fn   = &prologue_callback,
-        .disabled    = 0,
+        .priority    = 10, // Alecto collision, if Alecto checksum is correct it's not Prologue/ThermoPro-TX2
         .fields      = output_fields,
 };

--- a/src/devices/springfield.c
+++ b/src/devices/springfield.c
@@ -31,8 +31,6 @@ Actually 37 bits for all but last transmission which is 36 bits.
 
 #include "decoder.h"
 
-extern int alecto_checksum(uint8_t *b);
-
 static int springfield_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     int ret = 0;
@@ -54,10 +52,6 @@ static int springfield_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         chk = (chk >> 4) ^ (chk & 0x0f); // fold to nibble
         if (chk != 0)
             continue; // DECODE_FAIL_MIC
-
-        // Check for Alecto collision, if the checksum is correct it's not Springfield-Soil
-        if (alecto_checksum(b))
-            continue; // DECODE_FAIL_SANITY
 
         int sid      = (b[0]);
         int battery  = (b[1] >> 7) & 1;
@@ -117,6 +111,6 @@ r_device springfield = {
         .gap_limit   = 5000,
         .reset_limit = 9200,
         .decode_fn   = &springfield_decode,
-        .disabled    = 0,
-        .fields      = output_fields
+        .priority    = 10, // Alecto collision, if Alecto checksum is correct it's not Springfield-Soil
+        .fields      = output_fields,
 };

--- a/src/devices/tfa_30_3221.c
+++ b/src/devices/tfa_30_3221.c
@@ -110,5 +110,6 @@ r_device tfa_30_3221 = {
         .reset_limit = 850,
         .sync_width  = 836,
         .decode_fn   = &tfa_303221_callback,
+        .priority    = 10, // This is the same as LaCrosse-TX141THBv2
         .fields      = output_fields,
 };

--- a/src/devices/thermopro_tx2.c
+++ b/src/devices/thermopro_tx2.c
@@ -38,8 +38,6 @@ The data is grouped in 9 nibbles
 
 #include "decoder.h"
 
-extern int alecto_checksum(uint8_t *b);
-
 static int thermopro_tx2_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     uint8_t *b;
@@ -66,10 +64,6 @@ static int thermopro_tx2_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     b = bitbuffer->bb[r];
 
     if ((b[0] & 0xF0) != 0x90 && (b[0] & 0xF0) != 0x50)
-        return DECODE_FAIL_SANITY;
-
-    // Check for Alecto collision, if the checksum is correct it's not Prologue/ThermoPro-TX2
-    if (alecto_checksum(b))
         return DECODE_FAIL_SANITY;
 
     // Prologue/ThermoPro-TX2 sensor
@@ -120,5 +114,6 @@ r_device thermopro_tx2 = {
         .reset_limit = 10000,
         .decode_fn   = &thermopro_tx2_decode,
         .disabled    = 1,
+        .priority    = 10, // Alecto collision, if Alecto checksum is correct it's not Prologue/ThermoPro-TX2
         .fields      = output_fields,
 };

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -468,43 +468,56 @@ int run_ook_demods(list_t *r_devs, pulse_data_t *pulse_data)
 {
     int p_events = 0;
 
-    for (void **iter = r_devs->elems; iter && *iter; ++iter) {
-        r_device *r_dev = *iter;
-        switch (r_dev->modulation) {
-        case OOK_PULSE_PCM_RZ:
-            p_events += pulse_demod_pcm(pulse_data, r_dev);
-            break;
-        case OOK_PULSE_PPM:
-            p_events += pulse_demod_ppm(pulse_data, r_dev);
-            break;
-        case OOK_PULSE_PWM:
-            p_events += pulse_demod_pwm(pulse_data, r_dev);
-            break;
-        case OOK_PULSE_MANCHESTER_ZEROBIT:
-            p_events += pulse_demod_manchester_zerobit(pulse_data, r_dev);
-            break;
-        case OOK_PULSE_PIWM_RAW:
-            p_events += pulse_demod_piwm_raw(pulse_data, r_dev);
-            break;
-        case OOK_PULSE_PIWM_DC:
-            p_events += pulse_demod_piwm_dc(pulse_data, r_dev);
-            break;
-        case OOK_PULSE_DMC:
-            p_events += pulse_demod_dmc(pulse_data, r_dev);
-            break;
-        case OOK_PULSE_PWM_OSV1:
-            p_events += pulse_demod_osv1(pulse_data, r_dev);
-            break;
-        case OOK_PULSE_NRZS:
-            p_events += pulse_demod_nrzs(pulse_data, r_dev);
-            break;
-        // FSK decoders
-        case FSK_PULSE_PCM:
-        case FSK_PULSE_PWM:
-        case FSK_PULSE_MANCHESTER_ZEROBIT:
-            break;
-        default:
-            fprintf(stderr, "Unknown modulation %u in protocol!\n", r_dev->modulation);
+    unsigned next_priority = 0; // next smallest on each loop through decoders
+    // run all decoders of each priority, stop if an event is produced
+    for (unsigned priority = 0; !p_events && priority < UINT_MAX; priority = next_priority) {
+        next_priority = UINT_MAX;
+        for (void **iter = r_devs->elems; iter && *iter; ++iter) {
+            r_device *r_dev = *iter;
+
+            // Find next smallest priority
+            if (r_dev->priority > priority && r_dev->priority < next_priority)
+                next_priority = r_dev->priority;
+            // Run only current priority
+            if (r_dev->priority != priority)
+                continue;
+
+            switch (r_dev->modulation) {
+            case OOK_PULSE_PCM_RZ:
+                p_events += pulse_demod_pcm(pulse_data, r_dev);
+                break;
+            case OOK_PULSE_PPM:
+                p_events += pulse_demod_ppm(pulse_data, r_dev);
+                break;
+            case OOK_PULSE_PWM:
+                p_events += pulse_demod_pwm(pulse_data, r_dev);
+                break;
+            case OOK_PULSE_MANCHESTER_ZEROBIT:
+                p_events += pulse_demod_manchester_zerobit(pulse_data, r_dev);
+                break;
+            case OOK_PULSE_PIWM_RAW:
+                p_events += pulse_demod_piwm_raw(pulse_data, r_dev);
+                break;
+            case OOK_PULSE_PIWM_DC:
+                p_events += pulse_demod_piwm_dc(pulse_data, r_dev);
+                break;
+            case OOK_PULSE_DMC:
+                p_events += pulse_demod_dmc(pulse_data, r_dev);
+                break;
+            case OOK_PULSE_PWM_OSV1:
+                p_events += pulse_demod_osv1(pulse_data, r_dev);
+                break;
+            case OOK_PULSE_NRZS:
+                p_events += pulse_demod_nrzs(pulse_data, r_dev);
+                break;
+            // FSK decoders
+            case FSK_PULSE_PCM:
+            case FSK_PULSE_PWM:
+            case FSK_PULSE_MANCHESTER_ZEROBIT:
+                break;
+            default:
+                fprintf(stderr, "Unknown modulation %u in protocol!\n", r_dev->modulation);
+            }
         }
     }
 
@@ -515,31 +528,44 @@ int run_fsk_demods(list_t *r_devs, pulse_data_t *fsk_pulse_data)
 {
     int p_events = 0;
 
-    for (void **iter = r_devs->elems; iter && *iter; ++iter) {
-        r_device *r_dev = *iter;
-        switch (r_dev->modulation) {
-        // OOK decoders
-        case OOK_PULSE_PCM_RZ:
-        case OOK_PULSE_PPM:
-        case OOK_PULSE_PWM:
-        case OOK_PULSE_MANCHESTER_ZEROBIT:
-        case OOK_PULSE_PIWM_RAW:
-        case OOK_PULSE_PIWM_DC:
-        case OOK_PULSE_DMC:
-        case OOK_PULSE_PWM_OSV1:
-        case OOK_PULSE_NRZS:
-            break;
-        case FSK_PULSE_PCM:
-            p_events += pulse_demod_pcm(fsk_pulse_data, r_dev);
-            break;
-        case FSK_PULSE_PWM:
-            p_events += pulse_demod_pwm(fsk_pulse_data, r_dev);
-            break;
-        case FSK_PULSE_MANCHESTER_ZEROBIT:
-            p_events += pulse_demod_manchester_zerobit(fsk_pulse_data, r_dev);
-            break;
-        default:
-            fprintf(stderr, "Unknown modulation %u in protocol!\n", r_dev->modulation);
+    unsigned next_priority = 0; // next smallest on each loop through decoders
+    // run all decoders of each priority, stop if an event is produced
+    for (unsigned priority = 0; !p_events && priority < UINT_MAX; priority = next_priority) {
+        next_priority = UINT_MAX;
+        for (void **iter = r_devs->elems; iter && *iter; ++iter) {
+            r_device *r_dev = *iter;
+
+            // Find next smallest priority
+            if (r_dev->priority > priority && r_dev->priority < next_priority)
+                next_priority = r_dev->priority;
+            // Run only current priority
+            if (r_dev->priority != priority)
+                continue;
+
+            switch (r_dev->modulation) {
+            // OOK decoders
+            case OOK_PULSE_PCM_RZ:
+            case OOK_PULSE_PPM:
+            case OOK_PULSE_PWM:
+            case OOK_PULSE_MANCHESTER_ZEROBIT:
+            case OOK_PULSE_PIWM_RAW:
+            case OOK_PULSE_PIWM_DC:
+            case OOK_PULSE_DMC:
+            case OOK_PULSE_PWM_OSV1:
+            case OOK_PULSE_NRZS:
+                break;
+            case FSK_PULSE_PCM:
+                p_events += pulse_demod_pcm(fsk_pulse_data, r_dev);
+                break;
+            case FSK_PULSE_PWM:
+                p_events += pulse_demod_pwm(fsk_pulse_data, r_dev);
+                break;
+            case FSK_PULSE_MANCHESTER_ZEROBIT:
+                p_events += pulse_demod_manchester_zerobit(fsk_pulse_data, r_dev);
+                break;
+            default:
+                fprintf(stderr, "Unknown modulation %u in protocol!\n", r_dev->modulation);
+            }
         }
     }
 


### PR DESCRIPTION
Adds a priority to each decoder. This allows to define execution order with later stages only running as fallback.

The default priority is `0`. All decoders at a priority will run, the next priority will run only if no events have been produced so far. In other words, priorities will run in turn until an event is produced.

E.g. if AlectoV1, which has a strong checksum, decodes a frame, then Springfield-Soil, Prologue, ThermoPro-TX2 will not run, without the need to explicitly check for that false positive in each later decoder.

Another example is TPMS, if no decoder finds a known decoding we could fallback to a generic decoder.