### PR TITLE
Add support AVE TPMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [205]  Telldus weather station FT0385R sensors
     [206]  LaCrosse TX34-IT rain gauge
     [207]  SmartFire Proflame 2 remote control
+    [208]  AVE TPMS
 
 * Disabled by default, use -R n or -G
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -215,6 +215,7 @@
     DECL(telldus_ft0385r) \
     DECL(lacrosse_tx34) \
     DECL(proflame2) \
+    DECL(tpms_ave) \
 
     /* Add new decoders here. */
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -195,6 +195,7 @@ add_library(r_433 STATIC
     devices/thermopro_tp12.c
     devices/thermopro_tx2.c
     devices/tpms_abarth124.c
+    devices/tpms_ave.c
     devices/tpms_citroen.c
     devices/tpms_elantra2012.c
     devices/tpms_ford.c

--- a/src/devices/tpms_ave.c
+++ b/src/devices/tpms_ave.c
@@ -148,7 +148,7 @@ static char *output_fields[] = {
         "type",
         "id",
         "mode",
-        "pressure_PSI",
+        "pressure_kPa",
         "temperature_C",
         "battery_level",
         "flags",

--- a/src/devices/tpms_ave.c
+++ b/src/devices/tpms_ave.c
@@ -90,7 +90,6 @@ static int tpms_ave_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned r
         break;
     }
     pressure = ((double)pressure_raw - offset) * ratio;
-    pressure *= 0.1450377377; // kPa to PSI conversion
 
     sprintf(id_str, "%08x", id);
 
@@ -100,7 +99,7 @@ static int tpms_ave_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned r
             "type",             "Type",          DATA_STRING, "TPMS",
             "id",               "Id",            DATA_STRING, id_str,
             "mode",             "Mode",          DATA_FORMAT, "M%i", DATA_INT, mode,
-            "pressure_PSI",     "Pressure",      DATA_FORMAT, "%.1f PSI", DATA_DOUBLE, pressure,
+            "pressure_kPa",     "Pressure",      DATA_FORMAT, "%.1f kPa", DATA_DOUBLE, pressure,
             "temperature_C",    "Temperature",   DATA_FORMAT, "%.0f C", DATA_DOUBLE, (double)temperature - 50.0,
             "battery_ok",       "Battery level", DATA_COND, battery_level < 6, DATA_DOUBLE, 1.0,
             "battery_ok",       "Battery level", DATA_COND, battery_level == 6, DATA_DOUBLE, 0.75,

--- a/src/devices/tpms_ave.c
+++ b/src/devices/tpms_ave.c
@@ -1,0 +1,170 @@
+/** @file
+    AVE TPMS FSK 11 byte differential Manchester encoded CRC-8 TPMS data.
+
+    Copyright (C) 2021 Pascal Charest
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+/**
+AVE TPMS FSK 11 byte differential Manchester encoded CRC-8 TPMS data.
+
+
+Packet nibbles:
+
+    PRE    IIIIIIII PP TT FF  CC
+
+- PRE = preamble is 0xff 0xfe
+- I = sensor Id in hex
+- P = Pressure (4 conversion tables available)
+- T = Temperature (deg C offset by 50)
+- F = Flags
+--    mode: 2 bits, mode 0 and 1 are 2.35kPa per pressure bit, mode 2 and 3 are 5.5kPa
+--    battery: 3 bits, 7 is low, 6 not full and all other is full
+--    unknown: 3 bits, last bit seems to swap from time to time
+- C = CRC-8 with poly 0x31 init 0xff (alternatively, 0xd3 and 0x1e)
+*/
+
+#include "decoder.h"
+
+static int tpms_ave_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
+{
+    data_t *data;
+    bitbuffer_t packet_bits = {0};
+    uint8_t *b;
+    unsigned id;
+    char id_str[9 + 1];
+    int mode;
+    int pressure_raw;
+    double pressure;
+    int temperature;
+    int battery_level;
+    int flags;
+    int crc;
+    double ratio;
+    double offset;
+
+    bitbuffer_differential_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 160);
+
+    if (packet_bits.bits_per_row[row] < 64) {
+        return DECODE_ABORT_LENGTH; // too short to be a whole packet
+    }
+    if (decoder->verbose > 1) {
+        bitbuffer_print(&packet_bits);
+    }
+
+    b = packet_bits.bb[row];
+
+    id            = (unsigned)b[0] << 24 | b[1] << 16 | b[2] << 8 | b[3];
+    pressure_raw  = b[4];
+    temperature   = b[5];
+    mode          = b[6] >> 6 & 0x3;
+    battery_level = b[6] >> 3 & 0x7;
+    flags         = b[6] & 0x7;
+    crc           = b[7];
+
+    if (crc8(b, 7, 0x31, 0xff) != crc) {
+        return DECODE_FAIL_MIC; // bad checksum
+    }
+
+    switch (mode) {
+    case 0:
+        ratio = 2.352f;
+        offset = 47.0f;
+        break;
+    case 1:
+        ratio = 2.352f;
+        offset = 0.0f;
+        break;
+    case 2:
+        ratio = 5.491f;
+        offset = 18.2f;
+        break;
+    case 3:
+        ratio = 5.491f;
+        offset = 0.0f;
+        break;
+    }
+    pressure = ((double)pressure_raw - offset) * ratio;
+    pressure *= 0.1450377377;
+
+    sprintf(id_str, "%08x", id);
+
+    /* clang-format off */
+    data = data_make(
+            "model",            "Model",         DATA_STRING, "AVE",
+            "type",             "Type",          DATA_STRING, "TPMS",
+            "id",               "Id",            DATA_STRING, id_str,
+            "mode",             "Mode",          DATA_FORMAT, "M%i", DATA_INT, mode,
+            "pressure_PSI",     "Pressure",      DATA_FORMAT, "%.1f PSI", DATA_DOUBLE, pressure,
+            "temperature_C",    "Temperature",   DATA_FORMAT, "%.0f C", DATA_DOUBLE, (double)temperature - 50.0,
+            "battery_ok",       "Battery level", DATA_COND, battery_level < 6, DATA_STRING, "full",
+            "battery_ok",       "Battery level", DATA_COND, battery_level == 6, DATA_STRING, "ok",
+            "battery_ok",       "Battery level", DATA_COND, battery_level == 7, DATA_STRING, "low",
+            "flags",            "Flags",         DATA_FORMAT, "0x%x", DATA_INT, flags,
+            "mic",              "Integrity",     DATA_STRING, "CRC",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+/**
+Wrapper for the AVE tpms.
+@sa tpms_ave_decode()
+*/
+static int tpms_ave_callback(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    uint8_t const preamble_pattern[] = {0xcc, 0xcc, 0xcc, 0xcd}; // Raw pattern, before differential Manchester coding
+
+    int row;
+    unsigned bitpos;
+    int ret         = 0;
+    int events      = 0;
+
+    for (row = 0; row < bitbuffer->num_rows; ++row) {
+        bitpos = 0;
+        // Find a preamble with enough bits after it that it could be a complete packet
+	fprintf(stderr, "Bits: %i\n", bitbuffer->bits_per_row[0]);
+        while ((bitpos = bitbuffer_search(bitbuffer, 0, bitpos, preamble_pattern, 32)) + 132 <=
+                bitbuffer->bits_per_row[0]) {
+            ret = tpms_ave_decode(decoder, bitbuffer, row, bitpos + 32);
+            if (ret > 0) {
+                events += ret;
+	    	bitpos += 132;
+	    }
+            bitpos += 31;
+        }
+    }
+
+    return events > 0 ? events : ret;
+}
+
+static char *output_fields[] = {
+        "model",
+        "type",
+        "id",
+        "mode",
+        "pressure_PSI",
+        "temperature_C",
+        "battery_level",
+        "flags",
+        "mic",
+        NULL,
+};
+
+r_device tpms_ave = {
+        .name        = "AVE TPMS",
+        .modulation  = FSK_PULSE_PCM,
+        .short_width = 100, 
+        .long_width  = 100,
+        .reset_limit = 400,
+        .tolerance   = 15,
+        .decode_fn   = &tpms_ave_callback,
+        .disabled    = 0,
+        .fields      = output_fields,
+};


### PR DESCRIPTION
Add support for AVE TPMS device. Device information can be found at:
http://www.avetechnology.com/index.php?unit=products&lang=en&act=view&id=23