### PR TITLE
Fix spelling errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [189]  Somfy io-homecontrol
     [190]  Ambient Weather WH31L (FineOffset WH57) Lightning-Strike sensor
     [191]  Markisol, E-Motion, BOFU, Rollerhouse, BF-30x, BF-415 curtain remote
-    [192]  Govee Water Leak Dectector H5054, Door Contact Sensor B5023
+    [192]  Govee Water Leak Detector H5054, Door Contact Sensor B5023
     [193]  Clipsal CMR113 Cent-a-meter power meter
     [194]  Inkbird ITH-20R temperature humidity sensor
     [195]  RainPoint soil temperature and moisture sensor

--- a/conf/CAME-TOP432.conf
+++ b/conf/CAME-TOP432.conf
@@ -6,7 +6,7 @@
 # (as said on the FCC site https://www.fcc.gov/oet/ea/fccid with reference M48 TOP-NA)
 # 
 # It works with CAME radio receiver cards "AF43S", capable of handling 4096 codes. 
-# CAME is an italian company. Theses remote controls are mainly sold in europe (France, Italy, Belgium). 
+# CAME is an Italian company. These remote controls are mainly sold in Europe (France, Italy, Belgium). 
 # https://www.came.com and https://www.came-europe.com .
 
 # Device information and test files:

--- a/conf/HeatmiserPRT-W.conf
+++ b/conf/HeatmiserPRT-W.conf
@@ -21,7 +21,7 @@
 # Report iso time:
 report_meta time:iso
 
-# Including the 'report_meta level' switch (commented out below) means information on the signal quality and strength are added to the output. This was useful to me to determine which thermostat was which without running down 2 flights or stairs everytime I wanted to make a change. Basically the higher the rssi number, generally, the closer the stat was physically to my SDR aerial.
+# Including the 'report_meta level' switch (commented out below) means information on the signal quality and strength are added to the output. This was useful to me to determine which thermostat was which without running down 2 flights or stairs every time I wanted to make a change. Basically the higher the rssi number, generally, the closer the stat was physically to my SDR aerial.
 
 #report_meta level
 

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -412,7 +412,7 @@ stop_after_successful_events false
   protocol 189 # Somfy io-homecontrol
   protocol 190 # Ambient Weather WH31L (FineOffset WH57) Lightning-Strike sensor
   protocol 191 # Markisol, E-Motion, BOFU, Rollerhouse, BF-30x, BF-415 curtain remote
-  protocol 192 # Govee Water Leak Dectector H5054, Door Contact Sensor B5023
+  protocol 192 # Govee Water Leak Detector H5054, Door Contact Sensor B5023
   protocol 193 # Clipsal CMR113 Cent-a-meter power meter
   protocol 194 # Inkbird ITH-20R temperature humidity sensor
   protocol 195 # RainPoint soil temperature and moisture sensor

--- a/docs/ANALYZE.md
+++ b/docs/ANALYZE.md
@@ -16,7 +16,7 @@ First a radio data packet is found and framed.
 
 Get on overview of the band. Check if the transmission is visible and in the expected frequency range.
 Use CubicSDR, Gqrx, SigDigger, SDR#, SDRangel or similar SDR UIs to verify you receice a signal.
-If you have the SDR reciever on a headless machine try `rtl_tcp` to transport data to a GUI.
+If you have the SDR receiver on a headless machine try `rtl_tcp` to transport data to a GUI.
 
 ::: tip
 A quick substitute for an SDR UI is to record a sample, e.g. `-w file_433.92M_250k.cu -T 60` (adjust for the actual frequency and sample rate).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -118,7 +118,7 @@ Format string:
 
     ID:16h FLAGS:4h TEMP:12h HUMI:8h CRC:8h
 
