### PR TITLE
Change fprintf to log prints

### DIFF
--- a/src/baseband.c
+++ b/src/baseband.c
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <math.h>
 
+#include "logger.h"
 #include "r_util.h"
 
 static uint16_t scaled_squares[256];
@@ -210,7 +211,7 @@ void baseband_demod_FM(uint8_t const *x_buf, int16_t *y_buf, unsigned long num_s
         } else if (low_pass >= 1.0f) {
             low_pass = 1e6f / low_pass / samp_rate;
         }
-        fprintf(stderr, "%s: low pass filter for %u Hz at cutoff %.0f Hz, %.1f us\n", __func__,
+        print_logf(LOG_NOTICE, "Baseband", "low pass filter for %u Hz at cutoff %.0f Hz, %.1f us",
                 samp_rate, samp_rate * low_pass, 1e6 / (samp_rate * low_pass));
         double ita  = 1.0 / tan(M_PI_2 * low_pass);
         double gain = 1.0 / (1.0 + ita) / 2; // prescaled by div 2
@@ -303,7 +304,7 @@ void baseband_demod_FM_cs16(int16_t const *x_buf, int16_t *y_buf, unsigned long 
         } else if (low_pass >= 1.0f) {
             low_pass = 1e6f / low_pass / samp_rate;
         }
-        fprintf(stderr, "%s: low pass filter for %u Hz at cutoff %.0f Hz, %.1f us\n", __func__,
+        print_logf(LOG_NOTICE, "Baseband", "low pass filter for %u Hz at cutoff %.0f Hz, %.1f us",
                 samp_rate, samp_rate * low_pass, 1e6 / (samp_rate * low_pass));
         double ita  = 1.0 / tan(M_PI_2 * low_pass);
         double gain = 1.0 / (1.0 + ita);

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -105,6 +105,7 @@ or `(echo "GET /stream HTTP/1.0\n"; sleep 600) | socat - tcp:127.0.0.1:8433`
 #include "list.h" // used for protocols
 #include "jsmn.h"
 #include "mongoose.h"
+#include "logger.h"
 #include "fatal.h"
 #include <stdbool.h>
 
@@ -385,13 +386,13 @@ static int json_parse(rpc_t *rpc, struct mg_str const *json)
     jsmn_init(&p);
     r = jsmn_parse(&p, json->p, json->len, t, sizeof(t) / sizeof(t[0]));
     if (r < 0) {
-        printf("Failed to parse JSON: %d\n", r);
+        print_logf(LOG_WARNING, __func__, "Failed to parse JSON: %d", r);
         return -1;
     }
 
     /* Assume the top-level element is an object */
     if (r < 1 || t[0].type != JSMN_OBJECT) {
-        printf("Object expected\n");
+        print_log(LOG_WARNING, __func__, "Object expected");
         return -1;
     }
 
@@ -414,7 +415,7 @@ static int json_parse(rpc_t *rpc, struct mg_str const *json)
             // compare endptr to t[i].end
         }
         else {
-            printf("Unexpected key: %.*s\n", t[i].end - t[i].start, json->p + t[i].start);
+            print_logf(LOG_WARNING, __func__, "Unexpected key: %.*s", t[i].end - t[i].start, json->p + t[i].start);
         }
     }
 
@@ -443,13 +444,13 @@ static int jsonrpc_parse(rpc_t *rpc, struct mg_str const *json)
     jsmn_init(&p);
     r = jsmn_parse(&p, json->p, json->len, t, sizeof(t) / sizeof(t[0]));
     if (r < 0) {
-        printf("Failed to parse JSON: %d\n", r);
+        print_logf(LOG_WARNING, __func__, "Failed to parse JSON: %d", r);
         return -1;
     }
 
     /* Assume the top-level element is an object */
     if (r < 1 || t[0].type != JSMN_OBJECT) {
-        printf("Object expected\n");
+        print_log(LOG_WARNING, __func__, "Object expected");
         return -1;
     }
 
@@ -496,7 +497,7 @@ static int jsonrpc_parse(rpc_t *rpc, struct mg_str const *json)
             i += t[i + 1].size + 1;
         }
         else {
-            printf("Unexpected key: %.*s\n", t[i].end - t[i].start, json->p + t[i].start);
+            print_logf(LOG_WARNING, __func__, "Unexpected key: %.*s", t[i].end - t[i].start, json->p + t[i].start);
         }
     }
 
