### PR TITLE
Push the first row into the parent dataframe

### DIFF
--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -298,6 +298,7 @@ static int flex_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             "codes", "", DATA_ARRAY, data_array(bitbuffer->num_rows, DATA_STRING, row_codes),
             NULL);
     /* clang-format on */
+    render_getters(data, bitbuffer->bb[0], params);
 
     decoder_output_data(decoder, data);
     for (i = 0; i < bitbuffer->num_rows; i++) {


### PR DESCRIPTION
When creating a custom flex decoder such as 
```
decoder n=Doorbell,m=OOK_PWM,s=300,l=600,r=5256,g=548,t=134,y=0,bits=25,repeats>=3,match=cba,get={12}:protocol,get=:12:{8}:id
```

I'd like to collect the first row data into the parent object. This small patch (1 added line) allows this to happen. 

This means that my MQTT event is received as this structure

```
{
	"codes": [
		"{25}cba3fa8",
		"{25}cba3fa8",
		"{25}cba3fa8",
		"{25}cba3fa8",
		"{25}cba3fa8",
		"{25}cba3fa8",
		"{24}cb47f5"
	],
	"count": 6,
	"freq": 433.85766,
	"id": 203,
	"mod": "ASK",
	"model": "Doorbell",
	"noise": -16.4857,
	"num_rows": 7,
	"protocol": 3258,
	"rows": [
		{
			"data": "cba3fa8",
			"id": 203,
			"len": 25,
			"protocol": 3258
		},
		# more rows
	],
	"rssi": -0.09784320000000001,
	"snr": 16.38788,
	"time": "2022-04-19T15:30:45.095780"
}
```

This makes the device more usable in Home assistant.