### PR TITLE
Update HASS MQTT Parameter for Lux

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -459,7 +459,7 @@ mappings = {
         }
     },
 
-    "lux": {
+    "light_lux": {
         "device_type": "sensor",
         "object_suffix": "lux",
         "config": {


### PR DESCRIPTION
Change from old value of `lux` to `light_lux`

Tested with version 6.6 of HA OS and proven to work correctly