### PR TITLE
Fix spelling errors

### DIFF
--- a/include/r_device.h
+++ b/include/r_device.h
@@ -11,7 +11,7 @@
     Note that Modulation is a term used usually to refer to the analog domain.
     We refer to Modulation for the process of (de-)modulating a digital line code,
     represented as pulses and gaps (OOK) or mark and space (FSK) onto a RF carrier signal.
-    The line code is a coding of the bitstream data and refered to as the Coding of the data.
+    The line code is a coding of the bitstream data and referred to as the Coding of the data.
 
     We however use the well known terms to refer to the combinations of this.
     E.g. the term PWM is well known as anlog or discrete range modulation, but here used

--- a/src/devices/regency_fan.c
+++ b/src/devices/regency_fan.c
@@ -22,7 +22,7 @@ The packet starts with 576 uS start pulse.
 Transmissions consist of the start bit followed by bursts of 20 bits.
 These packets ar repeated up to 11 times.
 
-As written, the PPM code always interpets a narrow gap as a 1 and a
+As written, the PPM code always interprets a narrow gap as a 1 and a
 long gap as a 0, however the actual data over the air is inverted,
 i.e. a short gap is a 0 and a long gap is a 1. In addition, the data
 is 5 nibbles long and is represented in Little-Endian format. In the

--- a/src/devices/tpms_renault_0435r.c
+++ b/src/devices/tpms_renault_0435r.c
@@ -121,7 +121,7 @@ static int tpms_renault_0435r_decode(r_device *decoder, bitbuffer_t *bitbuffer, 
             "flags",           "",                         DATA_STRING, flags_str,
             "pressure_kPa",    "Pressure",                 DATA_FORMAT, "%.1f kPa",  DATA_DOUBLE, (double)pressure_kpa,
             "temperature_C",   "Temperature",              DATA_FORMAT, "%.0f C",    DATA_DOUBLE, (double)temp_c,
-            "centrifugal_acc", "Centrifugal Accelaration", DATA_FORMAT, "%.0f m/s2", DATA_DOUBLE, (double)rad_acc,
+            "centrifugal_acc", "Centrifugal Acceleration", DATA_FORMAT, "%.0f m/s2", DATA_DOUBLE, (double)rad_acc,
             "mic",             "",                         DATA_STRING, "CRC",
             "has_tick",        "",                         DATA_INT,    has_tick,
             "tick",            "",                         DATA_INT,    tick - 0x80*(1-has_tick), //set to negative value when has_tick == 0 (invert bit 7)


### PR DESCRIPTION
The only change in code is "Accelaration" in src/devices/tpms_renault_0435r.c the other changes are in documentation.

Fixed with:
codespell --interactive=1 --write-changes --ignore-words-list=als,ans,hass,produkt,proove,temperatur
