### PR TITLE
Change verbosity to match log level

### DIFF
--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -20,8 +20,8 @@
 
 # as command line option:
 #   [-v] Increase verbosity (can be used multiple times).
-#        -v : verbose, -vv : verbose decoders, -vvv : debug decoders, -vvvv : trace decoding).
-# 0 = normal, 1 = verbose, 2 = verbose decoders, 3 = debug decoders, 4 = trace decoding
+#        -v : verbose notice, -vv : verbose info, -vvv : debug, -vvvv : trace.
+# 1=fatal, 2=critical, 3=error, 4=warning (default), 5=notice, 6=info, 7=debug, 8=trace
 #verbose
 
 # as command line option:

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -15,6 +15,7 @@
 #include "pulse_data.h"
 #include "baseband.h"
 #include "util.h"
+#include "logger.h"
 #include "fatal.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -201,7 +202,7 @@ int pulse_detect_package(pulse_detect_t *pulse_detect, int16_t const *envelope_d
     while (s->data_counter < len) {
         // Calculate OOK detection threshold and hysteresis
         int16_t const am_n    = envelope_data[s->data_counter];
-        if (pulse_detect->verbosity) {
+        if (pulse_detect->verbosity >= LOG_NOTICE) {
             int att = pulse_detect->use_mag_est ? mag_to_att(am_n) : amp_to_att(am_n);
             att_hist[att] += 1;
         }
@@ -306,10 +307,10 @@ int pulse_detect_package(pulse_detect_t *pulse_detect, int16_t const *envelope_d
                         pulses->end_ago = len - s->data_counter;
                         fsk_pulses->end_ago = len - s->data_counter;
                         s->ook_state = PD_OOK_STATE_IDLE;    // Ensure everything is reset
-                        if (pulse_detect->verbosity > 1) {
+                        if (pulse_detect->verbosity >= LOG_INFO) {
                             print_att_hist("PULSE_DATA_FSK", att_hist);
                         }
-                        if (pulse_detect->verbosity) {
+                        if (pulse_detect->verbosity >= LOG_NOTICE) {
                             fprintf(stderr, "Levels low: -%d dB  high: -%d dB  thres: -%d dB  hyst: (-%d to -%d dB)\n",
                                     mag_to_att(s->ook_low_estimate), mag_to_att(s->ook_high_estimate),
                                     mag_to_att(ook_threshold),
@@ -342,7 +343,7 @@ int pulse_detect_package(pulse_detect_t *pulse_detect, int16_t const *envelope_d
                         pulses->ook_low_estimate = s->ook_low_estimate;
                         pulses->ook_high_estimate = s->ook_high_estimate;
                         pulses->end_ago = len - s->data_counter;
-                        if (pulse_detect->verbosity > 1) {
+                        if (pulse_detect->verbosity >= LOG_INFO) {
                             print_att_hist("PULSE_DATA_OOK MAX_PULSES", att_hist);
                         }
                         return PULSE_DATA_OOK;    // End Of Package!!
@@ -364,10 +365,10 @@ int pulse_detect_package(pulse_detect_t *pulse_detect, int16_t const *envelope_d
                     pulses->ook_low_estimate = s->ook_low_estimate;
                     pulses->ook_high_estimate = s->ook_high_estimate;
                     pulses->end_ago = len - s->data_counter;
-                    if (pulse_detect->verbosity > 1) {
+                    if (pulse_detect->verbosity >= LOG_INFO) {
                         print_att_hist("PULSE_DATA_OOK EOP", att_hist);
                     }
-                    if (pulse_detect->verbosity) {
+                    if (pulse_detect->verbosity >= LOG_NOTICE) {
                         fprintf(stderr, "Levels low: -%d dB  high: -%d dB  thres: -%d dB  hyst: (-%d to -%d dB)\n",
                                 mag_to_att(s->ook_low_estimate), mag_to_att(s->ook_high_estimate),
                                 mag_to_att(ook_threshold),
@@ -385,7 +386,7 @@ int pulse_detect_package(pulse_detect_t *pulse_detect, int16_t const *envelope_d
     } // while
 
     s->data_counter = 0;
-    if (pulse_detect->verbosity > 2) {
+    if (pulse_detect->verbosity >= LOG_DEBUG) {
         print_att_hist("Out of data", att_hist);
     }
     return 0;    // Out of data


### PR DESCRIPTION
Changes verbosity numbers (0-4) to match new log levels (1-8).
We default to a new level of 4 (WARNING) and each `-v` options increases the level by 1 unchanged.

The new level allow to distinguish between normal and abnormal state messages:

- FATAL (1): A fatal error. Not actually used, fatal errors usually fprintf and terminate. This is the highest priority.
- CRITICAL (2): A critical message. The user usually needs to see this.
- ERROR (3): An error. An operation did not complete successfully, but the application as a whole is not affected.
- WARNING (4): A warning. An operation completed with an unexpected result.
- NOTICE (5): A notice, which is an information with just a higher priority.
- INFO (6): An informational message, usually denoting the successful completion of an operation.
- DEBUG (7): A debugging message.
- TRACE (8): A tracing message. This is the lowest priority.

Note that we adopted the SoapySDR log levels but change CRITICAL to be a normal message.
We denote only FATAL, ERROR, and WARNING as abnormal. FATAL will terminate, ERROR indicates an important problem, and WARNING can likely be ignored.

This builds on #2263 and is preparation for #2254