### PR TITLE
Add ERT-SCM consumption data to rtl_433_mqtt_hass mappings

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -537,6 +537,16 @@ mappings = {
         }
     },
 
+    "consumption_data": {
+        "device_type": "sensor",
+        "object_suffix": "consumption",
+        "config": {
+            "name": "SCM Consumption Value",
+            "value_template": "{{ value|int }}",
+            "state_class": "total_increasing",
+        }
+    },
+
 }
 
 


### PR DESCRIPTION
This would let me see my electric and gas meters in Home Assistant more easily.