### PR TITLE
Fix MSVC build

### DIFF
--- a/include/mongoose.h
+++ b/include/mongoose.h
@@ -4657,7 +4657,9 @@ size_t mg_fwrite(const void *ptr, size_t size, size_t count, FILE *f);
 #endif /* MG_ENABLE_FILESYSTEM */
 
 #if MG_ENABLE_THREADS
+#if CS_PLATFORM == CS_P_UNIX
 #include <pthread.h>
+#endif
 /*
  * Starts a new detached thread.
  * Arguments and semantics are the same as pthead's `pthread_create()`.


### PR DESCRIPTION
PR #2291 mistakenly include pthread for all platforms instead of only Unix platforms.
On Visual Studio 2022, the following error occurs when including mongoose.h:
```
C:\Program Files\PothosSDR\include\sched.h(129,13): error C2040: 'HANDLE': 'int' differs in levels of indirection from 'void *'
```
It tries to use pthread.h from PothosSDR but there is a conflict on the definition of pid_t.

This PR restore the previous behavior: only include pthread on Unix platforms and thus, fix Windows build.