### PR TITLE
ADD support for Honeywell ceiling fans

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [209]  SimpliSafe Gen 3 Home Security System
     [210]  Yale HSA (Home Security Alarm), YES-Alarmkit
     [211]  Regency Ceiling Fan Remote (-f 303.75M to 303.96M)
-    [212]  Rolling Code Transmitter (-f 433.92M | 315M | 390M)
+    [212]  Honeywell Ceiling Fan Remote (-f 314.92M)
 
 * Disabled by default, use -R n or -G
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [209]  SimpliSafe Gen 3 Home Security System
     [210]  Yale HSA (Home Security Alarm), YES-Alarmkit
     [211]  Regency Ceiling Fan Remote (-f 303.75M to 303.96M)
+    [212]  Rolling Code Transmitter (-f 433.92M | 315M | 390M)
 
 * Disabled by default, use -R n or -G
 

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -437,7 +437,7 @@ stop_after_successful_events false
   protocol 209 # SimpliSafe Gen 3 Home Security System
   protocol 210 # Yale HSA (Home Security Alarm), YES-Alarmkit
   protocol 211 # Regency Ceiling Fan Remote (-f 303.75M to 303.96M)
-  protocol 212 # Rolling Code Transmitter (-f 433.92M | 315M | 390M)
+  protocol 212 # Honeywell Ceiling Fan Remote (-f 314.92M)
 
 ## Flex devices (command line option "-X")
 

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -437,6 +437,7 @@ stop_after_successful_events false
   protocol 209 # SimpliSafe Gen 3 Home Security System
   protocol 210 # Yale HSA (Home Security Alarm), YES-Alarmkit
   protocol 211 # Regency Ceiling Fan Remote (-f 303.75M to 303.96M)
+  protocol 212 # Rolling Code Transmitter (-f 433.92M | 315M | 390M)
 
 ## Flex devices (command line option "-X")
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -219,6 +219,7 @@
     DECL(simplisafe_gen3) \
     DECL(yale_hsa) \
     DECL(regency_fan) \
