### PR TITLE
Add support for new revision of Govee H5054 water leak detector

### DIFF
--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -231,6 +231,7 @@
     DECL(fineoffset_wn34) \
     DECL(rubicson_pool_48942) \
     DECL(badger_orion) \
+    DECL(govee_h5054)
 
     /* Add new decoders here. */
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -231,7 +231,7 @@
     DECL(fineoffset_wn34) \
     DECL(rubicson_pool_48942) \
     DECL(badger_orion) \
-    DECL(govee_h5054)
+    DECL(govee_h5054) \
 
     /* Add new decoders here. */
 

--- a/src/devices/govee.c
+++ b/src/devices/govee.c
@@ -280,7 +280,7 @@ Event Information:
 
     When the first leak occurs, E=2 D=00. This value is transmitted once very 5 seconds
     until the leak is cleared (sensor dried off). The next leak events will be:
-    
+
     E=2, D=01
     E=2, D=02
     E=2, D=03
@@ -292,7 +292,7 @@ The CRC was determined by using the tool CRC RevEng: https://reveng.sourceforge.
 
     ./reveng -w16 -s aaaaaaaaaaaa bbbbbbbbbbbb etc...
 
-where aaaaaaaaaaaa, bbbbbbbbbbbb, etc... were the unique codes collected from the 
+where aaaaaaaaaaaa, bbbbbbbbbbbb, etc... were the unique codes collected from the
 device.
 
 */
@@ -302,7 +302,6 @@ typedef enum {
     GOVEE_BATTERY_REPORT = 1,
     GOVEE_WATER_LEAK     = 2,
 } govee_h5054_event_t;
-
 
 static int govee_h5054_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {

--- a/src/devices/govee.c
+++ b/src/devices/govee.c
@@ -255,12 +255,15 @@ r_device govee = {
 /**
 Govee Water Leak Detector H5054
 
+This is an updated decoder for devices with board versions dated circa 2021 as originally
+reported in issue #2265.
+
 Data layout:
 
     II II XE DD CC CC
 
 - I: 16 bit ID, does not change with battery change
-- X: 4 bit, always 0x3 for the 5 sensors testsed
+- X: 4 bit, always 0x3 for the sensors evaluated
 - E: 4 bit event type
 - D: 8 bit event data
 - C: CRC-16/AUG-CCITT, poly=0x1021, init=0x1d0f
@@ -269,7 +272,7 @@ Data layout:
 Event Information:
 
 - 0x0 : Button Press
-  - The event data (DD) is always 0x54 for the 5 sensors evaluated. Unknown meaning.
+  - The event data (DD) is always 0x54 for the sensors evaluated. Unknown meaning.
 - 0x1 : Battery Report
   - The event data (DD) reported for new batteries = 0x64 (decimal 100). When inserting
     older batteries, this value decreased. Looking at prior versions of the device,


### PR DESCRIPTION
This adds support for the updated protocol used by newer revisions of the Govee H5054 water leak detector.

Closes #2265