### PR TITLE
fix crash when reading a conf file

### DIFF
--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1134,8 +1134,8 @@ static void parse_conf_option(r_cfg_t *cfg, int opt, char *arg)
         else if (strncmp(arg, "syslog", 6) == 0) {
             add_syslog_output(cfg, arg_param(arg));
         }
-        else if (strncmp(optarg, "http", 4) == 0) {
-            add_http_output(cfg, arg_param(optarg));
+        else if (strncmp(arg, "http", 4) == 0) {
+            add_http_output(cfg, arg_param(arg));
         }
         else if (strncmp(arg, "trigger", 7) == 0) {
             add_trigger_output(cfg, arg_param(arg));


### PR DESCRIPTION
I have rtl_433 running on an RPi4 in a docker container based on debian buster-slim, and when I use a .conf file to specify options, rtl_433 crashes if I try to set up an rtl_tcp output.  I dug down a bit and found that a strncmp() in parse_conf_option() blows up because optarg is NULL when reading a conf file.