### PR TITLE
Add trigger stream output

### DIFF
--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -180,7 +180,7 @@ signal_grabber none
 ## Data output options
 
 # as command line option:
-#   [-F kv|json|csv|mqtt|syslog|null] Produce decoded output in given format.
+#   [-F kv|json|csv|mqtt|influx|syslog|trigger|null] Produce decoded output in given format.
 #     Without this option the default is KV output. Use "-F null" to remove the default.
 #     Append output to file with :<filename> (e.g. -F csv:log.csv), defaults to stdout.
 #     Specify MQTT server with e.g. -F mqtt://localhost:1883
@@ -192,6 +192,11 @@ signal_grabber none
 #       devices: posts device and sensor info in nested topics
 #     The topic string will expand keys like [/model]
 #     E.g. -F "mqtt://localhost:1883,user=USERNAME,pass=PASSWORD,retain=0,devices=rtl_433[/id]"
+#     With MQTT each rtl_433 instance needs a distinct driver selection. The MQTT Client-ID is computed from the driver string.
+#     If you use multiple RTL-SDR, perhaps set a serial and select by that (helps not to get the wrong antenna).
+#     Specify InfluxDB 2.0 server with e.g. -F "influx://localhost:9999/api/v2/write?org=<org>&bucket=<bucket>,token=<authtoken>"
+#     Specify InfluxDB 1.x server with e.g. -F "influx://localhost:8086/write?db=<db>&p=<password>&u=<user>"
+#       Additional parameter -M time:unix:usec:utc for correct timestamps in InfluxDB recommended
 #     Specify host/port for syslog with e.g. -F syslog:127.0.0.1:1514
 # default is "kv", multiple outputs can be used.
 output json

--- a/include/output_trigger.h
+++ b/include/output_trigger.h
@@ -1,0 +1,33 @@
+/** @file
+    Trigger output for rtl_433 events.
+
+    Copyright (C) 2021 Christian Zuckschwerdt
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#ifndef INCLUDE_OUTPUT_TRIGGER_H_
+#define INCLUDE_OUTPUT_TRIGGER_H_
+
+#include "data.h"
+#include <stdio.h>
+
+/// Construct data output for a trigger stream.
+///
+/// This will print a `1` to the stream for every event.
+///
+/// Use e.g. on a Raspberry Pi to flash the LED:
+///
+///     $ sudo chmod a+w /sys/class/leds/led0/shot
+///     $ echo oneshot | sudo tee /sys/class/leds/led0/trigger
+///     $ rtl_433 ... -F trigger:/sys/class/leds/led0/shot
+///
+/// @param file a trigger output stream
+/// @return The initialized data output.
+///         You must release this object with data_output_free once you're done with it.
+struct data_output *data_output_trigger_create(FILE *file);
+
+#endif /* INCLUDE_OUTPUT_TRIGGER_H_ */

--- a/include/r_api.h
+++ b/include/r_api.h
@@ -81,6 +81,8 @@ void add_syslog_output(struct r_cfg *cfg, char *param);
 
 void add_http_output(struct r_cfg *cfg, char *param);
 
+void add_trigger_output(struct r_cfg *cfg, char *param);
+
 void add_null_output(struct r_cfg *cfg, char *param);
 
 void start_outputs(struct r_cfg *cfg, char const *const *well_known);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(r_433 STATIC
     output_file.c
     output_influx.c
     output_mqtt.c
+    output_trigger.c
     output_udp.c
     pulse_analyzer.c
     pulse_demod.c

--- a/src/output_trigger.c
+++ b/src/output_trigger.c
@@ -1,0 +1,59 @@
+/** @file
+    Trigger output for rtl_433 events.
+
+    Copyright (C) 2021 Christian Zuckschwerdt
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#include "output_trigger.h"
+
+#include "data.h"
+#include "r_util.h"
+#include "fatal.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Trigger printer */
+
+typedef struct {
+    struct data_output output;
+    FILE *file;
+} data_output_trigger_t;
+
+static void print_trigger_data(data_output_t *output, data_t *data, char const *format)
+{
+    UNUSED(data);
+    UNUSED(format);
+    data_output_trigger_t *trigger = (data_output_trigger_t *)output;
+
+    fputc('1', trigger->file);
+    fflush(trigger->file);
+}
+
+static void data_output_trigger_free(data_output_t *output)
+{
+    if (!output)
+        return;
+
+    free(output);
+}
+
+struct data_output *data_output_trigger_create(FILE *file)
+{
+    data_output_trigger_t *trigger = calloc(1, sizeof(data_output_trigger_t));
+    if (!trigger) {
+        WARN_CALLOC("data_output_trigger_create()");
+        return NULL; // NOTE: returns NULL on alloc failure.
+    }
+
+    trigger->output.print_data  = print_trigger_data;
+    trigger->output.output_free = data_output_trigger_free;
+    trigger->file               = file;
+
+    return &trigger->output;
+}

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -33,6 +33,7 @@
 #include "output_udp.h"
 #include "output_mqtt.h"
 #include "output_influx.h"
+#include "output_trigger.h"
 #include "write_sigrok.h"
 #include "mongoose.h"
 #include "compat_time.h"
@@ -985,6 +986,11 @@ void add_http_output(r_cfg_t *cfg, char *param)
     fprintf(stderr, "HTTP server at %s port %s\n", host, port);
 
     list_push(&cfg->output_handler, data_output_http_create(get_mgr(cfg), host, port, cfg));
+}
+
+void add_trigger_output(r_cfg_t *cfg, char *param)
+{
+    list_push(&cfg->output_handler, data_output_trigger_create(fopen_output(param)));
 }
 
 void add_null_output(r_cfg_t *cfg, char *param)

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -163,7 +163,7 @@ static void usage(int exit_code)
             "  [-w <filename> | help] Save data stream to output file (a '-' dumps samples to stdout)\n"
             "  [-W <filename> | help] Save data stream to output file, overwrite existing file\n"
             "\t\t= Data output options =\n"