-...Decoding notes like endianess, signedness
+...Decoding notes like endianness, signedness
 */
 ```
 

--- a/docs/DATA_FORMAT.md
+++ b/docs/DATA_FORMAT.md
@@ -4,7 +4,7 @@ See also the discussion and rationale in https://github.com/merbanan/rtl_433/pul
 
 ## Message Data
 These fields are the primary data fields containing the most basic message data and used to identify the specific device.
-For some devices these are the *only* fields contained in the message, as the message itself consitutes an event from this
+For some devices these are the *only* fields contained in the message, as the message itself constitutes an event from this
 particular device model.
 
 * **time** (string) (Required)

--- a/docs/IQ_FORMATS.md
+++ b/docs/IQ_FORMATS.md
@@ -17,7 +17,7 @@ The nature of an I/Q sample allows to use a bandwidth equal to the sample rate
 (with a purely real signal the Nyquist–Shannon sampling theorem would only allow half the bandwidth).
 
 Generally the data formats are header- (and thus metadata-)less,
-the used center frequency and sample rate must be transfered separately or encoded in the filename.
+the used center frequency and sample rate must be transferred separately or encoded in the filename.
 
 Formats differ in sample-(bit-)width and (bit-)number format,
 used bit-widths are 4, 8, 12, 16, 32, and 64, bit-formats are unsigned integer, signed integer, and float:

--- a/docs/OPERATION.md
+++ b/docs/OPERATION.md
@@ -279,7 +279,7 @@ The output might not be too useful, best to use the newer `-A` option.
 
 The `-A` option enables the (new) pulse analyzer.
 Each received transmission will be displayed in a statistical overview.
-A probable coding will be infered and attempted to decode.
+A probable coding will be inferred and attempted to decode.
 
 The "Pulse width distribution", "Gap width distribution", and "Pulse period distribution"
 can tell you about the timing in the `width` column,

--- a/src/baseband.c
+++ b/src/baseband.c
@@ -134,7 +134,7 @@ float magnitude_true_cs16(int16_t const *iq_buf, uint16_t *y_buf, uint32_t len)
     - Q1.15*Q15.0 = Q16.15
     - Q16.15>>1 = Q15.14
     - Q15.14 + Q15.14 + Q15.14 could possibly overflow to 17.14
-    - but the b coeffs are small so it wont happen
+    - but the b coeffs are small so it won't happen
     - Q15.14>>14 = Q15.0
 */
 void baseband_low_pass_filter(uint16_t const *x_buf, int16_t *y_buf, uint32_t len, filter_state_t *state)

--- a/src/devices/archos_tbh.c
+++ b/src/devices/archos_tbh.c
@@ -30,7 +30,7 @@ To get raw data:
 
 The application data is obfuscated by doing data[n] xor data[n-1] xor info[n%16].
 
-Payload foramt:
+Payload format:
 - Device id         {32}
 - Frame type        {8}
 - Frame Data        {x}

--- a/src/devices/blueline.c
+++ b/src/devices/blueline.c
@@ -128,7 +128,7 @@ which you should then use as a parameter when you re-run rtl_433 in the future.
 
 Finally, passing a parameter to this decoder requires specifying it explicitly, which normally disables all
 other default decoders.  If you want to pass an option to this decoder without disabling all the other defaults,
-the simplest method is to explicity exclude this one decoder (which implicitly says to leave all other defaults
+the simplest method is to explicitly exclude this one decoder (which implicitly says to leave all other defaults
 enabled), then add this decoder back with a parameter.  The command line looks like this:
 
     rtl_433 -R -176 -R 176:45364

--- a/src/devices/bresser_6in1.c
+++ b/src/devices/bresser_6in1.c
@@ -21,7 +21,7 @@ Decoder for Bresser Weather Center 6-in-1.
 - also Bresser 3-in-1 Professional Wind Gauge / Anemometer PN 7002531
 
 There are at least two different message types:
-- 24 seconds interval for temperatur, hum, uv and rain (alternating messages)
+- 24 seconds interval for temperature, hum, uv and rain (alternating messages)
 - 12 seconds interval for wind data (every message)
 
 Also Bresser Explore Scientific SM60020 Soil moisture Sensor.

--- a/src/devices/funkbus.c
+++ b/src/devices/funkbus.c
@@ -33,7 +33,7 @@ Data layout:
 
     TS II II IF FA AX
 
-- T: 4 bit type, there are multible types
+- T: 4 bit type, there are multiple types
 - S: 4 bit subtype
 - I: 20 bit serial number
 - F: 2 bit r1, unknown
@@ -44,7 +44,7 @@ Data layout:
 - A: 1 bit r3, unknown
 - A: 2 bit action, STOP, OFF, ON, SCENE
 - A: 1 bit repeat, 1 == not first send of packet
-- A: 1 bit longpress, longpress of button for (dim up/down, scene lerning)
+- A: 1 bit longpress, longpress of button for (dim up/down, scene learning)
 - A: 1 bit parity, parity over all bits before
 - X: 4 bit check, LFSR with 8 bit mask 0x8C shifted left by 2 each bit
 
@@ -129,7 +129,7 @@ static int funkbus_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         // int r3        = get_bits_reflect(b, 38, 1); // unknown
         int action    = get_bits_reflect(b, 39, 2); // STOP, OFF, ON, SCENE
         int repeat    = get_bits_reflect(b, 41, 1); // 1 == not first send of packet
-        int longpress = get_bits_reflect(b, 42, 1); // longpress of button for (dim up/down, scene lerning)
+        int longpress = get_bits_reflect(b, 42, 1); // longpress of button for (dim up/down, scene learning)
         int parity    = get_bits_reflect(b, 43, 1); // parity over all bits before
         int check     = get_bits_reflect(b, 44, 4); // lfsr with 8bit mask 0x8C shifted left by 2 each bit
 

--- a/src/devices/govee.c
+++ b/src/devices/govee.c
@@ -245,7 +245,7 @@ static char *output_fields[] = {
 };
 
 r_device govee = {
-        .name        = "Govee Water Leak Dectector H5054, Door Contact Sensor B5023",
+        .name        = "Govee Water Leak Detector H5054, Door Contact Sensor B5023",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 440,  // Threshold between short and long pulse [us]
         .long_width  = 940,  // Maximum gap size before new row of bits [us]

--- a/src/devices/gt_tmbbq05.c
+++ b/src/devices/gt_tmbbq05.c
@@ -23,7 +23,7 @@ Next 8 bits are static per device (even after battery change)
 Next 2 bits contain the upper 2 bits of the temperature
 Next 1 bit is unknown
 Next 1 bit is an odd parity bit
-Last 4 bits are the sum of the preceeding 5 nibbles (mod 0xf)
+Last 4 bits are the sum of the preceding 5 nibbles (mod 0xf)
 
 Here's the data I used to reverse engineer, more sampes in rtl_test
 

--- a/src/devices/kerui.c
+++ b/src/devices/kerui.c
@@ -21,7 +21,7 @@ also tested with:
 - Mini Pir P831
 
 Note: simple 24 bit fixed ID protocol (x1527 style) and should be handled by the flex decoder.
-There is a leading sync bit with a wide gap which runs into the preceeding packet, it's ignored as 25th data bit.
+There is a leading sync bit with a wide gap which runs into the preceding packet, it's ignored as 25th data bit.
 
 There are slight timing differences between the older sensors and new ones like Water leak sensor WD51 and Mini Pir P831.
 Long: 860-1016 us, short: 304-560 us, older sync: 480 us, newer sync: 340 us,

--- a/src/devices/klimalogg.c
+++ b/src/devices/klimalogg.c
@@ -25,7 +25,7 @@ Data layout:
 -  II(14:0): 15 bit ID of sensor (printed on the back and displayed after powerup)
 -  II(15) is either 1 or 0 (fixed, depends on the sensor)
 -  s(3:0): Learning sequence 0...f, after learning fixed 8
--  TTT: Temperatur in BCD in .1degC steps, offset +40degC (-> -40...+60)
+-  TTT: Temperature in BCD in .1degC steps, offset +40degC (-> -40...+60)
 -  HH(6:0): rel. Humidity in % (binary coded, no BCD!)
 -  BB(7): Low battery if =1
 -  BB(6:4): 110 or 111 (for 3199)

--- a/src/devices/lacrosse_tx141x.c
+++ b/src/devices/lacrosse_tx141x.c
@@ -106,7 +106,7 @@ Addition of TX141W and TX145wsdth:
 
 - type 1 has temp+hum (temp is offset 500 and scale 10)
 - type 2 has wind speed (km/h scale 10) and direction (degrees)
-- checksum is CRC-8 poly 0x31 init 0x00 over preceeding 7 bytes
+- checksum is CRC-8 poly 0x31 init 0x00 over preceding 7 bytes
 
 */
 

--- a/src/devices/mebus.c
+++ b/src/devices/mebus.c
@@ -82,6 +82,6 @@ r_device mebus433 = {
     .gap_limit      = 2400,
     .reset_limit    = 6000,
     .decode_fn      = &mebus433_callback,
-    .disabled       = 1, // add docs, tests, false positive checks and then reenable
+    .disabled       = 1, // add docs, tests, false positive checks and then re-enable
     .fields         = output_fields,
 };

--- a/src/devices/new_template.c
+++ b/src/devices/new_template.c
@@ -26,7 +26,7 @@
     - Add to include/rtl_433_devices.h
     - Run ./maintainer_update.py (needs a clean git stage or commit)
 
-    Note that for simple devices doorbell/PIR/remotes a flex conf (see conf dir) is prefered.
+    Note that for simple devices doorbell/PIR/remotes a flex conf (see conf dir) is preferred.
 */
 
 /**

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -119,7 +119,7 @@ static unsigned short int cm180i_power(uint8_t const *msg,unsigned int offset)
     unsigned short int val = 0;
 
     val = (msg[4+offset*2] << 8) | (msg[3+offset*2] & 0xF0);
-    // tested accross situations varying from 700 watt to more than 8000 watt to
+    // tested across situations varying from 700 watt to more than 8000 watt to
     // get same value as showed in physical CM180 panel (exactly equals to 1+1/160)
     val *= 1.00625;
     return val;
@@ -144,7 +144,7 @@ static unsigned short int cm180_power(uint8_t const *msg)
 {
     unsigned short int val = 0;
     val = (msg[4] << 8) | (msg[3] & 0xF0);
-    // tested accross situations varying from 700 watt to more than 8000 watt to
+    // tested across situations varying from 700 watt to more than 8000 watt to
     // get same value as showed in physical CM180 panel (exactly equals to 1+1/160)
     val *= 1.00625;
     return val;

--- a/src/devices/rojaflex.c
+++ b/src/devices/rojaflex.c
@@ -36,7 +36,7 @@ Data documentation:
 - 0xFF     - Size always "0x8"
 - 0xFFFFFF - ID, I assume that differs per installation, but is static then
 - 0xF      - Unknown (is static 0x2) - Not sure if it is also the HomeID
-- 0xF      - Channel: 1-15 single channels (one shutter is registert to one channel), 0 means all
+- 0xF      - Channel: 1-15 single channels (one shutter is registered to one channel), 0 means all
 - 0xFF     - Command ID    (0x0a = stop, 0x1a = up,0x8a = down, 0xea = Request)
 - 0xFF     - Command Value (in status from shutter this is the percent value. 0% for open 100% for close)
 

--- a/src/devices/secplus_v1.c
+++ b/src/devices/secplus_v1.c
@@ -253,7 +253,7 @@ static int secplus_v1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         memcpy(cached_result, result_2, 21);
         if (decoder->verbose)
             fprintf(stderr, "%s: caching part 2\n", __func__);
-        return -2; // found only 2st part
+        return -2; // found only 2nd part
     }
     else if (status == 3) {
         // fprintf(stderr, "%s: got both\n", __func__);

--- a/src/devices/secplus_v2.c
+++ b/src/devices/secplus_v2.c
@@ -224,7 +224,7 @@ static int _decode_v2_half(bitbuffer_t *bits, uint8_t roll_array[], bitbuffer_t 
                 roll_array[4], roll_array[5], roll_array[6], roll_array[7], roll_array[8]);
     }
 
-    // SANITY check trinary valuse, 00/01/10 are valid,  11 is not
+    // SANITY check trinary values, 00/01/10 are valid,  11 is not
     for (int i = 0; i < 9; i++) {
         if (roll_array[i] == 3) {
             fprintf(stderr, "roll_array val  FAIL\n");
@@ -302,7 +302,7 @@ static int secplus_v2_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             _decode_v2_half(&bits, rolling_1, &fixed_1, decoder->verbose);
         }
 
-        // break if we've received both halfs
+        // break if we've received both halves
         if (fixed_1.bits_per_row[0] > 1 && fixed_2.bits_per_row[0] > 1) {
             break;
         }

--- a/src/devices/telldus_ft0385r.c
+++ b/src/devices/telldus_ft0385r.c
@@ -56,7 +56,7 @@ Message layout
 - J : 9 bit: ? Wind direction 3 in degrees. MSB in byte 2
 - K : 16 bit: ? Rain rate in mm, scaled by 10
 - L : 16 bit: Rain 1h mm, scaled by 10
-- M : 16 bit: Rain 24h mm, scaled by 10. Unvailable value = 0x3ffb.
+- M : 16 bit: Rain 24h mm, scaled by 10. Unavailable value = 0x3ffb.
 - N : 16 bit: Rain week mm, scaled by 10
 - O : 16 bit: Rain month mm, scaled by 10
 - P : 16 bit: Rain total in mm, scaled by 10

--- a/src/devices/tfa_drop_30.3233.c
+++ b/src/devices/tfa_drop_30.3233.c
@@ -38,7 +38,7 @@ described below in the correct space, i.e. after the buffer has been
 inverted.
 
 Not every tip of the bucket triggers a message immediately. In some
-cases, artifically tipping the bucket many times lead to the base
+cases, artificially tipping the bucket many times lead to the base
 station ignoring the signal completely until the device was reset.
 
 Data layout:

--- a/src/devices/tpms_jansite_solar.c
+++ b/src/devices/tpms_jansite_solar.c
@@ -69,7 +69,7 @@ static int tpms_jansite_solar_decode(r_device *decoder, bitbuffer_t *bitbuffer, 
     /* Check crc */
     uint16_t crc_calc = crc16(&b[2], 7, 0x8005, 0x0000);
     if ( ((b[9]<<8) | b[10]) != crc_calc) {
-        fprintf(stderr, "CRC missmatch %04x vs %02x %02x\n", crc_calc, b[9], b[10]);
+        fprintf(stderr, "CRC mismatch %04x vs %02x %02x\n", crc_calc, b[9], b[10]);
         return DECODE_FAIL_MIC;
     }
 

--- a/src/pulse_detect_fsk.c
+++ b/src/pulse_detect_fsk.c
@@ -178,7 +178,7 @@ void pulse_FSK_detect_mm(int16_t fm_n, pulse_data_t *fsk_pulses, pulse_FSK_state
     int16_t mid = 0;
 
     /* Skip a few samples in the beginning, need for framing
-     * otherwise the min/max trackers wont converge properly
+     * otherwise the min/max trackers won't converge properly
      */
     if (!s->skip_samples) {
         s->var_test_max = MAX(fm_n, s->var_test_max);

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1052,7 +1052,7 @@ static void parse_conf_option(r_cfg_t *cfg, int opt, char *arg)
         else if (!strcasecmp(arg, "oldmodel"))
             fprintf(stderr, "oldmodel option (-M) is deprecated.\n");
         else if (!strncasecmp(arg, "stats", 5)) {
-            // there also should be options to set wether to flush on report
+            // there also should be options to set whether to flush on report
             char *p = arg_param(arg);
             cfg->report_stats = atoiv(p, 1);
             cfg->stats_interval = atoiv(arg_param(p), 600); // atoi_time_default()

--- a/vs15/README.md
+++ b/vs15/README.md
@@ -1,8 +1,8 @@
 # Compilation instructions for Visual Studio
 
-To compile the program in Visual Studio 2015 (newer versions should work as well) there are external dependancies that are required
+To compile the program in Visual Studio 2015 (newer versions should work as well) there are external dependencies that are required
 
-Dependancy | Source
+Dependency | Source
 ---------|----------
  rtl-sdr | You can use the official, but outdated (January 2014)) windows build <https://osmocom.org/attachments/2242/RelWithDebInfo.zip.> Or you can use the Win64 build of a more recent version from <https://github.com/winterrace/librtlsdr> (or follow the compilation instructions).
  libusb | Download prebuilt binaries or build from source <https://libusb.info/>


### PR DESCRIPTION
This PR fixes minor spelling errors, found with an automated tool and some manual editing and review.

I am in doubt about the change of the name s/Dectector/Detector/ in 3 places but it seems a real error.

Found with:
codespell --skip=AUTHORS,CHANGELOG.md --ignore-words-list=ans,ba,fo,hander,hass,hist,nd,proove,te,temperatur,ue --write --interactive 2