### PR TITLE
Add log option to all outputs

### DIFF
--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -176,8 +176,8 @@ signal_grabber none
 ## Data output options
 
 # as command line option:
-#   [-F kv|json|csv|mqtt|influx|syslog|trigger|null] Produce decoded output in given format.
-#     Without this option the default is KV output. Use "-F null" to remove the default.
+#   [-F log|kv|json|csv|mqtt|influx|syslog|trigger|null] Produce decoded output in given format.
+#     Without this option the default is LOG and KV output. Use "-F null" to remove the default.
 #     Append output to file with :<filename> (e.g. -F csv:log.csv), defaults to stdout.
 #     Specify MQTT server with e.g. -F mqtt://localhost:1883
 #     Add MQTT options with e.g. -F "mqtt://host:1883,opt=arg"

--- a/include/decoder_util.h
+++ b/include/decoder_util.h
@@ -34,6 +34,12 @@ r_device *create_device(r_device *dev_template);
 /// Output data.
 void decoder_output_data(r_device *decoder, data_t *data);
 
+/// Output log.
+void decoder_output_log(r_device *decoder, int level, data_t *data);
+
+// be terse, a maximum msg length of 60 characters is supported on the decoder_log_ functions
+// e.g. "FoobarCorp-XY3000: unexpected type code %02x"
+
 /// Output a log message.
 void decoder_log(r_device *decoder, int level, char const *func, char const *msg);
 
