### PR TITLE
rename duplicate dict key 'light_lux' back to 'lux', fixes #1986

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -467,17 +467,17 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "lux",
         "config": {
-            "name": "Outside Luminancee",
+            "name": "Outside Luminance",
             "unit_of_measurement": "lux",
             "value_template": "{{ value|int }}",
             "state_class": "measurement"
         }
     },
-    "light_lux": {
+    "lux": {
         "device_type": "sensor",
         "object_suffix": "lux",
         "config": {
-            "name": "Outside Luminancee",
+            "name": "Outside Luminance",
             "unit_of_measurement": "lux",
             "value_template": "{{ value|int }}",
             "state_class": "measurement"


### PR DESCRIPTION
* rename duplicate dict key 'light_lux' back to 'lux' for legacy reasons
* fix Luminancee typo
