### PR TITLE
Add support for selecting input channel if an SDR has more than one

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
   [-H <seconds>] Hop interval for polling of multiple frequencies (default: 600 seconds)
   [-p <ppm_error>] Correct rtl-sdr tuner frequency offset error (default: 0)
   [-s <sample rate>] Set sample rate (default: 250000 Hz)
+  [-N <channel number>] If the device supports more than one channel, then it may be sellected (default 0)
 		= Demodulator options =
   [-R <device> | help] Enable only the specified device decoding protocol (can be used multiple times)
        Specify a negative number to disable a device decoding protocol (can be used multiple times)

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -10,6 +10,7 @@
 #include <time.h>
 #include <signal.h>
 
+#define DEFAULT_CHANNEL         0
 #define DEFAULT_SAMPLE_RATE     250000
 #define DEFAULT_FREQUENCY       433920000
 #define DEFAULT_HOP_TIME        (60*10)
@@ -69,6 +70,7 @@ typedef struct r_cfg {
     time_t stop_time;
     int after_successful_events_flag;
     uint32_t samp_rate;
+    uint32_t channel;
     uint64_t input_pos;
     uint32_t bytes_to_read;
     struct sdr_dev *dev;

--- a/include/sdr.h
+++ b/include/sdr.h
@@ -47,7 +47,7 @@ typedef void (*sdr_event_cb_t)(sdr_event_t *ev, void *ctx);
     @param verbose the verbosity level for reports to stderr
     @return dev 0 if successful
 */
-int sdr_open(sdr_dev_t **out_dev, char const *dev_query, int verbose);
+int sdr_open(sdr_dev_t **out_dev, uint32_t channel, char const *dev_query, int verbose);
 
 /** Close the device.
 

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -146,6 +146,7 @@ void r_init_cfg(r_cfg_t *cfg)
 {
     cfg->out_block_size  = DEFAULT_BUF_LENGTH;
     cfg->samp_rate       = DEFAULT_SAMPLE_RATE;
+    cfg->channel         = DEFAULT_CHANNEL;
     cfg->conversion_mode = CONVERT_NATIVE;
     cfg->fsk_pulse_detect_mode = FSK_PULSE_DETECT_AUTO;
     // Default log level is to show all LOG_FATAL, LOG_ERROR, LOG_WARNING

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -151,6 +151,7 @@ static void usage(int exit_code)
             "  [-H <seconds>] Hop interval for polling of multiple frequencies (default: %i seconds)\n"
             "  [-p <ppm_error>] Correct rtl-sdr tuner frequency offset error (default: 0)\n"
             "  [-s <sample rate>] Set sample rate (default: %i Hz)\n"
+            "  [-N <channel number> If the device supports more than one channel, then it may be sellected (default %i)"
             "\t\t= Demodulator options =\n"
             "  [-R <device> | help] Enable only the specified device decoding protocol (can be used multiple times)\n"
             "       Specify a negative number to disable a device decoding protocol (can be used multiple times)\n"
@@ -185,7 +186,7 @@ static void usage(int exit_code)
             "  [-E hop | quit] Hop/Quit after outputting successful event(s)\n"
             "  [-h] Output this usage help and exit\n"
             "       Use -d, -g, -R, -X, -F, -M, -r, -w, or -W without argument for more help\n\n",
-            DEFAULT_FREQUENCY, DEFAULT_HOP_TIME, DEFAULT_SAMPLE_RATE);
+            DEFAULT_FREQUENCY, DEFAULT_HOP_TIME, DEFAULT_SAMPLE_RATE, DEFAULT_CHANNEL);
     exit(exit_code);
 }
 
@@ -746,7 +747,7 @@ static int hasopt(int test, int argc, char *argv[], char const *optstring)
 
 static void parse_conf_option(r_cfg_t *cfg, int opt, char *arg);
 
-#define OPTSTRING "hVvqDc:x:z:p:a:AI:S:m:M:r:w:W:l:d:t:f:H:g:s:b:n:R:X:F:K:C:T:UGy:E:Y:"
+#define OPTSTRING "hVvqDc:x:z:p:a:AI:S:m:M:r:w:W:l:d:t:f:H:g:s:N:b:n:R:X:F:K:C:T:UGy:E:Y:"
 
 // these should match the short options exactly
 static struct conf_keywords const conf_keywords[] = {
@@ -762,6 +763,7 @@ static struct conf_keywords const conf_keywords[] = {
         {"hop_interval", 'H'},
         {"ppm_error", 'p'},
         {"sample_rate", 's'},
+        {"channel", 'N'},
         {"protocol", 'R'},
         {"decoder", 'X'},
         {"register_all", 'G'},
@@ -910,6 +912,9 @@ static void parse_conf_option(r_cfg_t *cfg, int opt, char *arg)
         break;
     case 's':
         cfg->samp_rate = atouint32_metric(arg, "-s: ");
+        break;
+    case 'N':
+        cfg->channel = atouint32_metric(arg, "-N: ");
         break;
     case 'b':
         cfg->out_block_size = atouint32_metric(arg, "-b: ");
@@ -1789,7 +1794,7 @@ int main(int argc, char **argv) {
     }
 
     // Normal case, no test data, no in files
-    r = sdr_open(&cfg->dev, cfg->dev_query, cfg->verbosity);
+    r = sdr_open(&cfg->dev, cfg->channel, cfg->dev_query, cfg->verbosity);
     if (r < 0) {
         exit(2);
     }


### PR DESCRIPTION
Some SDRs (like LimeSDR) have more than one channel and it is convinient to be able to switch between them.
The change adds support for the command line argument that allows to select the input port.

`[-N <channel number> If the device supports more than one channel, then it may be sellected (default 0)`

I needed the change for myself so I implemented it and if it's possible I would also like to merge it to the main fork. 

This is my first contribution to this project. I tried to follow all the conventions that I was able to observe when reading the code. With some of my changes I needed to modify few `soapysdr_` function signatures but it didn't affect any tests (all are passing).
If I missed anything please let me know and I will fix my code.

Kind Regards.