### PR TITLE
Add support for AcuRite 01190 Leak Detector

### DIFF
--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -852,8 +852,6 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             // value if they successfully decoded a message.
             if (decoded > 0) {
                 valid++;
-            } else {
-                continue;
             }
         }
 

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -752,7 +752,7 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             battery_low = (bb[2] & 0x40) == 0;
 
             if (message_type == ACURITE_MSGTYPE_LEAK_DETECTOR) {
-                int is_dry = (bb[3] & 0x10) >> 4;
+                int is_wet = (bb[3] & 0x10) >> 4;
 
                 /* clang-format off */
                 data = data_make(
@@ -760,7 +760,7 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                         "id",                   "",             DATA_INT,    sensor_id,
                         "channel",              NULL,           DATA_STRING, channel_str,
                         "battery_ok",           "Battery",      DATA_INT,    !battery_low,
-                        "leak_detected",        "Leak",         DATA_INT,    !is_dry,
+                        "leak_detected",        "Leak",         DATA_INT,    is_wet,
                         "mic",                  "Integrity",    DATA_STRING, "CHECKSUM",
                         NULL);
                 /* clang-format on */

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -698,14 +698,6 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             continue; // DECODE_FAIL_MIC
         }
 
-        if (decoder->verbose) {
-            fprintf(stderr, "%s: Parity: ", __func__);
-            for (int i = 0; i < browlen; i++) {
-                fprintf(stderr, "%d", parity8(bb[i]));
-            }
-            fprintf(stderr, "\n");
-        }
-
         // acurite sensors with a common format appear to have a message type
         // in the lower 6 bits of the 3rd byte.
         // Format: PBMMMMMM

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -734,7 +734,15 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 continue; // return DECODE_FAIL_MIC;
             }
 
+            // Channel is the first two bits of the 0th byte
+            // but only 3 of the 4 possible values are valid
             char const *channel_str = acurite_getChannel(bb[0]);
+            if(strcmp(channel_str, "E") == 0) {
+                if(decoder->verbose)
+                    fprintf(stderr, "%s: Acurite TXR sensor : bad channel Ch %s\n", __func__, channel_str);
+                continue; 
+            }
+
             // Tower sensor ID is the last 14 bits of byte 0 and 1
             // CCII IIII | IIII IIII
             sensor_id = ((bb[0] & 0x3f) << 8) | bb[1];
