### PR TITLE
docs: Remove. Removed MQTT QoS from help

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ E.g. -X "n=doorbell,m=OOK_PWM,s=400,l=800,r=7000,g=1000,match={24}0xa9878c,repea
 	Append output to file with :<filename> (e.g. -F csv:log.csv), defaults to stdout.
 	Specify MQTT server with e.g. -F mqtt://localhost:1883
 	Add MQTT options with e.g. -F "mqtt://host:1883,opt=arg"
-	MQTT options are: user=foo, pass=bar, retain[=0|1], qos=N, <format>[=topic]
+	MQTT options are: user=foo, pass=bar, retain[=0|1], <format>[=topic]
 	Supported MQTT formats: (default is all)
 	  events: posts JSON event data
 	  states: posts JSON state data

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -185,7 +185,7 @@ signal_grabber none
 #     Append output to file with :<filename> (e.g. -F csv:log.csv), defaults to stdout.
 #     Specify MQTT server with e.g. -F mqtt://localhost:1883
 #     Add MQTT options with e.g. -F "mqtt://host:1883,opt=arg"
-#     MQTT options are: user=foo, pass=bar, retain[=0|1], qos=N, <format>[=topic]
+#     MQTT options are: user=foo, pass=bar, retain[=0|1], <format>[=topic]
 #     Supported MQTT formats: (default is all)
 #       events: posts JSON event data
 #       states: posts JSON state data

--- a/docs/OPERATION.md
+++ b/docs/OPERATION.md
@@ -441,7 +441,7 @@ Use `-F mqtt` to add an output in MQTT format.
 Specify MQTT server with e.g. `-F mqtt://localhost:1883`.
 
 Add MQTT options with e.g. `-F "mqtt://host:1883,opt=arg"`.
-Supported MQTT options are: `user=foo`, `pass=bar`, `retain[=0|1]`, `qos=N`, `<format>[=<topic>]`.
+Supported MQTT options are: `user=foo`, `pass=bar`, `retain[=0|1]`, `<format>[=<topic>]`.
 
 Supported MQTT formats: (default is all formats)
 - `events`: posts JSON event data

--- a/man/man1/rtl_433.1
+++ b/man/man1/rtl_433.1
@@ -330,7 +330,7 @@ Specify MQTT server with e.g. \-F mqtt://localhost:1883
 Add MQTT options with e.g. \-F "mqtt://host:1883,opt=arg"
 .RE
 .RS
-MQTT options are: user=foo, pass=bar, retain[=0|1], qos=N, <format>[=topic]
+MQTT options are: user=foo, pass=bar, retain[=0|1], <format>[=topic]
 .RE
 .RS
 Supported MQTT formats: (default is all)

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -254,7 +254,7 @@ static void help_output(void)
             "\tAppend output to file with :<filename> (e.g. -F csv:log.csv), defaults to stdout.\n"
             "\tSpecify MQTT server with e.g. -F mqtt://localhost:1883\n"
             "\tAdd MQTT options with e.g. -F \"mqtt://host:1883,opt=arg\"\n"
-            "\tMQTT options are: user=foo, pass=bar, retain[=0|1], qos=N, <format>[=topic]\n"
+            "\tMQTT options are: user=foo, pass=bar, retain[=0|1], <format>[=topic]\n"
             "\tSupported MQTT formats: (default is all)\n"
             "\t  events: posts JSON event data\n"
             "\t  states: posts JSON state data\n"


### PR DESCRIPTION
Code for qos=1 & 2 is unwritten, only qos=0 is functional which is the same as not supplying a qos command line argument. Ref #1937. Command line parser not removed so that development may continue.