### PR TITLE
Add ANSI colors for Windows 10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,7 +272,7 @@ endif()
 # Setup the include and linker paths
 ########################################################################
 if(MINGW OR MSVC)
-list(APPEND NET_LIBRARIES ws2_32 mswsock)
+list(APPEND NET_LIBRARIES ws2_32 mswsock netapi32)
 endif()
 
 include_directories(

--- a/src/term_ctl.c
+++ b/src/term_ctl.c
@@ -24,6 +24,7 @@
 #include <io.h>
 #include <limits.h>
 #include <windows.h>
+#include <lm.h>
 
 #ifndef STDOUT_FILENO
 #define STDOUT_FILENO   1
@@ -40,6 +41,7 @@
 typedef struct console {
     CONSOLE_SCREEN_BUFFER_INFO info;
     BOOL                       redirected;
+    BOOL                       ansi;
     HANDLE                     hnd;
     FILE                      *file;
     WORD                       fg, bg;
@@ -47,11 +49,12 @@ typedef struct console {
 
 static WORD _term_get_win_color(BOOL fore, term_color_t color)
 {
+    // applies intensity only on foreground,
+    // i.e. background will fallback to dim
     switch (color) {
        case TERM_COLOR_RESET: /* Cannot occur; just to suppress a warning */
             break;
        case TERM_COLOR_BLACK:
-       case TERM_COLOR_BRIGHT_BLACK:
             return (0);
        case TERM_COLOR_BLUE:
             return (1);
@@ -67,20 +70,22 @@ static WORD _term_get_win_color(BOOL fore, term_color_t color)
             return (6);
        case TERM_COLOR_WHITE:
             return (7);
+       case TERM_COLOR_BRIGHT_BLACK:
+            return (fore ? 0 + FOREGROUND_INTENSITY : 0);
        case TERM_COLOR_BRIGHT_BLUE:
-            return (1 + FOREGROUND_INTENSITY);
+            return (fore ? 1 + FOREGROUND_INTENSITY : 1);
        case TERM_COLOR_BRIGHT_GREEN:
-            return (2 + FOREGROUND_INTENSITY);
+            return (fore ? 2 + FOREGROUND_INTENSITY : 2);
        case TERM_COLOR_BRIGHT_CYAN:
-            return (3 + FOREGROUND_INTENSITY);
+            return (fore ? 3 + FOREGROUND_INTENSITY : 3);
        case TERM_COLOR_BRIGHT_RED:
-            return (4 + FOREGROUND_INTENSITY);
+            return (fore ? 4 + FOREGROUND_INTENSITY : 4);
        case TERM_COLOR_BRIGHT_MAGENTA:
-            return (5 + FOREGROUND_INTENSITY);
+            return (fore ? 5 + FOREGROUND_INTENSITY : 5);
        case TERM_COLOR_BRIGHT_YELLOW:
-            return (6 + FOREGROUND_INTENSITY);
+            return (fore ? 6 + FOREGROUND_INTENSITY : 6);
        case TERM_COLOR_BRIGHT_WHITE:
-            return (7 + FOREGROUND_INTENSITY);
+            return (fore ? 7 + FOREGROUND_INTENSITY : 7);
     }
     fprintf(stderr,"FATAL: No mapping for TERM_COLOR_x=%d (fore: %d)\n", color, fore);
     return (0);
@@ -100,7 +105,8 @@ static void _term_set_color(console_t *console, BOOL fore, term_color_t color)
     else if (fore) {
         console->fg = _term_get_win_color(TRUE, color);
     }
-    else if (color <= TERM_COLOR_WHITE) {
+    else if (color <= TERM_COLOR_WHITE ||
+            (color >= TERM_COLOR_BRIGHT_BLACK && color <= TERM_COLOR_BRIGHT_WHITE)) {
         console->bg = 16 * _term_get_win_color(FALSE, color);
     }
     else
@@ -159,6 +165,28 @@ static void *_term_init(FILE *fp)
     console->redirected = (console->hnd == INVALID_HANDLE_VALUE) ||
                          (!GetConsoleScreenBufferInfo(console->hnd, &console->info)) ||
                          (GetFileType(console->hnd) != FILE_TYPE_CHAR);
+
+    // Test for Windows 10 to enable ANSI output, needs netapi32.dll
+    LPWKSTA_INFO_100 pBuf = NULL;
+    NET_API_STATUS nStatus;
+    nStatus = NetWkstaGetInfo(NULL, 100, (LPBYTE *)&pBuf);
+    if (nStatus == NERR_Success) {
+        console->ansi = (pBuf->wki100_platform_id == 500) && (pBuf->wki100_ver_major >= 10);
+    }
+    if (pBuf != NULL) {
+        NetApiBufferFree(pBuf);
+    }
+
+    // Windows 10 version 1511 added ANSI filters to cmd and terminal.
+    // To use ANSI colors in Windows versions 1511 to 1903 requires setting VirtualTerminalLevel
+    // by calling the SetConsoleMode API with the ENABLE_VIRTUAL_TERMINAL_PROCESSING flag.
+    // ANSI colors are available by default in Windows version 1909 or newer
+    if (console->ansi) {
+        DWORD dwMode = 0;
+        GetConsoleMode(console->hnd, &dwMode);
+        dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+        SetConsoleMode(console->hnd, dwMode);
+    }
 
     _term_set_color(console, FALSE, TERM_COLOR_RESET); /* Set 'console->fg' and 'console->bg' */
 
@@ -236,7 +264,17 @@ void term_ring_bell(void *ctx)
 void term_set_fg(void *ctx, term_color_t color)
 {
 #ifdef _WIN32
-   _term_set_color(ctx, TRUE, color);
+    console_t *console = (console_t *)ctx;
+    if (console->ansi) {
+        FILE *fp = console->file;
+        if (color == TERM_COLOR_RESET)
+            fprintf(fp, "\033[0m");
+        else
+            fprintf(fp, "\033[%dm", color);
+    }
+    else {
+        _term_set_color(ctx, TRUE, color);
+    }
 #else
     FILE *fp = (FILE *)ctx;
     if (color == TERM_COLOR_RESET)
@@ -249,7 +287,17 @@ void term_set_fg(void *ctx, term_color_t color)
 void term_set_bg(void *ctx, term_color_t color)
 {
 #ifdef _WIN32
-    _term_set_color(ctx, FALSE, color);
+    console_t *console = (console_t *)ctx;
+    if (console->ansi) {
+       FILE *fp = console->file;
+       if (color == TERM_COLOR_RESET)
+           fprintf(fp, "\033[0m");
+       else
+           fprintf(fp, "\033[%dm", color + 10);
+    }
+    else {
+        _term_set_color(ctx, FALSE, color);
+    }
 #else
     FILE *fp = (FILE *)ctx;
     if (color == TERM_COLOR_RESET)


### PR DESCRIPTION
Runtime-detects Windows 10, if found switches to use ANSI colors.
This allows bright (intense) background colors. Fallback is to use dim background colors.