@@ -1127,7 +1128,7 @@ static struct http_server_context *http_server_start(struct mg_mgr *mgr, char co
 
     ctx->conn = mg_bind_opt(mgr, address, ev_handler, bind_opts);
     if (ctx->conn == NULL) {
-        fprintf(stderr, "Error starting server on address %s: %s\n", address,
+        print_logf(LOG_ERROR, __func__, "Error starting server on address %s: %s", address,
                 *bind_opts.error_string);
         free(ctx);
         return NULL;
@@ -1137,7 +1138,7 @@ static struct http_server_context *http_server_start(struct mg_mgr *mgr, char co
     ctx->server_opts.document_root            = "."; // Serve current directory
     ctx->server_opts.enable_directory_listing = "yes";
 
-    printf("Starting HTTP server on address %s, serving %s\n", address,
+    print_logf(LOG_NOTICE, __func__, "Starting HTTP server on address %s, serving %s", address,
             ctx->server_opts.document_root);
 
     return ctx;

--- a/src/pulse_slicer.c
+++ b/src/pulse_slicer.c
@@ -14,6 +14,7 @@
 #include "pulse_slicer.h"
 #include "bitbuffer.h"
 #include "util.h"
+#include "logger.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -39,7 +40,7 @@ static int account_event(r_device *device, bitbuffer_t *bits, char const *demod_
         ret = 0;
     }
     else {
-        fprintf(stderr, "Decoder \"%s\" gave invalid return value %d: notify maintainer\n", device->name, ret);
+        print_logf(LOG_ERROR, demod_name, "Decoder \"%s\" gave invalid return value %d: notify maintainer", device->name, ret);
         exit(1);
     }
 
@@ -77,7 +78,7 @@ int pulse_slicer_pcm(const pulse_data_t *pulses, r_device *device)
             || (device->gap_limit > 0 && s_gap <= 0)
             || (device->sync_width > 0 && s_sync <= 0)
             || (device->tolerance > 0 && s_tolerance <= 0)) {
-        fprintf(stderr, "sample rate too low for protocol %u \"%s\"\n", device->protocol_num, device->name);
+        print_logf(LOG_WARNING, __func__, "sample rate too low for protocol %u \"%s\"", device->protocol_num, device->name);
         return 0;
     }
 
@@ -119,7 +120,7 @@ int pulse_slicer_pcm(const pulse_data_t *pulses, r_device *device)
             preamble_len = count;
             if (device->verbose > 1) {
                 float to_us = 1e6 / pulses->sample_rate;
-                fprintf(stderr, "Exact bit width (in us) is %.2f vs %.2f (pulse width %.2f vs %.2f), %d bit preamble\n",
+                print_logf(LOG_INFO, __func__, "Exact bit width (in us) is %.2f vs %.2f (pulse width %.2f vs %.2f), %d bit preamble",
                         to_us / f_long, to_us * s_long,
                         to_us / f_short, to_us * s_short, count);
             }
@@ -145,7 +146,7 @@ int pulse_slicer_pcm(const pulse_data_t *pulses, r_device *device)
         f_short = (float)rz_count / rzs_width;
         if (device->verbose > 1) {
             float to_us = 1e6 / pulses->sample_rate;
-            fprintf(stderr, "Exact bit width (in us) is %.2f vs %.2f (pulse width %.2f vs %.2f), %d bit measured\n",
+            print_logf(LOG_INFO, __func__, "Exact bit width (in us) is %.2f vs %.2f (pulse width %.2f vs %.2f), %d bit measured",
                     to_us / f_long, to_us * s_long,
                     to_us / f_short, to_us * s_short, rz_count);
         }
@@ -168,7 +169,7 @@ int pulse_slicer_pcm(const pulse_data_t *pulses, r_device *device)
             preamble_len = count;
             if (device->verbose > 1) {
                 float to_us = 1e6 / pulses->sample_rate;
-                fprintf(stderr, "Exact bit width (in us) is %.2f vs %.2f, %d bit preamble\n",
+                print_logf(LOG_INFO, __func__, "Exact bit width (in us) is %.2f vs %.2f, %d bit preamble",
                         to_us / f_short, to_us * s_short, count);
             }
         }
@@ -203,7 +204,7 @@ int pulse_slicer_pcm(const pulse_data_t *pulses, r_device *device)
         f_short = f_long = (float)nrz_count / nrz_width;
         if (device->verbose > 1) {
             float to_us = 1e6 / pulses->sample_rate;
-            fprintf(stderr, "%s: Exact bit width (in us) is %.2f vs %.2f, %d bit measured\n", device->name,
+            print_logf(LOG_INFO, __func__, "%s: Exact bit width (in us) is %.2f vs %.2f, %d bit measured", device->name,
                     to_us / f_short, to_us * s_short, nrz_count);
         }
     }
@@ -231,7 +232,7 @@ int pulse_slicer_pcm(const pulse_data_t *pulses, r_device *device)
 
             // Data is corrupt
             if (device->verbose > 3) {
-                fprintf(stderr, "bitbuffer cleared at %u: pulse %d, gap %d, period %d\n",
+                print_logf(LOG_TRACE, __func__, "bitbuffer cleared at %u: pulse %d, gap %d, period %d",
                         n, pulses->pulse[n], pulses->gap[n],
                         pulses->pulse[n] + pulses->gap[n]);
             }
@@ -272,7 +273,7 @@ int pulse_slicer_ppm(const pulse_data_t *pulses, r_device *device)
             || (device->gap_limit > 0 && s_gap <= 0)
             || (device->sync_width > 0 && s_sync <= 0)
             || (device->tolerance > 0 && s_tolerance <= 0)) {
-        fprintf(stderr, "sample rate too low for protocol %u \"%s\"\n", device->protocol_num, device->name);
+        print_logf(LOG_WARNING, __func__, "sample rate too low for protocol %u \"%s\"", device->protocol_num, device->name);
         return 0;
     }
 
@@ -351,7 +352,7 @@ int pulse_slicer_pwm(const pulse_data_t *pulses, r_device *device)
             || (device->gap_limit > 0 && s_gap <= 0)
             || (device->sync_width > 0 && s_sync <= 0)
             || (device->tolerance > 0 && s_tolerance <= 0)) {
-        fprintf(stderr, "sample rate too low for protocol %u \"%s\"\n", device->protocol_num, device->name);
+        print_logf(LOG_WARNING, __func__, "sample rate too low for protocol %u \"%s\"", device->protocol_num, device->name);
         return 0;
     }
 
@@ -464,7 +465,7 @@ int pulse_slicer_manchester_zerobit(const pulse_data_t *pulses, r_device *device
             || (device->gap_limit > 0 && s_gap <= 0)
             || (device->sync_width > 0 && s_sync <= 0)
             || (device->tolerance > 0 && s_tolerance <= 0)) {
-        fprintf(stderr, "sample rate too low for protocol %u \"%s\"\n", device->protocol_num, device->name);
+        print_logf(LOG_WARNING, __func__, "sample rate too low for protocol %u \"%s\"", device->protocol_num, device->name);
         return 0;
     }
 
@@ -551,7 +552,7 @@ int pulse_slicer_dmc(const pulse_data_t *pulses, r_device *device)
             || (device->gap_limit > 0 && s_gap <= 0)
             || (device->sync_width > 0 && s_sync <= 0)
             || (device->tolerance > 0 && s_tolerance <= 0)) {
-        fprintf(stderr, "sample rate too low for protocol %u \"%s\"\n", device->protocol_num, device->name);
+        print_logf(LOG_WARNING, __func__, "sample rate too low for protocol %u \"%s\"", device->protocol_num, device->name);
         return 0;
     }
 
@@ -573,7 +574,7 @@ int pulse_slicer_dmc(const pulse_data_t *pulses, r_device *device)
                 else if (bits.num_rows > 0 && bits.bits_per_row[bits.num_rows - 1] > 0) {
                     bitbuffer_add_row(&bits);
 /*
-                    fprintf(stderr, "Detected error during pulse_slicer_dmc(): %s\n",
+                    print_logf(LOG_WARNING, __func__, "Detected error during pulse_slicer_dmc(): %s",
                             device->name);
 */
                 }
@@ -611,7 +612,7 @@ int pulse_slicer_piwm_raw(const pulse_data_t *pulses, r_device *device)
             || (device->gap_limit > 0 && s_gap <= 0)
             || (device->sync_width > 0 && s_sync <= 0)
             || (device->tolerance > 0 && s_tolerance <= 0)) {
-        fprintf(stderr, "sample rate too low for protocol %u \"%s\"\n", device->protocol_num, device->name);
+        print_logf(LOG_WARNING, __func__, "sample rate too low for protocol %u \"%s\"", device->protocol_num, device->name);
         return 0;
     }
 
@@ -639,7 +640,7 @@ int pulse_slicer_piwm_raw(const pulse_data_t *pulses, r_device *device)
                 && bits.bits_per_row[bits.num_rows - 1] > 0) {
             bitbuffer_add_row(&bits);
 /*
-            fprintf(stderr, "Detected error during pulse_slicer_piwm_raw(): %s\n",
+            print_logf(LOG_WARNING, __func__, "Detected error during pulse_slicer_piwm_raw(): %s",
                     device->name);
 */
         }
@@ -673,7 +674,7 @@ int pulse_slicer_piwm_dc(const pulse_data_t *pulses, r_device *device)
             || (device->gap_limit > 0 && s_gap <= 0)
             || (device->sync_width > 0 && s_sync <= 0)
             || (device->tolerance > 0 && s_tolerance <= 0)) {
-        fprintf(stderr, "sample rate too low for protocol %u \"%s\"\n", device->protocol_num, device->name);
+        print_logf(LOG_WARNING, __func__, "sample rate too low for protocol %u \"%s\"", device->protocol_num, device->name);
         return 0;
     }
 
