### PR TITLE
Improve/refactor shared Acurite TXR decoder

### DIFF
--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -161,7 +161,10 @@ static void data_append_exception(data_t* data, int exception, uint8_t* bb, int 
 }
 
 
+/**
+Acurite 896 rain gauge
 
+*/
 static int acurite_rain_896_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     uint8_t *b = bitbuffer->bb[0];
@@ -1634,6 +1637,10 @@ static int acurite_986_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return result;
 }
 
+/**
+Acurite 606 Temperature sensor
+
+*/
 static int acurite_606_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
@@ -1688,6 +1695,10 @@ static int acurite_606_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
+/**
+Acurite 590TX temperature/humidity sensor
+
+*/
 static int acurite_590tx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
@@ -1763,6 +1774,10 @@ static int acurite_590tx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
+/**
+Acurite 00275rm Room Monitor sensors
+
+*/
 static int acurite_00275rm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     int result = 0;

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -13,21 +13,23 @@
 /**
 Acurite weather stations and temperature / humidity sensors.
     Devices decoded:
-    - 5-n-1 weather sensor, Model; VN1TXC, 06004RM
-    - 5-n-1 pro weather sensor, Model: 06014RM
-    - 896 Rain gauge, Model: 00896
-    - 592TXR / 06002RM Tower sensor (temperature and humidity)
+    - Acurite Iris (5-n-1) weather station, Model; VN1TXC, 06004RM
+    - Acurite 5-n-1 pro weather sensor, Model: 06014RM
+    - Acurite Atlas (7-n-1) weather station
+    - Acurite Notos (3-n-1) weather station
+    - Acurite 896 Rain gauge, Model: 00896
+    - Acurite 592TXR / 06002RM / 6044m Tower sensor (temperature and humidity)
       (Note: Some newer sensors share the 592TXR coding for compatibility.
-    - 609TXC "TH" temperature and humidity sensor (609A1TX)
+    - Acurite 609TXC "TH" temperature and humidity sensor (609A1TX)
     - Acurite 986 Refrigerator / Freezer Thermometer
+    - Acurite 515 Refrigerator / Freezer Thermometer
     - Acurite 606TX temperature sensor
-    - Acurite 6045M Lightning Detector (Work in Progress)
+    - Acurite 6045M Lightning Detector
     - Acurite 00275rm and 00276rm temp. and humidity with optional probe.
+    - Acurite 1190/1192 leak/water detector
 */
 
 #include "decoder.h"
-
-// ** Acurite 5n1 functions **
 
 #define ACURITE_515_BITLEN        50
 #define ACURITE_TXR_BITLEN        56
@@ -35,23 +37,41 @@ Acurite weather stations and temperature / humidity sensors.
 #define ACURITE_6045_BITLEN       72
 #define ACURITE_ATLAS_BITLEN      80
 
+#define ACURITE_515_BYTELEN             6
+#define ACURITE_TXR_BYTELEN             7
+#define ACURITE_1190_BYTELEN            7
+#define ACURITE_3N1_BYTELEN             8
+#define ACURITE_5N1_BYTELEN             8
+#define ACURITE_899_BYTELEN             8
+#define ACURITE_ATLAS_BYTELEN           8
+#define ACURITE_6045_BYTELEN            9
+#define ACURITE_ATLAS_LTNG_BYTELEN      10
+
+
 // ** Acurite known message types
-#define ACURITE_MSGTYPE_LEAK_DETECTOR                   0x01
+#define ACURITE_MSGTYPE_1190_DETECTOR                   0x01
+
 #define ACURITE_MSGTYPE_TOWER_SENSOR                    0x04
-#define ACURITE_MSGTYPE_515_REFRIGERATOR                0x08
-#define ACURITE_MSGTYPE_515_FREEZER                     0x09
-#define ACURITE_MSGTYPE_6045M                           0x2f
-#define ACURITE_MSGTYPE_5N1_WINDSPEED_WINDDIR_RAINFALL  0x31
-#define ACURITE_MSGTYPE_5N1_WINDSPEED_TEMP_HUMIDITY     0x38
-#define ACURITE_MSGTYPE_3N1_WINDSPEED_TEMP_HUMIDITY     0x20
-#define ACURITE_MSGTYPE_RAINFALL                        0x30
 
 #define ACURITE_MSGTYPE_ATLAS_WNDSPD_TEMP_HUM           0x05
 #define ACURITE_MSGTYPE_ATLAS_WNDSPD_RAIN               0x06
 #define ACURITE_MSGTYPE_ATLAS_WNDSPD_UV_LUX             0x07
+
+#define ACURITE_MSGTYPE_515_REFRIGERATOR                0x08
+#define ACURITE_MSGTYPE_515_FREEZER                     0x09
+
+#define ACURITE_MSGTYPE_3N1_WINDSPEED_TEMP_HUMIDITY     0x20
+
 #define ACURITE_MSGTYPE_ATLAS_WNDSPD_TEMP_HUM_LTNG      0x25
 #define ACURITE_MSGTYPE_ATLAS_WNDSPD_RAIN_LTNG          0x26
 #define ACURITE_MSGTYPE_ATLAS_WNDSPD_UV_LUX_LTNG        0x27
+
+#define ACURITE_MSGTYPE_6045M                           0x2f
+#define ACURITE_MSGTYPE_899_RAINFALL                    0x30
+#define ACURITE_MSGTYPE_5N1_WINDSPEED_WINDDIR_RAINFALL  0x31
+#define ACURITE_MSGTYPE_5N1_WINDSPEED_TEMP_HUMIDITY     0x38
+
+
 
 // Acurite 5n1 Wind direction values.
 // There are seem to be conflicting decodings.
@@ -120,12 +140,26 @@ static char const *acurite_getChannel(uint8_t byte)
     return channel_strs[channel];
 }
 
-static char const *acurite_getChannelAndType(uint8_t byte, uint8_t mtype)
+// Add exception and raw message bytes to message to enable
+// later analysis of unexpected/possbily undecoded data
+static void data_append_exception(data_t* data, int exception, uint8_t* bb, int browlen)
 {
-    static char const *channel_strs[] = {"CR", "ER", "BR", "AR", "CF", "EF", "BF", "AF"}; // 'E' stands for error
+    char raw_str[31], *rawp;
 
-    int channel = ((mtype & 0x01) << 2) | ((byte & 0xC0) >> 6);
-    return channel_strs[channel];
+    rawp = (char *)raw_str;
+    for (int i=0; i < browlen; i++) {
+        sprintf(rawp,"%02x",bb[i]);
+        rawp += 2;
+    }
+    *rawp = '\0';
+
+    /* clang-format off */
+    data = data_append(data,
+            "exception",        "data_exception",   DATA_INT,    exception,
+            "raw_msg",          "raw_message",      DATA_STRING, raw_str,
+            NULL);
+    /* clang-format on */
+
 }
 
 static int acurite_rain_896_decode(r_device *decoder, bitbuffer_t *bitbuffer)
@@ -209,6 +243,12 @@ static int acurite_th_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         status       = (bb[1] & 0xf0) >> 4;
         battery_low  = status & 0x8;
         humidity     = bb[3];
