### PR TITLE
src/optparse.c: fix build without __has_attribute

### DIFF
--- a/src/optparse.c
+++ b/src/optparse.c
@@ -231,7 +231,7 @@ int atoi_time(char const *str, char const *error_hint)
                 break;
             }
             // intentional fallthrough
-#if defined(__GNUC__) || defined(__clang__)
+#if defined __has_attribute
 #if __has_attribute(fallthrough)
             __attribute__((fallthrough));
 #endif


### PR DESCRIPTION
Fix build failure without `__has_attribute` (e.g. gcc 4.8) which is raised since https://github.com/merbanan/rtl_433/commit/6c8af75c757712bd58b169317795484a72e9a16c

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>