### PR TITLE
Add support for Oil-SonicSmart

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [232]  TFA Dostmann 14.1504.V2 Radio-controlled grill and meat thermometer
     [233]* CED7000 Shot Timer
     [234]  Watchman Sonic Advanced / Plus
+    [235]  Oil Ultrasonic SMART FSK
 
 * Disabled by default, use -R n or a conf file to enable
 

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -456,6 +456,7 @@ stop_after_successful_events false
   protocol 232 # TFA Dostmann 14.1504.V2 Radio-controlled grill and meat thermometer
 # protocol 233 # CED7000 Shot Timer
   protocol 234 # Watchman Sonic Advanced / Plus
+  protocol 235 # Oil Ultrasonic SMART FSK
 
 ## Flex devices (command line option "-X")
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -242,6 +242,7 @@
     DECL(tfa_14_1504_v2) \
     DECL(ced7000) \
     DECL(oil_watchman_advanced) \
+    DECL(oil_smart) \
 
     /* Add new decoders here. */
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -170,6 +170,7 @@ add_library(r_433 STATIC
     devices/nexus.c
     devices/nice_flor_s.c
     devices/norgo.c
+    devices/oil_smart.c
     devices/oil_standard.c
     devices/oil_watchman.c
     devices/oil_watchman_advanced.c

--- a/src/devices/oil_smart.c
+++ b/src/devices/oil_smart.c
@@ -1,0 +1,144 @@
+/** @file
+    Oil tank monitor using manchester encoded FSK protocol with CRC.
+
+    Copyright (C) 2022 Christian W. Zuckschwerdt <zany@triq.net>
+    Device analysis by StarMonkey1
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#include "decoder.h"
+
+/**
+Oil tank monitor using manchester encoded FSK protocol with CRC.
+
+Tested devices:
+- Apollo Ultrasonic Smart liquid monitor (FSK, 433.92M) Issue #2244
+
+Should apply to similar Watchman, Beckett, and Apollo devices too.
+
+There is a preamble plus de-sync of 555558, then MC coded an inner preamble of 5558 (raw 9999996a).
+End of frame is the last half-bit repeated additional 2 times, then 4 times mark.
+
+The sensor sends a single packet once every half hour or twice a second
+for 5 minutes when in pairing/test mode.
+
+Depth reading is in cm, lowest reading is unknown, highest is unknown, invalid is unknown.
+
+Data Format:
+
+    PRE?16h ID?16h FLAGS?16h CM:8d CRC:8h
+
+Data Layout:
+
+    PP PP II II FF CC DD XX
+
+- P: 16 bit Preamble of 0x5558
+- I: 16 bit Sensor ID
+- F: 8 bit Flags maybe
+- C: 8 bit Counter maybe
+- D: 8 bit Depth in cm, could have a MSB somewhere?
+- X: 8 bit CRC-8, poly 0x31 init 0x00, bit reflected
+
+example packets are:
+
+- raw: {158}555558 9999 996a 6559aaa99996a55696a9a5963c
+- aligned: {134}9999996a 6559aaa999969aa6aa9a6995 fc
+- decoded: 5558 bd01 5642 0497
+
+TODO: this is not confirmed
+Start of frame full preamble is depending on first data bit either
+
+    0101 0101 0101 0101 0101 0111 01
+    0101 0101 0101 0101 0101 1000 10
+*/
+static int oil_smart_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
+{
+    bitbuffer_t databits = {0};
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &databits, 64);
+
+    if (databits.bits_per_row[0] < 64) {
+        return 0; // DECODE_ABORT_LENGTH; // TODO: fix calling code to handle negative return values
+    }
+
+    uint8_t *b = databits.bb[0];
+
+    if (b[0] != 0x55 || b[1] != 0x58) {
+        decoder_log(decoder, 2, __func__, "Couldn't find preamble");
+        return 0; // DECODE_FAIL_SANITY; // TODO: fix calling code to handle negative return values
+    }
+
+    if (crc8le(b, 8, 0x31, 0x00)) {
+        decoder_log(decoder, 2, __func__, "CRC8 fail");
+        return 0; // DECODE_FAIL_MIC; // TODO: fix calling code to handle negative return values
+    }
+
+    // We do not know if the unit ID changes when you rebind
+    // by holding a magnet to the sensor for long enough?
+    uint16_t unit_id = (b[2] << 8) | b[3];
+
+    // TODO: none of these are identified.
+    uint8_t unknown1 = b[4]; // idle seems to be 0x17
+    uint8_t unknown2 = b[5]; // appears to change variously to: 0c 0e 10 12
+
+    // TODO: the value for a bad reading has not been found?
+    // TODO: there could be more (MSB) bits to this?
+    uint16_t depth = b[6];
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",                "", DATA_STRING, "Oil-Ultrasonic",
+            "id",                   "", DATA_FORMAT, "%04x", DATA_INT, unit_id,
+            "depth_cm",             "", DATA_INT,    depth,
+            "unknown1",             "", DATA_FORMAT, "%02x", DATA_INT, unknown1,
+            "unknown2",             "", DATA_FORMAT, "%02x", DATA_INT, unknown2,
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+/**
+Oil tank monitor using manchester encoded FSK protocol with CRC.
+@sa oil_smart_decode()
+*/
+static int oil_smart_callback(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    uint8_t const preamble_pattern[2] = {0x55, 0x58};
+    // End of frame is the last half-bit repeated additional 2 times, then 4 times mark.
+
+    unsigned bitpos = 0;
+    int events      = 0;
+
+    // Find a preamble with enough bits after it that it could be a complete packet
+    while ((bitpos = bitbuffer_search(bitbuffer, 0, bitpos, preamble_pattern, 16)) + 128 <=
+            bitbuffer->bits_per_row[0]) {
+        events += oil_smart_decode(decoder, bitbuffer, 0, bitpos + 16);
+        bitpos += 2;
+    }
+
+    return events;
+}
+
+static char *output_fields[] = {
+        "model",
+        "id",
+        "depth_cm",
+        "unknown1",
+        "unknown2",
+        NULL,
+};
+
+r_device const oil_smart = {
+        .name        = "Oil Ultrasonic SMART FSK",
+        .modulation  = FSK_PULSE_PCM,
+        .short_width = 500,
+        .long_width  = 500,
+        .reset_limit = 2000,
+        .decode_fn   = &oil_smart_callback,
+        .fields      = output_fields,
+};

--- a/src/devices/oil_standard.c
+++ b/src/devices/oil_standard.c
@@ -1,12 +1,6 @@
 /** @file
     Oil tank monitor using manchester encoded FSK/ASK protocol.
 
-    Tested devices:
-    - APOLLO ULTRASONIC STANDARD (maybe also VISUAL but not SMART, FSK)
-    - Tekelek TEK377E (E: European, A: American version)
-    - Beckett Rocket TEK377A (915MHz, ASK)
-    Should apply to similar Watchman, Beckett, and Apollo devices too.
-
     Copyright (C) 2017 Christian W. Zuckschwerdt <zany@triq.net>
     based on code Copyright (C) 2015 David Woodhouse
 
@@ -20,6 +14,13 @@
 
 /**
 Oil tank monitor using manchester encoded FSK/ASK protocol.
+
+Tested devices:
+- APOLLO ULTRASONIC STANDARD (maybe also VISUAL but not SMART, FSK)
+- Tekelek TEK377E (E: European, A: American version)
+- Beckett Rocket TEK377A (915MHz, ASK)
+
+Should apply to similar Watchman, Beckett, and Apollo devices too.
 
 The sensor sends a single packet once every hour or twice a second
 for 11 minutes when in pairing/test mode (pairing needs 35 sec).
@@ -41,25 +42,17 @@ Start of frame full preamble is depending on first data bit either
 */
 static int oil_standard_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
-    data_t *data;
-    uint8_t *b;
-    uint16_t unit_id;
-    uint16_t depth             = 0;
-    uint16_t binding_countdown = 0;
-    uint8_t flags;
-    uint8_t alarm;
     bitbuffer_t databits = {0};
-
-    bitpos = bitbuffer_manchester_decode(bitbuffer, row, bitpos, &databits, 41);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &databits, 41);
 
     if (databits.bits_per_row[0] < 32 || databits.bits_per_row[0] > 40 || (databits.bb[0][4] & 0xfe) != 0)
         return 0; // TODO: fix calling code to handle negative return values
 