+
+        if (humidity > 100) {
+            decoder_logf(decoder, 1, __func__, "609txc 0x%04X: invalid humidity: %d %%rH",
+                         id, humidity);
+            return DECODE_FAIL_SANITY;
+        }
 
         /* clang-format off */
         data = data_make(
@@ -345,7 +385,6 @@ Notes:
 
 2020-08-29 - changed temperature decoding, was 2.0 F too low vs. Acurite Access
 
-@todo - check parity on bytes 2 - 7
 @todo - storm_distance conversion to miles/KM (should match Acurite consoles)
 
 */
@@ -354,7 +393,6 @@ static int acurite_6045_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
 {
     float tempf;
     uint8_t humidity;
-    // uint8_t message_type, l_status;
     char raw_str[31], *rawp;
     uint16_t sensor_id;
     uint8_t strike_count, strike_distance;
@@ -371,22 +409,39 @@ static int acurite_6045_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     // CCII IIII | IIII IIII
     sensor_id = ((bb[0] & 0x3f) << 8) | bb[1]; // same as TXR
     battery_low = (bb[2] & 0x40) == 0;
+
     humidity = (bb[3] & 0x7f); // 1-99 %rH, same as TXR
+    if (humidity > 100) {
+        decoder_logf(decoder, 1, __func__, "6045m 0x%04X Ch %s : invalid humidity: %d %%rH",
+                     sensor_id, channel_str, humidity);
+        return DECODE_FAIL_SANITY;
+    }
+
     active = (bb[4] & 0x40) == 0x40;    // Sensor is actively listening for strikes
     //message_type = bb[2] & 0x3f;
 
     // 12 bits of temperature after removing parity and status bits.
     // Message native format appears to be in 1/10 of a degree Fahrenheit
     // Device Specification: -40 to 158 F  / -40 to 70 C
-    // Available range given 12 bits with +1480 offset: -140.0 F to +261.5 F
+    // Available range given 12 bits with +1480 offset: -148.0 F to +261.5 F
     int temp_raw = ((bb[4] & 0x1F) << 7) | (bb[5] & 0x7F);
     tempf = (temp_raw - 1480) * 0.1f;
+
+    if (tempf < -40.0 || tempf > 158.0) {
+        decoder_logf(decoder, 1, __func__, "6045m 0x%04X Ch %s, invalid temperature: %0.1f F",
+                     sensor_id, channel_str, tempf);
+        return DECODE_FAIL_SANITY;
+    }
+
+    // flag if bits 13/14 of temperature are ever non-zero so
+    // they can be investigated
+    if (temp_raw & 0x3000)
+        exception++;
 
     // Strike count is 8 bits, LSB in following byte
     strike_count = ((bb[6] & 0x7f) << 1) | ((bb[7] & 0x40) >> 6);
     strike_distance = bb[7] & 0x1f;
     rfi_detect = (bb[7] & 0x20) == 0x20;
-    //l_status = (bb[7] & 0x60) >> 5;
 
     /*
      * 2018-04-21 rct - There are still a number of unknown bits in the
@@ -402,12 +457,8 @@ static int acurite_6045_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     *rawp = '\0';
 
     // Flag whether this message might need further analysis
-    if (((bb[4] & 0x20) != 0) ||  // unknown status bits, always off
-        (humidity > 100) ||
-        (tempf > 158) ||
-        (tempf < -40)) {
+    if ((bb[4] & 0x20) != 0) // unknown status bits, always off
         exception++;
-    }
 
     /* clang-format off */
     data = data_make(
@@ -419,15 +470,246 @@ static int acurite_6045_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
             "humidity",         "humidity",         DATA_FORMAT, "%u %%", DATA_INT,    humidity,
             "strike_count",     "strike_count",     DATA_INT,    strike_count,
             "storm_dist",       "storm_distance",   DATA_INT,    strike_distance,
-            "active",           "active_mode",      DATA_INT,    active,    // @todo convert to bool
-            "rfi",              "rfi_detect",       DATA_INT,    rfi_detect,     // @todo convert to bool
-            "exception",        "data_exception",   DATA_INT,    exception,    // @todo convert to bool
+            "active",           "active_mode",      DATA_INT,    active,
+            "rfi",              "rfi_detect",       DATA_INT,    rfi_detect,
+            "exception",        "data_exception",   DATA_INT,    exception,
             "raw_msg",          "raw_message",      DATA_STRING, raw_str,
             NULL);
     /* clang-format on */
 
     decoder_output_data(decoder, data);
-    return 1;
+
+    return 1; // If we got here 1 valid message was output
+}
+
+
+/*
+Acurite 899 Rain Gauge decoder
+
+*/
+static int acurite_899_decode(r_device* decoder, uint8_t* bb)
+{
+    // MIC (checkum, parity) validated in calling function
+
+    uint16_t sensor_id = ((bb[0] & 0x3f) << 8) | bb[1]; //
+    int battery_low = (bb[2] & 0x40) == 0;
+
+    /*
+      @todo bug? channel output isn't consistent with the rest of he Acurite
+      devices in this family, should output ('A', 'B', or 'C')
+      Currently outputing 00 = A, 01 = B, 10 = C
+      Leaving as is to maintain compatibility for now
+    */
+
+    int channel = bb[0] >> 6;
+    // @todo replace the above with this:
+    // char const* channel_str = acurite_getChannel(bb[0]);
+
+
+    /*
+      Rain counter - one tip is 0.01 inch, i.e. 0.254mm
+      Note: Device native unit arguably Imperial
+      but this is being converted to metric here, so -C native won't work
+      Leaving as is to maintain compatibility
+    */
+    int raincounter = ((bb[5] & 0x7f) << 7) | (bb[6] & 0x7f);
+
+    /* clang-format off */
+    data_t *data;
+    data = data_make(
+            "model",            "",                         DATA_STRING, "Acurite-Rain899",
+            "id",               "",                         DATA_INT,    sensor_id,
+            "channel",          "",                         DATA_INT,    channel,
+            // "channel",              NULL,           DATA_STRING, channel_str,
+            "battery_ok",       "Battery",                  DATA_INT,    !battery_low,
+            "rain_mm",          "Rainfall Accumulation",    DATA_FORMAT, "%.2f mm", DATA_DOUBLE, raincounter * 0.254,
+            "mic",                  "Integrity",    DATA_STRING, "CHECKSUM",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+
+    return 1; // if we got here, 1 message was output
+
+}
+
+/*
+Acurite 3n1 Weather Station decoder
+
+*/
+static int acurite_3n1_decode(r_device* decoder, uint8_t* bb)
+{
+    // MIC (checkum, parity) validated in calling function
+
+    char const* channel_str = acurite_getChannel(bb[0]);
+
+    // 3n1 sensor ID is 14 bits
+    uint16_t sensor_id = ((bb[0] & 0x3f) << 8) | bb[1];
+    uint8_t message_type = bb[2] & 0x3f;
+
+    if (*channel_str == 'E') {
+        decoder_logf(decoder, 1, __func__,
+                     "bad channel Ch %s, msg type 0x%02x",
+                     channel_str, message_type);
+        return DECODE_FAIL_SANITY;
+    }
+
+    /*
+      @todo bug, 3n1 data format includes sequence_num
+      which was copied from 5n1, but existing code 3n1 uses
+      14 bits for ID. so these bits are used twice.
+
+      Leaving for compatibility, but probaby sequence_num
+      doesn't exist and should be deleted. If the 3n1 did use
+      a sequence number, the ID would change on each output.
+    */
+    uint8_t sequence_num = (bb[0] & 0x30) >> 4;
+
+    int battery_low = (bb[2] & 0x40) == 0;
+    uint8_t humidity = (bb[3] & 0x7f); // 1-99 %rH
+    if (humidity > 100) {
+        decoder_logf(decoder, 1, __func__, "3n1 0x%04X Ch %s : invalid humidity: %d %%rH",
+                     sensor_id, channel_str, humidity);
+        return DECODE_FAIL_SANITY;
+    }
+
+    // note the 3n1 seems to have one more high bit than 5n1
+    // Spec: -40 to 158 F
+    int temp_raw = (bb[4] & 0x1F) << 7 | (bb[5] & 0x7F);
+    float tempf        = (temp_raw - 1480) * 0.1f; // regression yields (rawtemp-1480)*0.1
+
+    if (tempf < -40.0 || tempf > 158.0) {
+        decoder_logf(decoder, 1, __func__, "3n1 0x%04X Ch %s, invalid temperature: %0.1f F",
+                     sensor_id, channel_str, tempf);
+        return DECODE_FAIL_SANITY;
+    }
+
+
+    /*
+      @todo bug from original decoder
+      This can't be a float, must be uint8
+      leaving for compatibility
+    */
+    float wind_speed_mph = bb[6] & 0x7f; // seems to be plain MPH
+
+    /* clang-format off */
+    data_t *data;
+    data = data_make(
+            "model",        "",   DATA_STRING,    "Acurite-3n1",
+            "message_type", NULL,   DATA_INT,       message_type,
+            "id",    NULL,   DATA_FORMAT,    "0x%02X",   DATA_INT,       sensor_id,
+            "channel",      NULL,   DATA_STRING,    channel_str,
+            "sequence_num",  NULL,   DATA_INT,      sequence_num,
+            "battery_ok",       "Battery",      DATA_INT,    !battery_low,
+            "wind_avg_mi_h",   "wind_speed",   DATA_FORMAT,    "%.1f mi/h", DATA_DOUBLE,     wind_speed_mph,
+            "temperature_F",     "temperature",    DATA_FORMAT,    "%.1f F", DATA_DOUBLE,    tempf,
+            "humidity",     NULL,    DATA_FORMAT,    "%u %%",   DATA_INT,   humidity,
+            "mic",                  "Integrity",    DATA_STRING, "CHECKSUM",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+
+    return 1; // If we got here 1 valid message was output
+}
+
+
+/*
+Acurite 5n1 Weather Station decoder
+
+XXX todo docs
+
+*/
+
+static int acurite_5n1_decode(r_device* decoder, uint8_t* bb)
+{
+    // MIC (checkum, parity) validated in calling function
+
+
+    char const* channel_str = acurite_getChannel(bb[0]);
+    uint16_t sensor_id = ((bb[0] & 0x0f) << 8) | bb[1];
+    uint8_t sequence_num = (bb[0] & 0x30) >> 4;
+    int battery_low = (bb[2] & 0x40) == 0;
+    uint8_t message_type = bb[2] & 0x3f;
+
+    // Wind raw number is cup rotations per 4 seconds
+    // 8 bits gives range of 0 - 212 KPH
+    // http://www.wxforum.net/index.php?topic=27244.0 (found from weewx driver)
+    int wind_speed_raw = ((bb[3] & 0x1F) << 3)| ((bb[4] & 0x70) >> 4);
+    float wind_speed_kph = 0;
+    if (wind_speed_raw > 0) {
+        wind_speed_kph = wind_speed_raw * 0.8278 + 1.0;
+    }
+
+    if (message_type == ACURITE_MSGTYPE_5N1_WINDSPEED_WINDDIR_RAINFALL) {
+        // Wind speed, wind direction, and rain fall
+        float wind_dir = acurite_5n1_winddirections[bb[4] & 0x0f] * 22.5f;
+
+        // range: 0 to 99.99 in, 0.01 inch increments, accumulated
+        int raincounter = ((bb[5] & 0x7f) << 7) | (bb[6] & 0x7F);
+
+        /* clang-format off */
+        data_t *data;
+        data = data_make(
+                "model",        "",   DATA_STRING,    "Acurite-5n1",
+                "message_type", NULL,   DATA_INT,       message_type,
+                "id",           NULL, DATA_INT,       sensor_id,
+                "channel",      NULL,   DATA_STRING,    channel_str,
+                "sequence_num",  NULL,   DATA_INT,      sequence_num,
+                "battery_ok",       "Battery",      DATA_INT,    !battery_low,
+                "wind_avg_km_h",   "wind_speed",   DATA_FORMAT,    "%.1f km/h", DATA_DOUBLE,     wind_speed_kph,
+                "wind_dir_deg", NULL,   DATA_FORMAT,    "%.1f", DATA_DOUBLE,    wind_dir,
+                "rain_in",      "Rainfall Accumulation",   DATA_FORMAT, "%.2f in", DATA_DOUBLE, raincounter * 0.01f,
+                "mic",                  "Integrity",    DATA_STRING, "CHECKSUM",
+                NULL);
+        /* clang-format on */
+
+        decoder_output_data(decoder, data);
+    }
+    else if (message_type == ACURITE_MSGTYPE_5N1_WINDSPEED_TEMP_HUMIDITY) {
+        // Wind speed, temperature and humidity
+
+        // range -40 to 158 F
+        int temp_raw = (bb[4] & 0x0F) << 7 | (bb[5] & 0x7F);
+        float tempf = (temp_raw - 400) * 0.1f;
+
+        if (tempf > 158.0) {
+            decoder_logf(decoder, 1, __func__, "5n1 0x%04X Ch %s, invalid temperature: %0.1f F",
+                         sensor_id, channel_str, tempf);
+            return DECODE_FAIL_SANITY;
+        }
+
+        uint8_t humidity = (bb[6] & 0x7f); // 1-99 %rH
+        if (humidity > 100) {
+            decoder_logf(decoder, 1, __func__, "5n1 0x%04X Ch %s : invalid humidity: %d %%rH",
+                         sensor_id, channel_str, humidity);
+            return DECODE_FAIL_SANITY;
+        }
+
+
+        /* clang-format off */
+        data_t *data;
+        data = data_make(
+                "model",        "",   DATA_STRING,    "Acurite-5n1",
+                "message_type", NULL,   DATA_INT,       message_type,
+                "id",           NULL, DATA_INT,  sensor_id,
+                "channel",      NULL,   DATA_STRING,    channel_str,
+                "sequence_num",  NULL,   DATA_INT,      sequence_num,
+                "battery_ok",       "Battery",      DATA_INT,    !battery_low,
+                "wind_avg_km_h",   "wind_speed",   DATA_FORMAT,    "%.1f km/h", DATA_DOUBLE,     wind_speed_kph,
+                "temperature_F",     "temperature",    DATA_FORMAT,    "%.1f F", DATA_DOUBLE,    tempf,
+                "humidity",     NULL,    DATA_FORMAT,    "%u %%",   DATA_INT,   humidity,
+                "mic",                  "Integrity",    DATA_STRING, "CHECKSUM",
+                NULL);
+        /* clang-format on */
+
+        decoder_output_data(decoder, data);
+    } else {
+        decoder_logf(decoder, 1, __func__, "unknown message type 0x02%x", message_type);
+        return DECODE_FAIL_SANITY;
+    }
+
+    return 1; // If we got here 1 valid message was output
 }
 
 /**
@@ -510,14 +792,6 @@ static int acurite_atlas_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsig
     int browlen = (bitbuffer->bits_per_row[row] + 7) / 8;
     uint8_t *bb = bitbuffer->bb[row];
 
-    // {80} 82 f3 65 00 88 72 22 00 9f 95  {80} 86 f3 65 00 88 72 22 00 9f 99  {80} 8a f3 65 00 88 72 22 00 9f 9d
-    // {80} 82 f3 66 00 05 e4 81 00 9f e4  {80} 86 f3 66 00 05 e4 81 00 9f e8  {80} 8a f3 66 00 05 e4 81 00 9f ec
-    // {80} 82 f3 e7 00 00 00 96 00 9f 91  {80} 86 f3 e7 00 00 00 96 00 9f 95  {80} 8a f3 e7 00 00 00 96 00 9f 99
-    // {80} 82 f3 66 00 05 60 81 00 9f 60  {80} 86 f3 66 00 05 60 81 00 9f 64  {80} 8a f3 66 00 05 60 81 00 9f 68
-    // {80} 82 f3 65 00 88 71 24 00 9f 96  {80} 86 f3 65 00 88 71 24 00 9f 9a  {80} 8a f3 65 00 88 71 24 00 9f 9e
-    // {80} 82 f3 65 00 88 71 a5 00 9f 17  {80} 86 f3 65 00 88 71 a5 00 9f 1b  {80} 8a f3 65 00 88 71 a5 00 9f 1f
-
-    // decoder_log_bitrow(decoder, 0, __func__, bb, bitbuffer->bits_per_row[brow], "Acurite Atlas raw msg");
     message_type = bb[2] & 0x3f;
     sensor_id = ((bb[0] & 0x03) << 8) | bb[1];
     char const *channel_str = acurite_getChannel(bb[0]);
@@ -545,7 +819,14 @@ static int acurite_atlas_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsig
     battery_low = (bb[2] & 0x40) == 0;
 
     // Wind speed is 8-bits raw MPH
+    // Spec is 0-200 MPH
     wind_speed_mph = ((bb[3] & 0x7F) << 1) | ((bb[4] & 0x40) >> 6);
+
+    if (wind_speed_mph > 200) {
+        decoder_logf(decoder, 1, __func__, "Atlas 0x%04X Ch %s, invalid wind spped: %.1f MPH",
+                     sensor_id, channel_str, wind_speed_mph);
+        return DECODE_FAIL_SANITY;
+    }
 
     /* clang-format off */
     data = data_make(
@@ -563,12 +844,35 @@ static int acurite_atlas_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsig
             message_type == ACURITE_MSGTYPE_ATLAS_WNDSPD_TEMP_HUM_LTNG) {
         // Wind speed, temperature and humidity
 
-        // range -40 to 160 F
-        // TODO: are there really 13 bits? use 11 for now.
+        // Spec: temperature range -40 to 158 F
+        // There seem to be 13 bits for temperature but only 11 needed.
+        // Decode as 11 bits, flag exception if the other two bits are ever
+        // non-zero so they can be investigated.
         int temp_raw = (bb[4] & 0x0F) << 7 | (bb[5] & 0x7F);
-        tempf = (temp_raw - 400) * 0.1;
+        if ((bb[4] & 0x30) != 0)
+            exception++;
 
-        humidity = (bb[6] & 0x7f); // 1-99 %rH
+        tempf = (temp_raw - 400) * 0.1;
+        if (tempf > 158.0) {
+            decoder_logf(decoder, 1, __func__, "Atlas 0x%04X Ch %s, invalid temperature: %0.1f F",
+                         sensor_id, channel_str, tempf);
+            return DECODE_FAIL_SANITY;
+        }
+
+
+        // Fail sanity check over 100% humidity
+        // Allow 0 because very low battery or defective sensor will report
+        // those values.
+        humidity = (bb[6] & 0x7f);
+        if (humidity > 100) {
+            decoder_logf(decoder, 1, __func__, "0x%04X Ch %s : Impossible humidity: %d %%rH",
+                         sensor_id, channel_str, humidity);
+            return DECODE_FAIL_SANITY;
+        }
+
+        if (humidity == 0)
+            exception++;
+
 
         /* clang-format off */
         data = data_append(data,
@@ -581,7 +885,22 @@ static int acurite_atlas_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsig
     if (message_type == ACURITE_MSGTYPE_ATLAS_WNDSPD_RAIN ||
             message_type == ACURITE_MSGTYPE_ATLAS_WNDSPD_RAIN_LTNG) {
         // Wind speed, wind direction, and rain fall
+
+        // Wind direction is in degrees, 0-360, only 9 bits needed
+        // but historically decoded as 10 bits.
+        // There seems to be 11 bits available
+        // As with temperatuve message, flag msg if those two extra bits
+        // are ever non-zero so they can be investigated
+        // Note: output as float, but currently can only be decoded an integer
         wind_dir = ((bb[4] & 0x1f) << 5) | ((bb[5] & 0x7c) >> 2);
+        if ((bb[4] & 0x30) != 0)
+            exception++;
+
+        if (wind_dir > 360) {
+            decoder_logf(decoder, 1, __func__, "Atlas 0x%04X Ch %s, invalid wind direction: %0.1fF",
+                         sensor_id, channel_str, wind_dir);
+            return DECODE_FAIL_SANITY;
+        }
 
         // range: 0 to 5.11 in, 0.01 inch increments, accumulated
         // JRH: Confirmed 9 bits, counter rolls over after 5.11 inches
@@ -597,9 +916,19 @@ static int acurite_atlas_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsig
 
     if (message_type == ACURITE_MSGTYPE_ATLAS_WNDSPD_UV_LUX ||
             message_type == ACURITE_MSGTYPE_ATLAS_WNDSPD_UV_LUX_LTNG) {
-        // Wind speed, UV Index, Light Intensity, Lightning?
+        // Wind speed, UV Index, Light Intensity, and optionally Lightning
+
+        // Spec UV index is 0-16 (but can only be 0-15)
         int uv  = (bb[4] & 0x0f);
+
+        // Light intensity 0 - 120,000 lumens / 10
+        // 14 bits are available (0-16,383)
         int lux = ((bb[5] & 0x7f) << 7) | (bb[6] & 0x7F);
+        if (lux > 12000) {
+            decoder_logf(decoder, 1, __func__, "Atlas 0x%04X Ch %s, invalid lux %d",
+                         sensor_id, channel_str, lux);
+            return DECODE_FAIL_SANITY;
+        }
 
         /* clang-format off */
         data = data_append(data,
@@ -625,8 +954,9 @@ static int acurite_atlas_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsig
         /* clang-format on */
     }
 
+    // @todo only do this if exception != 0, but would be somewhat incompatible
     data = data_append(data,
-            "exception",        "data_exception",   DATA_INT,    exception,    // @todo convert to bool
+            "exception",        "data_exception",   DATA_INT,    exception,
             "raw_msg",          "raw_message",      DATA_STRING, raw_str,
             NULL);
 
@@ -635,39 +965,45 @@ static int acurite_atlas_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsig
     return 1; // one valid message decoded
 }
 
+/*
+Acurite 592TXR Temperature Humidity sensor decoder
+
+Message Type 0x04, 7 bytes
+
+| Byte 0    | Byte 1    | Byte 2    | Byte 3    | Byte 4    | Byte 5    | Byte 6    |
+| --------- | --------- | --------- | --------- | --------- | --------- | --------- |
+| CCII IIII | IIII IIII | pB00 0100 | pHHH HHHH | p??T TTTT | pTTT TTTT | KKKK KKKK |
+
+
+* C: Channel 00: C, 10: B, 11: A, (01 is invalid)
+* I: Device ID (14 bits)
+* B: Battery, 1 is battery OK, 0 is battery low
+* M: Message type (6 bits), 0x04
+* T: Temperature Celsius (11 - 14 bits?), + 1000 * 10
+* H: Relative Humidity (%) (7 bits)
+* K: Checksum (8 bits)
+* p: Parity bit
+
+Notes:
+
+* Temperature
+  * Encoded as Celsius + 1000 * 10
+  * only 11 bits needed for specified range -40 C to 70 C (-40 F - 158 F)
+  * However 14 bits available for temperature, giving possible range of -100 C to 1538.4 C
+  * @todo - check if high 3 bits ever used for anything else
+
+*/
 static int acurite_tower_decode(r_device* decoder, uint8_t* bb)
 {
-    // checksum in the last byte has been validated in the calling function
+    // MIC (checkum, parity) validated in calling function
 
-    // Verify parity bits
-    // Bytes 2, 3, 4, and 5 should all have a parity bit in their MSB
-    int parity = parity_bytes(&bb[2], 4);
-    if (parity) {
-        decoder_log_bitrow(decoder, 1, __func__, bb, 7 * 8, "bad parity");
-        return DECODE_FAIL_MIC;
-    }
-
-    // Channel is the first two bits of the 0th byte
-    // but only 3 of the 4 possible values are valid
+    int exception = 0;
     char const* channel_str = acurite_getChannel(bb[0]);
-    if (*channel_str == 'E') {
-        decoder_logf(decoder, 1, __func__, "bad channel Ch %s", channel_str);
-        return DECODE_FAIL_SANITY;
-    }
-
-    // Tower sensor ID is the last 14 bits of byte 0 and 1
-    // CCII IIII | IIII IIII
     int sensor_id = ((bb[0] & 0x3f) << 8) | bb[1];
-
-    // Battery status is the 7th bit 0x40. 1 = normal, 0 = low
-    // pxxx xxxB
     int battery_low = (bb[2] & 0x40) == 0;
 
-    // Humidity is stored in byte 3
-    // The value is directly encoded as %rH
-    // The possible values here are 0-128, but the manufacturer specifies that valid values
-    // are only 1-99 %rH
-    // pIII IIII
+    // Spec is relative humidity 1-99%
+    // Allowing value of 0, very low battery or broken sensor can return 0% or 1%
     int humidity = (bb[3] & 0x7f);
     if (humidity < 0 || humidity > 100) {
         decoder_logf(decoder, 1, __func__, "0x%04X Ch %s : Impossible humidity: %d %%rH",
@@ -689,6 +1025,11 @@ static int acurite_tower_decode(r_device* decoder, uint8_t* bb)
         return DECODE_FAIL_SANITY;
     }
 
+    // flag if bits 12-14 of temperature are ever non-zero
+    // so they can be investigated for other possible information
+    if ((temp_raw & 0x3800) != 0)
+        exception++;
+
     data_t* data;
     /* clang-format off */
     data = data_make(
@@ -702,30 +1043,29 @@ static int acurite_tower_decode(r_device* decoder, uint8_t* bb)
             NULL);
     /* clang-format on */
 
+    if (exception)
+        data_append_exception(data, exception, bb, ACURITE_TXR_BYTELEN);
+
     decoder_output_data(decoder, data);
 
     return 1;
 }
 
-static int acurite_leak_detector_decode(r_device* decoder, uint8_t* bb)
-{
-    // checksum in the last byte has been validated in the calling function
+/*
+Acurite 1190/1192 leak detector
 
-    // Verify parity bits
-    // Bytes 2, 3, 4, and 5 should all have a parity bit in their MSB
-    int parity = parity_bytes(&bb[2], 4);
-    if (parity) {
-        decoder_log_bitrow(decoder, 1, __func__, bb, 7 * 8, "bad parity");
-        return DECODE_FAIL_MIC;
-    }
+Note: it seems like Acurite has deleted this product and
+related information from their website so specs, manual, etc.
+aren't easy to find
+
+*/
+static int acurite_1190_decode(r_device* decoder, uint8_t* bb)
+{
+    // MIC (checkum, parity) validated in calling function
 
     // Channel is the first two bits of the 0th byte
     // but only 3 of the 4 possible values are valid
     char const* channel_str = acurite_getChannel(bb[0]);
-    if (*channel_str == 'E') {
-        decoder_logf(decoder, 1, __func__, "Acurite TXR sensor : bad channel Ch %s", channel_str);
-        return DECODE_FAIL_SANITY;
-    }
 
     // Tower sensor ID is the last 14 bits of byte 0 and 1
     // CCII IIII | IIII IIII
@@ -754,67 +1094,211 @@ static int acurite_leak_detector_decode(r_device* decoder, uint8_t* bb)
     return 1;
 }
 
-/**
-This callback handles several Acurite devices that use a very
-similar RF encoding and data format:
+/*
+Decode Acurite 515 Refrigerator/Freezer sensors
 
-- 592TXR temperature and humidity sensor
-- 5-n-1 weather station
-- 6045M Lightning Detector with Temperature and Humidity
-- Atlas
-- 899 Rain Fall Gauge
+Byte 0    | Byte 1    | Byte 2    | Byte 3    | Byte 4    | Byte 5
+CCII IIII | IIII IIII | pBMM MMMM | bTTT TTTT | bTTT TTTT | KKKK KKKK
 
-    CC RR IIII | IIII IIII | pBMMMMMM | pxxWWWWW | pWWWTTTT | pTTTTTTT | pSSSSSSS
-    C:2d R:2d ID:12d 1x BATT:1b TYPE:6h 1x ?2b W:5b 1x 3b T:4b 1x 7b S: 1x 7d
-
-@todo - refactor, move 5n1 and txr decoding into separate functions.
-@todo - TBD Are parity and checksum the same across these devices?
-        (opportunity to DRY-up and simplify?)
+- C: Channel 00: C, 10: B, 11: A
+- I: Device ID (14 bits), volatie, resets at power up
+- B: Battery, 1 is battery OK, 0 is battery low
+- M: Message type (6 bits), 0x8: Refrigerator, 0x9: Freezer
+- T: Temperature Fahrenheit (14 bits?), + 1480 * 10
+- K: Checksum (8 bits)
+- p: Parity bit
 
 */
-static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+
+static int acurite_515_decode(r_device* decoder, uint8_t* bb)
 {
-    int browlen, valid = 0;
+    // length, MIC (checkum, parity) validated in calling function
+
+    int exception = 0;
+    char channel_type_str[3];
+    uint8_t message_type = bb[2] & 0x3f;
+
+    // Channel A, B, C, common with other Acurite devices
+    char const* channel_str = acurite_getChannel(bb[0]);
+
+    channel_type_str[0] = channel_str[0];
+
+    if (message_type == ACURITE_MSGTYPE_515_REFRIGERATOR)
+        channel_type_str[1] = 'R';
+    else if (message_type == ACURITE_MSGTYPE_515_FREEZER)
+        channel_type_str[1] = 'F';
+    else {
+        decoder_logf(decoder, 1, __func__, "unknown message type 0x02%x", message_type);
+        return DECODE_FAIL_SANITY;
+    }
+
+    channel_type_str[2] = 0;
+
+    // Sensor ID is the last 14 bits of byte 0 and 1
+    // CCII IIII | IIII IIII
+    // The sensor ID changes on each power-up of the sensor.
+    uint16_t sensor_id = ((bb[0] & 0x3f) << 8) | bb[1];
+
+    // temperature encoding 14 bits after removing both parity bits.
+    // Spec range from Manual: -40 F to 158 F  (-40 to 70 C)
+    // Offset to avoid negative values is 1480
+    // Possible encoding range with 14 bits (0-16383) is -148.0 F to 1490.3 F
+    // Only 12 bits needed to represent -40 F to 158 F with encoding offset of 1480.
+    //   encoding range at 12 bits with +1480 offset: -148.0 F to +261.5 F
+    int temp_raw = ((bb[3] & 0x7F) << 7) | (bb[4] & 0x7F);
+    float tempf = (temp_raw - 1480) * 0.1f;
+    if (tempf < -40.0 || tempf > 158.0) {
+        decoder_logf(decoder, 1, __func__, "515 0x%04X Ch %s, invalid temperature: %0.1f F",
+                     sensor_id, channel_str, tempf);
+        return DECODE_FAIL_SANITY;
+    }
+
+    // flag if bits 13 - 14 of temperature are ever non-zero
+    // so they can be investigated
+    if ((temp_raw & 0x3000) != 0)
+        exception++;
+
+    // Battery status is the 7th bit 0x40. 1 = normal, 0 = low
+    int battery_low = (bb[2] & 0x40) == 0;
+
+    data_t* data;
+    /* clang-format off */
+    data = data_make(
+        "model",                "",             DATA_STRING, "Acurite-515",
+        "id",                   "",             DATA_INT,    sensor_id,
+        "channel",              NULL,           DATA_STRING, channel_type_str,
+        "battery_ok",           "Battery",      DATA_INT,    !battery_low,
+        "temperature_F",        "Temperature",  DATA_FORMAT, "%.1f F", DATA_DOUBLE, tempf,
+        "mic",                  "Integrity",    DATA_STRING, "CHECKSUM",
+        NULL);
+    /* clang-format on */
+
+    if (exception)
+        data_append_exception(data, exception, bb, ACURITE_515_BYTELEN);
+
+    decoder_output_data(decoder, data);
+
+    return 1;
+}
+
+/*
+Check Acurite TXR message integrity (length, checksum, parity)
+
+Need to pass in expected length - correct number of bytes for
+that message type.
+
+Return 0 for valid roe or DECODE_ABORT_LENGHT, DECODE_FAIL_MIC, DECODE_FAIL_SANITY
+
+Long rows with extra bits/bytes (from demod/bit slicing)
+will be accepted as long the bytes up to the expected length
+pass checksum and parity tests.
+*/
+static int acurite_txr_check(r_device *decoder, uint8_t const bb[], unsigned browlen, unsigned explen)
+{
+
+    // Currently shortest Acurite "TXR" message is 6 bytes
+    // 5 bytes could possibly be valid, but would only have
+    // a single data byte after Channel, ID, message type, and checksum
+    // Really short rows (1-2) bytes, should be rejected quietly earlier
+    // so real error types can be seen
+    if (browlen < 6)
+        return DECODE_ABORT_LENGTH;
+
+    if (browlen < explen) {
+        decoder_log_bitrow(decoder, 1, __func__, bb, browlen * 8, "wrong length for msg type");
+        return DECODE_ABORT_LENGTH;
+    }
+
+    // 8 bit checksum in the last byte
+    if ((add_bytes(bb, explen - 1) & 0xff) != bb[explen - 1]) {
+        decoder_log_bitrow(decoder, 1, __func__, bb, browlen * 8, "bad checksum");
+        return DECODE_FAIL_MIC;
+    }
+
+    // Verify parity bits
+    // Bytes 2 ... n-1 should all have even parity
+    // (ID bytes and checksum byte are all 8 bit, so no parity check)
+    int parity = parity_bytes(&bb[2], explen - 3);
+
+    if (parity) {
+        decoder_log_bitrow(decoder, 1, __func__, bb, browlen * 8,"bad parity");
+        return DECODE_FAIL_MIC;
+    }
+
+    // All of these devices have channel (A, B, C) in two bits (mask 0c0) of byte 0
+    // 00: C, 10: B, 11: A, (01 aka 'E' is invalid)
+    // check sanity to cut down an bad messages that pass MIC checks
+    char const *channel_str = acurite_getChannel(bb[0]);
+    if (*channel_str == 'E') {
+	uint8_t message_type = bb[2] & 0x3f;
+        decoder_logf(decoder, 1, __func__,
+                     "bad channel Ch %s, msg type 0x%02x, msg len %d",
+                     channel_str, message_type, browlen);
+        return DECODE_FAIL_SANITY;
+    }
+
+    return 0;
+}
+
+
+/**
+Process messages for Acurite weather stations, tower, and related sensors
+
+This callback is used for devices that use a very similar message format:
+
+- 592TXR / 6002RM / 6044m Tower sensor and related temperature/humidity sensors
+- Atlas (7-in-1) Weather Station
+- Iris (5-in-1) weather station
+- Notos (3-in-1) Weather station
+- 6045M Lightning Detector with Temperature and Humidity
+- 899 Rain Fall Gauge
+- 515 Refrigerator/Freezer sensors
+- 1190/1192 Water alarm
+
+These devices have a message type in the 3rd byte and an 8 bit checksum
+in the last byte.
+
+
+*/
+static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    int decoded = 0;
+    int error_ret = 0;
+    int ret = 0;
     uint8_t *bb;
-    float tempf, wind_dir, wind_speed_kph, wind_speed_mph;
-    uint8_t humidity, sequence_num, message_type;
-    // uint8_t sensor_status;
-    uint16_t sensor_id;
-    int raincounter, battery_low;
-    data_t *data;
+    uint8_t message_type;
 
     bitbuffer_invert(bitbuffer);
 
     for (uint16_t brow = 0; brow < bitbuffer->num_rows; ++brow) {
-        browlen = (bitbuffer->bits_per_row[brow] + 7)/8;
+        int row_bit_cnt = bitbuffer->bits_per_row[brow];
+        int browlen = row_bit_cnt / 8;  // assumption: safe to round down, extra bits are spurious
+
         bb = bitbuffer->bb[brow];
 
-        decoder_logf(decoder, 2, __func__, "row %u bits %u, bytes %d", brow, bitbuffer->bits_per_row[brow], browlen);
-
-        if ((bitbuffer->bits_per_row[brow] < ACURITE_TXR_BITLEN ||
-                bitbuffer->bits_per_row[brow] > ACURITE_5N1_BITLEN + 1)
-                && bitbuffer->bits_per_row[brow] != ACURITE_6045_BITLEN
-                && bitbuffer->bits_per_row[brow] != ACURITE_ATLAS_BITLEN
-                && bitbuffer->bits_per_row[brow] != ACURITE_515_BITLEN) {
-            if (bitbuffer->bits_per_row[brow] > 16)
-                decoder_log(decoder, 2, __func__, "skipping wrong len");
-            continue; // DECODE_ABORT_LENGTH
+        // Known messages in this family are between 6 and 10 bytes
+        if (browlen < 6) {
+            continue; // quietly skip short rows
         }
 
-        // There will be 1 extra false zero bit added by the demod.
-        // this forces an extra zero byte to be added
-        if (bb[browlen - 1] == 0)
-            browlen--;
-
-        // sum of first n-1 bytes modulo 256 should equal nth byte
-        // also disregard a row of all zeros
-        int sum = add_bytes(bb, browlen - 1);
-        if (sum == 0 || (sum & 0xff) != bb[browlen - 1]) {
-            decoder_log_bitrow(decoder, 1, __func__, bb, bitbuffer->bits_per_row[brow], "bad checksum");
-            continue; // DECODE_FAIL_MIC
+        // Currently known longest message is 10 bytes (Atlas with lightning sensorr)
+        if (browlen > 10) {
+            decoder_logf(decoder, 2, __func__, "Skipping wrong len row %u bits %u, bytes %d",
+                         brow, row_bit_cnt, browlen);
+            error_ret = DECODE_ABORT_LENGTH;
+            continue;
         }
 
-        // acurite sensors with a common format appear to have a message type
+        decoder_logf(decoder, 2, __func__,
+                     "row %u bits %u, bytes %d, extra bits %d, msg type 0x%02x",
+                     brow, row_bit_cnt, browlen, row_bit_cnt % 8, bb[2] & 0x3f);
+
+
+        // quietly ignore rows of zeros (ID, msg type, checksum)
+        if (bb[0] == 0 && bb[1] == 0 && bb[2] == 0 && bb[browlen - 1] == 0)
+            continue;
+
+        // acurite sensors with a common format have a message type
         // in the lower 6 bits of the 3rd byte.
         // Format: PBMMMMMM
         // P = Parity
@@ -822,228 +1306,188 @@ static int acurite_txr_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         // M = Message type
         message_type = bb[2] & 0x3f;
 
-        // Multiple AcuRite sensors use the same basic message format,
-        // with a shared header and integrity scheme. These are differentiated
-        // by the message_type.
-        if (browlen == ACURITE_TXR_BITLEN / 8) {
-            int decoded = 0;
+        // Check so that unknown message type can be flagged
+        // and dispatching to decoders can be easier to maintain
+        switch(message_type) {
+            case ACURITE_MSGTYPE_1190_DETECTOR:
+            case ACURITE_MSGTYPE_TOWER_SENSOR:
+            case ACURITE_MSGTYPE_6045M:
+            case ACURITE_MSGTYPE_5N1_WINDSPEED_WINDDIR_RAINFALL:
+            case ACURITE_MSGTYPE_5N1_WINDSPEED_TEMP_HUMIDITY:
+            case ACURITE_MSGTYPE_ATLAS_WNDSPD_TEMP_HUM:
+            case ACURITE_MSGTYPE_ATLAS_WNDSPD_RAIN:
+            case ACURITE_MSGTYPE_ATLAS_WNDSPD_UV_LUX:
+            case ACURITE_MSGTYPE_ATLAS_WNDSPD_TEMP_HUM_LTNG:
+            case ACURITE_MSGTYPE_ATLAS_WNDSPD_RAIN_LTNG:
+            case ACURITE_MSGTYPE_ATLAS_WNDSPD_UV_LUX_LTNG:
+            case ACURITE_MSGTYPE_515_REFRIGERATOR:
+            case ACURITE_MSGTYPE_515_FREEZER:
+            case ACURITE_MSGTYPE_3N1_WINDSPEED_TEMP_HUMIDITY:
+            case ACURITE_MSGTYPE_899_RAINFALL:
+                break;
 
-            if (message_type == ACURITE_MSGTYPE_LEAK_DETECTOR) {
-                decoded = acurite_leak_detector_decode(decoder, bb);
-            } else if (message_type == ACURITE_MSGTYPE_TOWER_SENSOR) {
-                decoded = acurite_tower_decode(decoder, bb);
-            }
+            default:
+                decoder_log_bitrow(decoder, 1, __func__, bb, row_bit_cnt,
+                                   "Unknown message type");
+                error_ret = DECODE_FAIL_SANITY;
+                continue;
+                break;
+        }
 
-            // The decoder attempts for this size message will return a positive
-            // value if they successfully decoded a message.
-            if (decoded > 0) {
-                valid++;
+        // Check message type and dispatch to appropriate decoders
+        // NOTE: since we are processing each row, do not return
+        // until all rows have been processed
+        if (message_type == ACURITE_MSGTYPE_TOWER_SENSOR) {
+            if ((ret = acurite_txr_check(decoder, bb, browlen, ACURITE_TXR_BYTELEN)) != 0) {
+                error_ret = ret;
+            } else {
+                if ((ret = acurite_tower_decode(decoder, bb)) > 0) {
+                    decoded += ret;
+                } else if (ret < 0) {
+                    error_ret = ret;
+                }
             }
         }
 
-        // 515 sensor messages are 6 bytes.
-        if (browlen == ACURITE_515_BITLEN / 8) {
-            char const *channel_str = acurite_getChannelAndType(bb[0], message_type);
-
-            // Sensor ID is the last 14 bits of byte 0 and 1
-            // CCII IIII | IIII IIII
-            // The sensor ID changes on each power-up of the sensor.
-            sensor_id = ((bb[0] & 0x3f) << 8) | bb[1];
-
-            // Sensor type (refrigerator, freezer) is determined by the message_type.
-            if (message_type != ACURITE_MSGTYPE_515_REFRIGERATOR
-                    && message_type != ACURITE_MSGTYPE_515_FREEZER) {
-                decoder_logf(decoder, 2, __func__, "Acurite 515 sensor 0x%04X Ch %s, Unknown message type 0x%02x",
-                        sensor_id, channel_str, message_type);
-                continue; // DECODE_FAIL_MIC
-            }
-
-            // temperature encoding used by 515 sensors
-            // 14 bits available after removing both parity bits.
-            int temp_raw = ((bb[3] & 0x7F) << 7) | (bb[4] & 0x7F);
-            tempf = (temp_raw - 1480) * 0.1f;
-            // Battery status is the 7th bit 0x40. 1 = normal, 0 = low
-            battery_low = (bb[2] & 0x40) == 0;
-
-            /* clang-format off */
-            data = data_make(
-                    "model",                "",             DATA_STRING, "Acurite-515",
-                    "id",                   "",             DATA_INT,    sensor_id,
-                    "channel",              NULL,           DATA_STRING, channel_str,
-                    "battery_ok",           "Battery",      DATA_INT,    !battery_low,
-                    "temperature_F",        "Temperature",  DATA_FORMAT, "%.1f F", DATA_DOUBLE, tempf,
-                    "mic",                  "Integrity",    DATA_STRING, "CHECKSUM",
-                    NULL);
-            /* clang-format on */
-
-            decoder_output_data(decoder, data);
-            valid++;
-        }
-
-        // The 5-n-1 weather sensor messages are 8 bytes.
-        else if (message_type == ACURITE_MSGTYPE_5N1_WINDSPEED_WINDDIR_RAINFALL ||
-                 message_type == ACURITE_MSGTYPE_5N1_WINDSPEED_TEMP_HUMIDITY ||
-                 message_type == ACURITE_MSGTYPE_3N1_WINDSPEED_TEMP_HUMIDITY ||
-                 message_type == ACURITE_MSGTYPE_RAINFALL) {
-            decoder_log_bitrow(decoder, 1, __func__, bb, bitbuffer->bits_per_row[brow], "Acurite 5n1 raw msg");
-            char const *channel_str = acurite_getChannel(bb[0]);
-
-            // 5-n-1 sensor ID is the last 12 bits of byte 0 & 1
-            // byte 0     | byte 1
-            // CC RR IIII | IIII IIII
-            sensor_id    = ((bb[0] & 0x0f) << 8) | bb[1];
-            // The sensor sends the same data three times, each of these have
-            // an indicator of which one of the three it is. This means the
-            // checksum and first byte will be different for each one.
-            // The bits 5,4 of byte 0 indicate which copy of the 65 bit data string
-            //  00 = first copy
-            //  01 = second copy
-            //  10 = third copy
-            //  1100 xxxx  = channel A 1st copy
-            //  1101 xxxx  = channel A 2nd copy
-            //  1110 xxxx  = channel A 3rd copy
-            sequence_num = (bb[0] & 0x30) >> 4;
-            battery_low = (bb[2] & 0x40) == 0;
-
-            // Only for 5N1, range: 0 to 159 kph
-            // raw number is cup rotations per 4 seconds
-            // http://www.wxforum.net/index.php?topic=27244.0 (found from weewx driver)
-            int speed_raw = ((bb[3] & 0x1F) << 3)| ((bb[4] & 0x70) >> 4);
-            wind_speed_kph = 0;
-            if (speed_raw > 0) {
-                wind_speed_kph = speed_raw * 0.8278 + 1.0;
-            }
-
-            if (message_type == ACURITE_MSGTYPE_5N1_WINDSPEED_WINDDIR_RAINFALL) {
-                // Wind speed, wind direction, and rain fall
-                wind_dir = acurite_5n1_winddirections[bb[4] & 0x0f] * 22.5f;
-
-                // range: 0 to 99.99 in, 0.01 inch increments, accumulated
-                raincounter = ((bb[5] & 0x7f) << 7) | (bb[6] & 0x7F);
-
-                /* clang-format off */
-                data = data_make(
-                        "model",        "",   DATA_STRING,    "Acurite-5n1",
-                        "message_type", NULL,   DATA_INT,       message_type,
-                        "id",           NULL, DATA_INT,       sensor_id,
-                        "channel",      NULL,   DATA_STRING,    channel_str,
-                        "sequence_num",  NULL,   DATA_INT,      sequence_num,
-                        "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-                        "wind_avg_km_h",   "wind_speed",   DATA_FORMAT,    "%.1f km/h", DATA_DOUBLE,     wind_speed_kph,
-                        "wind_dir_deg", NULL,   DATA_FORMAT,    "%.1f", DATA_DOUBLE,    wind_dir,
-                        "rain_in",      "Rainfall Accumulation",   DATA_FORMAT, "%.2f in", DATA_DOUBLE, raincounter * 0.01f,
-                        "mic",                  "Integrity",    DATA_STRING, "CHECKSUM",
-                        NULL);
-                /* clang-format on */
-
-                decoder_output_data(decoder, data);
-                valid++;
-            }
-            else if (message_type == ACURITE_MSGTYPE_5N1_WINDSPEED_TEMP_HUMIDITY) {
-                // Wind speed, temperature and humidity
-
-                // range -40 to 158 F
-                int temp_raw = (bb[4] & 0x0F) << 7 | (bb[5] & 0x7F);
-                tempf = (temp_raw - 400) * 0.1f;
-
-                humidity = (bb[6] & 0x7f); // 1-99 %rH
-
-                /* clang-format off */
-                data = data_make(
-                        "model",        "",   DATA_STRING,    "Acurite-5n1",
-                        "message_type", NULL,   DATA_INT,       message_type,
-                        "id",           NULL, DATA_INT,  sensor_id,
-                        "channel",      NULL,   DATA_STRING,    channel_str,
-                        "sequence_num",  NULL,   DATA_INT,      sequence_num,
-                        "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-                        "wind_avg_km_h",   "wind_speed",   DATA_FORMAT,    "%.1f km/h", DATA_DOUBLE,     wind_speed_kph,
-                        "temperature_F",     "temperature",    DATA_FORMAT,    "%.1f F", DATA_DOUBLE,    tempf,
-                        "humidity",     NULL,    DATA_FORMAT,    "%u %%",   DATA_INT,   humidity,
-                        "mic",                  "Integrity",    DATA_STRING, "CHECKSUM",
-                        NULL);
-                /* clang-format on */
-
-                decoder_output_data(decoder, data);
-                valid++;
-            }
-            else if (message_type == ACURITE_MSGTYPE_3N1_WINDSPEED_TEMP_HUMIDITY) {
-                // Wind speed, temperature and humidity for 3-n-1
-                sensor_id = ((bb[0] & 0x3f) << 8) | bb[1]; // 3-n-1 sensor ID is the bottom 14 bits of byte 0 & 1
-                humidity = (bb[3] & 0x7f); // 1-99 %rH
-
-                // note the 3n1 seems to have one more high bit than 5n1
-                int temp_raw = (bb[4] & 0x1F) << 7 | (bb[5] & 0x7F);
-                tempf        = (temp_raw - 1480) * 0.1f; // regression yields (rawtemp-1480)*0.1
-
-                wind_speed_mph = bb[6] & 0x7f; // seems to be plain MPH
-
-                /* clang-format off */
-                data = data_make(
-                        "model",        "",   DATA_STRING,    "Acurite-3n1",
-                        "message_type", NULL,   DATA_INT,       message_type,
-                        "id",    NULL,   DATA_FORMAT,    "0x%02X",   DATA_INT,       sensor_id,
-                        "channel",      NULL,   DATA_STRING,    channel_str,
-                        "sequence_num",  NULL,   DATA_INT,      sequence_num,
-                        "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-                        "wind_avg_mi_h",   "wind_speed",   DATA_FORMAT,    "%.1f mi/h", DATA_DOUBLE,     wind_speed_mph,
-                        "temperature_F",     "temperature",    DATA_FORMAT,    "%.1f F", DATA_DOUBLE,    tempf,
-                        "humidity",     NULL,    DATA_FORMAT,    "%u %%",   DATA_INT,   humidity,
-                        "mic",                  "Integrity",    DATA_STRING, "CHECKSUM",
-                        NULL);
-                /* clang-format on */
-
-                decoder_output_data(decoder, data);
-                valid++;
-            }
-            else if (message_type == ACURITE_MSGTYPE_RAINFALL) {
-                // The earlier length check passes as ACURITE_TXR_BITLEN is 56
-                // bits / 7 bytes. This message type is always 8 bytes.
-                if (browlen != 8) {
-                    decoder_log(decoder, 2, __func__, "skipping wrong len");
-                    continue;
-                } // DECODE_ABORT_LENGTH
-
-                // Rain Fall Gauge 899
-                // The high 2 bits of byte zero are the channel (bits 7,6), 00 = A, 01 = B, 10 = C
-                int channel = bb[0] >> 6;
-                raincounter = ((bb[5] & 0x7f) << 7) | (bb[6] & 0x7f); // one tip is 0.01 inch, i.e. 0.254mm
-
-                /* clang-format off */
-                data = data_make(
-                        "model",            "",                         DATA_STRING, "Acurite-Rain899",
-                        "id",               "",                         DATA_INT,    sensor_id,
-                        "channel",          "",                         DATA_INT,    channel,
-                        "battery_ok",       "Battery",                  DATA_INT,    !battery_low,
-                        "rain_mm",          "Rainfall Accumulation",    DATA_FORMAT, "%.2f mm", DATA_DOUBLE, raincounter * 0.254,
-                        "mic",                  "Integrity",    DATA_STRING, "CHECKSUM",
-                        NULL);
-                /* clang-format on */
-
-                decoder_output_data(decoder, data);
-                valid++;
-            }
-            else {
-                decoder_logf(decoder, 2, __func__, "Acurite 5n1 sensor 0x%04X Ch %s, Status %02X, Unknown message type 0x%02x",
-                        sensor_id, channel_str, bb[3], message_type);
+        if (message_type == ACURITE_MSGTYPE_1190_DETECTOR) {
+            if ((ret = acurite_txr_check(decoder, bb, browlen, ACURITE_1190_BYTELEN)) != 0) {
+                error_ret = ret;
+            } else {
+                if ((ret = acurite_1190_decode(decoder, bb)) > 0) {
+                    decoded += ret;
+                } else if (ret < 0) {
+                    error_ret = ret;
+                }
             }
         }
 
-        else if (message_type == ACURITE_MSGTYPE_6045M) {
-            // TODO: check parity and reject if invalid
-            valid += acurite_6045_decode(decoder, bitbuffer, brow);
+        if (message_type == ACURITE_MSGTYPE_6045M) {
+            if ((ret = acurite_txr_check(decoder, bb, browlen, ACURITE_6045_BYTELEN)) != 0) {
+                error_ret = ret;
+            } else {
+                if ((ret = acurite_6045_decode(decoder, bitbuffer, brow)) > 0) {
+                    decoded += ret;
+                } else if (ret < 0) {
+                    error_ret = ret;
+                }
+            }
         }
 
-        else if ((message_type == ACURITE_MSGTYPE_ATLAS_WNDSPD_TEMP_HUM ||
-                  message_type == ACURITE_MSGTYPE_ATLAS_WNDSPD_RAIN ||
-                  message_type == ACURITE_MSGTYPE_ATLAS_WNDSPD_UV_LUX ||
-                  message_type == ACURITE_MSGTYPE_ATLAS_WNDSPD_TEMP_HUM_LTNG ||
-                  message_type == ACURITE_MSGTYPE_ATLAS_WNDSPD_RAIN_LTNG ||
-                  message_type == ACURITE_MSGTYPE_ATLAS_WNDSPD_UV_LUX_LTNG)) {
-            valid += acurite_atlas_decode(decoder, bitbuffer, brow);
+        if (message_type == ACURITE_MSGTYPE_515_REFRIGERATOR ||
+            message_type == ACURITE_MSGTYPE_515_FREEZER) {
+            if ((ret = acurite_txr_check(decoder, bb, browlen, ACURITE_515_BYTELEN)) != 0) {
+                error_ret = ret;
+            } else {
+                if ((ret = acurite_515_decode(decoder, bb)) > 0) {
+                    decoded += ret;
+                } else if (ret < 0) {
+                    error_ret = ret;
+                }
+            }
         }
+
+        if (message_type == ACURITE_MSGTYPE_5N1_WINDSPEED_TEMP_HUMIDITY ||
+            message_type == ACURITE_MSGTYPE_5N1_WINDSPEED_WINDDIR_RAINFALL) {
+            if ((ret = acurite_txr_check(decoder, bb, browlen, ACURITE_5N1_BYTELEN)) != 0) {
+                error_ret = ret;
+            } else {
+                if ((ret = acurite_5n1_decode(decoder, bb)) > 0) {
+                    decoded += ret;
+                } else if (ret < 0) {
+                    error_ret = ret;
+                }
+            }
+        }
+
+        if (message_type == ACURITE_MSGTYPE_3N1_WINDSPEED_TEMP_HUMIDITY) {
+            /*
+              @todo - does 3n1 use parity checking?
+              3n1 g001 in rtl_433_test has odd parity the 2nd to last byte in both copies
+              but g002 passes parity check
+            */
+
+            if (browlen < ACURITE_3N1_BYTELEN) {
+                decoder_log_bitrow(decoder, 1, __func__, bb, browlen * 8, "3n1 wrong length");
+                error_ret = DECODE_ABORT_LENGTH;
+                continue;
+            }
+
+            if ((add_bytes(bb, ACURITE_3N1_BYTELEN - 1) & 0xff) !=
+                bb[ACURITE_3N1_BYTELEN - 1]) {
+                decoder_log_bitrow(decoder, 1, __func__, bb, browlen * 8, "bad checksum");
+                error_ret = DECODE_FAIL_MIC;
+                continue;
+            }
+
+            if ((ret = acurite_3n1_decode(decoder, bb)) > 0) {
+                decoded += ret;
+            } else if (ret < 0) {
+                error_ret = ret;
+            }
+        }
+
+        if (message_type == ACURITE_MSGTYPE_899_RAINFALL) {
+            /*
+              @todo - does the 899 use parity checking?
+              The available sample shows a parity bit in the message byte
+              but there isn't enough accumulated rain in the data bytes
+              to see if parity is used
+            */
+            if ((ret = acurite_txr_check(decoder, bb, browlen, ACURITE_899_BYTELEN)) != 0) {
+                error_ret = ret;
+            } else {
+                if ((ret = acurite_899_decode(decoder, bb)) > 0) {
+                    decoded += ret;
+                } else if (ret < 0) {
+                    error_ret = ret;
+                }
+            }
+        }
+
+        // process Atlas
+        switch(message_type) {
+            // Atlas messages without lightning sensor installed - 8 bytes
+            case ACURITE_MSGTYPE_ATLAS_WNDSPD_TEMP_HUM:
+            case ACURITE_MSGTYPE_ATLAS_WNDSPD_RAIN:
+            case ACURITE_MSGTYPE_ATLAS_WNDSPD_UV_LUX:
+                if ((ret = acurite_txr_check(decoder, bb, browlen, ACURITE_ATLAS_BYTELEN)) != 0) {
+                    error_ret = ret;
+                } else {
+                    if ((ret = acurite_atlas_decode(decoder, bitbuffer, brow)) > 0) {
+                        decoded += ret;
+                    } else if (ret < 0) {
+                        error_ret = ret;
+                    }
+                }
+                break;
+
+            // Atlas messages with lightning sensor installed - 10 bytes
+            case ACURITE_MSGTYPE_ATLAS_WNDSPD_TEMP_HUM_LTNG:
+            case ACURITE_MSGTYPE_ATLAS_WNDSPD_RAIN_LTNG:
+            case ACURITE_MSGTYPE_ATLAS_WNDSPD_UV_LUX_LTNG:
+                if ((ret = acurite_txr_check(decoder, bb, browlen, ACURITE_ATLAS_LTNG_BYTELEN)) != 0) {
+                    error_ret = ret;
+                } else {
+                    if ((ret = acurite_atlas_decode(decoder, bitbuffer, brow)) > 0) {
+                        decoded += ret;
+                    } else if (ret < 0) {
+                        error_ret = ret;
+                    }
+                }
+                break;
+
+        }
+
+        decoder_logf(decoder, 2, __func__,
+                     "stats: row %u, msg type 0x%02x, bytes %d, decoded %d, error %d",
+                     brow, message_type, browlen, decoded, error_ret);
+
     }
 
-    return valid;
+    if (decoded > 0)
+        return decoded;
+    else
+        return error_ret;
 }
 
 /**
@@ -1258,7 +1702,7 @@ static int acurite_590tx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     if (b[4] != 0) // last byte should be zero
         return DECODE_FAIL_SANITY;
 
-    // reject all blank messages
+    // reject rows that are mostly zero
     if (b[0] == 0 && b[1] == 0 && b[2] == 0 && b[3] == 0)
         return DECODE_FAIL_SANITY;
 
@@ -1475,7 +1919,7 @@ r_device acurite_txr = {
         .sync_width  = 620,  // sync pulse is 620 us + 596 us gap
         .gap_limit   = 500,  // longest data gap is 392 us, sync gap is 596 us
         .reset_limit = 4000, // packet gap is 2192 us
-        .decode_fn   = &acurite_txr_decode,
+        .decode_fn   = &acurite_txr_callback,
         .fields      = acurite_txr_output_fields,
 };
 

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -162,6 +162,8 @@ static void data_append_exception(data_t* data, int exception, uint8_t* bb, int 
 
 }
 
+
+
 static int acurite_rain_896_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     uint8_t *b = bitbuffer->bb[0];
@@ -443,6 +445,7 @@ static int acurite_6045_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     strike_distance = bb[7] & 0x1f;
     rfi_detect = (bb[7] & 0x20) == 0x20;
 
+
     /*
      * 2018-04-21 rct - There are still a number of unknown bits in the
      * message that need to be figured out. Add the raw message hex to
@@ -455,6 +458,7 @@ static int acurite_6045_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
         rawp += 2;
     }
     *rawp = '\0';
+
 
     // Flag whether this message might need further analysis
     if ((bb[4] & 0x20) != 0) // unknown status bits, always off
@@ -712,6 +716,7 @@ static int acurite_5n1_decode(r_device* decoder, uint8_t* bb)
     return 1; // If we got here 1 valid message was output
 }
 
+
 /**
 Acurite Atlas weather and lightning sensor.
 
@@ -964,6 +969,7 @@ static int acurite_atlas_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsig
 
     return 1; // one valid message decoded
 }
+
 
 /*
 Acurite 592TXR Temperature Humidity sensor decoder
@@ -1489,6 +1495,7 @@ static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     else
         return error_ret;
 }
+
 
 /**
 Acurite 00986 Refrigerator / Freezer Thermometer.

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -8,25 +8,23 @@
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
 
-
-*/
-/**
 Acurite weather stations and temperature / humidity sensors.
-    Devices decoded:
-    - Acurite Iris (5-n-1) weather station, Model; VN1TXC, 06004RM
-    - Acurite 5-n-1 pro weather sensor, Model: 06014RM
-    - Acurite Atlas (7-n-1) weather station
-    - Acurite Notos (3-n-1) weather station
-    - Acurite 896 Rain gauge, Model: 00896
-    - Acurite 592TXR / 06002RM / 6044m Tower sensor (temperature and humidity)
-      (Note: Some newer sensors share the 592TXR coding for compatibility.
-    - Acurite 609TXC "TH" temperature and humidity sensor (609A1TX)
-    - Acurite 986 Refrigerator / Freezer Thermometer
-    - Acurite 515 Refrigerator / Freezer Thermometer
-    - Acurite 606TX temperature sensor
-    - Acurite 6045M Lightning Detector
-    - Acurite 00275rm and 00276rm temp. and humidity with optional probe.
-    - Acurite 1190/1192 leak/water detector
+
+Devices decoded:
+- Acurite Iris (5-n-1) weather station, Model; VN1TXC, 06004RM
+- Acurite 5-n-1 pro weather sensor, Model: 06014RM
+- Acurite Atlas (7-n-1) weather station
+- Acurite Notos (3-n-1) weather station
+- Acurite 896 Rain gauge, Model: 00896
+- Acurite 592TXR / 06002RM / 6044m Tower sensor (temperature and humidity)
+  (Note: Some newer sensors share the 592TXR coding for compatibility.
+- Acurite 609TXC "TH" temperature and humidity sensor (609A1TX)
+- Acurite 986 Refrigerator / Freezer Thermometer
+- Acurite 515 Refrigerator / Freezer Thermometer
+- Acurite 606TX temperature sensor
+- Acurite 6045M Lightning Detector
+- Acurite 00275rm and 00276rm temp. and humidity with optional probe.
+- Acurite 1190/1192 leak/water detector
 */
 
 #include "decoder.h"
@@ -390,7 +388,6 @@ Notes:
 @todo - storm_distance conversion to miles/KM (should match Acurite consoles)
 
 */
-
 static int acurite_6045_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row)
 {
     float tempf;
@@ -486,13 +483,13 @@ static int acurite_6045_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     return 1; // If we got here 1 valid message was output
 }
 
-
-/*
+/**
 Acurite 899 Rain Gauge decoder
 
 */
-static int acurite_899_decode(r_device* decoder, uint8_t* bb)
+static int acurite_899_decode(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t *bb)
 {
+    (void)bitbuffer;
     // MIC (checkum, parity) validated in calling function
 
     uint16_t sensor_id = ((bb[0] & 0x3f) << 8) | bb[1]; //
@@ -537,13 +534,14 @@ static int acurite_899_decode(r_device* decoder, uint8_t* bb)
 
 }
 
-/*
+/**
 Acurite 3n1 Weather Station decoder
 
 */
-static int acurite_3n1_decode(r_device* decoder, uint8_t* bb)
+static int acurite_3n1_decode(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t *bb)
 {
     // MIC (checkum, parity) validated in calling function
+    (void)bitbuffer;
 
     char const* channel_str = acurite_getChannel(bb[0]);
 
@@ -618,17 +616,16 @@ static int acurite_3n1_decode(r_device* decoder, uint8_t* bb)
 }
 
 
-/*
+/**
 Acurite 5n1 Weather Station decoder
 
 XXX todo docs
 
 */
-
-static int acurite_5n1_decode(r_device* decoder, uint8_t* bb)
+static int acurite_5n1_decode(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t* bb)
 {
     // MIC (checkum, parity) validated in calling function
-
+    (void)bitbuffer;
 
     char const* channel_str = acurite_getChannel(bb[0]);
     uint16_t sensor_id = ((bb[0] & 0x0f) << 8) | bb[1];
@@ -970,8 +967,7 @@ static int acurite_atlas_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsig
     return 1; // one valid message decoded
 }
 
-
-/*
+/**
 Acurite 592TXR Temperature Humidity sensor decoder
 
 Message Type 0x04, 7 bytes
@@ -981,28 +977,29 @@ Message Type 0x04, 7 bytes
 | CCII IIII | IIII IIII | pB00 0100 | pHHH HHHH | p??T TTTT | pTTT TTTT | KKKK KKKK |
 
 
-* C: Channel 00: C, 10: B, 11: A, (01 is invalid)
-* I: Device ID (14 bits)
-* B: Battery, 1 is battery OK, 0 is battery low
-* M: Message type (6 bits), 0x04
-* T: Temperature Celsius (11 - 14 bits?), + 1000 * 10
-* H: Relative Humidity (%) (7 bits)
-* K: Checksum (8 bits)
-* p: Parity bit
+- C: Channel 00: C, 10: B, 11: A, (01 is invalid)
+- I: Device ID (14 bits)
+- B: Battery, 1 is battery OK, 0 is battery low
+- M: Message type (6 bits), 0x04
+- T: Temperature Celsius (11 - 14 bits?), + 1000 * 10
+- H: Relative Humidity (%) (7 bits)
+- K: Checksum (8 bits)
+- p: Parity bit
 
 Notes:
 
-* Temperature
-  * Encoded as Celsius + 1000 * 10
-  * only 11 bits needed for specified range -40 C to 70 C (-40 F - 158 F)
-  * However 14 bits available for temperature, giving possible range of -100 C to 1538.4 C
-  * @todo - check if high 3 bits ever used for anything else
+- Temperature
+  - Encoded as Celsius + 1000 * 10
+  - only 11 bits needed for specified range -40 C to 70 C (-40 F - 158 F)
+  - However 14 bits available for temperature, giving possible range of -100 C to 1538.4 C
+  - @todo - check if high 3 bits ever used for anything else
 
 */
-static int acurite_tower_decode(r_device* decoder, uint8_t* bb)
+static int acurite_tower_decode(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t *bb)
 {
     // MIC (checkum, parity) validated in calling function
 
+    (void)bitbuffer;
     int exception = 0;
     char const* channel_str = acurite_getChannel(bb[0]);
     int sensor_id = ((bb[0] & 0x3f) << 8) | bb[1];
@@ -1057,7 +1054,7 @@ static int acurite_tower_decode(r_device* decoder, uint8_t* bb)
     return 1;
 }
 
-/*
+/**
 Acurite 1190/1192 leak detector
 
 Note: it seems like Acurite has deleted this product and
@@ -1065,10 +1062,9 @@ related information from their website so specs, manual, etc.
 aren't easy to find
 
 */
-static int acurite_1190_decode(r_device* decoder, uint8_t* bb)
+static int acurite_1190_decode(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t *bb)
 {
-    // MIC (checkum, parity) validated in calling function
-
+    (void)bitbuffer;
     // Channel is the first two bits of the 0th byte
     // but only 3 of the 4 possible values are valid
     char const* channel_str = acurite_getChannel(bb[0]);
@@ -1100,7 +1096,7 @@ static int acurite_1190_decode(r_device* decoder, uint8_t* bb)
     return 1;
 }
 
-/*
+/**
 Decode Acurite 515 Refrigerator/Freezer sensors
 
 Byte 0    | Byte 1    | Byte 2    | Byte 3    | Byte 4    | Byte 5
@@ -1115,11 +1111,11 @@ CCII IIII | IIII IIII | pBMM MMMM | bTTT TTTT | bTTT TTTT | KKKK KKKK
 - p: Parity bit
 
 */
-
-static int acurite_515_decode(r_device* decoder, uint8_t* bb)
+static int acurite_515_decode(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t *bb)
 {
     // length, MIC (checkum, parity) validated in calling function
 
+    (void)bitbuffer;
     int exception = 0;
     char channel_type_str[3];
     uint8_t message_type = bb[2] & 0x3f;
@@ -1187,7 +1183,7 @@ static int acurite_515_decode(r_device* decoder, uint8_t* bb)
     return 1;
 }
 
-/*
+/**
 Check Acurite TXR message integrity (length, checksum, parity)
 
 Need to pass in expected length - correct number of bytes for
@@ -1236,7 +1232,7 @@ static int acurite_txr_check(r_device *decoder, uint8_t const bb[], unsigned bro
     // check sanity to cut down an bad messages that pass MIC checks
     char const *channel_str = acurite_getChannel(bb[0]);
     if (*channel_str == 'E') {
-	uint8_t message_type = bb[2] & 0x3f;
+        uint8_t message_type = bb[2] & 0x3f;
         decoder_logf(decoder, 1, __func__,
                      "bad channel Ch %s, msg type 0x%02x, msg len %d",
                      channel_str, message_type, browlen);
@@ -1248,7 +1244,15 @@ static int acurite_txr_check(r_device *decoder, uint8_t const bb[], unsigned bro
 
 
 /**
-Process messages for Acurite weather stations, tower, and related sensors
+Process messages for Acurite weather stations, tower and related sensors
+@sa acurite_1190_decode()
+@sa acurite_515_decode()
+@sa acurite_6045_decode()
+@sa acurite_899_decode()
+#sa acurite_3n1_decode()
+@sa acurite_5n1_decode()
+@sa acurite_atlas_decode()
+@sa acurite_tower_decode()
 
 This callback is used for devices that use a very similar message format:
 
@@ -1263,7 +1267,6 @@ This callback is used for devices that use a very similar message format:
 
 These devices have a message type in the 3rd byte and an 8 bit checksum
 in the last byte.
-
 
 */
 static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
@@ -1347,7 +1350,7 @@ static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             if ((ret = acurite_txr_check(decoder, bb, browlen, ACURITE_TXR_BYTELEN)) != 0) {
                 error_ret = ret;
             } else {
-                if ((ret = acurite_tower_decode(decoder, bb)) > 0) {
+                    if ((ret = acurite_tower_decode(decoder, bitbuffer, bb)) > 0) {
                     decoded += ret;
                 } else if (ret < 0) {
                     error_ret = ret;
@@ -1359,7 +1362,7 @@ static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             if ((ret = acurite_txr_check(decoder, bb, browlen, ACURITE_1190_BYTELEN)) != 0) {
                 error_ret = ret;
             } else {
-                if ((ret = acurite_1190_decode(decoder, bb)) > 0) {
+                    if ((ret = acurite_1190_decode(decoder, bitbuffer, bb)) > 0) {
                     decoded += ret;
                 } else if (ret < 0) {
                     error_ret = ret;
@@ -1384,7 +1387,7 @@ static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             if ((ret = acurite_txr_check(decoder, bb, browlen, ACURITE_515_BYTELEN)) != 0) {
                 error_ret = ret;
             } else {
-                if ((ret = acurite_515_decode(decoder, bb)) > 0) {
+                if ((ret = acurite_515_decode(decoder, bitbuffer, bb)) > 0) {
                     decoded += ret;
                 } else if (ret < 0) {
                     error_ret = ret;
@@ -1397,7 +1400,7 @@ static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             if ((ret = acurite_txr_check(decoder, bb, browlen, ACURITE_5N1_BYTELEN)) != 0) {
                 error_ret = ret;
             } else {
-                if ((ret = acurite_5n1_decode(decoder, bb)) > 0) {
+                if ((ret = acurite_5n1_decode(decoder, bitbuffer, bb)) > 0) {
                     decoded += ret;
                 } else if (ret < 0) {
                     error_ret = ret;
@@ -1425,7 +1428,7 @@ static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                 continue;
             }
 
-            if ((ret = acurite_3n1_decode(decoder, bb)) > 0) {
+            if ((ret = acurite_3n1_decode(decoder, bitbuffer, bb)) > 0) {
                 decoded += ret;
             } else if (ret < 0) {
                 error_ret = ret;
@@ -1442,7 +1445,7 @@ static int acurite_txr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             if ((ret = acurite_txr_check(decoder, bb, browlen, ACURITE_899_BYTELEN)) != 0) {
                 error_ret = ret;
             } else {
-                if ((ret = acurite_899_decode(decoder, bb)) > 0) {
+                if ((ret = acurite_899_decode(decoder, bitbuffer, bb)) > 0) {
                     decoded += ret;
                 } else if (ret < 0) {
                     error_ret = ret;


### PR DESCRIPTION
The `acurite_txr_decode` function that handles Atlas, 5n1, and 3n1 weather stations, TXR temperature/humidity, 6045 lightning, 515 refrigerator/freezer and1190/1192 water sensors, and 899 rain gauge has been refactored. Changes:

* Refactor 5n1, 3n1, 515, 899 decoders into separate decoding function
  * The shared callback function should be easier to understand and add new devices
* Fix: valid messages with checksum == 0 were being rejected
  * This was due to a bad check for an extra byte being added by demodulators
  * Test case `-y 3863187dbbc6f3d87bff`
* Fix: Invalid short messages could be accepted resulting in bad data if last byte of message resulted in a valid checksum
  * Test case 9 byte Atlas message that should be rejected `-y 'f8 63 99 fc 7b af 3f 5f'`
  * See also PR #2116
* Improve rejection of invalid messages
  * Use message type, rather than message length as the primary identifier
  * Validate minimum message length by specific message type
  * Accept messages with one or more extra bytes (demodulator can add extra bits)
    * but only use correct number of bytes for the specific message type.
  * Add parity check to MIC for all devices except the 3n1 weather station
    * Parity was previously only being checked correctly for the tower and leak detector
    * (The 3n1's g001 sample in rtl_433_tests has odd parity on the 2nd to last byte of both message copies. It seems unlikely both repeats would have the same problem. However the g002 sample does use even parity on all bytes.
    *  Note: the samples for the 899 range gauge do not have enough data to verify parity is used on the whole message. Need testing from someone with this device.
  * Reject messages if certain fields such as temperature, humidity, wind direction, and other fields have invalid values (such as humidity > 100). This helps when the MIC passes, but there is invalid data in the message.
    * Previously some sanity checks for humidity and temperature were added to a few devices like the tower sensor. Most devices now have humidity validated at a minimum.

These tests should work with both the old code and the new code:

```
-y '{64}3c003a7df6e8a37a {80}3c009a7df6e8a3d8782c {64}7800397dfca3bb8e {80}7800997dfca3bbd87840 {64}f400b87dfa47d747 {80}f400187dfa47d7d878f9 {64}3D6C87FF5A3AAC75ff {64}2D6C8EFF747290A2 {56}1D9C7E78177E49ff {56}1D9CBEE8177EF9 f4880ffffffffa88/ 20c79fd47209fad5/ 20c79fd4728878d2/ f4880ffffffffa88/ f4880ffffffffa88ff/ {50}3f85b7ee53c0c0/ {50}39083674a998ff'
```