### PR TITLE
Fix Chuango devices with some zeroes in their ID

### DIFF
--- a/src/devices/chuango.c
+++ b/src/devices/chuango.c
@@ -48,7 +48,7 @@ static int chuango_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // Validate package
     if (!(b[3] & 0x80)                           // Last bit (MSB here) is always 1
-            || !b[0] || !b[1] || !(b[2] & 0xF0)) // Reduce false positives. ID 0x00000 not supported
+            || (!b[0] && !b[1] && !(b[2] & 0xF0))) // Reduce false positives. ID 0x00000 not supported
         return DECODE_ABORT_EARLY;
 
     id  = (b[0] << 12) | (b[1] << 4) | (b[2] >> 4); // ID is 20 bits (Ad: "1 Million combinations" :-)


### PR DESCRIPTION
My PIR sensor wasn't being detected by rtl_433 anymore since after the last refactor of this code, but it works again with this change