### PR TITLE
ci: Fix Maverick ET73 temperature_1 and recognize negative temps

### DIFF
--- a/src/devices/maverick_et73.c
+++ b/src/devices/maverick_et73.c
@@ -73,12 +73,12 @@ static int maverick_et73_sensor_callback(r_device *decoder, bitbuffer_t *bitbuff
         bitrow_print(bytes, 48);
     }
 
-    /* Repack the nibbles to form a 12-bit field representing the temperatures, 
-       then sign-extend the 12-bit field to a 16-bit integer for float conversion */
-    temp1_raw = ( (int16_t)( bytes[1]<<8 | ( bytes[2] & 0xf0 ) ) )>>4; 
-    temp1_c = temp1_raw * 0.1f;
-    temp2_raw = ( (int16_t)( ( bytes[2] & 0x0f) << 12) | bytes[3]<<4)>>4;
-    temp2_c = temp2_raw * 0.1f;
+    // Repack the nibbles to form a 12-bit field representing the 2's-complement temperatures,
+    //   then right shift by 4 to sign-extend the 12-bit field to a 16-bit integer for float conversion
+    temp1_raw = (int16_t)( bytes[1]<<8 | ( bytes[2] & 0xf0 ) );
+    temp1_c = (temp1_raw>>4) * 0.1f;
+    temp2_raw = (int16_t)( ( (bytes[2] & 0x0f) << 12) | bytes[3]<<4 );
+    temp2_c = (temp2_raw>>4) * 0.1f;
 
     /* clang-format off */
     data = data_make(

--- a/src/devices/maverick_et73.c
+++ b/src/devices/maverick_et73.c
@@ -80,7 +80,6 @@ static int maverick_et73_sensor_callback(r_device *decoder, bitbuffer_t *bitbuff
     /*[hdt] corrected to recognize negative temperatures */
     temp1_c = ((temp1_raw & 0x800) == 0) ? (temp1_raw * 0.1f) : ( m1mask | temp1_raw) * 0.1f;
     temp2_c = ((temp2_raw & 0x800) == 0) ? (temp2_raw * 0.1f) : ( m1mask | temp2_raw) * 0.1f;
-    
     /* clang-format off */
     data = data_make(
             "model",            "",                 DATA_STRING, "Maverick-ET73",


### PR DESCRIPTION
The Maverick ET73 decoder for temperature_1 doesn't align the right-most nibble of the 12-bit
raw temp integer correctly, so that value is always incorrect.  temperature_2 is fine in that regard.

However, neither decoding accounts for possible negative temperatures.  The ET73 has a range of -10˚C to +210˚C.  Seems unlikely that a smoker thermometer would need to report below freezing, but the second edit to the .c file accounts correctly for negative temps.

Test files, and a replay of a prior test file, are coming in a subsequent pull request for the test directory.

Sorry if I got any of this process wrong ... I'm new to some of these tools and your (well-organized) procedures.  
