### PR TITLE
Add rtl_tcp pass-through output 

### DIFF
--- a/include/output_rtltcp.h
+++ b/include/output_rtltcp.h
@@ -1,0 +1,31 @@
+/** @file
+    rtl_tcp output for rtl_433 raw data.
+
+    Copyright (C) 2022 Christian Zuckschwerdt
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#ifndef INCLUDE_OUTPUT_RTLTCP_H_
+#define INCLUDE_OUTPUT_RTLTCP_H_
+
+#include "raw_output.h"
+
+#include <stdint.h>
+
+struct r_cfg;
+
+/** Construct rtl_tcp data output.
+
+    @param host the server host to bind
+    @param port the server port to bind
+    @param cfg the r_api config to use
+    @return The initialized rtltcp output instance.
+            You must release this object with raw_output_free once you're done with it.
+*/
+struct raw_output *raw_output_rtltcp_create(char const *host, char const *port, struct r_cfg *cfg);
+
+#endif /* INCLUDE_OUTPUT_RTLTCP_H_ */

--- a/include/r_api.h
+++ b/include/r_api.h
@@ -85,6 +85,8 @@ void add_trigger_output(struct r_cfg *cfg, char *param);
 
 void add_null_output(struct r_cfg *cfg, char *param);
 
+void add_rtltcp_output(struct r_cfg *cfg, char *param);
+
 void start_outputs(struct r_cfg *cfg, char const *const *well_known);
 
 void add_sr_dumper(struct r_cfg *cfg, char const *spec, int overwrite);