-    b = databits.bb[0];
+    uint8_t *b = databits.bb[0];
 
     // The unit ID changes when you rebind by holding a magnet to the
     // sensor for long enough.
-    unit_id = (b[0] << 8) | b[1];
+    uint16_t unit_id = (b[0] << 8) | b[1];
 
     // 0x01: Rebinding (magnet held to sensor)
     // 0x02: High-bit for depth
@@ -69,22 +62,26 @@ static int oil_standard_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     // 0x20: (unknown toggle)
     // 0x40: (unknown toggle)
     // 0x80: (always zero?)
-    flags = b[2] & ~0x0A;
-    alarm = (b[2] & 0x08) >> 3;
+    uint8_t flags = b[2] & ~0x0A;
+    uint8_t alarm = (b[2] & 0x08) >> 3;
 
-    if (flags & 1)
+    uint16_t depth             = 0;
+    uint16_t binding_countdown = 0;
+    if (flags & 1) {
         // When binding, the countdown counts up from 0x40 to 0x4a
         // (as long as you hold the magnet to it for long enough)
         // before the device ID changes. The receiver unit needs
         // to receive this *strongly* in order to change its
         // allegiance.
         binding_countdown = b[3];
-    else
+    }
+    else {
         // A depth reading of zero indicates no reading.
         depth = ((b[2] & 0x02) << 7) | b[3];
+    }
 
     /* clang-format off */