+    DECL(honeywell_fan) \
 
     /* Add new decoders here. */
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,6 +114,7 @@ add_library(r_433 STATIC
     devices/hondaremote.c
     devices/honeywell.c
     devices/honeywell_cm921.c
+    devices/honeywell_fan.c
     devices/honeywell_wdb.c
     devices/ht680.c
     devices/ibis_beacon.c

--- a/src/devices/honeywell_fan.c
+++ b/src/devices/honeywell_fan.c
@@ -40,14 +40,14 @@ there's no such command/value distinction. It looks very suspicious that the fan
 speed commands all share command 000 and the speed value (bit-reversed) appears in the
 value area.
 
-Button  Fixed Other Bits       Function
-ONE     16CD  1 0 0 0 0 1 !d d  Low speed fan
-TWO     16CD  0 1 0 0 0 1 !d d  Medium speed fan
-THREE   16CD  1 1 0 0 0 1 !d d  High speed fan
-OFF-M   16CD  0 0 0 1 0 1 !d d  Fan off (momentary press)
-OFF-C   16CD  0 0 1 0 1 1 !d d  Light off delay (continuous press)
-STAR-M  16CD  1 1 0 1 0 1 !d d  Light on/off (momentary press)
-STAR-C  16CD  0 1 1 1 0 1 !d d  Light dim/brighten (continuous press)
+    Button  Fixed Other Bits       Function
+    ONE     16CD  1 0 0 0 0 1 !d d  Low speed fan
+    TWO     16CD  0 1 0 0 0 1 !d d  Medium speed fan
+    THREE   16CD  1 1 0 0 0 1 !d d  High speed fan
+    OFF-M   16CD  0 0 0 1 0 1 !d d  Fan off (momentary press)
+    OFF-C   16CD  0 0 1 0 1 1 !d d  Light off delay (continuous press)
+    STAR-M  16CD  1 1 0 1 0 1 !d d  Light on/off (momentary press)
+    STAR-C  16CD  0 1 1 1 0 1 !d d  Light dim/brighten (continuous press)
 
 The 'd' bit indicates whether the D/CFL button in the battery compartment
 is set to 'D' (1 bit) or 'CFL' (0 bit). This switch inhibits the dim
@@ -57,7 +57,8 @@ Since the COMMAND/VALUE paradigm is not verified and only seems to apply to the 
 buttons, we'll decode using the full 3rd byte right-shifted by 3 bits to omit the fixed '1'
 and 'Dim' bits.
 
-byte[2] >> 3:
+    byte[2] >> 3:
+    -------------
     0x10: Low fan speed
     0x08: Medium fan speed
     0x18: High fan speed

--- a/src/devices/honeywell_fan.c
+++ b/src/devices/honeywell_fan.c
@@ -1,3 +1,4 @@
+/** @file
     Decoder for Honeywell fan remotes.
 
     Copyright (C) 2020-2022 David E. Tiller
@@ -13,135 +14,115 @@
 /**
 Decoder for Honeywell fan remotes.
 
+This fan is made by Intertek (model 4003229) but is sold by Honeywell
+as a 'Harbor Breeze Salermo'.
+
 Honeywell fans use OOK_PULSE_PPM encoding.
 The packet starts with 576 uS start pulse.
-- 0 is defined as a 375 uS gap followed by a 970 uS pulse.
-- 1 is defined as a 880 uS gap followed by a 450 uS pulse.
+- 0 is defined as a 300 uS gap followed by a 900 uS pulse.
+- 1 is defined as a 900 uS gap followed by a 300 uS pulse.
 
-Transmissions consist of the start bit followed by bursts of 20 bits.
-These packets ar repeated up to 11 times.
+Transmissions consist of a short start bit followed by bursts of 24 bits.
+These packets are repeated up to 23 times.
 
-As written, the PPM code always interpets a narrow gap as a 1 and a
-long gap as a 0, however the actual data over the air is inverted,
-i.e. a short gap is a 0 and a long gap is a 1. In addition, the data
-is 5 nibbles long and is represented in Little-Endian format. In the
-code I invert the bits and also reflect the bytes. Reflection introduces
-an additional nibble at bit offsets 16-19, so the data is expressed a 3
-complete bytes.
+Possible packet layout:
 
-The examples below are _after_ inversion and reflection (MSB's are on
-the left).
+    Bit number 0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17 18 19 20 21 22 23
+               -----------------------------------------------------------------------
+    Value      0  0  0  1  0  1  1  0  1  1  0  0  1  1  0  1 |Value|  Cmd   | 1 !d  d
 
-Packet layout:
+It is pure supposition that the leading 0x16CD and bit 21 are fixed values.
+I do not have more than 1 remote to test and there's no mention in the manual about
+dip switch settings, nor are there any on the remote. It's also possible that the
+value occupies 3 bits and the command is only two bits. It's also possible that
+there's no such command/value distinction. It looks very suspicious that the fan
+speed commands all share command 000 and the speed value (bit-reversed) appears in the
+value area.
 
-     Bit number
-     0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17 18 19 20 21 22 23
-      CHANNEL  |  COMMAND  |            VALUE       | 0  0  0  0| 4 bit checksum
+Button  Fixed Other Bits       Function
+ONE     16CD  1 0 0 0 0 1 !d d  Low speed fan
+TWO     16CD  0 1 0 0 0 1 !d d  Medium speed fan
+THREE   16CD  1 1 0 0 0 1 !d d  High speed fan
+OFF-M   16CD  0 0 0 1 0 1 !d d  Fan off (momentary press)
+OFF-C   16CD  0 0 1 0 1 1 !d d  Light off delay (continuous press)
+STAR-M  16CD  1 1 0 1 0 1 !d d  Light on/off (momentary press)
+STAR-C  16CD  0 1 1 1 0 1 !d d  Light dim/brighten (continuous press)
 
-CHANNEL is determined by the bit switches in the battery compartment. All
-switches in the 'off' position result in a channel of 15, implying that the
-switches pull the address lines down when in the on position.
+The 'd' bit indicates whether the D/CFL button in the battery compartment
+is set to 'D' (1 bit) or 'CFL' (0 bit). This switch inhibits the dim
+function when set to CFL. The !d bit seems to just be the complement of 'd'.
 
-COMMAND is one of the following:
+Since the COMMAND/VALUE paradigm is not verified and only seems to apply to the fan speed
+buttons, we'll decode using the full 3rd byte right-shifted by 3 bits to omit the fixed '1'
+and 'Dim' bits.
 
-- 1 (0x01)
-    value: (0xc0, unused).
-
-- 2 (0x02)
-    value: 0x01-0x07. On my remote, the speeds are shown as 8 - value.
-
-- 4 (0x04)
-    value: 0x00-0xc3. The value is the intensity percentage.
-           0x00 is off, 0xc3 is 99% (full).
-
-- 5 (0x05)
-    value: 0x00 is 'off', 0x01 is on.
-
-- 6 (0x06)
-    value: 0x07 is one way, 0x83 is the other.
-
-The CHECKSUM is calculated by adding the nibbles of the first two bytes
-and ANDing the result with 0x0f.
+byte[2] >> 3:
+    0x10: Low fan speed
+    0x08: Medium fan speed
+    0x18: High fan speed
+    0x02: Fan off, momentary press of the power button
+    0x05: Delayed light off, extended press of the power button
+    0x1A: Light on/off, momentary press of the 'star' button
+    0x0E: Light dim/brighten, extended press of the 'star' button
 
 */
 
-static int regency_fan_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+static int honeywell_fan_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    char const * const command_names[] = {
-            /* 0  */ "invalid",
-            /* 1  */ "fan_speed",
-            /* 2  */ "fan_speed",
-            /* 3  */ "invalid",
-            /* 4  */ "light_intensity",
-            /* 5  */ "light_delay",
-            /* 6  */ "fan_direction",
-            /* 7  */ "invalid",
-            /* 8  */ "invalid",
-            /* 9  */ "invalid",
-            /* 10 */ "invalid",
-            /* 11 */ "invalid",
-            /* 12 */ "invalid",
-            /* 13 */ "invalid",
-            /* 14 */ "invalid",
-            /* 15 */ "invalid",
-    };
-
     int return_code = 0;
-
-bitbuffer_print(const bitbuffer);
-return 0;
-/*
-    bitbuffer_invert(bitbuffer);
 
     for (int row = 0; row < bitbuffer->num_rows; row++) {
         int num_bits = bitbuffer->bits_per_row[row];
 
-        if (num_bits != 21) { // Max number of bits is 21
+        if (num_bits != 24) { // Correct number of bits is 24
             if (decoder->verbose > 1) {
                 fprintf(stderr, "%s: Expected %d bits, got %d.\n", __func__, 21, num_bits); // Max number of bits is 21
             }
             continue;
         }
 
-        uint8_t bytes[3]; // Max number of bytes is 3
-        bitbuffer_extract_bytes(bitbuffer, row, 1, bytes, 21); // Valid byte offset is 1, Max number of bits is 21
-        reflect_bytes(bytes, 3); // Max number of bytes is 3
+        uint8_t bytes[3] = {0}; // Max number of bytes is 3
+        bitbuffer_extract_bytes(bitbuffer, row, 0, bytes, 24); // Valid byte offset is 0, Max number of bits is 24
 
-        // Calculate nibble sum and compare
-        int checksum = add_nibbles(bytes, 2) & 0x0f;
-        if (checksum != bytes[2]) { // Sum is in byte 2
+        // Sanity check leading 'fixed' portion
+        if (bytes[0] != 0x16 || bytes[1] != 0xcd) {
             if (decoder->verbose > 1) {
-                fprintf(stderr, "%s: Checksum failure: expected %0x, got %0x\n", __func__, bytes[2], checksum); // Sum is in byte 2
+                fprintf(stderr, "%s: Expected leading fixed bits 0x16CD, got %x%x.\n", __func__, bytes[0], bytes[1]);
             }
             continue;
         }
 
-        // Now that message "envelope" has been validated, start parsing data.
-        int command = bytes[0] >> 4;    // Command and Channel are in byte 0
-        int channel = ~bytes[0] & 0x0f; // Command and Channel are in byte 0
-        int value   = bytes[1];         // Value is in byte 1
-
-        char value_string[64] = {0};
+        int dimmable = bytes[2] & 0x01;
+        int command = (bytes[2] >> 3) & 0x1f;
+        char command_string[80] = {0};
 
         switch (command) {
-        case 1: // 1 is the command to STOP
-            sprintf(value_string, "stop");
+        case 0x10: // Low fan speed
+            sprintf(command_string, "fan_low");
             break;
 
-        case 2: // 2 is the command to change fan speed
-            sprintf(value_string, "speed %d", value);
+        case 0x08: // Medium fan speed
+            sprintf(command_string, "fan_medium");
             break;
 
-        case 4: // 4 is the command to change the light intensity
-            sprintf(value_string, "%d %%", value);
+        case 0x18: // Hign fan speed
+            sprintf(command_string, "fan_high");
             break;
 
-        case 5: // 5 is the command to set the light delay
-            sprintf(value_string, "%s", value == 0 ? "off" : "on");
+        case 0x02: // Fan off
+            sprintf(command_string, "fan_off");
             break;
 
-        case 6: // 6 is the command to change fan direction
-            sprintf(value_string, "%s", value == 0x07 ? "clockwise" : "counter-clockwise");
+        case 0x05: // Delayed light off
+            sprintf(command_string, "light_off_delayed");
+            break;
+
+        case 0x1a: // Light on/off
+            sprintf(command_string, "light_on_off");
+            break;
+
+        case 0x0e: // Light dim/brighten
+            sprintf(command_string, "light_dim_brighten");
             break;
 
         default:
@@ -152,42 +133,37 @@ return 0;
             break;
         }
 
-        /* clang-format off */
+        // clang-format off
         data_t *data = data_make(
                 "model",            "",     DATA_STRING,    "Honeywell-Remote",
-                "channel",          "",     DATA_INT,       channel,
-                "command",          "",     DATA_STRING,    command_names[command],
-                "value",            "",     DATA_STRING,    value_string,
-                "mic",              "",     DATA_STRING,    "CHECKSUM",
+                "command",          "",     DATA_STRING,    command_string,
+                "dimmable",         "",     DATA_INT   ,    dimmable,
+                "mic",              "",     DATA_STRING,    "FIXED_BITS",
                 NULL);
-        /* clang-format on */
+        // clang-format on
 
         decoder_output_data(decoder, data);
         return_code++;
     }
