### PR TITLE
"wind_max_km_h" should also be a key

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -292,6 +292,17 @@ mappings = {
             "state_class": "measurement"
         }
     },
+  
+    "wind_max_km_h": {
+        "device_type": "sensor",
+        "object_suffix": "GS",
+        "config": {
+            "name": "Wind max speed",
+            "unit_of_measurement": "km/h",
+            "value_template": "{{ value|float }}",
+            "state_class": "measurement"
+        }
+    },
 
     "wind_max_m_s": {
         "device_type": "sensor",


### PR DESCRIPTION
 alternative to "gust_speed_km_h".
This is what my station publishes:
{"time" : "2021-12-23 18:45:20", "model" : "Fineoffset-WHx080", "subtype" : 0, "id" : 5, "battery_ok" : 1, "temperature_C" : 0.200, "humidity" : 69, "wind_dir_deg" : 113, "wind_avg_km_h" : 3.672, "wind_max_km_h" : 6.120, "rain_mm" : 135.300, "mic" : "CRC", "mod" : "ASK", "freq" : 868.359, "rssi" : -0.104, "snr" : 17.791, "noise" : -17.895}