### PR TITLE
Refactor Security+ 2.0 receiver and add support for PIN pads

### DIFF
--- a/src/devices/secplus_v2.c
+++ b/src/devices/secplus_v2.c
@@ -2,6 +2,7 @@
     Security+ 2.0 rolling code.
 
     Copyright (C) 2020 Peter Shipley <peter.shipley@gmail.com>
+    Copyright (C) 2022 Clayton Smith <argilo@gmail.com>
     Based on code by Clayton Smith https://github.com/argilo/secplus
 
     This program is free software; you can redistribute it and/or modify
@@ -19,6 +20,7 @@ Security+ 2.0  is described in [US patent application US20110317835A1](https://p
 */
 
 #include "decoder.h"
+#include "compat_time.h"
 
 /**
 Security+ 2.0 rolling code.
@@ -27,29 +29,30 @@ Data comes in two bursts/packets.
 
 Layout:
 
-    bits = `AA BB IIII OOOO X*30`
+    bits = `AA BB IIII OOOO XXXX....`
 
-- AA = payload type  (2 bits 00 or 01)
-- BB = FrameID (2 bits always 00)
+- AA = Frame ID (2 bits 00 or 01)
+- BB = Frame type (2 bits 00 or 01)
 - IIII = inversion indicator (4 bits)
-- OOOO = Order indicator (4 bits).
-- XXXX....  = data (30 bits)
+- OOOO = Order indicator (4 bits)
+- XXXX....  = data (30 or 54 bits)
 
 ---
 
 data is broken up into 3 parts (p0 p1 p2)
 eg:
 
-data = `ABCABCABCABCABCABCABCABCABCABC`
+data = `ABCABCABCABCABCABCABCABCABCABC(ABCABCABCABCABCABCABCABC)`
 becomes:
 
-    `p0 = AAAAAAAAAA`
-    `p1 = BBBBBBBBBB`
-    `p2 = CCCCCCCCCC`
+    `p0 = AAAAAAAAAA(AAAAAAAA)`
+    `p1 = BBBBBBBBBB(BBBBBBBB)`
+    `p2 = CCCCCCCCCC(CCCCCCCC)`
 
 these three parts are then inverted and reordered based on the 4bit Order and Inversion indicators
 
-fixed generated from concatenate  p0 + p1
+fixed generated from concatenating first 10 bits of p0 & p1
+(optional) data generated from concatenating last 8 bits of p0 & p1
 
 roll_array is generated from the 8 bit used for Order and Inversion indicators + p3
 by reading the buffer in binary bit pairs forming trinary values
@@ -58,7 +61,7 @@ EG:
 `1 0 0 1 1 0 1 0 0 1 1 0=> [1 0] [0 1] [1 0] [1 0] [0 1] [1 0] => 2 1 2 2 1 2`
 
 Returns data in :
-  * roll_array as an array of trinary values  0, 1, 2) the value 3 is invalid
+  * roll_array as an array of trinary values (0, 1, 2) the value 3 is invalid
   * fixed_p as an bitbuffer_t with 20 bits of data
 
 
@@ -68,167 +71,180 @@ Once the above has been run twice the two are merged
 
 */
 
-static int secplus_v2_decode_v2_half(r_device *decoder, bitbuffer_t *bits, uint8_t roll_array[], bitbuffer_t *fixed_p)
+static int8_t v2_check_parity(const uint64_t fixed, const uint32_t data)
 {
-    uint8_t invert = 0;
-    uint8_t order  = 0;
-    uint32_t x    = 0;
-    unsigned int start_pos = 2; //
-    uint8_t buffy[10];
+    uint32_t parity = (fixed >> 32) & 0xf;
+    int8_t offset;
 
-    uint8_t part_id = (bits->bb[0][0] >> 6);
-
-    decoder_log_bitrow(decoder, 1, __func__, bits->bb[0], bits->bits_per_row[0], "");
-
-    bitbuffer_extract_bytes(bits, 0, start_pos, buffy, 2);
-    start_pos += 2;
-
-    bitbuffer_extract_bytes(bits, 0, start_pos, buffy, 8);
-    start_pos += 8;
-    order = buffy[0] >> 4;
-
-    invert = buffy[0] & 0x0f;
-    // bitrow_debug(&invert, 8);
-
-    bitbuffer_extract_bytes(bits, 0, start_pos, buffy, 30);
-    start_pos += 30;
-
-    // copy 30 bits of data into 32bit int then shift >> 2
-    // memcpy(&dat, buffy, 4);
-    x = ((uint32_t)buffy[0] << 24) | (buffy[1] << 16) | (buffy[2] << 8) | (buffy[3]);
-
-    x >>= 2;
-
-    // using short to store 10bit values
-    uint16_t p0 = 0, p1 = 0, p2 = 0;
-
-    // sort 30 bits of interleaved data into three 10 bit buffers
-    for (int i = 0; i < 10; i++) {
-        p2 ^= (x & 0x00000001) << i; // 9-
-        x >>= 1;
-        p1 ^= (x & 0x00000001) << i;
-        x >>= 1;
-        p0 ^= (x & 0x00000001) << i;
-        x >>= 1;
+    for (offset = 0; offset < 32; offset += 4) {
+        parity ^= ((data >> offset) & 0xf);
     }
 
-    // selectively invert buffers
-    switch (invert) {
-    case 0x00: // 0b0000 (True, True, False),
-        p0 = ~p0 & 0x03FF;
-        p1 = ~p1 & 0x03FF;
-        break;
-    case 0x01: // 0b0001 (False, True, False),
-        p1 = ~p1 & 0x03FF;
-        break;
-    case 0x02: // 0b0010 (False, False, True),
-        p2 = ~p2 & 0x03FF;
-        break;
-    case 0x04: // 0b0100 (True, True, True),
-        p0 = ~p0 & 0x03FF;
-        p1 = ~p1 & 0x03FF;
-        p2 = ~p2 & 0x03FF;
-        break;
-    case 0x05: // 0b0101 (True, False, True),
-    case 0x0a: // 0b1010 (True, False, True),
-        p0 = ~p0 & 0x03FF;
-        p2 = ~p2 & 0x03FF;
-        break;
-    case 0x06: // 0b0110 (False, True, True),
-        p1 = ~p1 & 0x03FF;
-        p2 = ~p2 & 0x03FF;
-        break;
-    case 0x08: // 0b1000 (True, False, False),
-        p0 = ~p0 & 0x03FF;
-        break;
-    case 0x09: // 0b1001 (False, False, False),
-        break;
-    default:
-        decoder_log(decoder, 1, __func__, "Invert FAIL");
-        return 1;
+    if (parity != 0) {
+        return -1;
     }
 
-    uint16_t a = p0, b = p1, c = p2;
+    return 0;
+}
 
-    // selectively reorder buffers
-    switch (order) {
-    case 0x06: // 0b0110  2, 1, 0],
-    case 0x09: // 0b1001  2, 1, 0],
-        p2 = a;
-        p1 = b;
-        p0 = c;
-        break;
+static int8_t decode_v2_rolling(const uint32_t *rolling_halves, uint32_t *rolling)
+{
+    int8_t i, half;
+    uint32_t rolling_reversed;
 
-    case 0x08: // 0b1000  1, 2, 0],
-    case 0x04: // 0b0100  1, 2, 0],
-        p1 = a;
-        p2 = b;
-        p0 = c;
-        break;
+    rolling_reversed = (rolling_halves[1] >> 8) & 3;
+    rolling_reversed = (rolling_reversed * 3) + ((rolling_halves[0] >> 8) & 3);
 
-    case 0x01: // 0b0001 2, 0, 1],
-        p2 = a;
-        p0 = b;
-        p1 = c;
-        break;
-
-    case 0x00: // 0b0000  0, 2, 1],
-        p0 = a;
-        p2 = b;
-        p1 = c;
-        break;
-
-    case 0x05: // 0b0101 1, 0, 2],
-        p1 = a;
-        p0 = b;
-        p2 = c;
-        break;
-
-    case 0x02: // 0b0010 0, 1, 2],
-    case 0x0A: // 0b1010 0, 1, 2],
-        p0 = a;
-        p1 = b;
-        p2 = c;
-        break;
-
-    default:
-        decoder_log(decoder, 1, __func__, "Order FAIL");
-        return 2;
-    }
-
-    bitbuffer_extract_bytes(bits, 0, 4, buffy, 8);
-    x     = buffy[0];
-    int k = 0;
-    for (int i = 6; i >= 0; i -= 2) {
-        roll_array[k++] = (x >> i) & 0x03;
-    }
-
-    // decoder_log_bitrow(decoder, 3, __func__, buffy, 8, "")
-
-    // assemble binary bits into trinary
-    x = p2;
-    for (int i = 8; i >= 0; i -= 2) {
-        roll_array[k++] = (x >> i) & 0x03;
-    }
-
-    decoder_logf(decoder, 1, __func__, "roll_array : (%d) %d %d %d %d %d %d %d %d %d", part_id,
-                roll_array[0], roll_array[1], roll_array[2], roll_array[3],
-                roll_array[4], roll_array[5], roll_array[6], roll_array[7], roll_array[8]);
-
-    // SANITY check trinary values, 00/01/10 are valid,  11 is not
-    for (int i = 0; i < 9; i++) {
-        if (roll_array[i] == 3) {
-            decoder_log(decoder, 0, __func__, "roll_array val FAIL");
-            return 1; // DECODE_FAIL_SANITY;
+    for (half = 1; half >= 0; half--) {
+        for (i = 16; i >= 10; i -= 2) {
+            rolling_reversed = (rolling_reversed * 3) + ((rolling_halves[half] >> i) & 3);
         }
     }
 
-    // fixed_p = p0 + p1
-    for (int i = 9; i >= 0; i--) {
-        bitbuffer_add_bit(fixed_p, (p0 >> i) & 0x01);
+    for (half = 1; half >= 0; half--) {
+        for (i = 6; i >= 0; i -= 2) {
+            rolling_reversed = (rolling_reversed * 3) + ((rolling_halves[half] >> i) & 3);
+        }
     }
-    for (int i = 9; i >= 0; i--) {
-        bitbuffer_add_bit(fixed_p, (p1 >> i) & 0x01);
+
+    if (rolling_reversed >= 0x10000000) {
+        return -1;
+    }
+
+    *rolling = 0;
+    for (i = 0; i < 28; i++) {
+        *rolling |= ((rolling_reversed >> i) & 1) << (28 - i - 1);
+    }
+
+    return 0;
+}
+
+static int8_t v2_combine_halves(const uint8_t frame_type,
+        const uint32_t *rolling_halves, const uint32_t *fixed_halves, const uint16_t *data_halves,
+        uint32_t *rolling, uint64_t *fixed, uint32_t *data)
+{
+    int8_t err = 0;
+
+    err = decode_v2_rolling(rolling_halves, rolling);
+    if (err < 0) {
+        return err;
+    }
+
+    *fixed = ((uint64_t)fixed_halves[0] << 20) | fixed_halves[1];
+
+    if (frame_type == 1) {
+        *data = ((uint32_t)data_halves[0] << 16) | data_halves[1];
+
+        err = v2_check_parity(*fixed, *data);
+        if (err < 0) {
+            return err;
+        }
+    }
+
+    return 0;
+}
+
+static const int8_t ORDER[16]  = {9, 33, 6, -1, 24, 18, 36, -1, 24, 36, 6, -1, -1, -1, -1, -1};
+static const int8_t INVERT[16] = {6, 2, 1, -1, 7, 5, 3, -1, 4, 0, 5, -1, -1, -1, -1, -1};
+
+static int8_t v2_unscramble(const uint8_t frame_type, const uint8_t indicator,
+        const uint8_t *packet_half, uint32_t *parts)
+{
+    const int8_t order  = ORDER[indicator >> 4];
+    const int8_t invert = INVERT[indicator & 0xf];
+    int8_t i;
+    uint8_t out_offset         = 10;
+    const int8_t end           = (frame_type == 0 ? 8 : 0);
+    uint32_t parts_permuted[3] = {0, 0, 0};
+
+    if ((order == -1) || (invert == -1)) {
+        return -1;
+    }
+
+    for (i = 18 - 1; i >= end; i--) {
+        parts_permuted[0] |= (uint32_t)((packet_half[out_offset >> 3] >> (7 - (out_offset % 8))) & 1) << i;
+        out_offset++;
+        parts_permuted[1] |= (uint32_t)((packet_half[out_offset >> 3] >> (7 - (out_offset % 8))) & 1) << i;
+        out_offset++;
+        parts_permuted[2] |= (uint32_t)((packet_half[out_offset >> 3] >> (7 - (out_offset % 8))) & 1) << i;
+        out_offset++;
+    }
+
+    parts[(order >> 4) & 3] = (invert & 4) ? ~parts_permuted[0] : parts_permuted[0];
+    parts[(order >> 2) & 3] = (invert & 2) ? ~parts_permuted[1] : parts_permuted[1];
+    parts[order & 3]        = (invert & 1) ? ~parts_permuted[2] : parts_permuted[2];
+
+    return 0;
+}
+
+static int8_t decode_v2_half_parts(const uint8_t frame_type, const uint8_t indicator,
+        const uint8_t *packet_half, uint32_t *rolling, uint32_t *fixed, uint16_t *data)
+{
+    int8_t err = 0;
+    int8_t i;
+    uint32_t parts[3];
+
+    err = v2_unscramble(frame_type, indicator, packet_half, parts);
+    if (err < 0) {
+        return err;
+    }
+
+    if ((frame_type == 1) && ((parts[2] & 0xff) != indicator)) {
+        return -1;
+    }
+
+    for (i = 8; i < 18; i += 2) {
+        if (((parts[2] >> i) & 3) == 3) {
+            return -1;
+        }
+    }
+
+    *rolling = (parts[2] & 0x3ff00) | indicator;
+    *fixed   = ((parts[0] & 0x3ff00) << 2) | ((parts[1] & 0x3ff00) >> 8);
+    *data    = ((parts[0] & 0xff) << 8) | (parts[1] & 0xff);
+
+    return 0;
+}
+
+static int8_t decode_v2_half(const uint8_t frame_type, const uint8_t *packet_half,
+        uint32_t *rolling, uint32_t *fixed, uint16_t *data)
+{
+    int8_t err              = 0;
+    const uint8_t indicator = (packet_half[0] << 2) | (packet_half[1] >> 6);
+
+    if ((packet_half[0] >> 6) != frame_type) {
+        return -1;
+    }
+
+    err = decode_v2_half_parts(frame_type, indicator, packet_half, rolling, fixed, data);
+    if (err < 0) {
+        return err;
+    }
+
+    return 0;
+}
+
+static int8_t decode_v2(uint8_t frame_type, const uint8_t *packet1, const uint8_t *packet2,
+        uint32_t *rolling, uint64_t *fixed, uint32_t *data)
+{
+    int8_t err = 0;
+    uint32_t rolling_halves[2];
+    uint32_t fixed_halves[2];
+    uint16_t data_halves[2];
+
+    err = decode_v2_half(frame_type, packet1, &rolling_halves[0], &fixed_halves[0], &data_halves[0]);
+    if (err < 0) {
+        return err;
+    }
+
+    err = decode_v2_half(frame_type, packet2, &rolling_halves[1], &fixed_halves[1], &data_halves[1]);
+    if (err < 0) {
+        return err;
+    }
+
+    err = v2_combine_halves(frame_type, rolling_halves, fixed_halves, data_halves, rolling, fixed, data);
+    if (err < 0) {
+        return err;
     }
 
     return 0;
@@ -237,146 +253,121 @@ static int secplus_v2_decode_v2_half(r_device *decoder, bitbuffer_t *bits, uint8
 static const uint8_t _preamble[] = {0xaa, 0xaa, 0x95, 0x60};
 unsigned _preamble_len           = 28;
 
+// max age for cache in us
+#define MAX_TIME_DIFF 800000
+
+static uint8_t packet[2][8]        = {0};
+static struct timeval packet_tv[2] = {0};
+
 /**
 Security+ 2.0 rolling code.
-@sa secplus_v2_decode_v2_half()
 */
 static int secplus_v2_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     unsigned search_index = 0;
-    bitbuffer_t bits = {0};
-    // int i            = 0;
+    bitbuffer_t bits      = {0};
 
-    //bitbuffer_t bits_1    = {0};
-    bitbuffer_t fixed_1   = {0};
-    uint8_t rolling_1[16] = {0};
+    if (bitbuffer->bits_per_row[0] < 110) {
+        return DECODE_ABORT_LENGTH;
+    }
 
-    //bitbuffer_t bits_2    = {0};
-    bitbuffer_t fixed_2   = {0};
-    uint8_t rolling_2[16] = {0};
+    search_index = bitbuffer_search(bitbuffer, 0, 0, _preamble, _preamble_len);
 
-    for (uint16_t row = 0; row < bitbuffer->num_rows; ++row) {
-        if (bitbuffer->bits_per_row[row] < 110) {
-            continue;
+    if (search_index >= bitbuffer->bits_per_row[0]) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    bitbuffer_clear(&bits);
+    bitbuffer_manchester_decode(bitbuffer, 0, search_index + 14, &bits, 72);
+    if (bits.bits_per_row[0] < 42) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    decoder_log_bitrow(decoder, 1, __func__, bits.bb[0], bits.bits_per_row[0], "manchester decoded");
+
+    uint8_t frame_id = bits.bb[0][0] & 3;
+    if (frame_id > 1) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    uint8_t frame_type = (bits.bb[0][1] >> 6) & 3;
+    if (frame_type > 1) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    int frame_len = (frame_type == 0) ? 40 : 64;
+    if (bits.bits_per_row[0] < 2 + frame_len) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    gettimeofday(&packet_tv[frame_id], NULL);
+
+    if (memcmp(packet[frame_id], &bits.bb[0][1], frame_len / 8) == 0) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    memcpy(packet[frame_id], &bits.bb[0][1], frame_len / 8);
+
+    if (packet_tv[frame_id ^ 1].tv_sec && ((packet[frame_id ^ 1][0] >> 6) & 3) == frame_type) {
+        struct timeval res_tv;
+        timeval_subtract(&res_tv, &packet_tv[frame_id], &packet_tv[frame_id ^ 1]);
+        if (res_tv.tv_sec == 0 && res_tv.tv_usec < MAX_TIME_DIFF) {
+            uint32_t rolling      = 0;
+            uint64_t fixed        = 0;
+            uint32_t secplus_data = 0;
+            int8_t ret            = decode_v2(frame_type, packet[0], packet[1], &rolling, &fixed, &secplus_data);
+            if (ret < 0) {
+                return DECODE_FAIL_SANITY;
+            }
+
+            int button = (fixed >> 32) & 0xf;
+            // int remote_id = fixed & 0xffffffff;
+            char rolling_str[9];
+            char fixed_str[17];
+            char remote_id_str[17];
+            char data_str[9] = "";
+            char pin_str[7]  = "";
+
+            // rolling_total is a 28 bit unsigned number
+            // fixed_totals is 40 bit in a uint64_t
+            snprintf(rolling_str, sizeof(rolling_str), "%07x", rolling);
+            snprintf(fixed_str, sizeof(fixed_str), "%010llx", (long long unsigned)fixed);
+            snprintf(remote_id_str, sizeof(fixed_str), "%010llx", (long long unsigned)fixed & 0xf0ffffffff);
+            if (frame_type == 1) {
+                snprintf(data_str, sizeof(rolling_str), "%08x", secplus_data);
+                int pin = (((secplus_data >> 16) & 0xff) << 8) | (secplus_data >> 24);
+                if (button == 3) {
+                    strcat(pin_str, "enter");
+                }
+                else {
+                    snprintf(pin_str, sizeof(pin_str), "%04d", pin);
+                    if (button == 1) {
+                        strcat(pin_str, "*");
+                    }
+                    else if (button == 2) {
+                        strcat(pin_str, "#");
+                    }
+                }
+            }
+
+            /* clang-format off */
+            data_t *data;
+            data = data_make(
+                    "model",     "Model",        DATA_STRING, "Secplus-v2",
+                    "id",        "",             DATA_INT,    (fixed & 0xffffffff),
+                    "button_id", "Button-ID",    DATA_INT,    button,
+                    "remote_id", "Remote-ID",    DATA_STRING, remote_id_str,
+                    "rolling",   "Rolling_Code", DATA_STRING, rolling_str,
+                    "fixed",     "Fixed_Code",   DATA_STRING, fixed_str,
+                    "data",      "Data",         DATA_STRING, data_str,
+                    "pin",       "PIN",          DATA_STRING, pin_str,
+                    NULL);
+            /* clang-format on */
+
+            decoder_output_data(decoder, data);
         }
-
-        search_index = bitbuffer_search(bitbuffer, row, 0, _preamble, _preamble_len);
-
-        if (search_index >= bitbuffer->bits_per_row[row]) {
-            break;
-        }
-
-        bitbuffer_clear(&bits);
-        bitbuffer_manchester_decode(bitbuffer, row, search_index + 26, &bits, 80);
-        search_index += 20;
-        if (bits.bits_per_row[0] < 42) {
-            continue; // DECODE_ABORT_LENGTH;
-        }
-
-        decoder_log_bitrow(decoder, 1, __func__, bits.bb[0], bits.bits_per_row[0], "manchester decoded");
-
-        // valid = 0X00XXXX
-        // 1st 3rs and 4th bits should always be 0
-        if (bits.bb[0][0] & 0xB0) {
-            continue; // DECODE_FAIL_SANITY;
-        }
-
-        // 2nd bit indicates with half of the data
-        if (bits.bb[0][0] & 0xC0) {
-            decoder_log(decoder, 1, __func__, "Set 2");
-            secplus_v2_decode_v2_half(decoder, &bits, rolling_2, &fixed_2);
-        }
-        else {
-            decoder_log(decoder, 1, __func__, "Set 1");
-            secplus_v2_decode_v2_half(decoder, &bits, rolling_1, &fixed_1);
-        }
-
-        // break if we've received both halves
-        if (fixed_1.bits_per_row[0] > 1 && fixed_2.bits_per_row[0] > 1) {
-            break;
-        }
     }
 
-    // Do we have what we need ??
-    if (fixed_1.bits_per_row[0] == 0 || fixed_2.bits_per_row[0] == 0) {
-        return DECODE_FAIL_SANITY;
-    }
-
-    // Assemble rolling_1[] and rolling_2[] into rolling_digits[]
-    uint8_t rolling_digits[24] = {0};
-    uint8_t *r;
-
-    r    = rolling_digits;
-    *r++ = rolling_2[8];
-    *r++ = rolling_1[8];
-    for (int i = 4; i < 8; i++) {
-        *r++ = rolling_2[i];
-    }
-    for (int i = 4; i < 8; i++) {
-        *r++ = rolling_1[i];
-    }
-
-    for (int i = 0; i < 4; i++) {
-        *r++ = rolling_2[i];
-    }
-    for (int i = 0; i < 4; i++) {
-        *r++ = rolling_1[i];
-    }
-
-    // compute rolling_total from rolling_digits[]
-    uint32_t rolling_total = 0;
-    uint32_t rolling_temp  = 0;
-
-    for (int i = 0; i < 18; i++) {
-        rolling_temp = (rolling_temp * 3) + rolling_digits[i];
-    }
-
-    // Max value = 2^28 (268435456)
-    if (rolling_temp >= 0x10000000) {
-        return DECODE_FAIL_SANITY;
-    }
-
-    // value is 28 bits thus need to shift over 4 bit
-    rolling_total = reverse32(rolling_temp);
-    rolling_total = rolling_total >> 4;
-
-    // Assemble "fixed" data part
-    uint64_t fixed_total = 0;
-    uint8_t *bb;
-    bb = fixed_1.bb[0];
-    fixed_total ^= ((uint64_t)bb[0]) << 32;
-    fixed_total ^= ((uint64_t)bb[1]) << 24;
-    fixed_total ^= ((uint64_t)bb[2]) << 16;
-
-    bb = fixed_2.bb[0];
-    fixed_total ^= ((uint64_t)bb[0]) << 12;
-    fixed_total ^= ((uint64_t)bb[1]) << 4;
-    fixed_total ^= (bb[2] >> 4) & 0x0f;
-
-    // int button    = fixed_total >> 32;
-    // int remote_id = fixed_total & 0xffffffff;
-    char fixed_str[16];
-    char rolling_str[16];
-
-    // rolling_total is a 28 bit unsigned number
-    // fixed_totals is 40 bit in a uint64_t
-    snprintf(fixed_str, sizeof(fixed_str), "%llu", (long long unsigned)fixed_total);
-    snprintf(rolling_str, sizeof(rolling_str), "%u", rolling_total);
-
-    /* clang-format off */
-    data_t *data;
-    data = data_make(
-            "model",       "Model",    DATA_STRING, "Secplus-v2",
-            "id",          "",       DATA_INT, (fixed_total & 0xffffffff),
-            "button_id",   "Button-ID",    DATA_INT,    (fixed_total >> 32),
-            "remote_id",   "Remote-ID",    DATA_INT,    (fixed_total & 0xffffffff),
-            // "fixed",       "",    DATA_INT,    fixed_total,
-            "fixed",       "Fixed_Code",    DATA_STRING,    fixed_str,
-            "rolling",     "Rolling_Code",    DATA_STRING,    rolling_str,
-            NULL);
-    /* clang-format on */
-
-    decoder_output_data(decoder, data);
     return 1;
 }
 
@@ -386,8 +377,10 @@ static char const *const output_fields[] = {
         "id",
         "rolling",
         "fixed",
+        "data",
         "button_id",
         "remote_id",
+        "pin",
         NULL,
 };
 
@@ -400,8 +393,7 @@ r_device const secplus_v2 = {
         .short_width = 250,
         .long_width  = 250,
         .tolerance   = 50,
-        .gap_limit   = 1500,
-        .reset_limit = 9000,
+        .reset_limit = 1500,
         .decode_fn   = &secplus_v2_callback,
         .fields      = output_fields,
 };


### PR DESCRIPTION
Support for Security+ 2.0 was originally added by @evilpete in #1480, based on my code in https://github.com/argilo/secplus. Since that time, I have learned more about the packet format:

1. While the off-brand transmitter I originally tested with transmits its packets in rapid succession, genuine transmitters space them 100ms apart, much like the older Security+ protocol. Because the data is split across two packets with a large time gap in between, it seems that rtl_433 cannot provide the required data in the rows of a single bitbuffer, regardless of the `reset_limit` value. As a result, I've adopted the caching approach used in the Security+ receiver (#1483). (If there's a better approach, please let me know.)
2. PIN pads transmit using a longer 64-bit packet format, which has "01" for the frame type bit, and includes a 32-bit "supplemental data" field.
3. The "button ID" field is 4 bits long, not 8.

I recently updated https://github.com/argilo/secplus to support Security+ 2.0 PIN pads, and I also added a unit-tested C implementation (https://github.com/argilo/secplus/tree/master/src). I've copied in the functions needed to decode Security+ 2.0 packets.

After these changes, the code is able to receive genuine and off-brand remotes, as well as PIN pads.