### PR TITLE
Add ESIC/SCMplus fields to rtl_433_mqtt_hass

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -456,6 +456,42 @@ mappings = {
             "state_class": "measurement"
         }
     },
+  
+    "energy_kWh": {
+        "device_type": "sensor",
+        "object_suffix": "kwh",
+        "config": {
+            "device_class": "power",
+            "name": "Energy",
+            "unit_of_measurement": "kWh",
+            "value_template": "{{ value|float }}",
+            "state_class": "measurement"
+        }
+    },
+  
+    "current_A": {
+        "device_type": "sensor",
+        "object_suffix": "A",
+        "config": {
+            "device_class": "power",
+            "name": "Current",
+            "unit_of_measurement": "A",
+            "value_template": "{{ value|float }}",
+            "state_class": "measurement"
+        }
+    },
+  
+    "voltage_V": {
+        "device_type": "sensor",
+        "object_suffix": "V",
+        "config": {
+            "device_class": "power",
+            "name": "Voltage",
+            "unit_of_measurement": "V",
+            "value_template": "{{ value|float }}",
+            "state_class": "measurement"
+        }
+    },
 
     "light_lux": {
         "device_type": "sensor",
@@ -536,6 +572,16 @@ mappings = {
         "object_suffix": "consumption",
         "config": {
             "name": "SCM Consumption Value",
+            "value_template": "{{ value|int }}",
+            "state_class": "total_increasing",
+        }
+    },
+  
+    "consumption": {
+        "device_type": "sensor",
+        "object_suffix": "consumption",
+        "config": {
+            "name": "SCMplus Consumption Value",
             "value_template": "{{ value|int }}",
             "state_class": "total_increasing",
         }


### PR DESCRIPTION
Adding power meter energy/current/voltage values, as well as consumption from SCMplus meters (water/gas)