### PR TITLE
Add Dockerfile for creating a Docker image around rtl_433_mqtt_hass.py

### DIFF
--- a/examples/Dockerfile-rtl_433_mqtt_hass
+++ b/examples/Dockerfile-rtl_433_mqtt_hass
@@ -1,0 +1,16 @@
+# Install python/pip
+FROM alpine
+
+ENV PYTHONUNBUFFERED=1
+RUN apk add --update --no-cache python3 py3-paho-mqtt && ln -sf python3 /usr/bin/python
+
+RUN mkdir /app
+WORKDIR /app
+
+ENV MQTT_USERNAME=""
+ENV MQTT_PASSWORD=""
+ENV MQTT_HOSTNAME=""
+
+COPY ./rtl_433_mqtt_hass.py /app
+
+CMD ["python3", "/app/rtl_433_mqtt_hass.py", "-H", "$MQTT_HOSTNAME"]


### PR DESCRIPTION
I made a Dockerfile that wraps the Home Assistant MQTT wrapper because I run RTL 433 dockerized and missed the possibility to also run the wrapper in Docker.

I'll try to keep the Image updated (the MQTT wrapper doesn't change that often I think). Does it make sense to add the Dockerfile to the repo so that others can also build the image or improve it?