### PR TITLE
Fix: changed moisture to humidity class

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -193,7 +193,7 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "H",
         "config": {
-            "device_class": "moisture",
+            "device_class": "humidity",
             "name": "Moisture",
             "unit_of_measurement": "%",
             "value_template": "{{ value|float }}",


### PR DESCRIPTION
'moisture' is not a valid class, which creates a problem when relying on the 'rtl_433 MQTT Auto Discovery' add-on to detect Moisture sensors (such as the Ecowitt WH51).  Switching it to the humidity class resolves this issue.