@@ -751,7 +759,7 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             tempc = temp_raw * 0.1 - 100;
             if (tempc < -40 || tempc > 70) {
                 if(decoder->verbose) {
-                    fprintf(stderr, "%s: Acurite TXR sensor 0x%04X Ch %s -- Impossible temperature: %0.2f C\n",
+                    fprintf(stderr, "%s: Acurite TXR sensor 0x%04X Ch %s : Impossible temperature: %0.2f C\n",
                             __func__, sensor_id, channel_str, tempc);
                 }
                 continue;

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -738,10 +738,10 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             // Channel is the first two bits of the 0th byte
             // but only 3 of the 4 possible values are valid
             char const *channel_str = acurite_getChannel(bb[0]);
-            if(strcmp(channel_str, "E") == 0) {
-                if(decoder->verbose)
+            if (strcmp(channel_str, "E") == 0) {
+                if (decoder->verbose)
                     fprintf(stderr, "%s: Acurite TXR sensor : bad channel Ch %s\n", __func__, channel_str);
-                continue; 
+                continue;
             }
 
             // Tower sensor ID is the last 14 bits of byte 0 and 1
@@ -764,19 +764,16 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                         "mic",                  "Integrity",    DATA_STRING, "CHECKSUM",
                         NULL);
                 /* clang-format on */
-
             }
-            else if (message_type == ACURITE_MSGTYPE_TOWER_SENSOR)
-            {
+            else if (message_type == ACURITE_MSGTYPE_TOWER_SENSOR) {
 
                 // Humidity is stored in byte 3
                 // The value is directly encoded as %rH
                 // The possible values here are 0-128, but real values are only 1-99 %rH
                 // pIII IIII
-                humidity = (bb[3] & 0x7f); 
-                if (humidity < 1 || humidity > 99)
-                {
-                    if(decoder->verbose) {
+                humidity = (bb[3] & 0x7f);
+                if (humidity < 1 || humidity > 99) {
+                    if (decoder->verbose) {
                         fprintf(stderr, "%s: Acurite TXR sensor 0x%04X Ch %s : Impossible humidity: %d %%rH\n",
                                 __func__, sensor_id, channel_str, humidity);
                     }
@@ -789,16 +786,14 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 // Possible ranges are -100 C to 1538.4 C, but most of that range
                 // is not possible on Earth.
                 int temp_raw = ((bb[4] & 0x7F) << 7) | (bb[5] & 0x7F);
-                tempc = temp_raw * 0.1 - 100;
+                tempc        = temp_raw * 0.1 - 100;
                 if (tempc < -40 || tempc > 70) {
-                    if(decoder->verbose) {
+                    if (decoder->verbose) {
                         fprintf(stderr, "%s: Acurite TXR sensor 0x%04X Ch %s : Impossible temperature: %0.2f C\n",
                                 __func__, sensor_id, channel_str, tempc);
                     }
                     continue;
                 }
-
-
 
                 /* clang-format off */
                 data = data_make(

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -637,10 +637,7 @@ static int acurite_atlas_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsig
     return 1; // one valid message decoded
 }
 
-int acurite_tower_sensor_decode(r_device*, uint8_t*);
-int acurite_leak_detector_decode(r_device*, uint8_t*);
-
-int acurite_tower_sensor_decode(r_device* decoder, uint8_t* bb)
+static int acurite_tower_sensor_decode(r_device* decoder, uint8_t* bb)
 {
     // checksum in the last byte has been validated in the calling function
 
@@ -718,7 +715,7 @@ int acurite_tower_sensor_decode(r_device* decoder, uint8_t* bb)
     return 1;
 }
 
-int acurite_leak_detector_decode(r_device* decoder, uint8_t* bb)
+static int acurite_leak_detector_decode(r_device* decoder, uint8_t* bb)
 {
     // checksum in the last byte has been validated in the calling function
 

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -727,14 +727,6 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 continue; // return DECODE_FAIL_MIC;
             }
 
-            // Verify checksum, add with carry
-            int chk = add_bytes(bb, 6);
-            if ((chk & 0xff) != bb[6]) {
-                if (decoder->verbose)
-                    bitrow_printf(bb, 7 * 8, "%s: bad checksum: ", __func__);
-                continue; // return DECODE_FAIL_MIC;
-            }
-
             // Channel is the first two bits of the 0th byte
             // but only 3 of the 4 possible values are valid
             char const *channel_str = acurite_getChannel(bb[0]);

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -717,7 +717,14 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         // TODO: - see if there is a type in the message that
         // can be used instead of length to determine type
         if (browlen == ACURITE_TXR_BITLEN / 8) {
-            // TODO: Verify parity bits
+            // Verify parity bits
+            // Bytes 2, 3, 4, and 5 should all have a parity bit in their MSB
+            int parity = parity_bytes(&bb[2], 4);
+            if (parity) {
+                if (decoder->verbose)
+                    bitrow_printf(bb, 7 * 8, "%s: bad parity: ", __func__);
+                continue; // return DECODE_FAIL_MIC;
+            }
 
             // Verify checksum, add with carry
             int chk = add_bytes(bb, 6);

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -738,7 +738,7 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             // Channel is the first two bits of the 0th byte
             // but only 3 of the 4 possible values are valid
             char const *channel_str = acurite_getChannel(bb[0]);
-            if (strcmp(channel_str, "E") == 0) {
+            if (*channel_str == 'E') {
                 if (decoder->verbose)
                     fprintf(stderr, "%s: Acurite TXR sensor : bad channel Ch %s\n", __func__, channel_str);
                 continue;

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -1424,7 +1424,7 @@ static char *acurite_txr_output_fields[] = {
         "channel",
         "sequence_num",
         "battery_ok",
-        "battery_ok",
+        "leak_detected",
         "temperature_C",
         "temperature_F",
         "humidity",


### PR DESCRIPTION
This PR adds support for the AcuRite 01190M leak detector module (instruction manual [here](https://www.acurite.com/media/manuals/01190M-instructions.pdf)). 

As a side effect of adding support for this sensor, the integrity checks for a few other similar sensors have been improved, most specifically the AcuRite Wireless Temperature and Humidity Sensor (called a tower sensor in the existing code base).