-*/
 
     return return_code;
 }
 
 static char *output_fields[] = {
         "model",
-        "type",
-        "channel",
         "command",
-        "value",
+        "dimmable",
         "mic",
         NULL,
 };
-
-r_device regency_fan = {
+// OOK_PULSE_PPM,s=300,l=900,r=1300 works to get one row
+r_device honeywell_fan = {
         .name        = "Honeywell Ceiling Fan Remote (-f 303.75M to 303.96M)",
-        .modulation  = OOK_PULSE_PWM,
+        .modulation  = OOK_PULSE_PPM,
         .short_width = 300,
         .long_width  = 900,
-        .gap_limit   = 8000,
-        .reset_limit = 14000,
+        //.gap_limit   = 2200,
+        .reset_limit = 1300,
         .decode_fn   = &honeywell_fan_decode,
         .fields      = output_fields,
 };
-/** @file

--- a/src/devices/honeywell_fan.c
+++ b/src/devices/honeywell_fan.c
@@ -15,10 +15,11 @@
 Decoder for Honeywell fan remotes.
 
 This fan is made by Intertek (model 4003229) but is sold by Honeywell
-as a 'Harbor Breeze Salermo'.
+as a model 'Salermo', number 10285. This fan may be sold under different
+makes and models, YMMV.
 
 Honeywell fans use OOK_PULSE_PPM encoding.
-The packet starts with 576 uS start pulse.
+The packet starts with a 300 uS start pulse.
 - 0 is defined as a 300 uS gap followed by a 900 uS pulse.
 - 1 is defined as a 900 uS gap followed by a 300 uS pulse.
 
@@ -133,14 +134,14 @@ static int honeywell_fan_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             break;
         }
 
-        // clang-format off
+        /* clang-format off */
         data_t *data = data_make(
                 "model",            "",     DATA_STRING,    "Honeywell-Remote",
                 "command",          "",     DATA_STRING,    command_string,
                 "dimmable",         "",     DATA_INT   ,    dimmable,
                 "mic",              "",     DATA_STRING,    "FIXED_BITS",
                 NULL);
-        // clang-format on
+        /* clang-format on */
 
         decoder_output_data(decoder, data);
         return_code++;
@@ -158,7 +159,7 @@ static char *output_fields[] = {
 };
 // OOK_PULSE_PPM,s=300,l=900,r=1300 works to get one row
 r_device honeywell_fan = {
-        .name        = "Honeywell Ceiling Fan Remote (-f 303.75M to 303.96M)",
+        .name        = "Honeywell Ceiling Fan Remote (-f 314.92M)",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 300,
         .long_width  = 900,

--- a/src/devices/honeywell_fan.c
+++ b/src/devices/honeywell_fan.c
@@ -140,7 +140,7 @@ static int honeywell_fan_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 "model",            "",     DATA_STRING,    "Honeywell-Remote",
                 "command",          "",     DATA_STRING,    command_string,
                 "dimmable",         "",     DATA_INT   ,    dimmable,
-                "mic",              "",     DATA_STRING,    "FIXED_BITS",
+                "mic",              "",     DATA_STRING,    "PARITY",
                 NULL);
         /* clang-format on */
 

--- a/src/devices/honeywell_fan.c
+++ b/src/devices/honeywell_fan.c
@@ -1,0 +1,193 @@
+    Decoder for Honeywell fan remotes.
+
+    Copyright (C) 2020-2022 David E. Tiller
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#include "decoder.h"
+
+/**
+Decoder for Honeywell fan remotes.
+
+Honeywell fans use OOK_PULSE_PPM encoding.
+The packet starts with 576 uS start pulse.
+- 0 is defined as a 375 uS gap followed by a 970 uS pulse.
+- 1 is defined as a 880 uS gap followed by a 450 uS pulse.
+
+Transmissions consist of the start bit followed by bursts of 20 bits.
+These packets ar repeated up to 11 times.
+
+As written, the PPM code always interpets a narrow gap as a 1 and a
+long gap as a 0, however the actual data over the air is inverted,
+i.e. a short gap is a 0 and a long gap is a 1. In addition, the data
+is 5 nibbles long and is represented in Little-Endian format. In the
+code I invert the bits and also reflect the bytes. Reflection introduces
+an additional nibble at bit offsets 16-19, so the data is expressed a 3
+complete bytes.
+
+The examples below are _after_ inversion and reflection (MSB's are on
+the left).
+
+Packet layout:
+
+     Bit number
+     0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17 18 19 20 21 22 23
+      CHANNEL  |  COMMAND  |            VALUE       | 0  0  0  0| 4 bit checksum
+
+CHANNEL is determined by the bit switches in the battery compartment. All
+switches in the 'off' position result in a channel of 15, implying that the
+switches pull the address lines down when in the on position.
+
+COMMAND is one of the following:
+
+- 1 (0x01)
+    value: (0xc0, unused).
+
+- 2 (0x02)
+    value: 0x01-0x07. On my remote, the speeds are shown as 8 - value.
+
+- 4 (0x04)
+    value: 0x00-0xc3. The value is the intensity percentage.
+           0x00 is off, 0xc3 is 99% (full).
+
+- 5 (0x05)
+    value: 0x00 is 'off', 0x01 is on.
+
+- 6 (0x06)
+    value: 0x07 is one way, 0x83 is the other.
+
+The CHECKSUM is calculated by adding the nibbles of the first two bytes
+and ANDing the result with 0x0f.
+
+*/
+
+static int regency_fan_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    char const * const command_names[] = {
+            /* 0  */ "invalid",
+            /* 1  */ "fan_speed",
+            /* 2  */ "fan_speed",
+            /* 3  */ "invalid",
+            /* 4  */ "light_intensity",
+            /* 5  */ "light_delay",
+            /* 6  */ "fan_direction",
+            /* 7  */ "invalid",
+            /* 8  */ "invalid",
+            /* 9  */ "invalid",
+            /* 10 */ "invalid",
+            /* 11 */ "invalid",
+            /* 12 */ "invalid",
+            /* 13 */ "invalid",
+            /* 14 */ "invalid",
+            /* 15 */ "invalid",
+    };
+
+    int return_code = 0;
+
+bitbuffer_print(const bitbuffer);
+return 0;
+/*
+    bitbuffer_invert(bitbuffer);
+
+    for (int row = 0; row < bitbuffer->num_rows; row++) {
+        int num_bits = bitbuffer->bits_per_row[row];
+
+        if (num_bits != 21) { // Max number of bits is 21
+            if (decoder->verbose > 1) {
+                fprintf(stderr, "%s: Expected %d bits, got %d.\n", __func__, 21, num_bits); // Max number of bits is 21
+            }
+            continue;
+        }
+
+        uint8_t bytes[3]; // Max number of bytes is 3
+        bitbuffer_extract_bytes(bitbuffer, row, 1, bytes, 21); // Valid byte offset is 1, Max number of bits is 21
+        reflect_bytes(bytes, 3); // Max number of bytes is 3
+
+        // Calculate nibble sum and compare
+        int checksum = add_nibbles(bytes, 2) & 0x0f;
+        if (checksum != bytes[2]) { // Sum is in byte 2
+            if (decoder->verbose > 1) {
+                fprintf(stderr, "%s: Checksum failure: expected %0x, got %0x\n", __func__, bytes[2], checksum); // Sum is in byte 2
+            }
+            continue;
+        }
+
+        // Now that message "envelope" has been validated, start parsing data.
+        int command = bytes[0] >> 4;    // Command and Channel are in byte 0
+        int channel = ~bytes[0] & 0x0f; // Command and Channel are in byte 0
+        int value   = bytes[1];         // Value is in byte 1
+
+        char value_string[64] = {0};
+
+        switch (command) {
+        case 1: // 1 is the command to STOP
+            sprintf(value_string, "stop");
+            break;
+
+        case 2: // 2 is the command to change fan speed
+            sprintf(value_string, "speed %d", value);
+            break;
+
+        case 4: // 4 is the command to change the light intensity
+            sprintf(value_string, "%d %%", value);
+            break;
+
+        case 5: // 5 is the command to set the light delay
+            sprintf(value_string, "%s", value == 0 ? "off" : "on");
+            break;
+
+        case 6: // 6 is the command to change fan direction
+            sprintf(value_string, "%s", value == 0x07 ? "clockwise" : "counter-clockwise");
+            break;
+
+        default:
+            if (decoder->verbose > 1) {
+                fprintf(stderr, "%s: Unknown command: %d\n", __func__, command);
+                continue;
+            }
+            break;
+        }
+
+        /* clang-format off */
+        data_t *data = data_make(
+                "model",            "",     DATA_STRING,    "Honeywell-Remote",
+                "channel",          "",     DATA_INT,       channel,
+                "command",          "",     DATA_STRING,    command_names[command],
+                "value",            "",     DATA_STRING,    value_string,
+                "mic",              "",     DATA_STRING,    "CHECKSUM",
+                NULL);
+        /* clang-format on */
+
+        decoder_output_data(decoder, data);
+        return_code++;
+    }
+*/
+
+    return return_code;
+}
+
+static char *output_fields[] = {
+        "model",
+        "type",
+        "channel",
+        "command",
+        "value",
+        "mic",
+        NULL,
+};
+
+r_device regency_fan = {
+        .name        = "Honeywell Ceiling Fan Remote (-f 303.75M to 303.96M)",
+        .modulation  = OOK_PULSE_PWM,
+        .short_width = 300,
+        .long_width  = 900,
+        .gap_limit   = 8000,
+        .reset_limit = 14000,
+        .decode_fn   = &honeywell_fan_decode,
+        .fields      = output_fields,
+};
+/** @file

--- a/vs15/rtl_433.vcxproj
+++ b/vs15/rtl_433.vcxproj
@@ -246,6 +246,7 @@ COPY ..\..\libusb\MS64\dll\libusb*.dll $(TargetDir)</Command>
     <ClCompile Include="..\src\devices\hondaremote.c" />
     <ClCompile Include="..\src\devices\honeywell.c" />
     <ClCompile Include="..\src\devices\honeywell_cm921.c" />
+    <ClCompile Include="..\src\devices\honeywell_fan.c" />
     <ClCompile Include="..\src\devices\honeywell_wdb.c" />
     <ClCompile Include="..\src\devices\ht680.c" />
     <ClCompile Include="..\src\devices\ibis_beacon.c" />

--- a/vs15/rtl_433.vcxproj.filters
+++ b/vs15/rtl_433.vcxproj.filters
@@ -475,6 +475,9 @@
     <ClCompile Include="..\src\devices\honeywell_cm921.c">
       <Filter>Source Files\devices</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\devices\honeywell_fan.c">
+      <Filter>Source Files\devices</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\devices\honeywell_wdb.c">
       <Filter>Source Files\devices</Filter>
     </ClCompile>


### PR DESCRIPTION
This decoder handles the Honeywell model Salermo ceiling fan. The fan is actually made by Intertek but sold under Honeywell's name.