--- a/include/raw_output.h
+++ b/include/raw_output.h
@@ -1,0 +1,28 @@
+/** @file
+    Raw I/Q data output handler.
+
+    Copyright (C) 2022 Christian Zuckschwerdt
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#ifndef INCLUDE_RAW_OUTPUT_H_
+#define INCLUDE_RAW_OUTPUT_H_
+
+#include <stdint.h>
+
+struct raw_output;
+
+typedef struct raw_output {
+    void (*output_frame)(struct raw_output *output, uint8_t const *data, uint32_t len);
+    void (*output_free)(struct raw_output *output);
+} raw_output_t;
+
+void raw_output_frame(struct raw_output *output, uint8_t const *data, uint32_t len);
+
+void raw_output_free(struct raw_output *output);
+
+#endif /* INCLUDE_RAW_OUTPUT_H_ */

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -94,6 +94,7 @@ typedef struct r_cfg {
     uint16_t num_r_devices;
     list_t data_tags;
     list_t output_handler;
+    list_t raw_handler;
     struct dm_state *demod;
     char const *sr_filename;
     int sr_execopen;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(r_433 STATIC
     output_file.c
     output_influx.c
     output_mqtt.c
+    output_rtltcp.c
     output_trigger.c
     output_udp.c
     pulse_analyzer.c
@@ -33,6 +34,7 @@ add_library(r_433 STATIC
     pulse_detect_fsk.c
     r_api.c
     r_util.c
+    raw_output.c
     rfraw.c
     samp_grab.c
     sdr.c

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -34,6 +34,7 @@
 #include "output_mqtt.h"
 #include "output_influx.h"
 #include "output_trigger.h"
+#include "output_rtltcp.h"
 #include "write_sigrok.h"
 #include "mongoose.h"
 #include "compat_time.h"
@@ -222,6 +223,8 @@ void r_free_cfg(r_cfg_t *cfg)
     free(cfg->demod);
 
     free(cfg->devices);
+
+    list_free_elems(&cfg->raw_handler, (list_elem_free_fn)raw_output_free);
 
     list_free_elems(&cfg->output_handler, (list_elem_free_fn)data_output_free);
 
@@ -997,6 +1000,16 @@ void add_null_output(r_cfg_t *cfg, char *param)
 {
     UNUSED(param);
     list_push(&cfg->output_handler, NULL);
+}
+
+void add_rtltcp_output(r_cfg_t *cfg, char *param)
+{
+    char *host = "localhost";
+    char *port = "1234";
+    hostport_param(param, &host, &port);
+    fprintf(stderr, "rtl_tcp server at %s port %s\n", host, port);
+
+    list_push(&cfg->raw_handler, raw_output_rtltcp_create(host, port, cfg));
 }
 
 void add_sr_dumper(r_cfg_t *cfg, char const *spec, int overwrite)

--- a/src/raw_output.c
+++ b/src/raw_output.c
@@ -1,0 +1,30 @@
+/** @file
+    Raw I/Q data output handler.
+
+    Copyright (C) 2022 Christian Zuckschwerdt
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#include "raw_output.h"
+
+#include <stdint.h>
+
+/* generic raw_output */
+
+void raw_output_frame(struct raw_output *output, uint8_t const *data, uint32_t len)
+{
+    if (!output)
+        return;
+    output->output_frame(output, data, len);
+}
+
+void raw_output_free(struct raw_output *output)
+{
+    if (!output)
+        return;
+    output->output_free(output);
+}

--- a/vs15/rtl_433.vcxproj
+++ b/vs15/rtl_433.vcxproj
@@ -116,6 +116,7 @@ COPY ..\..\libusb\MS64\dll\libusb*.dll $(TargetDir)</Command>
     <ClInclude Include="..\include\output_file.h" />
     <ClInclude Include="..\include\output_influx.h" />
     <ClInclude Include="..\include\output_mqtt.h" />
+    <ClInclude Include="..\include\output_rtltcp.h" />
     <ClInclude Include="..\include\output_trigger.h" />
     <ClInclude Include="..\include\output_udp.h" />
     <ClInclude Include="..\include\pulse_analyzer.h" />
@@ -126,6 +127,7 @@ COPY ..\..\libusb\MS64\dll\libusb*.dll $(TargetDir)</Command>
     <ClInclude Include="..\include\r_device.h" />
     <ClInclude Include="..\include\r_private.h" />
     <ClInclude Include="..\include\r_util.h" />
+    <ClInclude Include="..\include\raw_output.h" />
     <ClInclude Include="..\include\rfraw.h" />
     <ClInclude Include="..\include\rtl_433.h" />
     <ClInclude Include="..\include\rtl_433_devices.h" />
@@ -157,6 +159,7 @@ COPY ..\..\libusb\MS64\dll\libusb*.dll $(TargetDir)</Command>
     <ClCompile Include="..\src\output_file.c" />
     <ClCompile Include="..\src\output_influx.c" />
     <ClCompile Include="..\src\output_mqtt.c" />
+    <ClCompile Include="..\src\output_rtltcp.c" />
     <ClCompile Include="..\src\output_trigger.c" />
     <ClCompile Include="..\src\output_udp.c" />
     <ClCompile Include="..\src\pulse_analyzer.c" />
@@ -165,6 +168,7 @@ COPY ..\..\libusb\MS64\dll\libusb*.dll $(TargetDir)</Command>
     <ClCompile Include="..\src\pulse_detect_fsk.c" />
     <ClCompile Include="..\src\r_api.c" />
     <ClCompile Include="..\src\r_util.c" />
+    <ClCompile Include="..\src\raw_output.c" />
     <ClCompile Include="..\src\rfraw.c" />
     <ClCompile Include="..\src\rtl_433.c" />
     <ClCompile Include="..\src\samp_grab.c" />

--- a/vs15/rtl_433.vcxproj.filters
+++ b/vs15/rtl_433.vcxproj.filters
@@ -86,6 +86,9 @@
     <ClInclude Include="..\include\output_mqtt.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\output_rtltcp.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\include\output_trigger.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -114,6 +117,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\include\r_util.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\raw_output.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\include\rfraw.h">
@@ -205,6 +211,9 @@
     <ClCompile Include="..\src\output_mqtt.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\output_rtltcp.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\output_trigger.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -227,6 +236,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\src\r_util.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\raw_output.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\src\rfraw.c">


### PR DESCRIPTION
This adds an rtl_tcp pass-through output for received I/Q data.
Use with `-F rtl_tcp` / `-F rtl_tcp:127.0.0.1:1234` and Gqrx to see the live data as rtl_433 sees it.