@@ -61,52 +67,6 @@ void decoder_log_bitrow(r_device *decoder, int level, char const *func, uint8_t 
 void decoder_logf_bitrow(r_device *decoder, int level, char const *func, uint8_t const *bitrow, unsigned bit_len, _Printf_format_string_ const char *format, ...)
 #if defined(__GNUC__) || defined(__clang__)
         __attribute__((format(printf, 6, 7)))
-#endif
-        ;
-
-// be terse, a maximum msg length of 60 characters is supported on the decoder_output_ functions
-// e.g. "FoobarCorp-XY3000: unexpected type code %02x"
-
-/// Output a message.
-void decoder_output_message(r_device *decoder, char const *msg);
-
-/// Output a message and the content of a bitbuffer.
-void decoder_output_bitbuffer(r_device *decoder, bitbuffer_t const *bitbuffer, char const *msg);
-
-/// Output a message and the content of a bitbuffer.
-/// Usage not recommended.
-void decoder_output_bitbuffer_array(r_device *decoder, bitbuffer_t const *bitbuffer, char const *msg);
-
-/// Output a message and the content of a bit row (byte buffer).
-void decoder_output_bitrow(r_device *decoder, uint8_t const *bitrow, unsigned bit_len, char const *msg);
-
-// print helpers
-
-/// Output a message with args.
-void decoder_output_messagef(r_device *decoder, _Printf_format_string_ char const *restrict format, ...)
-#if defined(__GNUC__) || defined(__clang__)
-        __attribute__((format(printf, 2, 3)))
-#endif
-        ;
-
-/// Output a message with args and the content of a bitbuffer.
-void decoder_output_bitbufferf(r_device *decoder, bitbuffer_t const *bitbuffer, _Printf_format_string_ char const *restrict format, ...)
-#if defined(__GNUC__) || defined(__clang__)
-        __attribute__((format(printf, 3, 4)))
-#endif
-        ;
-
-/// Output a message with args and the content of a bitbuffer.
-void decoder_output_bitbuffer_arrayf(r_device *decoder, bitbuffer_t const *bitbuffer, _Printf_format_string_ char const *restrict format, ...)
-#if defined(__GNUC__) || defined(__clang__)
-        __attribute__((format(printf, 3, 4)))
-#endif
-        ;
-
-/// Output a message with args and the content of a bit row (byte buffer).
-void decoder_output_bitrowf(r_device *decoder, uint8_t const *bitrow, unsigned bit_len, _Printf_format_string_ char const *restrict format, ...)
-#if defined(__GNUC__) || defined(__clang__)
-        __attribute__((format(printf, 4, 5)))
 #endif
         ;
 

--- a/include/output_log.h
+++ b/include/output_log.h
@@ -1,0 +1,26 @@
+/** @file
+    Log outputs for rtl_433 events.
+
+    Copyright (C) 2022 Christian Zuckschwerdt
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#ifndef INCLUDE_OUTPUT_LOG_H_
+#define INCLUDE_OUTPUT_LOG_H_
+
+#include "data.h"
+#include <stdio.h>
+
+/** Construct data output for LOG printer.
+
+    @param file the optional output stream, defaults to stderr
+    @return The auxiliary data to pass along with data_log_printer to data_print.
+            You must release this object with data_output_free once you're done with it.
+*/
+struct data_output *data_output_log_create(int log_level, FILE *file);
+
+#endif /* INCLUDE_OUTPUT_LOG_H_ */

--- a/include/r_api.h
+++ b/include/r_api.h
@@ -57,7 +57,11 @@ int run_fsk_demods(struct list *r_devs, struct pulse_data *fsk_pulse_data);
 
 /* handlers */
 
+void r_redirect_logging(struct r_cfg *cfg);
+
 void event_occurred_handler(struct r_cfg *cfg, struct data *data);
+
+void log_device_handler(struct r_device *r_dev, int level, struct data *data);
 
 void data_acquired_handler(struct r_device *r_dev, struct data *data);
 
@@ -70,6 +74,8 @@ void flush_report_data(struct r_cfg *cfg);
 void add_json_output(struct r_cfg *cfg, char *param);
 
 void add_csv_output(struct r_cfg *cfg, char *param);
+
+void add_log_output(struct r_cfg *cfg, char *param);
 
 void add_kv_output(struct r_cfg *cfg, char *param);
 

--- a/include/r_device.h
+++ b/include/r_device.h
@@ -76,6 +76,7 @@ typedef struct r_device {
     /* public for each decoder */
     int verbose;
     int verbose_bits;
+    void (*log_fn)(struct r_device *decoder, int level, struct data *data);
     void (*output_fn)(struct r_device *decoder, struct data *data);
 
     /* Decoder results / statistics */

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -95,6 +95,7 @@ typedef struct r_cfg {
     list_t data_tags;
     list_t output_handler;
     list_t raw_handler;
+    int has_logout;
     struct dm_state *demod;
     char const *sr_filename;
     int sr_execopen;

--- a/include/term_ctl.h
+++ b/include/term_ctl.h
@@ -44,9 +44,18 @@ typedef enum term_color {
     TERM_COLOR_BRIGHT_WHITE   = 97,
 } term_color_t;
 
+/**
+ * Sets the terminal text foreground color.
+ * Always sets the bold font attribute, except for TERM_COLOR_RESET.
+ */
 void term_set_fg(void *ctx, term_color_t color);
 
-void term_set_bg(void *ctx, term_color_t color);
+/**
+ * Sets the terminal background and foreground color.
+ * Both are optional, use `0` to omit a color.
+ * Must not be used for TERM_COLOR_RESET.
+ */
+void term_set_bg(void *ctx, term_color_t bg, term_color_t fg);
 
 /*
  * Defined in newer <sal.h> for MSVC.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(r_433 STATIC
     optparse.c
     output_file.c
     output_influx.c
+    output_log.c
     output_mqtt.c
     output_rtltcp.c
     output_trigger.c

--- a/src/decoder_util.c
+++ b/src/decoder_util.c
@@ -29,130 +29,19 @@ r_device *create_device(r_device *dev_template)
     return r_dev;
 }
 
-// variadic output functions
-
-void decoder_log(r_device *decoder, int level, char const *func, char const *msg)
-{
-    // TODO: pass to interested outputs
-    if (decoder->verbose >= level) {
-        fprintf(stderr, "%s: %s\n", func, msg);
-    }
-}
-
-void decoder_logf(r_device *decoder, int level, char const *func, _Printf_format_string_ const char *format, ...)
-{
-    // TODO: join prints to be thread-safe
-    // TODO: pass to interested outputs
-    if (decoder->verbose >= level) {
-        fprintf(stderr, "%s: ", func);
-        va_list ap;
-        va_start(ap, format);
-        vfprintf(stderr, format, ap);
-        va_end(ap);
-        fprintf(stderr, "\n");
-    }
-}
-
-void decoder_log_bitbuffer(r_device *decoder, int level, char const *func, const bitbuffer_t *bitbuffer, char const *msg)
-{
-    // TODO: pass to interested outputs
-    if (decoder->verbose >= level) {
-        fprintf(stderr, "%s: %s: ", func, msg);
-        bitbuffer_print(bitbuffer);
-    }
-}
-
-void decoder_logf_bitbuffer(r_device *decoder, int level, char const *func, const bitbuffer_t *bitbuffer, _Printf_format_string_ const char *format, ...)
-{
-    // TODO: pass to interested outputs
-    if (decoder->verbose >= level) {
-        fprintf(stderr, "%s: ", func);
-        va_list ap;
-        va_start(ap, format);
-        vfprintf(stderr, format, ap);
-        va_end(ap);
-        fprintf(stderr, ": ");
-        bitbuffer_print(bitbuffer);
-    }
-}
-
-void decoder_log_bitrow(r_device *decoder, int level, char const *func, uint8_t const *bitrow, unsigned bit_len, char const *msg)
-{
-    // TODO: pass to interested outputs
-    if (decoder->verbose >= level) {
-        fprintf(stderr, "%s: %s: ", func, msg);
-        bitrow_print(bitrow, bit_len);
-    }
-}
-
-void decoder_logf_bitrow(r_device *decoder, int level, char const *func, uint8_t const *bitrow, unsigned bit_len, _Printf_format_string_ const char *format, ...)
-{
-    // TODO: pass to interested outputs
-    if (decoder->verbose >= level) {
-        fprintf(stderr, "%s: ", func);
-        va_list ap;
-        va_start(ap, format);
-        vfprintf(stderr, format, ap);
-        va_end(ap);
-        fprintf(stderr, ": ");
-        bitrow_print(bitrow, bit_len);
-    }
-}
-
-void decoder_output_messagef(r_device *decoder, _Printf_format_string_ char const *restrict format, ...)
-{
-    char msg[60]; // fixed length limit
-    va_list ap;
-    va_start(ap, format);
-    vsnprintf(msg, 60, format, ap);
-    va_end(ap);
-    decoder_output_message(decoder, msg);
-}
-
-void decoder_output_bitbufferf(r_device *decoder, bitbuffer_t const *bitbuffer, _Printf_format_string_ char const *restrict format, ...)
-{
-    char msg[60]; // fixed length limit
-    va_list ap;
-    va_start(ap, format);
-    vsnprintf(msg, 60, format, ap);
-    va_end(ap);
-    decoder_output_bitbuffer(decoder, bitbuffer, msg);
-}
-
-void decoder_output_bitbuffer_arrayf(r_device *decoder, bitbuffer_t const *bitbuffer, _Printf_format_string_ char const *restrict format, ...)
-{
-    char msg[60]; // fixed length limit
-    va_list ap;
-    va_start(ap, format);
-    vsnprintf(msg, 60, format, ap);
-    va_end(ap);
-    decoder_output_bitbuffer_array(decoder, bitbuffer, msg);
-}
-
-void decoder_output_bitrowf(r_device *decoder, uint8_t const *bitrow, unsigned bit_len, _Printf_format_string_ char const *restrict format, ...)
-{
-    char msg[60]; // fixed length limit
-    va_list ap;
-    va_start(ap, format);
-    vsnprintf(msg, 60, format, ap);
-    va_end(ap);
-    decoder_output_bitrow(decoder, bitrow, bit_len, msg);
-}
-
 // output functions
+
+void decoder_output_log(r_device *decoder, int level, data_t *data)
+{
+    decoder->log_fn(decoder, level, data);
+}
 
 void decoder_output_data(r_device *decoder, data_t *data)
 {
     decoder->output_fn(decoder, data);
 }
 
-void decoder_output_message(r_device *decoder, char const *msg)
-{
-    data_t *data = data_make(
-            "msg", "", DATA_STRING, msg,
-            NULL);
-    decoder_output_data(decoder, data);
-}
+// helper
 
 static char *bitrow_asprint_code(uint8_t const *bitrow, unsigned bit_len)
 {
@@ -205,41 +94,142 @@ static char *bitrow_asprint_bits(uint8_t const *bitrow, unsigned bit_len)
     return row_bits;
 }
 
-void decoder_output_bitbuffer(r_device *decoder, bitbuffer_t const *bitbuffer, char const *msg)
+// variadic output functions
+
+void decoder_log(r_device *decoder, int level, char const *func, char const *msg)
 {
-    data_t *data;
-    char *row_codes[BITBUF_ROWS];
-    char *row_bits[BITBUF_ROWS] = {0};
-    unsigned i;
+    if (decoder->verbose >= level) {
+        // note that decoder levels start at LOG_WARNING
+        level += 4;
 
-    for (i = 0; i < bitbuffer->num_rows; i++) {
-        row_codes[i] = bitrow_asprint_code(bitbuffer->bb[i], bitbuffer->bits_per_row[i]);
-
-        if (decoder->verbose_bits) {
-            row_bits[i] = bitrow_asprint_bits(bitbuffer->bb[i], bitbuffer->bits_per_row[i]);
-        }
-    }
-
-    data = data_make(
-            "msg", "", DATA_STRING, msg,
-            "num_rows", "", DATA_INT, bitbuffer->num_rows,
-            "codes", "", DATA_ARRAY, data_array(bitbuffer->num_rows, DATA_STRING, row_codes),
-            NULL);
-
-    if (decoder->verbose_bits) {
-        data_append(data,
-                "bits", "", DATA_ARRAY, data_array(bitbuffer->num_rows, DATA_STRING, row_bits),
+        /* clang-format off */
+        data_t *data = data_make(
+                "src",     "",     DATA_STRING, func,
+                "lvl",      "",     DATA_INT,    level,
+                "msg",      "",     DATA_STRING, msg,
                 NULL);
-    }
-
-    decoder_output_data(decoder, data);
-
-    for (i = 0; i < bitbuffer->num_rows; i++) {
-        free(row_codes[i]);
-        free(row_bits[i]);
+        /* clang-format on */
+        decoder_output_log(decoder, level, data);
     }
 }
 
+void decoder_logf(r_device *decoder, int level, char const *func, _Printf_format_string_ const char *format, ...)
+{
+    if (decoder->verbose >= level) {
+        char msg[60]; // fixed length limit
+        va_list ap;
+        va_start(ap, format);
+        vsnprintf(msg, sizeof(msg), format, ap);
+        va_end(ap);
+
+        decoder_log(decoder, level, func, msg);
+    }
+}
+
+void decoder_log_bitbuffer(r_device *decoder, int level, char const *func, const bitbuffer_t *bitbuffer, char const *msg)
+{
+    if (decoder->verbose >= level) {
+        // note that decoder levels start at LOG_WARNING
+        level += 4;
+
+        char *row_codes[BITBUF_ROWS];
+        char *row_bits[BITBUF_ROWS] = {0};
+
+        for (unsigned i = 0; i < bitbuffer->num_rows; i++) {
+            row_codes[i] = bitrow_asprint_code(bitbuffer->bb[i], bitbuffer->bits_per_row[i]);
+
+            if (decoder->verbose_bits) {
+                row_bits[i] = bitrow_asprint_bits(bitbuffer->bb[i], bitbuffer->bits_per_row[i]);
+            }
+        }
+
+        /* clang-format off */
+        data_t *data = data_make(
+                "src",     "",     DATA_STRING, func,
+                "lvl",      "",     DATA_INT,    level,
+                "msg",      "",     DATA_STRING, msg,
+                "num_rows", "",     DATA_INT, bitbuffer->num_rows,
+                "codes",    "",     DATA_ARRAY, data_array(bitbuffer->num_rows, DATA_STRING, row_codes),
+                NULL);
+        /* clang-format on */
+
+        if (decoder->verbose_bits) {
+            data_append(data,
+                    "bits", "", DATA_ARRAY, data_array(bitbuffer->num_rows, DATA_STRING, row_bits),
+                    NULL);
+        }
+
+        decoder_output_log(decoder, level, data);
+
+        for (unsigned i = 0; i < bitbuffer->num_rows; i++) {
+            free(row_codes[i]);
+            free(row_bits[i]);
+        }
+    }
+}
+
+void decoder_logf_bitbuffer(r_device *decoder, int level, char const *func, const bitbuffer_t *bitbuffer, _Printf_format_string_ const char *format, ...)
+{
+    // TODO: pass to interested outputs
+    if (decoder->verbose >= level) {
+        char msg[60]; // fixed length limit
+        va_list ap;
+        va_start(ap, format);
+        vsnprintf(msg, sizeof(msg), format, ap);
+        va_end(ap);
+
+        decoder_log_bitbuffer(decoder, level, func, bitbuffer, msg);
+    }
+}
+
+void decoder_log_bitrow(r_device *decoder, int level, char const *func, uint8_t const *bitrow, unsigned bit_len, char const *msg)
+{
+    if (decoder->verbose >= level) {
+        // note that decoder levels start at LOG_WARNING
+        level += 4;
+
+        char *row_code;
+        char *row_bits = NULL;
+
+        row_code = bitrow_asprint_code(bitrow, bit_len);
+
+        /* clang-format off */
+        data_t *data = data_make(
+                "src",     "",     DATA_STRING, func,
+                "lvl",      "",     DATA_INT,    level,
+                "msg",      "",     DATA_STRING, msg,
+                "codes",    "",     DATA_STRING, row_code,
+                NULL);
+        /* clang-format on */
+
+        if (decoder->verbose_bits) {
+            row_bits = bitrow_asprint_bits(bitrow, bit_len);
+            data_append(data,
+                    "bits", "", DATA_STRING, row_bits,
+                    NULL);
+        }
+
+        decoder_output_log(decoder, level, data);
+
+        free(row_code);
+        free(row_bits);
+    }
+}
+
+void decoder_logf_bitrow(r_device *decoder, int level, char const *func, uint8_t const *bitrow, unsigned bit_len, _Printf_format_string_ const char *format, ...)
+{
+    if (decoder->verbose >= level) {
+        char msg[60]; // fixed length limit
+        va_list ap;
+        va_start(ap, format);
+        vsnprintf(msg, sizeof(msg), format, ap);
+        va_end(ap);
+
+        decoder_log_bitrow(decoder, level, func, bitrow, bit_len, msg);
+    }
+}
+
+/* TODO: maybe use as decoder_log function
 void decoder_output_bitbuffer_array(r_device *decoder, bitbuffer_t const *bitbuffer, char const *msg)
 {
     data_t *data;
@@ -278,29 +268,4 @@ void decoder_output_bitbuffer_array(r_device *decoder, bitbuffer_t const *bitbuf
         free(row_codes[i]);
     }
 }
-
-void decoder_output_bitrow(r_device *decoder, uint8_t const *bitrow, unsigned bit_len, char const *msg)
-{
-    data_t *data;
-    char *row_code;
-    char *row_bits = NULL;
-
-    row_code = bitrow_asprint_code(bitrow, bit_len);
-
-    data = data_make(
-            "msg", "", DATA_STRING, msg,
-            "codes", "", DATA_STRING, row_code,
-            NULL);
-
-    if (decoder->verbose_bits) {
-        row_bits = bitrow_asprint_bits(bitrow, bit_len);
-        data_append(data,
-                "bits", "", DATA_STRING, row_bits,
-                NULL);
-    }
-
-    decoder_output_data(decoder, data);
-
-    free(row_code);
-    free(row_bits);
-}
+*/

--- a/src/output_file.c
+++ b/src/output_file.c
@@ -14,6 +14,7 @@
 #include "data.h"
 #include "term_ctl.h"
 #include "r_util.h"
+#include "logger.h"
 #include "fatal.h"
 
 #include <string.h>
@@ -207,10 +208,26 @@ static void R_API_CALLCONV print_kv_data(data_output_t *output, data_t *data, ch
 
     int color = kv->color;
     int ring_bell = kv->ring_bell;
+    int is_log = 0;
 
     // top-level: update width and print separator
     if (!kv->data_recursion) {
+        // collect well-known top level keys
+        data_t *data_src = NULL;
+        data_t *data_lvl  = NULL;
+        data_t *data_msg  = NULL;
+        for (data_t *d = data; d; d = d->next) {
+            if (!strcmp(d->key, "src"))
+                data_src = d;
+            else if (!strcmp(d->key, "lvl"))
+                data_lvl = d;
+            else if (!strcmp(d->key, "msg"))
+                data_msg = d;
+        }
+        is_log = data_src && data_lvl && data_msg;
+
         kv->term_width = term_get_columns(kv->term); // update current term width
+        if (!is_log) {
         if (color)
             term_set_fg(kv->term, TERM_COLOR_BLACK);
         if (ring_bell)
@@ -221,6 +238,56 @@ static void R_API_CALLCONV print_kv_data(data_output_t *output, data_t *data, ch
         fprintf(kv->file, "%s\n", sep);
         if (color)
             term_set_fg(kv->term, TERM_COLOR_RESET);
+        }
+
+        // print special log format
+        if (is_log) {
+            int level = 0;
+            if (data_lvl->type == DATA_INT) {
+                level = data_lvl->value.v_int;
+            }
+            term_color_t src_bg = TERM_COLOR_RESET;
+            term_color_t src_fg = TERM_COLOR_RESET;
+            if (level == LOG_FATAL) {
+                src_bg = TERM_COLOR_BRIGHT_BLACK;
+                src_fg = TERM_COLOR_WHITE;
+            } else if (level == LOG_CRITICAL) {
+                src_bg = TERM_COLOR_BRIGHT_GREEN;
+                src_fg = TERM_COLOR_BLACK;
+            } else if (level == LOG_ERROR) {
+                src_bg = TERM_COLOR_BRIGHT_RED;
+                src_fg = TERM_COLOR_WHITE;
+            } else if (level == LOG_WARNING) {
+                src_bg = TERM_COLOR_BRIGHT_YELLOW;
+                src_fg = TERM_COLOR_BLACK;
+            } else if (level == LOG_NOTICE) {
+                src_bg = TERM_COLOR_BRIGHT_CYAN;
+                src_fg = TERM_COLOR_BLACK;
+            } else if (level == LOG_INFO) {
+                src_bg = TERM_COLOR_BRIGHT_BLUE;
+                src_fg = TERM_COLOR_WHITE;
+            } else if (level == LOG_DEBUG) {
+                src_bg = TERM_COLOR_BRIGHT_MAGENTA;
+                src_fg = TERM_COLOR_WHITE;
+            } else if (level == LOG_TRACE) {
+                src_bg = TERM_COLOR_BRIGHT_BLACK;
+                src_fg = TERM_COLOR_WHITE;
+            }
+            term_set_bg(kv->term, src_bg, src_bg); // hides the brackets
+            fprintf(kv->file, "[");
+            term_set_bg(kv->term, 0, src_fg);
+            print_value(output, data_src->type, data_src->value, data_src->format);
+            term_set_bg(kv->term, 0, src_bg); // hides the brackets
+            fprintf(kv->file, "]");
+            term_set_fg(kv->term, TERM_COLOR_RESET);
+            // fprintf(kv->file, " (");
+            // print_value(output, data_lvl->type, data_lvl->value, data_lvl->format);
+            // fprintf(kv->file, ") ");
+            fprintf(kv->file, " ");
+            print_value(output, data_msg->type, data_msg->value, data_msg->format);
+            // force break on next key
+            kv->column = kv->term_width;
+        }
     }
     // nested data object: break before
     else {
@@ -231,7 +298,13 @@ static void R_API_CALLCONV print_kv_data(data_output_t *output, data_t *data, ch
     }
 
     ++kv->data_recursion;
-    while (data) {
+    for (; data; data = data->next) {
+        // skip logging keys
+        if (is_log && (!strcmp(data->key, "time") || !strcmp(data->key, "src") || !strcmp(data->key, "lvl")
+                || !strcmp(data->key, "msg") || !strcmp(data->key, "num_rows"))) {
+            continue;
+        }
+
         // break before some known keys
         if (kv->column > 0 && kv_break_before_key(data->key)) {
             fprintf(kv->file, "\n");
@@ -261,8 +334,6 @@ static void R_API_CALLCONV print_kv_data(data_output_t *output, data_t *data, ch
         if (kv->column > 0 && kv_break_after_key(data->key)) {
             kv->column = kv->term_width; // force break;
         }
-
-        data = data->next;
     }
     --kv->data_recursion;
 

--- a/src/output_log.c
+++ b/src/output_log.c
@@ -1,0 +1,168 @@
+/** @file
+    Log outputs for rtl_433 events.
+
+    Copyright (C) 2022 Christian Zuckschwerdt
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#include "output_log.h"
+
+#include "data.h"
+#include "r_util.h"
+#include "fatal.h"
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+/* LOG printer */
+
+typedef struct {
+    struct data_output output;
+    FILE *file;
+} data_output_log_t;
+
+static void R_API_CALLCONV print_log_array(data_output_t *output, data_array_t *array, char const *format)
+{
+    data_output_log_t *log = (data_output_log_t *)output;
+
+    fprintf(log->file, "[");
+    for (int c = 0; c < array->num_values; ++c) {
+        if (c)
+            fprintf(log->file, ", ");
+        print_array_value(output, array, format, c);
+    }
+    fprintf(log->file, "]");
+}
+
+static void R_API_CALLCONV print_log_data(data_output_t *output, data_t *data, char const *format)
+{
+    UNUSED(format);
+    data_output_log_t *log = (data_output_log_t *)output;
+
+    fputc('{', log->file);
+    for (bool separator = false; data; data = data->next) {
+        if (separator)
+            fprintf(log->file, ", ");
+        output->print_string(output, data->key, NULL);
+        fprintf(log->file, ": ");
+        print_value(output, data->type, data->value, data->format);
+        separator = true;
+    }
+    fputc('}', log->file);
+}
+
+static void R_API_CALLCONV print_log_string(data_output_t *output, const char *str, char const *format)
+{
+    UNUSED(format);
+    data_output_log_t *log = (data_output_log_t *)output;
+
+    fprintf(log->file, "%s", str);
+}
+
+static void R_API_CALLCONV print_log_double(data_output_t *output, double data, char const *format)
+{
+    UNUSED(format);
+    data_output_log_t *log = (data_output_log_t *)output;
+
+    fprintf(log->file, "%.3f", data);
+}
+
+static void R_API_CALLCONV print_log_int(data_output_t *output, int data, char const *format)
+{
+    UNUSED(format);
+    data_output_log_t *log = (data_output_log_t *)output;
+
+    fprintf(log->file, "%d", data);
+}
+
+static void R_API_CALLCONV data_output_log_print(data_output_t *output, data_t *data)
+{
+    data_output_log_t *log = (data_output_log_t *)output;
+
+    // collect well-known top level keys
+    data_t *data_src = NULL;
+    data_t *data_lvl = NULL;
+    data_t *data_msg = NULL;
+    for (data_t *d = data; d; d = d->next) {
+        if (!strcmp(d->key, "src"))
+            data_src = d;
+        else if (!strcmp(d->key, "lvl"))
+            data_lvl = d;
+        else if (!strcmp(d->key, "msg"))
+            data_msg = d;
+    }
+
+    int is_log = data_src && data_lvl && data_msg;
+    if (!is_log) {
+        return; // print log messages only
+    }
+
+    // int level = 0;
+    // if (data_lvl->type == DATA_INT) {
+    //     level = data_lvl->value.v_int;
+    // }
+    print_value(output, data_src->type, data_src->value, data_src->format);
+    // fprintf(log->file, "(");
+    // print_value(output, data_lvl->type, data_lvl->value, data_lvl->format);
+    // fprintf(log->file, ") ");
+    fprintf(log->file, ": ");
+    print_value(output, data_msg->type, data_msg->value, data_msg->format);
+
+    for (; data; data = data->next) {
+        // skip logging keys
+        if (!strcmp(data->key, "time")
+                || !strcmp(data->key, "src")
+                || !strcmp(data->key, "lvl")
+                || !strcmp(data->key, "msg")
+                || !strcmp(data->key, "num_rows")) {
+            continue;
+        }
+
+        fprintf(log->file, " ");
+        output->print_string(output, data->key, NULL);
+        fprintf(log->file, " ");
+        print_value(output, data->type, data->value, data->format);
+    }
+
+    fputc('\n', log->file);
+    fflush(log->file);
+}
+
+static void R_API_CALLCONV data_output_log_free(data_output_t *output)
+{
+    if (!output) {
+        return;
+    }
+    free(output);
+}
+
+struct data_output *data_output_log_create(int log_level, FILE *file)
+{
+    data_output_log_t *log = calloc(1, sizeof(data_output_log_t));
+    if (!log) {
+        WARN_CALLOC("data_output_log_create()");
+        return NULL; // NOTE: returns NULL on alloc failure.
+    }
+
+    if (!file) {
+        file = stderr; // print to stderr by default
+    }
+
+    log->output.log_level    = log_level;
+    log->output.print_data   = print_log_data;
+    log->output.print_array  = print_log_array;
+    log->output.print_string = print_log_string;
+    log->output.print_double = print_log_double;
+    log->output.print_int    = print_log_int;
+    log->output.output_print = data_output_log_print;
+    log->output.output_free  = data_output_log_free;
+    log->file                = file;
+
+    return &log->output;
+}

--- a/src/pulse_slicer.c
+++ b/src/pulse_slicer.c
@@ -15,6 +15,7 @@
 #include "bitbuffer.h"
 #include "util.h"
 #include "logger.h"
+#include "decoder_util.h" // TODO: this should be refactored
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -54,8 +55,7 @@ static int account_event(r_device *device, bitbuffer_t *bits, char const *demod_
 
     // Debug printout
     if (!device->decode_fn || (device->verbose && ret > 0) || (device->verbose > 1 && max_bits > 16) || (device->verbose > 2)) {
-        fprintf(stderr, "%s(): %s\n", demod_name, device->name);
-        bitbuffer_print(bits);
+        decoder_log_bitbuffer(device, 2, demod_name, bits, device->name);
     }
 
     return ret;

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -30,6 +30,7 @@
 #include "list.h"
 #include "optparse.h"
 #include "output_file.h"
+#include "output_log.h"
 #include "output_udp.h"
 #include "output_mqtt.h"
 #include "output_influx.h"
@@ -276,6 +277,7 @@ void register_protocol(r_cfg_t *cfg, r_device *r_dev, char *arg)
 
     p->verbose      = dev_verbose ? dev_verbose : (cfg->verbosity > 4 ? cfg->verbosity - 5 : 0);
     p->verbose_bits = cfg->verbose_bits;
+    p->log_fn       = log_device_handler;
 
     p->output_fn  = data_acquired_handler;
     p->output_ctx = cfg;
@@ -588,6 +590,44 @@ int run_fsk_demods(list_t *r_devs, pulse_data_t *fsk_pulse_data)
 
 /* handlers */
 
+static void log_handler(log_level_t level, char const *src, char const *msg, void *userdata)
+{
+    r_cfg_t *cfg = userdata;
+
+    if (cfg->verbosity < (int)level) {
+        return;
+    }
+    /* clang-format off */
+    data_t *data = data_make(
+            "src",     "",     DATA_STRING, src,
+            "lvl",      "",     DATA_INT,    level,
+            "msg",      "",     DATA_STRING, msg,
+            NULL);
+    /* clang-format on */
+
+    // prepend "time" if requested
+    if (cfg->report_time != REPORT_TIME_OFF) {
+        char time_str[LOCAL_TIME_BUFLEN];
+        time_pos_str(cfg, 0, time_str);
+        data = data_prepend(data,
+                "time", "", DATA_STRING, time_str,
+                NULL);
+    }
+
+    for (size_t i = 0; i < cfg->output_handler.len; ++i) { // list might contain NULLs
+        data_output_t *output = cfg->output_handler.elems[i];
+        if (output && output->log_level >= (int)level) {
+            data_output_print(output, data);
+        }
+    }
+    data_free(data);
+}
+
+void r_redirect_logging(r_cfg_t *cfg)
+{
+    r_logger_set_log_handler(log_handler, cfg);
+}
+
 /** Pass the data structure to all output handlers. Frees data afterwards. */
 void event_occurred_handler(r_cfg_t *cfg, data_t *data)
 {
@@ -601,7 +641,31 @@ void event_occurred_handler(r_cfg_t *cfg, data_t *data)
     }
 
     for (size_t i = 0; i < cfg->output_handler.len; ++i) { // list might contain NULLs
-        data_output_print(cfg->output_handler.elems[i], data);
+        data_output_t *output = cfg->output_handler.elems[i];
+        data_output_print(output, data);
+    }
+    data_free(data);
+}
+
+/** Pass the data structure to all output handlers. Frees data afterwards. */
+void log_device_handler(r_device *r_dev, int level, data_t *data)
+{
+    r_cfg_t *cfg = r_dev->output_ctx;
+
+    // prepend "time" if requested
+    if (cfg->report_time != REPORT_TIME_OFF) {
+        char time_str[LOCAL_TIME_BUFLEN];
+        time_pos_str(cfg, cfg->demod->pulse_data.start_ago, time_str);
+        data = data_prepend(data,
+                "time", "", DATA_STRING, time_str,
+                NULL);
+    }
+
+    for (size_t i = 0; i < cfg->output_handler.len; ++i) { // list might contain NULLs
+        data_output_t *output = cfg->output_handler.elems[i];
+        if (output && output->log_level >= level) {
+            data_output_print(output, data);
+        }
     }
     data_free(data);
 }
@@ -829,7 +893,8 @@ void data_acquired_handler(r_device *r_dev, data_t *data)
     }
 
     for (size_t i = 0; i < cfg->output_handler.len; ++i) { // list might contain NULLs
-        data_output_print(cfg->output_handler.elems[i], data);
+        data_output_t *output = cfg->output_handler.elems[i];
+        data_output_print(output, data);
     }
     data_free(data);
 }
@@ -968,7 +1033,7 @@ static int lvlarg_param(char **param, int default_verb)
 static FILE *fopen_output(char *param)
 {
     FILE *file;
-    if (!param || !*param) {
+    if (!param || !*param || (*param == '-' && param[1] == '\0')) {
         return stdout;
     }
     file = fopen(param, "a");
@@ -997,10 +1062,17 @@ void start_outputs(r_cfg_t *cfg, char const *const *well_known)
     char const **output_fields = determine_csv_fields(cfg, well_known, &num_output_fields);
 
     for (size_t i = 0; i < cfg->output_handler.len; ++i) { // list might contain NULLs
-        data_output_start(cfg->output_handler.elems[i], output_fields, num_output_fields);
+        data_output_t *output = cfg->output_handler.elems[i];
+        data_output_start(output, output_fields, num_output_fields);
     }
 
     free((void *)output_fields);
+}
+
+void add_log_output(r_cfg_t *cfg, char *param)
+{
+    int log_level = lvlarg_param(&param, LOG_TRACE);
+    list_push(&cfg->output_handler, data_output_log_create(log_level, fopen_output(param)));
 }
 
 void add_kv_output(r_cfg_t *cfg, char *param)


### PR DESCRIPTION
Logging used to be simple messages on stderr. Limitations:
- Always visible on the console (KV output), not available at other outputs (JSON, Syslog, HTTP)
- Not really inline with events (events: stdout, log: stderr)
- No severity visible (by color or common markers)

Logging now changed to be messages along the same path as events:
- Selectable for any output
- Inline with events
- Severity by color (or level markers)

Usage changes:
- If you **don't select any outputs** then **logging will go to KV** output (equivalent to `-F kv`, i.e. `-F kv,v=8`)
- If you **select the KV** output then **logging will be shown**, suppress with `-F kv,v=0`)
- If you **don't select the KV** output then **no logging** will be shown, add it with `-F log`)
- If you want **logging back to stderr and suppressed in KV use** `-F log -F kv,v=0`

### Implementation
Now that refactoring from `fprintf()`s in decoders to `decoder_log*()` calls is done this will finally allow all logging to selectively (verbosity levels) go to outputs (KV, JSON, CSV, MQTT, HTTP, …).

One would raise the verbosity globally (`-v`) or per decoder (`-R 99,v`) and configure outputs to display those messages (e.g. `-F json,v`).

### Tasks
- [x] Outputs need to parse the level option
- [x] Global prints ("noise level") need to be converted to log
- [x] KV ouput should prettify the logs
- [x] Looks like there is an overflow somewhere? (6e1f120)