@@ -695,7 +696,7 @@ int pulse_slicer_piwm_dc(const pulse_data_t *pulses, r_device *device)
                 && bits.bits_per_row[bits.num_rows - 1] > 0) {
             bitbuffer_add_row(&bits);
 /*
-            fprintf(stderr, "Detected error during pulse_slicer_piwm_dc(): %s\n",
+            print_logf(LOG_WARNING, __func__, "Detected error during pulse_slicer_piwm_dc(): %s",
                     device->name);
 */
         }
@@ -729,7 +730,7 @@ int pulse_slicer_nrzs(const pulse_data_t *pulses, r_device *device)
             || (device->gap_limit > 0 && s_gap <= 0)
             || (device->sync_width > 0 && s_sync <= 0)
             || (device->tolerance > 0 && s_tolerance <= 0)) {
-        fprintf(stderr, "sample rate too low for protocol %u \"%s\"\n", device->protocol_num, device->name);
+        print_logf(LOG_WARNING, __func__, "sample rate too low for protocol %u \"%s\"", device->protocol_num, device->name);
         return 0;
     }
 
@@ -789,7 +790,7 @@ int pulse_slicer_osv1(const pulse_data_t *pulses, r_device *device)
             || (device->gap_limit > 0 && s_gap <= 0)
             || (device->sync_width > 0 && s_sync <= 0)
             || (device->tolerance > 0 && s_tolerance <= 0)) {
-        fprintf(stderr, "sample rate too low for protocol %u \"%s\"\n", device->protocol_num, device->name);
+        print_logf(LOG_WARNING, __func__, "sample rate too low for protocol %u \"%s\"", device->protocol_num, device->name);
         return 0;
     }
 
@@ -814,7 +815,7 @@ int pulse_slicer_osv1(const pulse_data_t *pulses, r_device *device)
     }
     if (preamble != 12) {
         if (device->verbose)
-            fprintf(stderr, "preamble %d  %d %d\n", preamble, pulses->pulse[0], pulses->gap[0]);
+            print_logf(LOG_WARNING, __func__, "preamble %d  %d %d", preamble, pulses->pulse[0], pulses->gap[0]);
         return events;
     }
 

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -383,10 +383,10 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx)
 
     n_samples = len / demod->sample_size;
     if (n_samples * demod->sample_size != len) {
-        fprintf(stderr, "Sample buffer length not aligned to sample size!\n");
+        print_log(LOG_WARNING, __func__, "Sample buffer length not aligned to sample size!");
     }
     if (!n_samples) {
-        fprintf(stderr, "Sample buffer too short!\n");
+        print_log(LOG_WARNING, __func__, "Sample buffer too short!");
         return; // keep the watchdog timer running
     }
 
@@ -433,7 +433,8 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx)
         if (demod->auto_level > 0 && demod->noise_level < demod->min_level - 3.0f
                 && fabsf(demod->min_level_auto - demod->noise_level - 3.0f) > 1.0f) {
             demod->min_level_auto = demod->noise_level + 3.0f;
-            fprintf(stderr, "Estimated noise level is %.1f dB, adjusting minimum detection level to %.1f dB\n", demod->noise_level, demod->min_level_auto);
+            print_logf(LOG_WARNING, "Auto Level", "Estimated noise level is %.1f dB, adjusting minimum detection level to %.1f dB",
+                    demod->noise_level, demod->min_level_auto);
             pulse_detect_set_levels(demod->pulse_detect, demod->use_mag_est, demod->level_limit, demod->min_level_auto, demod->min_snr, demod->detect_verbosity);
         }
     } else {
@@ -441,7 +442,7 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx)
     }
     // Report noise every report_noise seconds, but only for the first frame that second
     if (cfg->report_noise && last_frame_sec != demod->now.tv_sec && demod->now.tv_sec % cfg->report_noise == 0) {
-        fprintf(stderr, "Current %s level %.1f dB, estimated noise %.1f dB\n",
+        print_logf(LOG_WARNING, "Auto Level", "Current %s level %.1f dB, estimated noise %.1f dB",
                 noise_only ? "noise" : "signal", avg_db, demod->noise_level);
     }
 
@@ -681,7 +682,7 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx)
         }
 
         if (fwrite(out_buf, 1, out_len, dumper->file) != out_len) {
-            fprintf(stderr, "Short write, samples lost, exiting!\n");
+            print_log(LOG_ERROR, __func__, "Short write, samples lost, exiting!");
             cfg->exit_async = 1;
         }
     }
@@ -712,7 +713,7 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx)
     if (cfg->duration > 0 && rawtime >= cfg->stop_time) {
         alarm(0); // cancel the watchdog timer
         cfg->exit_async = 1;
-        fprintf(stderr, "Time expired, exiting!\n");
+        print_log(LOG_CRITICAL, __func__, "Time expired, exiting!");
     }
     if (cfg->stats_now || (cfg->report_stats && cfg->stats_interval && rawtime >= cfg->stats_time)) {
         event_occurred_handler(cfg, create_report_data(cfg, cfg->stats_now ? 3 : cfg->report_stats));
@@ -1476,7 +1477,7 @@ int main(int argc, char **argv) {
             }
             abuf_printf(&p, " ]");
         }
-        fprintf(stderr, "Registered %zu out of %u device decoding protocols%s\n",
+        print_logf(LOG_CRITICAL, "Protocols", "Registered %zu out of %u device decoding protocols%s",
                 demod->r_devs.len, cfg->num_r_devices, decoders_str);
     }
 
