### PR TITLE
examples: Revise comments near the MQTT relay example, and support MQTT authentication

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,16 +1,94 @@
-# rtl_433 examples
+# rtl_433 scripts (example and useful)
 
-You likely need to filter and transform rtl_433's output before sending it to a database.
-It's recommended you read the JSON data and process it to your specific requirements.
+This directory contains a number of scripts to process the output of
+rtl_433 in various ways.  Some are truly examples; they worked for
+someone else and won't work for you but will help understanding.  Some
+are (or will be once enhanced) actually useful to a fairly broad set
+of people.
 
-Some example pipes/relays for rtl_433 JSON data. Should work with Python 2 and also Python 3.
+It is likely that a use outside what has been contemplated will
+require writing new code, with some kind of filtering and
+transformation.
+
+Generally, python scripts should work with Python 2 or relatively
+recent Python 3.  (It is TBD to deprecate Python 2; it is not clear
+that anyone still cares.)
+
+These scripts typically send data to some other system, store it in a
+database, or process it in some way.  Recall that rtl_433's philosophy
+is to just output received transmissions, with minimal processing and
+with no checking/correlation of adjacent repeated frames.
+
+This directory has a strong bias to the use of JSON; the point of that
+encoding is that it is machine parseble and that's what we want to do.
+
+At some point, generally-usable scripts should perhaps be promoted
+from examples.
+
+# Styles of Plumbing
+
+There are two main mechanisms: piping the output json, and
+syslog-style UDP with one json object per packet.
+
+## pipe
 
 The `pipe` examples read JSON output from `rtl_433` using a pipe, i.e.
 
     rtl_433 -F json ... | rtl_433_statsd_pipe.py
+
+This is in many ways simple, but the programs must be started and
+stopped together, and only one rtl_433 can write to the processing
+script.
+
+There are only two pipe progams, collectd and statsd.
+
+## UDP syslog
 
 The `relay` examples consumes the (UDP) Syslog output from rtl_433 (or a legacy plain JSON datagram).
 Basically run `rtl_433` with `-F syslog:127.0.0.1:1433` and the relay script as an unrelated process, i.e.
 
     rtl_433_mqtt_relay.py &
     rtl_433 -F syslog:127.0.0.1:1433