-            "  [-F kv | json | csv | mqtt | influx | syslog | null | help] Produce decoded output in given format.\n"
+            "  [-F kv | json | csv | mqtt | influx | syslog | trigger | null | help] Produce decoded output in given format.\n"
             "       Append output to file with :<filename> (e.g. -F csv:log.csv), defaults to stdout.\n"
             "       Specify host/port for syslog with e.g. -F syslog:127.0.0.1:1514\n"
             "  [-M time[:<options>] | protocol | level | noise[:secs] | stats | bits | help] Add various meta data to each output.\n"
@@ -239,7 +239,7 @@ static void help_output(void)
 {
     term_help_printf(
             "\t\t= Output format option =\n"
-            "  [-F kv|json|csv|mqtt|influx|syslog|null] Produce decoded output in given format.\n"
+            "  [-F kv|json|csv|mqtt|influx|syslog|trigger|null] Produce decoded output in given format.\n"
             "\tWithout this option the default is KV output. Use \"-F null\" to remove the default.\n"
             "\tAppend output to file with :<filename> (e.g. -F csv:log.csv), defaults to stdout.\n"
             "\tSpecify MQTT server with e.g. -F mqtt://localhost:1883\n"
@@ -1127,6 +1127,9 @@ static void parse_conf_option(r_cfg_t *cfg, int opt, char *arg)
         }
         else if (strncmp(optarg, "http", 4) == 0) {
             add_http_output(cfg, arg_param(optarg));
+        }
+        else if (strncmp(arg, "trigger", 7) == 0) {
+            add_trigger_output(cfg, arg_param(arg));
         }
         else if (strncmp(arg, "null", 4) == 0) {
             add_null_output(cfg, arg_param(arg));

--- a/vs15/rtl_433.vcxproj
+++ b/vs15/rtl_433.vcxproj
@@ -115,6 +115,7 @@ COPY ..\..\libusb\MS64\dll\libusb*.dll $(TargetDir)</Command>
     <ClInclude Include="..\include\output_file.h" />
     <ClInclude Include="..\include\output_influx.h" />
     <ClInclude Include="..\include\output_mqtt.h" />
+    <ClInclude Include="..\include\output_trigger.h" />
     <ClInclude Include="..\include\output_udp.h" />
     <ClInclude Include="..\include\pulse_analyzer.h" />
     <ClInclude Include="..\include\pulse_demod.h" />
@@ -155,6 +156,7 @@ COPY ..\..\libusb\MS64\dll\libusb*.dll $(TargetDir)</Command>
     <ClCompile Include="..\src\output_file.c" />
     <ClCompile Include="..\src\output_influx.c" />
     <ClCompile Include="..\src\output_mqtt.c" />
+    <ClCompile Include="..\src\output_trigger.c" />
     <ClCompile Include="..\src\output_udp.c" />
     <ClCompile Include="..\src\pulse_analyzer.c" />
     <ClCompile Include="..\src\pulse_demod.c" />

--- a/vs15/rtl_433.vcxproj.filters
+++ b/vs15/rtl_433.vcxproj.filters
@@ -83,6 +83,9 @@
     <ClInclude Include="..\include\output_mqtt.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\output_trigger.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\include\output_udp.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -197,6 +200,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\src\output_mqtt.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\output_trigger.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\src\output_udp.c">


### PR DESCRIPTION
Adds a trigger stream output.
This will simply print a `1` to the stream for every event.

- as a very simple example to build more outputs
- for e.g. a Raspberry Pi to flash the LED on every received data packet:

```
$ sudo chmod a+w /sys/class/leds/led0/shot
$ echo oneshot | sudo tee /sys/class/leds/led0/trigger
$ rtl_433 ... -F trigger:/sys/class/leds/led0/shot
```