### PR TITLE
Add output log level options

### DIFF
--- a/include/data.h
+++ b/include/data.h
@@ -150,6 +150,7 @@ typedef struct data_output {
     void (R_API_CALLCONV *output_start)(struct data_output *output, char const *const *fields, int num_fields);
     void (R_API_CALLCONV *output_print)(struct data_output *output, data_t *data);
     void (R_API_CALLCONV *output_free)(struct data_output *output);
+    int log_level; ///< the maximum log level (verbosity) allowed, more verbose messages must be ignored.
 } data_output_t;
 
 /** Setup known field keys and start output, used by CSV only.

--- a/include/output_file.h
+++ b/include/output_file.h
@@ -21,10 +21,10 @@
     @return The auxiliary data to pass along with data_csv_printer to data_print.
             You must release this object with data_output_free once you're done with it.
 */
-struct data_output *data_output_csv_create(FILE *file);
+struct data_output *data_output_csv_create(int log_level, FILE *file);
 
-struct data_output *data_output_json_create(FILE *file);
+struct data_output *data_output_json_create(int log_level, FILE *file);
 
-struct data_output *data_output_kv_create(FILE *file);
+struct data_output *data_output_kv_create(int log_level, FILE *file);
 
 #endif /* INCLUDE_OUTPUT_FILE_H_ */

--- a/include/output_udp.h
+++ b/include/output_udp.h
@@ -14,6 +14,6 @@
 
 #include "data.h"
 
-struct data_output *data_output_syslog_create(const char *host, const char *port);
+struct data_output *data_output_syslog_create(int log_level, const char *host, const char *port);
 
 #endif /* INCLUDE_OUTPUT_UDP_H_ */

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -1242,6 +1242,7 @@ struct data_output *data_output_http_create(struct mg_mgr *mgr, char const *host
         return NULL;
     }
 
+    http->output.log_level    = LOG_TRACE; // sensible default, not parsed from args
     http->output.print_data   = print_http_data;
     http->output.output_free  = data_output_http_free;
 

--- a/src/output_file.c
+++ b/src/output_file.c
@@ -129,7 +129,7 @@ static void R_API_CALLCONV data_output_json_free(data_output_t *output)
     free(output);
 }
 
-struct data_output *data_output_json_create(FILE *file)
+struct data_output *data_output_json_create(int log_level, FILE *file)
 {
     data_output_json_t *json = calloc(1, sizeof(data_output_json_t));
     if (!json) {
@@ -137,6 +137,7 @@ struct data_output *data_output_json_create(FILE *file)
         return NULL; // NOTE: returns NULL on alloc failure.
     }
 
+    json->output.log_level    = log_level;
     json->output.print_data   = print_json_data;
     json->output.print_array  = print_json_array;
     json->output.print_string = print_json_string;
@@ -329,7 +330,7 @@ static void R_API_CALLCONV data_output_kv_free(data_output_t *output)
 
     free(output);
 }
-struct data_output *data_output_kv_create(FILE *file)
+struct data_output *data_output_kv_create(int log_level, FILE *file)
 {
     data_output_kv_t *kv = calloc(1, sizeof(data_output_kv_t));
     if (!kv) {
@@ -337,6 +338,7 @@ struct data_output *data_output_kv_create(FILE *file)
         return NULL; // NOTE: returns NULL on alloc failure.
     }
 
+    kv->output.log_level    = log_level;
     kv->output.print_data   = print_kv_data;
     kv->output.print_array  = print_kv_array;
     kv->output.print_string = print_kv_string;
@@ -546,7 +548,7 @@ static void R_API_CALLCONV data_output_csv_free(data_output_t *output)
     free(csv);
 }
 
-struct data_output *data_output_csv_create(FILE *file)
+struct data_output *data_output_csv_create(int log_level, FILE *file)
 {
     data_output_csv_t *csv = calloc(1, sizeof(data_output_csv_t));
     if (!csv) {
@@ -554,6 +556,7 @@ struct data_output *data_output_csv_create(FILE *file)
         return NULL; // NOTE: returns NULL on alloc failure.
     }
 
+    csv->output.log_level    = log_level;
     csv->output.print_data   = print_csv_data;
     csv->output.print_array  = print_csv_array;
     csv->output.print_string = print_csv_string;

--- a/src/output_udp.c
+++ b/src/output_udp.c
@@ -193,7 +193,7 @@ static void R_API_CALLCONV data_output_syslog_free(data_output_t *output)
     free(syslog);
 }
 
-struct data_output *data_output_syslog_create(const char *host, const char *port)
+struct data_output *data_output_syslog_create(int log_level, const char *host, const char *port)
 {
     data_output_syslog_t *syslog = calloc(1, sizeof(data_output_syslog_t));
     if (!syslog) {
@@ -210,6 +210,7 @@ struct data_output *data_output_syslog_create(const char *host, const char *port
     }
 #endif
 
+    syslog->output.log_level    = log_level;
     syslog->output.output_print = data_output_syslog_print;
     syslog->output.output_free  = data_output_syslog_free;
     // Severity 5 "Notice", Facility 20 "local use 4"

--- a/tests/data-test.c
+++ b/tests/data-test.c
@@ -37,9 +37,9 @@ int main(void)
 				 NULL);
 	const char *fields[] = { "label", "house_code", "temp", "array", "array2", "array3", "data", "house_code" };
 
-	void *json_output = data_output_json_create(stdout);
-	void *kv_output = data_output_kv_create(stdout);
-	void *csv_output = data_output_csv_create(stdout);
+	void *json_output = data_output_json_create(0, stdout);
+	void *kv_output = data_output_kv_create(0, stdout);
+	void *csv_output = data_output_csv_create(0, stdout);
 	data_output_start(csv_output, fields, sizeof fields / sizeof *fields);
 
 	data_output_print(json_output, data); fprintf(stdout, "\n");


### PR DESCRIPTION
Adds an option to all outputs to set a maximum log level to proccess.

E.g. interesting uses might be:
- `-F json,v=5` : print logs up to NOTICE as json
- `-F csv,v=8:out.csv` : log everything to a CSV file
- `-F kv,v=0`, disable all logging on console

Defaults are:
- `json`: `v=0`, log nothing
- `csv`: `v=0`, log nothing
- `kv`: `v=8`, log everything
- `syslog`: `v=4`, log CRITICAL, ERROR, WARNING only
- `http`: not configurable, the API offers all log levels

Preparation for #2254