### PR TITLE
Add missing angle bracket to man page

### DIFF
--- a/man/man1/rtl_433.1
+++ b/man/man1/rtl_433.1
@@ -63,7 +63,7 @@ Receive frequency(s) (default: 433920000 Hz)
 [ \fB\-H\fI <seconds>\fP ]
 Hop interval for polling of multiple frequencies (default: 600 seconds)
 .TP
-[ \fB\-p\fI <ppm_error\fP ]
+[ \fB\-p\fI <ppm_error>\fP ]
 Correct rtl\-sdr tuner frequency offset error (default: 0)
 .TP
 [ \fB\-s\fI <sample rate>\fP ]

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -147,7 +147,7 @@ static void usage(int exit_code)
             "       e.g. -t \"antenna=A,bandwidth=4.5M,rfnotch_ctrl=false\"\n"
             "  [-f <frequency>] Receive frequency(s) (default: %i Hz)\n"
             "  [-H <seconds>] Hop interval for polling of multiple frequencies (default: %i seconds)\n"
-            "  [-p <ppm_error] Correct rtl-sdr tuner frequency offset error (default: 0)\n"
+            "  [-p <ppm_error>] Correct rtl-sdr tuner frequency offset error (default: 0)\n"
             "  [-s <sample rate>] Set sample rate (default: %i Hz)\n"
             "\t\t= Demodulator options =\n"
             "  [-R <device> | help] Enable only the specified device decoding protocol (can be used multiple times)\n"


### PR DESCRIPTION
Close the angle brackets around the -p option's required ppm_error parameter.