### PR TITLE
Add decode symbol helper and flex option

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -71,6 +71,18 @@ unsigned extract_nibbles_4b1s(uint8_t *message, unsigned offset_bits, unsigned n
 /// @return number of successful decoded bytes
 unsigned extract_bytes_uart(uint8_t *message, unsigned offset_bits, unsigned num_bits, uint8_t *dst);
 
+/// Decode symbols to bits.
+///
+/// @param message bytes of message data
+/// @param offset_bits start offset of message in bits
+/// @param num_bits message length in bits
+/// @param zero symbol for zero bit, bits MSB aligned, count in LSB
+/// @param one symbol for one bit, bits MSB aligned, count in LSB
+/// @param sync symbol for sync bit, ignored at start, terminates at end
+/// @param dst target buffer for extracted bits, at least num_bits/symbol_x_len size
+/// @return number of successful decoded bits
+unsigned extract_bits_symbols(uint8_t *message, unsigned offset_bits, unsigned num_bits, uint32_t zero, uint32_t one, uint32_t sync, uint8_t *dst);
+
 /// CRC-4.
 ///
 /// @param message array of bytes to check

--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -92,6 +92,9 @@ struct flex_params {
     uint8_t match_bits[128];
     unsigned preamble_len;
     uint8_t preamble_bits[128];
+    uint32_t symbol_zero;
+    uint32_t symbol_one;
+    uint32_t symbol_sync;
     struct flex_get getter[GETTER_SLOTS];
     unsigned decode_uart;
     char const *fields[7 + GETTER_SLOTS + 1]; // NOTE: needs to match output_fields
@@ -221,13 +224,29 @@ static int flex_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             return DECODE_FAIL_SANITY;
     }
 
+    if (params->symbol_zero) {
+        uint32_t zero = params->symbol_zero;
+        uint32_t one  = params->symbol_one;
+        uint32_t sync = params->symbol_sync;
+
+        for (i = 0; i < bitbuffer->num_rows; i++) {
+            // TODO: refactor to bitbuffer_decode_symbol_row()
+            unsigned len    = bitbuffer->bits_per_row[i];
+            bitbuffer_t tmp = {0};
+            len             = extract_bits_symbols(bitbuffer->bb[i], 0, len, zero, one, sync, tmp.bb[0]);
+            memcpy(bitbuffer->bb[i], tmp.bb[0], len); // safe to write over: can only be shorter
+            bitbuffer->bits_per_row[i] = len;
+        }
+        // TODO: apply min_bits, max_bits check
+    }
+
     if (params->decode_uart) {
         for (i = 0; i < bitbuffer->num_rows; i++) {
             // TODO: refactor to bitbuffer_decode_uart_row()
             unsigned len = bitbuffer->bits_per_row[i];
             bitbuffer_t tmp = {0};
             len = extract_bytes_uart(bitbuffer->bb[i], 0, len, tmp.bb[0]);
-            memcpy(bitbuffer->bb[i], tmp.bb[0], len);
+            memcpy(bitbuffer->bb[i], tmp.bb[0], len); // safe to write over: can only be shorter
             bitbuffer->bits_per_row[i] = len * 8;
         }
     }
@@ -376,6 +395,7 @@ static void help()
             "\t\tuse opt>=n to match at least <n> and opt<=n to match at most <n>\n"
             "\tinvert : invert all bits\n"
             "\treflect : reflect each byte (MSB first to MSB last)\n"
+            "\tdecode_uart : UART 8n1 (10-to-8) decode\n"
             "\tmatch=<bits> : only match if the <bits> are found\n"
             "\tpreamble=<bits> : match and align at the <bits> preamble\n"
             "\t\t<bits> is a row spec of {<bit count>}<bits as hex number>\n"
@@ -429,11 +449,29 @@ static unsigned parse_bits(const char *code, uint8_t *bitrow)
     }
     unsigned len = bits.bits_per_row[0];
     if (len > 1024) {
-        fprintf(stderr, "Bad flex spec, \"match\", \"preamble\", and getter mask mayb have up to 1024 bits (%d found)!\n", len);
+        fprintf(stderr, "Bad flex spec, \"match\", \"preamble\", and getter mask may have up to 1024 bits (%u found)!\n", len);
         usage();
     }
     memcpy(bitrow, bits.bb[0], (len + 7) / 8);
     return len;
+}
+
+// used for symbol decode, limited to 27 bits (32 - 5).
+static uint32_t parse_symbol(const char *code)
+{
+    bitbuffer_t bits = {0};
+    bitbuffer_parse(&bits, code);
+    if (bits.num_rows != 1) {
+        fprintf(stderr, "Bad flex spec, \"symbol\" needs exactly one bit row (%d found)!\n", bits.num_rows);
+        usage();
+    }
+    unsigned len = bits.bits_per_row[0];
+    if (len > 27) {
+        fprintf(stderr, "Bad flex spec, \"symbol\" may have up to 27 bits (%u found)!\n", len);
+        usage();
+    }
+    uint8_t *b = bits.bb[0];
+    return ((uint32_t)b[0] << 24) | (b[1] << 16) | (b[2] << 8) | (b[3] << 0) | len;
 }
 
 static const char *parse_map(const char *arg, struct flex_get *getter)
@@ -624,6 +662,13 @@ r_device *flex_create_device(char *spec)
         else if (!strcasecmp(key, "decode_uart"))
             params->decode_uart = val ? atoi(val) : 1;
 
+        else if (!strcasecmp(key, "symbol_zero"))
+            params->symbol_zero = parse_symbol(val);
+        else if (!strcasecmp(key, "symbol_one"))
+            params->symbol_one = parse_symbol(val);
+        else if (!strcasecmp(key, "symbol_sync"))
+            params->symbol_sync = parse_symbol(val);
+
         else if (!strcasecmp(key, "get")) {
             if (get_count < GETTER_SLOTS)
                 parse_getter(val, &params->getter[get_count++]);
@@ -695,6 +740,15 @@ r_device *flex_create_device(char *spec)
             fprintf(stderr, "Bad flex spec, missing tolerance limit!\n");
             usage();
         }
+    }
+
+    if (params->symbol_zero && !params->symbol_one) {
+        fprintf(stderr, "Bad flex spec, symbol-one missing!\n");
+        usage();
+    }
+    if (params->symbol_one && !params->symbol_zero) {
+        fprintf(stderr, "Bad flex spec, symbol-zero missing!\n");
+        usage();
     }
 
     /*


### PR DESCRIPTION
This adds a helper to decode symbols.

I.e. for a code of `{25}7d577d8`, which  is `01 11 11 01 01 01 01 11 01 11 11 01 1`
using symbols of `01` and `11` the result is `{12}616`, which is `011000010110`

Available as flex decoder option, note that the symbols bits need to be MSB aligned:
`symbol_zero={2}4,symbol_one={2}c`