+
+With this, one can run `tcpdump -A -i lo0 udp and port 1433`
+(substitute your loopback interface) to watch the traffic.  One can
+also run multiple rtl_433 processes.
+
+# Strategies for Processing, Transmitting and Storing
+
+(This does not belong here, but is useful to those contemplating the
+scripts, so it's here pending a proper home.)
+
+This section is speculative.
+
+## Checksums and Repeated transmissions
+
+Many devices will send a frame multiple times, perhaps 3 or 4, as a
+form of redundancy.  Many devices have non-robust checksums.  If
+displaying a temperature, that is often not a big deal.  If storing it
+in a datbase, bad data is troublesome.  One could process multiple
+frames that arrive close in time and try to infer which are bad
+decodes and what the consensus data is, and from tha output one good
+frame.  One could further reject physically implausible data (temp of
+fridge has been 2C and we just got a 30C reading), but this needs to
+recover from arbitrary situations so that would be tricky code to
+write.  There is no code yet; this is merely a suggestion to future
+hackers.
+
+## Precision
+
+Actual precision of devices varies, and there is unit conversion.
+There should be some scheme to ensure reasonable values (vs 5 decimal
+digits of temperature).  This is also for future work.
+
+## Calibration
+
+So far, rtl_433 does not deal with calibration; the job is to output
+what was received.  A system design where the json to mqtt program has
+calibration data and applies it might be sensible, but this is far from clear.
+
+## Health monitoring
+
+The main data is logging what was received, but it is also interesting
+to know what channel rtl_433 is listening to, noise levels, that the
+translation script is up, etc.   This is also for future work.

--- a/examples/rtl_433_custom.php
+++ b/examples/rtl_433_custom.php
@@ -19,7 +19,7 @@ Restart=always
 RestartSec=5
 RemainAfterExit=no
 User=root
-ExecStart=/bin/bash -c "/usr/bin/rtl_433 -f 433920000 -f 433920000 -H 120 -F syslog:127.0.0.1:1433"
+ExecStart=/bin/sh -c "/usr/bin/rtl_433 -f 433920000 -f 433920000 -H 120 -F syslog:127.0.0.1:1433"
 
 [Install]
 WantedBy=multi-user.target

--- a/examples/rtl_433_mqtt_relay.py
+++ b/examples/rtl_433_mqtt_relay.py
@@ -2,10 +2,19 @@
 
 """MQTT monitoring relay for rtl_433 communication."""
 
-# Needs Paho-MQTT https://pypi.python.org/pypi/paho-mqtt
+# This program listens on a UDP socket for syslog messages with a json
+# payload, and publishes the data via MQTT.  The broker connection is
+# kept open (and automatically reconnects on failure).  Each device
+# is mapped to its own topic,
 
-# Option: PEP 3143 - Standard daemon process library
-# (use Python 3.x or pip install python-daemon)
+# Dependencies:
+#   Paho-MQTT; see https://pypi.python.org/pypi/paho-mqtt
+
+#   Optionally: PEP 3143 - Standard daemon process library
+#      (on 2.7,  pip install python-daemon)
+
+# To enable daemon support, uncomment the following line and adjust
+# run().  Note that print() is still used.
 # import daemon
 
 from __future__ import print_function
@@ -15,28 +24,35 @@ import socket
 import json
 import paho.mqtt.client as mqtt
 
+# Syslog socket configuration
 UDP_IP = "127.0.0.1"
 UDP_PORT = 1433
 
+# MQTT broker configuration
 MQTT_HOST = "127.0.0.1"
 MQTT_PORT = 1883
+MQTT_USERNAME = None
+MQTT_PASSWORD = None
+MQTT_TLS = False
 MQTT_PREFIX = "sensor/rtl_433"
 
-
 def mqtt_connect(client, userdata, flags, rc):
-    """Log MQTT connects."""
+    """Handle MQTT connection callback."""
     print("MQTT connected: " + mqtt.connack_string(rc))
 
 
 def mqtt_disconnect(client, userdata, rc):
-    """Log MQTT disconnects."""
+    """Handle MQTT disconnection callback."""
     print("MQTT disconnected: " + mqtt.connack_string(rc))
 
 
+# Create listener for incoming json string packets.
 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
 sock.bind((UDP_IP, UDP_PORT))
 
 
+# Map characters that will cause problems or be confusing in mqtt
+# topics.
 def sanitize(text):
     """Sanitize a name for Graphite/MQTT use."""
     return (text
@@ -48,6 +64,10 @@ def sanitize(text):
 
 def publish_sensor_to_mqtt(mqttc, data, line):
     """Publish rtl_433 sensor data to MQTT."""
+
+    # Construct a topic from the information that identifies which
+    # device this frame is from.
+    # NB: id is only used if channel is not present.
     path = MQTT_PREFIX
     if "model" in data:
         path += "/" + sanitize(data["model"])
@@ -56,6 +76,7 @@ def publish_sensor_to_mqtt(mqttc, data, line):
     elif "id" in data:
         path += "/" + str(data["id"])
 
+    # Publish some specific items on subtopics.
     if "battery_ok" in data:
         mqttc.publish(path + "/battery", data["battery_ok"])
 
@@ -68,6 +89,7 @@ def publish_sensor_to_mqtt(mqttc, data, line):
     if "depth_cm" in data:
         mqttc.publish(path + "/depth", data["depth_cm"])
 
+    # Publish the entire json string on the main topic.
     mqttc.publish(path, line)
 
 
@@ -75,20 +97,31 @@ def parse_syslog(line):
     """Try to extract the payload from a syslog line."""
     line = line.decode("ascii")  # also UTF-8 if BOM
     if line.startswith("<"):
-        # fields should be "<PRI>VER", timestamp, hostname, command, pid, mid, sdata, payload
+        # Fields should be "<PRI>VER", timestamp, hostname, command, pid, mid, sdata, payload.
+        # The payload might have spaces, so force split to stop after the sixth space.
         fields = line.split(None, 7)
         line = fields[-1]
+    else:
+        # Hope that the line was just json without the syslog header.
+        pass
     return line
 
 
 def rtl_433_probe():
     """Run a rtl_433 UDP listener."""
+
+    ## Connect to MQTT
     mqttc = mqtt.Client()
     mqttc.on_connect = mqtt_connect
     mqttc.on_disconnect = mqtt_disconnect
+    if MQTT_USERNAME != None:
+        mqttc.username_pw_set(MQTT_USERNAME, password=MQTT_PASSWORD)
+    if MQTT_TLS:
+        mqttc.tls_set()
     mqttc.connect_async(MQTT_HOST, MQTT_PORT, 60)
     mqttc.loop_start()
 
+    ## Receive UDP datagrams, extract json, and publish.
     while True:
         line, addr = sock.recvfrom(1024)
         try:

--- a/examples/sigrok-conv.sh
+++ b/examples/sigrok-conv.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 echo 'Please use "rtl_433 [-s <samplerate>] -w <output>.sr -r <input>.cu8"'

--- a/examples/sigrok-open.sh
+++ b/examples/sigrok-open.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 echo 'Please use "rtl_433 [-s <samplerate>] -W <output>.sr -r <input>.cu8"'


### PR DESCRIPTION
These commits aren't super related, but are all under the general umbrella of improving the MQTT relay and specfically documentation.  I'm submitting this PR now so that more invasive and perhaps controversial changes will be separate.
There are three unrelated commits (please don't squash):
  - Rototill README
  - Remove unnecessary dependency on bash
  - Add comments to the mqtt relay script, and add the ability to set the username/password and TLS variables
