### PR TITLE
Add InFactory PT-310 parsing to Rubicson (longer packet length)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
 
 		= Supported device protocols =
     [01]  Silvercrest Remote Control
-    [02]  Rubicson Temperature Sensor
+    [02]  Rubicson or InFactory PT-310 Temperature Sensor
     [03]  Prologue, FreeTec NC-7104, NC-7159-675 temperature sensor
     [04]  Waveman Switch Transmitter
     [06]* ELV EM 1000

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
 
 		= Supported device protocols =
     [01]  Silvercrest Remote Control
-    [02]  Rubicson or InFactory PT-310 Temperature Sensor
+    [02]  Rubicson, TFA 30.3197 or InFactory PT-310 Temperature Sensor
     [03]  Prologue, FreeTec NC-7104, NC-7159-675 temperature sensor
     [04]  Waveman Switch Transmitter
     [06]* ELV EM 1000
@@ -304,7 +304,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [219]  Fine Offset Electronics WH45 air quality sensor
     [220]  Maverick XR-30 BBQ Sensor
     [221]  Fine Offset Electronics WN34 temperature sensor
-    [222]  Rubicson pool thermometer 48942
+    [222]  Rubicson Pool Thermometer 48942
 
 * Disabled by default, use -R n or a conf file to enable
 

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -229,7 +229,7 @@ stop_after_successful_events false
 ## Protocols to enable (command line option "-R")
 
   protocol 1   # Silvercrest Remote Control
-  protocol 2   # Rubicson Temperature Sensor
+  protocol 2   # Rubicson or InFactory PT-310 Temperature Sensor
   protocol 3   # Prologue, FreeTec NC-7104, NC-7159-675 temperature sensor
   protocol 4   # Waveman Switch Transmitter
 # protocol 6   # ELV EM 1000

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -229,7 +229,7 @@ stop_after_successful_events false
 ## Protocols to enable (command line option "-R")
 
   protocol 1   # Silvercrest Remote Control
-  protocol 2   # Rubicson or InFactory PT-310 Temperature Sensor
+  protocol 2   # Rubicson, TFA 30.3197 or InFactory PT-310 Temperature Sensor
   protocol 3   # Prologue, FreeTec NC-7104, NC-7159-675 temperature sensor
   protocol 4   # Waveman Switch Transmitter
 # protocol 6   # ELV EM 1000
@@ -443,7 +443,7 @@ stop_after_successful_events false
   protocol 219 # Fine Offset Electronics WH45 air quality sensor
   protocol 220 # Maverick XR-30 BBQ Sensor
   protocol 221 # Fine Offset Electronics WN34 temperature sensor
-  protocol 222 # Rubicson pool thermometer 48942
+  protocol 222 # Rubicson Pool Thermometer 48942
 
 ## Flex devices (command line option "-X")
 

--- a/src/devices/rubicson.c
+++ b/src/devices/rubicson.c
@@ -107,7 +107,7 @@ static char *output_fields[] = {
 
 // timings based on samp_rate=1024000
 r_device rubicson = {
-        .name        = "Rubicson or InFactory PT-310 Temperature Sensor",
+        .name        = "Rubicson, TFA 30.3197 or InFactory PT-310 Temperature Sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 1000, // Gaps:  Short 976us, Long 1940us, Sync 4000us
         .long_width  = 2000, // Pulse: 500us (Initial pulse in each package is 388us)

--- a/src/devices/rubicson.c
+++ b/src/devices/rubicson.c
@@ -1,5 +1,5 @@
 /** @file
-    Rubicson temperature sensor.
+    Rubicson or InFactory PT-310 temperature sensor.
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -11,6 +11,10 @@
 Rubicson temperature sensor.
 
 Also older TFA 30.3197 sensors.
+
+Also InFactory PT-310 pool temperature sensor (AKA ZX-7074/7073). This device
+has longer packet lengths of 37 or 38 bits but is otherwise compatible. See more at
+https://github.com/merbanan/rtl_433/issues/2119
 
 The sensor sends 12 packets of  36 bits pwm modulated data.
 
@@ -26,7 +30,7 @@ data is grouped into 9 nibbles
 - F is always 0xf
 - crc1 and crc2 forms a 8-bit crc, polynomial 0x31, initial value 0x6c, final value 0x0
 
-The sensor can be bought at Kjell&Co
+The sensor can be bought at Kjell&Co. The Infactory pool sensor can be bought at Pearl.
 */
 
 #include "decoder.h"
@@ -60,7 +64,8 @@ static int rubicson_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     b = bitbuffer->bb[r];
 
-    if (bitbuffer->bits_per_row[r] != 36)
+    // Infactory devices report 38 (or for last repetition) 37 bits
+    if (bitbuffer->bits_per_row[r] < 36 || bitbuffer->bits_per_row[r] > 38)
         return DECODE_ABORT_LENGTH;
 
     if ((b[3] & 0xf0) != 0xf0)
@@ -77,7 +82,7 @@ static int rubicson_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",            "",             DATA_STRING, "Rubicson-Temperature",
+            "model",            "",             DATA_STRING, "Rubicson or Infactory PT-310 Temperature",
             "id",               "House Code",   DATA_INT,    id,
             "channel",          "Channel",      DATA_INT,    channel,
             "battery_ok",       "Battery",      DATA_INT,    !!battery,
@@ -102,7 +107,7 @@ static char *output_fields[] = {
 
 // timings based on samp_rate=1024000
 r_device rubicson = {
-        .name        = "Rubicson Temperature Sensor",
+        .name        = "Rubicson or InFactory PT-310 Temperature Sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 1000, // Gaps:  Short 976us, Long 1940us, Sync 4000us
         .long_width  = 2000, // Pulse: 500us (Initial pulse in each package is 388us)

--- a/src/devices/rubicson.c
+++ b/src/devices/rubicson.c
@@ -82,7 +82,7 @@ static int rubicson_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",            "",             DATA_STRING, "Rubicson or Infactory PT-310 Temperature",
+            "model",            "",             DATA_STRING, "Rubicson-Temperature",
             "id",               "House Code",   DATA_INT,    id,
             "channel",          "Channel",      DATA_INT,    channel,
             "battery_ok",       "Battery",      DATA_INT,    !!battery,


### PR DESCRIPTION
Adds the parsing for InFactory PT-310 (aka ZX...) to the Rubicson device.

As discussed in issue #2119.