@@ -1486,12 +1487,12 @@ int main(int argc, char **argv) {
 
     if (cfg->out_block_size < MINIMAL_BUF_LENGTH ||
             cfg->out_block_size > MAXIMAL_BUF_LENGTH) {
-        fprintf(stderr,
-                "Output block size wrong value, falling back to default\n");
-        fprintf(stderr,
-                "Minimal length: %d\n", MINIMAL_BUF_LENGTH);
-        fprintf(stderr,
-                "Maximal length: %d\n", MAXIMAL_BUF_LENGTH);
+        print_logf(LOG_ERROR, "Block Size",
+                "Output block size wrong value, falling back to default (%d)", DEFAULT_BUF_LENGTH);
+        print_logf(LOG_ERROR, "Block Size",
+                "Minimal length: %d", MINIMAL_BUF_LENGTH);
+        print_logf(LOG_ERROR, "Block Size",
+                "Maximal length: %d", MAXIMAL_BUF_LENGTH);
         cfg->out_block_size = DEFAULT_BUF_LENGTH;
     }
 
@@ -1501,27 +1502,27 @@ int main(int argc, char **argv) {
         char line[INPUT_LINE_MAX];
 
         if (*cfg->test_data == '@') {
-            fprintf(stderr, "Reading test data from \"%s\"\n", &cfg->test_data[1]);
+            print_logf(LOG_CRITICAL, "Input", "Reading test data from \"%s\"", &cfg->test_data[1]);
             fp = fopen(&cfg->test_data[1], "r");
         } else {
-            fprintf(stderr, "Reading test data from stdin\n");
+            print_log(LOG_CRITICAL, "Input", "Reading test data from stdin");
             fp = stdin;
         }
         if (!fp) {
-            fprintf(stderr, "Failed to open %s\n", cfg->test_data);
+            print_logf(LOG_ERROR, "Input", "Failed to open %s", cfg->test_data);
             exit(1);
         }
 
         while (fgets(line, INPUT_LINE_MAX, fp)) {
             if (cfg->verbosity >= LOG_NOTICE)
-                fprintf(stderr, "Processing test data \"%s\"...\n", line);
+                print_logf(LOG_NOTICE, "Input", "Processing test data \"%s\"...", line);
             r = 0;
             // test a single decoder?
             if (*line == '[') {
                 char *e = NULL;
                 unsigned d = (unsigned)strtol(&line[1], &e, 10);
                 if (!e || *e != ']') {
-                    fprintf(stderr, "Bad protocol number %.5s.\n", line);
+                    print_logf(LOG_ERROR, "Protocol", "Bad protocol number %.5s.", line);
                     exit(1);
                 }
                 e++;
@@ -1534,11 +1535,11 @@ int main(int argc, char **argv) {
                     }
                 }
                 if (!r_dev) {
-                    fprintf(stderr, "Unknown protocol number %u.\n", d);
+                    print_logf(LOG_ERROR, "Protocol", "Unknown protocol number %u.", d);
                     exit(1);
                 }
                 if (cfg->verbosity >= LOG_NOTICE)
-                    fprintf(stderr, "Verifying test data with device %s.\n", r_dev->name);
+                    print_logf(LOG_NOTICE, "Input", "Verifying test data with device %s.", r_dev->name);
                 if (rfraw_check(e)) {
                     pulse_data_t pulse_data = {0};
                     rfraw_parse(&pulse_data, e);
@@ -1565,7 +1566,7 @@ int main(int argc, char **argv) {
             for (void **iter = demod->r_devs.elems; iter && *iter; ++iter) {
                 r_device *r_dev = *iter;
                 if (cfg->verbosity >= LOG_NOTICE)
-                    fprintf(stderr, "Verifying test data with device %s.\n", r_dev->name);
+                    print_logf(LOG_NOTICE, "Input", "Verifying test data with device %s.", r_dev->name);
                 r += pulse_slicer_string(line, r_dev);
             }
         }
@@ -1591,7 +1592,7 @@ int main(int argc, char **argv) {
         for (void **iter = demod->r_devs.elems; iter && *iter; ++iter) {
             r_device *r_dev = *iter;
             if (cfg->verbosity >= LOG_NOTICE)
-                fprintf(stderr, "Verifying test data with device %s.\n", r_dev->name);
+                print_logf(LOG_NOTICE, "Input", "Verifying test data with device %s.", r_dev->name);
             r += pulse_slicer_string(cfg->test_data, r_dev);
         }
         r_free_cfg(cfg);
@@ -1627,11 +1628,11 @@ int main(int argc, char **argv) {
             } else {
                 in_file = fopen(demod->load_info.path, "rb");
                 if (!in_file) {
-                    fprintf(stderr, "Opening file: %s failed!\n", cfg->in_filename);
+                    print_logf(LOG_ERROR, "Input", "Opening file \"%s\" failed!", cfg->in_filename);
                     break;
                 }
             }
-            fprintf(stderr, "Test mode active. Reading samples from file: %s\n", cfg->in_filename);  // Essential information (not quiet)
+            print_logf(LOG_CRITICAL, "Input", "Test mode active. Reading samples from file: %s", cfg->in_filename); // Essential information (not quiet)
             if (demod->load_info.format == CU8_IQ
                     || demod->load_info.format == CS8_IQ
                     || demod->load_info.format == S16_AM
@@ -1643,11 +1644,11 @@ int main(int argc, char **argv) {
             } else if (demod->load_info.format == PULSE_OOK) {
                 // ignore
             } else {
-                fprintf(stderr, "Input format invalid: %s\n", file_info_string(&demod->load_info));
+                print_logf(LOG_ERROR, "Input", "Input format invalid \"%s\"", file_info_string(&demod->load_info));
                 break;
             }
             if (cfg->verbosity >= LOG_NOTICE) {
-                fprintf(stderr, "Input format: %s\n", file_info_string(&demod->load_info));
+                print_logf(LOG_NOTICE, "Input", "Input format \"%s\"", file_info_string(&demod->load_info));
             }
             demod->sample_file_pos = 0.0;
 
@@ -1665,7 +1666,7 @@ int main(int argc, char **argv) {
                         } else if (dumper->format == PULSE_OOK) {
                             pulse_data_dump(dumper->file, &demod->pulse_data);
                         } else {
-                            fprintf(stderr, "Dumper (%s) not supported on OOK input\n", dumper->spec);
+                            print_logf(LOG_ERROR, "Input", "Dumper (%s) not supported on OOK input", dumper->spec);
                             exit(1);
                         }
                     }
@@ -1750,7 +1751,7 @@ int main(int argc, char **argv) {
             if (demod->am_analyze)
                 am_analyze_classify(demod->am_analyze);
             if (cfg->verbosity >= LOG_NOTICE) {
-                fprintf(stderr, "Test mode file issued %d packets\n", n_blocks);
+                print_logf(LOG_NOTICE, "Input", "Test mode file issued %d packets", n_blocks);
             }
 
             if (in_file != stdin)
@@ -1765,7 +1766,7 @@ int main(int argc, char **argv) {
     }
 
     if (cfg->sr_filename) {
-        fprintf(stderr, "SR writing not recommended for live input\n");
+        print_logf(LOG_ERROR, "Input", "SR writing not recommended for live input");
         exit(1);
     }
 
@@ -1795,7 +1796,7 @@ int main(int argc, char **argv) {
     r = sdr_set_sample_rate(cfg->dev, cfg->samp_rate, 1); // always verbose
 
     if (cfg->verbosity >= LOG_NOTICE || demod->level_limit < 0.0)
-        fprintf(stderr, "Bit detection level set to %.1f%s.\n", demod->level_limit, (demod->level_limit < 0.0 ? "" : " (Auto)"));
+        print_logf(LOG_NOTICE, "Input", "Bit detection level set to %.1f%s.", demod->level_limit, (demod->level_limit < 0.0 ? "" : " (Auto)"));
 
     r = sdr_apply_settings(cfg->dev, cfg->settings_str, 1); // always verbose for soapy
 
@@ -1808,11 +1809,11 @@ int main(int argc, char **argv) {
     /* Reset endpoint before we start reading from it (mandatory) */
     r = sdr_reset(cfg->dev, cfg->verbosity);
     if (r < 0)
-        fprintf(stderr, "WARNING: Failed to reset buffers.\n");
+        print_log(LOG_ERROR, "Input", "Failed to reset buffers.");
     r = sdr_activate(cfg->dev);
 
     if (cfg->verbosity >= LOG_NOTICE) {
-        fprintf(stderr, "Reading samples in async mode...\n");
+        print_log(LOG_NOTICE, "Input", "Reading samples in async mode...");
     }
     if (cfg->duration > 0) {
         time(&cfg->stop_time);
@@ -1828,7 +1829,7 @@ int main(int argc, char **argv) {
         r = sdr_start(cfg->dev, sdr_handler, (void *)cfg,
                 DEFAULT_ASYNC_BUF_NUMBER, cfg->out_block_size);
         if (r < 0) {
-            fprintf(stderr, "WARNING: async read failed (%i).\n", r);
+            print_logf(LOG_ERROR, "Input", "async read failed (%i).", r);
         }
 
         alarm(0); // cancel the watchdog timer
@@ -1839,7 +1840,7 @@ int main(int argc, char **argv) {
     }
 
     if (!cfg->exit_async) {
-        fprintf(stderr, "\nLibrary error %d, exiting...\n", r);
+        print_logf(LOG_ERROR, "rtl_433", "Library error %d, exiting...", r);
         cfg->exit_code = r;
     }
 

--- a/src/sdr.c
+++ b/src/sdr.c
@@ -183,7 +183,7 @@ static int rtltcp_open(sdr_dev_t **out_dev, char const *dev_query, int verbose)
     hostport[sizeof(hostport) - 1] = '\0';
     hostport_param(hostport, &host, &port);
 
-    fprintf(stderr, "rtl_tcp input from %s port %s\n", host, port);
+    print_logf(LOG_CRITICAL, "SDR", "rtl_tcp input from %s port %s", host, port);
 
 #ifdef _WIN32
     WSADATA wsa;
@@ -206,7 +206,7 @@ static int rtltcp_open(sdr_dev_t **out_dev, char const *dev_query, int verbose)
 
     ret = getaddrinfo(host, port, &hints, &res0);
     if (ret) {
-        fprintf(stderr, "%s\n", gai_strerror(ret));
+        print_log(LOG_ERROR, __func__, gai_strerror(ret));
         return -1;
     }
     sock = INVALID_SOCKET;
@@ -236,12 +236,12 @@ static int rtltcp_open(sdr_dev_t **out_dev, char const *dev_query, int verbose)
     struct rtl_tcp_info info;
     ret = recv(sock, (char *)&info, sizeof (info), 0);
     if (ret != 12) {
-        fprintf(stderr, "Bad rtl_tcp header (%d)\n", ret);
+        print_logf(LOG_ERROR, __func__, "Bad rtl_tcp header (%d)", ret);
         return -1;
     }
     if (strncmp(info.magic, "RTL0", 4)) {
         info.tuner_number = 0; // terminate magic
-        fprintf(stderr, "Bad rtl_tcp header magic \"%s\"\n", info.magic);
+        print_logf(LOG_ERROR, __func__, "Bad rtl_tcp header magic \"%s\"", info.magic);
         return -1;
     }
 
@@ -251,7 +251,7 @@ static int rtltcp_open(sdr_dev_t **out_dev, char const *dev_query, int verbose)
     char const *tuner_names[] = { "Unknown", "E4000", "FC0012", "FC0013", "FC2580", "R820T", "R828D" };
     char const *tuner_name = tuner_number > sizeof (tuner_names) ? "Invalid" : tuner_names[tuner_number];
 
-    fprintf(stderr, "rtl_tcp connected to %s:%s (Tuner: %s)\n", host, port, tuner_name);
+    print_logf(LOG_CRITICAL, "SDR", "rtl_tcp connected to %s:%s (Tuner: %s)", host, port, tuner_name);
 
     sdr_dev_t *dev = calloc(1, sizeof(sdr_dev_t));
     if (!dev) {
@@ -318,7 +318,7 @@ static int rtltcp_read_loop(sdr_dev_t *dev, sdr_event_cb_t cb, void *ctx, uint32
         //fprintf(stderr, "readStream ret=%d (read %u)\n", r, n_read);
 
         if (r < 0) {
-            fprintf(stderr, "WARNING: sync read failed. %d\n", r);
+            print_logf(LOG_WARNING, __func__, "sync read failed. %d", r);
         }
         if (n_read == 0) {
             perror("rtl_tcp");
@@ -381,12 +381,12 @@ static int sdr_open_rtl(sdr_dev_t **out_dev, char const *dev_query, int verbose)
 {
     uint32_t device_count = rtlsdr_get_device_count();
     if (!device_count) {
-        fprintf(stderr, "No supported devices found.\n");
+        print_log(LOG_CRITICAL, "SDR", "No supported devices found.");
         return -1;
     }
 
     if (verbose)
-        fprintf(stderr, "Found %u device(s)\n\n", device_count);
+        print_logf(LOG_CRITICAL, "SDR", "Found %u device(s)", device_count);
 
     int dev_index = 0;
     // select rtlsdr device by serial (-d :<serial>)
@@ -394,7 +394,7 @@ static int sdr_open_rtl(sdr_dev_t **out_dev, char const *dev_query, int verbose)
         dev_index = rtlsdr_get_index_by_serial(&dev_query[1]);
         if (dev_index < 0) {
             if (verbose)
-                fprintf(stderr, "Could not find device with serial '%s' (err %d)",
+                print_logf(LOG_ERROR, "SDR", "Could not find device with serial '%s' (err %d)",
                         &dev_query[1], dev_index);
             return -1;
         }
@@ -426,17 +426,17 @@ static int sdr_open_rtl(sdr_dev_t **out_dev, char const *dev_query, int verbose)
         rtlsdr_get_device_usb_strings(i, vendor, product, serial);
 
         if (verbose)
-            fprintf(stderr, "trying device  %u:  %s, %s, SN: %s\n",
+            print_logf(LOG_CRITICAL, "SDR", "trying device  %u:  %s, %s, SN: %s",
                     i, vendor, product, serial);
 
         r = rtlsdr_open(&dev->rtlsdr_dev, i);
         if (r < 0) {
             if (verbose)
-                fprintf(stderr, "Failed to open rtlsdr device #%u.\n\n", i);
+                print_logf(LOG_ERROR, __func__, "Failed to open rtlsdr device #%u.", i);
         }
         else {
             if (verbose)
-                fprintf(stderr, "Using device %u: %s\n",
+                print_logf(LOG_CRITICAL, "SDR", "Using device %u: %s",
                         i, rtlsdr_get_device_name(i));
             dev->sample_size = sizeof(uint8_t) * 2; // CU8
             dev->sample_signed = 0;
@@ -453,7 +453,7 @@ static int sdr_open_rtl(sdr_dev_t **out_dev, char const *dev_query, int verbose)
     if (r < 0) {
         free(dev);
         if (verbose)
-            fprintf(stderr, "Unable to open a device\n");
+            print_log(LOG_ERROR, __func__, "Unable to open a device");
     }
     else {
         *out_dev = dev;
@@ -467,12 +467,12 @@ static int rtlsdr_find_tuner_gain(sdr_dev_t *dev, int centigain, int verbose)
     int gains_count = rtlsdr_get_tuner_gains(dev->rtlsdr_dev, NULL);
     if (gains_count < 0) {
         if (verbose)
-            fprintf(stderr, "Unable to get exact gains\n");
+            print_log(LOG_WARNING, __func__, "Unable to get exact gains");
         return centigain;
     }
     if (gains_count < 1) {
         if (verbose)
-            fprintf(stderr, "No exact gains\n");
+            print_log(LOG_WARNING, __func__, "No exact gains");
         return centigain;
     }
     int *gains = calloc(gains_count, sizeof(int));
@@ -551,12 +551,12 @@ static int rtlsdr_read_loop(sdr_dev_t *dev, sdr_event_cb_t cb, void *ctx, uint32
         // We can safely assume it's an libusb error.
         if (r < 0) {
 #ifdef LIBUSB1
-            fprintf(stderr, "\n%s: %s!\n"
-                            "Check your RTL-SDR dongle, USB cables, and power supply.\n\n",
+            print_logf(LOG_ERROR, __func__, "%s: %s!"
+                            "Check your RTL-SDR dongle, USB cables, and power supply.",
                     libusb_error_name(r), libusb_strerror(r));
 #else
-            fprintf(stderr, "\nLIBUSB_ERROR: %d\n"
-                            "Check your RTL-SDR dongle, USB cables, and power supply.\n\n",
+            print_logf(LOG_ERROR, __func__, "LIBUSB_ERROR: %d"
+                            "Check your RTL-SDR dongle, USB cables, and power supply.",
                     r);
 #endif
             dev->running = 0;
@@ -581,17 +581,17 @@ static int soapysdr_set_bandwidth(SoapySDRDevice *dev, uint32_t bandwidth)
     r = (int)SoapySDRDevice_setBandwidth(dev, SOAPY_SDR_RX, 0, (double)bandwidth);
     uint32_t applied_bw = 0;
     if (r != 0) {
-        fprintf(stderr, "WARNING: Failed to set bandwidth.\n");
+        print_log(LOG_WARNING, "SDR", "Failed to set bandwidth.");
     }
     else if (bandwidth > 0) {
         applied_bw = (uint32_t)SoapySDRDevice_getBandwidth(dev, SOAPY_SDR_RX, 0);
         if (applied_bw)
-            fprintf(stderr, "Bandwidth parameter %u Hz resulted in %u Hz.\n", bandwidth, applied_bw);
+            print_logf(LOG_NOTICE, "SDR", "Bandwidth parameter %u Hz resulted in %u Hz.", bandwidth, applied_bw);
         else
-            fprintf(stderr, "Set bandwidth parameter %u Hz.\n", bandwidth);
+            print_logf(LOG_NOTICE, "SDR", "Set bandwidth parameter %u Hz.", bandwidth);
     }
     else {
-        fprintf(stderr, "Bandwidth set to automatic resulted in %u Hz.\n", applied_bw);
+        print_logf(LOG_NOTICE, "SDR", "Bandwidth set to automatic resulted in %u Hz.", applied_bw);
     }
     return r;
 }
@@ -612,18 +612,18 @@ static int soapysdr_direct_sampling(SoapySDRDevice *dev, int on)
     char *set_value = SoapySDRDevice_readSetting(dev, "direct_samp");
 
     if (set_value == NULL) {
-        fprintf(stderr, "WARNING: Failed to set direct sampling mode.\n");
+        print_log(LOG_ERROR, __func__, "Failed to set direct sampling moden");
         return r;
     }
     int set_num = atoi(set_value);
     if (set_num == 0) {
-        fprintf(stderr, "Direct sampling mode disabled.\n");}
+        print_log(LOG_CRITICAL, "SDR", "Direct sampling mode disabled.");}
     else if (set_num == 1) {
-        fprintf(stderr, "Enabled direct sampling mode, input 1/I.\n");}
+        print_log(LOG_CRITICAL, "SDR", "Enabled direct sampling mode, input 1/I.");}
     else if (set_num == 2) {
-        fprintf(stderr, "Enabled direct sampling mode, input 2/Q.\n");}
+        print_log(LOG_CRITICAL, "SDR", "Enabled direct sampling mode, input 2/Q.");}
     else if (set_num == 3) {
-        fprintf(stderr, "Enabled no-mod direct sampling mode.\n");}
+        print_log(LOG_CRITICAL, "SDR", "Enabled no-mod direct sampling mode.");}
     SoapySDR_free(set_value);
     return r;
 }
@@ -637,15 +637,15 @@ static int soapysdr_offset_tuning(SoapySDRDevice *dev)
     if (strcmp(set_value, "true") != 0) {
         /* TODO: detection of failure modes
         if ( r == -2 )
-            fprintf(stderr, "WARNING: Failed to set offset tuning: tuner doesn't support offset tuning!\n");
+            print_log(LOG_WARNING, __func__, "Failed to set offset tuning: tuner doesn't support offset tuning!");
         else if ( r == -3 )
-            fprintf(stderr, "WARNING: Failed to set offset tuning: direct sampling not combinable with offset tuning!\n");
+            print_log(LOG_WARNING, __func__, "Failed to set offset tuning: direct sampling not combinable with offset tuning!");
         else
         */
-            fprintf(stderr, "WARNING: Failed to set offset tuning.\n");
+            print_log(LOG_WARNING, __func__, "Failed to set offset tuning.");
     }
     else {
-        fprintf(stderr, "Offset tuning mode enabled.\n");
+        print_log(LOG_CRITICAL, "SDR", "Offset tuning mode enabled.");
     }
     SoapySDR_free(set_value);
     return r;
@@ -659,11 +659,11 @@ static int soapysdr_auto_gain(SoapySDRDevice *dev, int verbose)
     if (r) {
         r = SoapySDRDevice_setGainMode(dev, SOAPY_SDR_RX, 0, 1);
         if (r != 0) {
-            fprintf(stderr, "WARNING: Failed to enable automatic gain.\n");
+            print_log(LOG_WARNING, __func__, "Failed to enable automatic gain.");
         }
         else {
             if (verbose)
-                fprintf(stderr, "Tuner set to automatic gain.\n");
+                print_log(LOG_CRITICAL, "SDR", "Tuner set to automatic gain.");
         }
     }
 
@@ -676,15 +676,15 @@ static int soapysdr_auto_gain(SoapySDRDevice *dev, int verbose)
         // TODO: generic means to set all gains, of any SDR? string parsing LNA=#,VGA=#,AMP=#?
         r = SoapySDRDevice_setGainElement(dev, SOAPY_SDR_RX, 0, "LNA", 40.); // max 40
         if (r != 0) {
-            fprintf(stderr, "WARNING: Failed to set LNA tuner gain.\n");
+            print_log(LOG_WARNING, __func__, "Failed to set LNA tuner gain.");
         }
         r = SoapySDRDevice_setGainElement(dev, SOAPY_SDR_RX, 0, "VGA", 20.); // max 65
         if (r != 0) {
-            fprintf(stderr, "WARNING: Failed to set VGA tuner gain.\n");
+            print_log(LOG_WARNING, __func__, "Failed to set VGA tuner gain.");
         }
         r = SoapySDRDevice_setGainElement(dev, SOAPY_SDR_RX, 0, "AMP", 0.); // on or off
         if (r != 0) {
-            fprintf(stderr, "WARNING: Failed to set AMP tuner gain.\n");
+            print_log(LOG_WARNING, __func__, "Failed to set AMP tuner gain.");
         }
 
     }
@@ -706,11 +706,11 @@ static int soapysdr_gain_str_set(SoapySDRDevice *dev, char const *gain_str, int 
     if (r) {
         r = SoapySDRDevice_setGainMode(dev, SOAPY_SDR_RX, 0, 0);
         if (r != 0) {
-            fprintf(stderr, "WARNING: Failed to disable automatic gain.\n");
+            print_log(LOG_WARNING, __func__, "Failed to disable automatic gain.");
         }
         else {
             if (verbose)
-                fprintf(stderr, "Tuner set to manual gain.\n");
+                print_log(LOG_NOTICE, "SDR", "Tuner set to manual gain.");
         }
     }
 
@@ -725,10 +725,10 @@ static int soapysdr_gain_str_set(SoapySDRDevice *dev, char const *gain_str, int 
         while (getkwargs(&gain_p, &name, &value)) {
             double num = atof(value);
             if (verbose)
-                fprintf(stderr, "Setting gain element %s: %f dB\n", name, num);
+                print_logf(LOG_NOTICE, "SDR", "Setting gain element %s: %f dB", name, num);
             r = SoapySDRDevice_setGainElement(dev, SOAPY_SDR_RX, 0, name, num);
             if (r != 0) {
-                fprintf(stderr, "WARNING: setGainElement(%s, %f) failed: %d\n", name, num, r);
+                print_logf(LOG_WARNING, __func__, "setGainElement(%s, %f) failed: %d", name, num, r);
             }
         }
     }
@@ -737,11 +737,11 @@ static int soapysdr_gain_str_set(SoapySDRDevice *dev, char const *gain_str, int 
         double value = atof(gain_str);
         r = SoapySDRDevice_setGain(dev, SOAPY_SDR_RX, 0, value);
         if (r != 0) {
-            fprintf(stderr, "WARNING: Failed to set tuner gain.\n");
+            print_log(LOG_WARNING, __func__, "Failed to set tuner gain.");
         }
         else {
             if (verbose)
-                fprintf(stderr, "Tuner gain set to %0.2f dB.\n", value);
+                print_logf(LOG_NOTICE, __func__, "Tuner gain set to %0.2f dB.", value);
         }
         // read back and print each individual gain element
         if (verbose) {
@@ -871,7 +871,7 @@ static int sdr_open_soapy(sdr_dev_t **out_dev, char const *dev_query, int verbos
     dev->soapy_dev = SoapySDRDevice_makeStrArgs(dev_query);
     if (!dev->soapy_dev) {
         if (verbose)
-            fprintf(stderr, "Failed to open sdr device matching '%s'.\n", dev_query);
+            print_logf(LOG_ERROR, __func__, "Failed to open sdr device matching '%s'.", dev_query);
         free(dev);
         return -1;
     }
@@ -939,7 +939,7 @@ static int sdr_open_soapy(sdr_dev_t **out_dev, char const *dev_query, int verbos
 #endif
     if (r != 0) {
         if (verbose)
-            fprintf(stderr, "Failed to setup sdr device\n");
+            print_log(LOG_ERROR, __func__, "Failed to setup sdr device");
         free(dev);
         return -3;
     }
@@ -993,7 +993,7 @@ static int soapysdr_read_loop(sdr_dev_t *dev, sdr_event_cb_t cb, void *ctx, uint
                 fflush(stderr);
                 continue;
             }
-            fprintf(stderr, "WARNING: sync read failed. %d\n", r);
+            print_logf(LOG_WARNING, __func__, "sync read failed. %d", r);
         }
 
         // convert to CS16 or CU8 if needed
@@ -1040,7 +1040,7 @@ int sdr_open(sdr_dev_t **out_dev, char const *dev_query, int verbose)
 
 #if !defined(RTLSDR) && !defined(SOAPYSDR)
     if (verbose)
-        fprintf(stderr, "No input drivers (RTL-SDR or SoapySDR) compiled in.\n");
+        print_log(LOG_ERROR, __func__, "No input drivers (RTL-SDR or SoapySDR) compiled in.");
     return -1;
 #endif
 
@@ -1049,7 +1049,7 @@ int sdr_open(sdr_dev_t **out_dev, char const *dev_query, int verbose)
 #ifdef RTLSDR
         return sdr_open_rtl(out_dev, dev_query, verbose);
 #else
-        fprintf(stderr, "No input driver for RTL-SDR compiled in.\n");
+        print_log(LOG_ERROR, __func__, "No input driver for RTL-SDR compiled in.");
         return -1;
 #endif
     }
@@ -1062,7 +1062,7 @@ int sdr_open(sdr_dev_t **out_dev, char const *dev_query, int verbose)
     /* Open SoapySDR otherwise, if available */
     return sdr_open_soapy(out_dev, dev_query, verbose);
 #endif
-    fprintf(stderr, "No input driver for SoapySDR compiled in.\n");
+    print_log(LOG_ERROR, __func__, "No input driver for SoapySDR compiled in.");
 
     return -1;
 }
@@ -1153,9 +1153,9 @@ int sdr_set_center_freq(sdr_dev_t *dev, uint32_t freq, int verbose)
 
     if (verbose) {
         if (r < 0)
-            fprintf(stderr, "WARNING: Failed to set center freq.\n");
+            print_log(LOG_WARNING, __func__, "Failed to set center freq.");
         else
-            fprintf(stderr, "Tuned to %s.\n", nice_freq(sdr_get_center_freq(dev)));
+            print_logf(LOG_NOTICE, "SDR", "Tuned to %s.", nice_freq(sdr_get_center_freq(dev)));
     }
     return r;
 }
@@ -1216,9 +1216,9 @@ int sdr_set_freq_correction(sdr_dev_t *dev, int ppm, int verbose)
 
     if (verbose) {
         if (r < 0)
-            fprintf(stderr, "WARNING: Failed to set frequency correction.\n");
+            print_log(LOG_WARNING, __func__, "Failed to set frequency correction.");
         else
-            fprintf(stderr, "Frequency correction set to %d ppm.\n", ppm);
+            print_logf(LOG_NOTICE, "SDR", "Frequency correction set to %d ppm.", ppm);
     }
     return r;
 }
@@ -1256,9 +1256,9 @@ int sdr_set_auto_gain(sdr_dev_t *dev, int verbose)
 
     if (verbose) {
         if (r < 0)
-            fprintf(stderr, "WARNING: Failed to enable automatic gain.\n");
+            print_log(LOG_WARNING, __func__, "Failed to enable automatic gain.");
         else
-            fprintf(stderr, "Tuner gain set to Auto.\n");
+            print_log(LOG_NOTICE, "SDR", "Tuner gain set to Auto.");
     }
     return r;
 }
@@ -1315,16 +1315,16 @@ int sdr_set_tuner_gain(sdr_dev_t *dev, char const *gain_str, int verbose)
     r = rtlsdr_set_tuner_gain_mode(dev->rtlsdr_dev, 1);
     if (verbose)
         if (r < 0)
-            fprintf(stderr, "WARNING: Failed to enable manual gain.\n");
+            print_log(LOG_WARNING, __func__, "Failed to enable manual gain.");
 
     /* Set the tuner gain */
     gain = rtlsdr_find_tuner_gain(dev, gain, verbose);
     r = rtlsdr_set_tuner_gain(dev->rtlsdr_dev, gain);
     if (verbose) {
         if (r < 0)
-            fprintf(stderr, "WARNING: Failed to set tuner gain.\n");
+            print_log(LOG_WARNING, __func__, "Failed to set tuner gain.");
         else
-            fprintf(stderr, "Tuner gain set to %f dB.\n", gain / 10.0);
+            print_logf(LOG_NOTICE, "SDR", "Tuner gain set to %f dB.", gain / 10.0);
     }
 #endif
 
@@ -1348,11 +1348,11 @@ int sdr_set_antenna(sdr_dev_t *dev, char const *antenna_str, int verbose)
 
         if (verbose) {
             if (r < 0)
-                fprintf(stderr, "WARNING: Failed to set antenna.\n");
+                print_log(LOG_WARNING, __func__, "Failed to set antenna.");
 
             // report the antenna that is actually used
             char *antenna = SoapySDRDevice_getAntenna(dev->soapy_dev, SOAPY_SDR_RX, 0);
-            fprintf(stderr, "Antenna set to '%s'.\n", antenna);
+            print_logf(LOG_NOTICE, "SDR", "Antenna set to '%s'.", antenna);
             free(antenna);
         }
         return r;
@@ -1360,7 +1360,7 @@ int sdr_set_antenna(sdr_dev_t *dev, char const *antenna_str, int verbose)
 #endif
 
   // currently only SoapySDR supports devices with multiple antennas
-  fprintf(stderr, "WARNING: Antenna selection only available for SoapySDR devices\n");
+  print_log(LOG_WARNING, __func__, "Antenna selection only available for SoapySDR devices");
 
   return r;
 }
@@ -1399,9 +1399,9 @@ int sdr_set_sample_rate(sdr_dev_t *dev, uint32_t rate, int verbose)
 
     if (verbose) {
         if (r < 0)
-            fprintf(stderr, "WARNING: Failed to set sample rate.\n");
+            print_log(LOG_WARNING, __func__, "Failed to set sample rate.");
         else
-            fprintf(stderr, "Sample rate set to %u S/s.\n", sdr_get_sample_rate(dev)); // Unfortunately, doesn't return real rate
+            print_logf(LOG_NOTICE, "SDR", "Sample rate set to %u S/s.", sdr_get_sample_rate(dev)); // Unfortunately, doesn't return real rate
     }
     return r;
 }
@@ -1459,7 +1459,7 @@ int sdr_apply_settings(sdr_dev_t *dev, char const *sdr_settings, int verbose)
                 r = rtltcp_command(dev, RTLTCP_SET_BIAS_TEE, biastee);
             }
             else {
-                fprintf(stderr, "Unknown rtl_tcp setting: %s\n", sdr_settings);
+                print_logf(LOG_ERROR, __func__, "Unknown rtl_tcp setting: %s", sdr_settings);
                 return -1;
             }
             sdr_settings = kwargs_skip(sdr_settings);
@@ -1474,24 +1474,24 @@ int sdr_apply_settings(sdr_dev_t *dev, char const *sdr_settings, int verbose)
             const char *key   = settings.keys[i];
             const char *value = settings.vals[i];
             if (verbose)
-                fprintf(stderr, "Setting %s to %s\n", key, value);
+                print_logf(LOG_NOTICE, "SDR", "Setting %s to %s", key, value);
             if (!strcmp(key, "antenna")) {
                 if (SoapySDRDevice_setAntenna(dev->soapy_dev, SOAPY_SDR_RX, 0, value) != 0) {
                     r = -1;
-                    fprintf(stderr, "WARNING: Antenna setting failed: %s\n", SoapySDRDevice_lastError());
+                    print_logf(LOG_WARNING, __func__, "Antenna setting failed: %s", SoapySDRDevice_lastError());
                 }
             }
             else if (!strcmp(key, "bandwidth")) {
                 uint32_t f_value = atouint32_metric(value, "-t bandwidth= ");
                 if (SoapySDRDevice_setBandwidth(dev->soapy_dev, SOAPY_SDR_RX, 0, (double)f_value) != 0) {
                     r = -1;
-                    fprintf(stderr, "WARNING: Bandwidth setting failed: %s\n", SoapySDRDevice_lastError());
+                    print_logf(LOG_WARNING, __func__, "Bandwidth setting failed: %s", SoapySDRDevice_lastError());
                 }
             }
             else {
                 if (SoapySDRDevice_writeSetting(dev->soapy_dev, key, value) != 0) {
                     r = -1;
-                    fprintf(stderr, "WARNING: sdr setting failed: %s\n", SoapySDRDevice_lastError());
+                    print_logf(LOG_WARNING, __func__, "sdr setting failed: %s", SoapySDRDevice_lastError());
                 }
             }
         }
@@ -1521,7 +1521,7 @@ int sdr_apply_settings(sdr_dev_t *dev, char const *sdr_settings, int verbose)
 #if defined(__linux__) && (defined(__GNUC__) || defined(__clang__))
                 // check weak link for Linux with older rtlsdr
                 if (!rtlsdr_set_bias_tee) {
-                    fprintf(stderr, "This librtlsdr version does not support biastee setting\n");
+                    print_log(LOG_ERROR, __func__, "This librtlsdr version does not support biastee setting");
                     return -1;
                 }
 #endif
@@ -1529,7 +1529,7 @@ int sdr_apply_settings(sdr_dev_t *dev, char const *sdr_settings, int verbose)
                 r = rtlsdr_set_bias_tee(dev->rtlsdr_dev, biastee);
             }
             else {
-                fprintf(stderr, "Unknown RTLSDR setting: %s\n", sdr_settings);
+                print_logf(LOG_ERROR, __func__, "Unknown RTLSDR setting: %s", sdr_settings);
                 return -1;
             }
             sdr_settings = kwargs_skip(sdr_settings);
@@ -1538,7 +1538,7 @@ int sdr_apply_settings(sdr_dev_t *dev, char const *sdr_settings, int verbose)
     }
 #endif
 
-    fprintf(stderr, "WARNING: sdr settings not available.\n"); // no open device
+    print_log(LOG_WARNING, __func__, "sdr settings not available."); // no open device
 
     return -1;
 }
@@ -1551,7 +1551,7 @@ int sdr_activate(sdr_dev_t *dev)
 #ifdef SOAPYSDR
     if (dev->soapy_dev) {
         if (SoapySDRDevice_activateStream(dev->soapy_dev, dev->soapy_stream, 0, 0, 0) != 0) {
-            fprintf(stderr, "Failed to activate stream\n");
+            print_log(LOG_ERROR, __func__, "Failed to activate stream");
             exit(1);
         }
     }
@@ -1589,7 +1589,7 @@ int sdr_reset(sdr_dev_t *dev, int verbose)
 
     if (verbose) {
         if (r < 0)
-            fprintf(stderr, "WARNING: Failed to reset buffers.\n");
+            print_log(LOG_WARNING, __func__, "Failed to reset buffers.");
     }
     return r;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ target_link_libraries(data-test data)
 
 add_test(data-test data-test)
 
-add_executable(baseband-test baseband-test.c ../src/baseband.c)
+add_executable(baseband-test baseband-test.c ../src/baseband.c ../src/logger.c)
 
 if(UNIX)
 target_link_libraries(baseband-test m)


### PR DESCRIPTION
Changes most `fprintf()`s to log prints.

More work is needed to convert remaining `fprintf()`s and adjust levels and messages. But this should be a good starting point.

Generally I found that normal messages should use a module name (Title Case) as source to be user friendly and abnormal messages should use the function name (`__func__`) for easier debugging.

Note that this might break scripts that string match on messages.