### PR TITLE
feat: add light_klx from bresser 7 in 1

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -477,7 +477,16 @@ mappings = {
             "state_class": "measurement"
         }
     },
-
+    "light_klx": {
+        "device_type": "sensor",
+        "object_suffix": "lux",
+        "config": {
+            "name": "Outside Luminance",
+            "unit_of_measurement": "lux",
+            "value_template": "{{ value|int }}",
+            "state_class": "measurement"
+        }
+    },
     "uv": {
         "device_type": "sensor",
         "object_suffix": "uv",


### PR DESCRIPTION
Add missing `light_klx`

Logs :
```
INFO:root:Published Bresser-7in1/47539: time, temperature_C, humidity, wind_max_m_s, wind_avg_m_s, wind_dir_deg, rain_mm, uv, battery_ok
INFO:root:Skipped Bresser-7in1/47539: light_klx
```