### PR TITLE
Add support for HCS200/HCS300 based remotes with FSK transmitters

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [215]  Altronics X7064 temperature and humidity sensor
     [216]* ANT and ANT+ devices
     [217]  EMOS E6016 rain gauge
+    [218]  Microchip HCS200/HCS300 KeeLoq Hopping Encoder based remotes (FSK)
 
 * Disabled by default, use -R n or a conf file to enable
 

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -439,6 +439,7 @@ stop_after_successful_events false
   protocol 215 # Altronics X7064 temperature and humidity sensor
 # protocol 216 # ANT and ANT+ devices
   protocol 217 # EMOS E6016 rain gauge
+  protocol 218 # Microchip HCS200/HCS300 KeeLoq Hopping Encoder based remotes (FSK)
 
 ## Flex devices (command line option "-X")
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -225,6 +225,7 @@
     DECL(altronics_7064) \
     DECL(ant_antplus) \
     DECL(emos_e6016_rain) \
+    DECL(hcs200_fsk) \
 
     /* Add new decoders here. */
 

--- a/src/devices/hcs200.c
+++ b/src/devices/hcs200.c
@@ -108,3 +108,15 @@ r_device hcs200 = {
         .decode_fn   = &hcs200_callback,
         .fields      = output_fields,
 };
+
+r_device hcs200_fsk = {
+        .name        = "Microchip HCS200/HCS300 KeeLoq Hopping Encoder based remotes (FSK)",
+        .modulation  = FSK_PULSE_PWM,
+        .short_width = 370,
+        .long_width  = 772,
+        .gap_limit   = 1500,
+        .reset_limit = 9000,
+        .tolerance   = 152, // us
+        .decode_fn   = &hcs200_callback,
+        .fields      = output_fields,
+};


### PR DESCRIPTION
The existing decoder works fine but some remotes based on the same chips transmit using FSK instead of OOK.

I own one of such remotes so I initially tried running rtl_433 with this custom decoder:

`rtl_433 -R 0 -X 'n=hcs200,m=FSK_PWM,s=370,l=772,r=9000,g=1500,t=152'`

I confirmed that it works but it's a bit inconvenient, I'm not sure if adding a separate device protocol is the way to go but it might be useful to somebody else.