-    data = data_make(
+    data_t *data = data_make(
             "model",                "", DATA_STRING, "Oil-SonicStd",
             "id",                   "", DATA_FORMAT, "%04x", DATA_INT, unit_id,
             "flags",                "", DATA_FORMAT, "%02x", DATA_INT, flags,

--- a/src/devices/oil_watchman.c
+++ b/src/devices/oil_watchman.c
@@ -8,15 +8,16 @@
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
 */
+
+#include "decoder.h"
+
 /**
 Oil tank monitor using Si4320 framed FSK protocol.
 
 Tested devices:
 - Sensor Systems Watchman Sonic
 */
-#include "decoder.h"
-
-static int oil_watchman_callback(r_device *decoder, bitbuffer_t *bitbuffer)
+static int oil_watchman_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     // Start of frame preamble is 111000xx
     uint8_t const preamble_pattern[] = {0xe0};
@@ -24,16 +25,7 @@ static int oil_watchman_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     // End of frame is 00xxxxxx or 11xxxxxx depending on final data bit
     uint8_t const postamble_pattern[2] = {0x00, 0xc0};
 
-    uint8_t *b;
-    uint32_t unit_id;
-    uint16_t depth             = 0;
-    uint16_t binding_countdown = 0;
-    uint8_t flags;
-    uint8_t maybetemp;
-    double temperature;
-    data_t *data;
     unsigned bitpos      = 0;
-    bitbuffer_t databits = {0};
     int events           = 0;
 
     // Find a preamble with enough bits after it that it could be a complete packet
@@ -43,11 +35,12 @@ static int oil_watchman_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         // Skip the matched preamble bits to point to the data
         bitpos += 6;
 
+        bitbuffer_t databits = {0};
         bitpos = bitbuffer_manchester_decode(bitbuffer, 0, bitpos, &databits, 64);
         if (databits.bits_per_row[0] != 64)
             continue; // DECODE_ABORT_LENGTH
 
-        b = databits.bb[0];
+        uint8_t *b = databits.bb[0];
 
         // Check for postamble, depending on last data bit
         if (bitbuffer_search(bitbuffer, 0, bitpos, &postamble_pattern[b[7] & 1], 2) != bitpos)
@@ -58,31 +51,36 @@ static int oil_watchman_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         // The unit ID changes when you rebind by holding a magnet to the
         // sensor for long enough; it seems to be time-based.
-        unit_id = ((unsigned)b[0] << 24) | (b[1] << 16) | (b[2] << 8) | b[3];
+        uint32_t unit_id = ((unsigned)b[0] << 24) | (b[1] << 16) | (b[2] << 8) | b[3];
 
         // 0x01: Rebinding (magnet held to sensor)
         // 0x08: Leak/theft alarm
         // top three bits seem also to vary with temperature (independently of maybetemp)
-        flags = b[4];
+        uint8_t flags = b[4];
 
         // Not entirely sure what this is but it might be inversely
         // proportional to temperature.
-        maybetemp   = b[5] >> 2;
-        temperature = (double)(145.0 - 5.0 * maybetemp) / 3.0;
-        if (flags & 1)
+        uint8_t maybetemp  = b[5] >> 2;
+        double temperature = (double)(145.0 - 5.0 * maybetemp) / 3.0;
+
+        uint16_t depth             = 0;
+        uint16_t binding_countdown = 0;
+        if (flags & 1) {
             // When binding, the countdown counts up from 0x51 to 0x5a
             // (as long as you hold the magnet to it for long enough)
             // before the device ID changes. The receiver unit needs
             // to receive this *strongly* in order to change its
             // allegiance.
             binding_countdown = b[6];
-        else
+        }
+        else {
             // A depth reading of zero indicates no reading. Even with
             // the sensor flat down on a table, it still reads about 13.
             depth = ((b[5] & 3) << 8) | b[6];
+        }
 
         /* clang-format off */
-        data = data_make(
+        data_t *data = data_make(
                 "model",                "", DATA_STRING, "Oil-SonicSmart",
                 "id",                   "", DATA_FORMAT, "%06x", DATA_INT, unit_id,
                 "flags",                "", DATA_FORMAT, "%02x", DATA_INT, flags,
@@ -116,6 +114,6 @@ r_device const oil_watchman = {
         .short_width = 1000,
         .long_width  = 1000, // NRZ
         .reset_limit = 4000,
-        .decode_fn   = &oil_watchman_callback,
+        .decode_fn   = &oil_watchman_decode,
         .fields      = output_fields,
 };


### PR DESCRIPTION
See #2244

Open questions:

- [ ] How long does the pairing/test mode last? (the captures are only 30 secs).
- [ ] What is the stated range of depth readings? Esp. is the maximum over 255?
- [ ] What triggered the pairing/test mode? A magent like for other sensors?
- [ ] Does the unit ID change when you rebind by holding a magnet to the sensor for long enough?
- [ ] Can you simulate alarms like Leak/theft alarm?
- [ ] Confirm the binding counter, i.e. something that's only active in test mode.
- [ ] I.e. does the counter stop when the magnet is removed?
- [ ] Is there an error flag for "no reading"?
