### PR TITLE
added conf for xmas tree remote 2APJZ-CW002

### DIFF
--- a/conf/xmas-tree-remote-2APJZ-CW002.conf
+++ b/conf/xmas-tree-remote-2APJZ-CW002.conf
@@ -1,0 +1,26 @@
+# Decoder for Christmas Tree Lights Remote
+# FCC ID: 2APJZ-CW002
+#
+# Reference:
+# https://fccid.io/2APJZ-CW002
+# https://github.com/merbanan/rtl_433/issues/2247
+#
+# Remote has three buttons that provide functions:
+# - Brightness down
+# - Brightness up
+# - Change light display mode
+#
+# 32 bits are sent. The first 20 bit are fixed, assumed to be the ID.
+# The last 12 bit change depending on which of the 3 buttons are pressed, defined as the action.
+
+decoder {
+    name        = Xmas-Tree-Remote-2APJZ-CW002,
+    modulation  = OOK_PWM,
+    short       = 1000,
+    long        = 2000,
+    gap         = 0,
+    reset       = 3000,
+    bits        = 32,
+    get         = id:@0:{20},
+    get         = action:@20:{12},
+}


### PR DESCRIPTION
Resolves https://github.com/merbanan/rtl_433/issues/2247

cu8 showing one of the button presses: [g003_433.92M_250k.cu8.zip](https://github.com/merbanan/rtl_433/files/10105275/g003_433.92M_250k.cu8.zip)

FCCID: https://fccid.io/2APJZ-CW002

Remote has three buttons that provide functions:
- Brightness down
- Brightness up
- Change light display mode

32 bits are sent. The first 20 bit are fixed, assumed to be the ID. The last 12 bit change depending on which of the 3 buttons are pressed, defined as the action. I am not sure if these actions are the same between different remotes, but I don't think it matters since you just need to know the distinct values and can map from there.