### PR TITLE
Fix json keys for wmbus to be unique

### DIFF
--- a/src/devices/m_bus.c
+++ b/src/devices/m_bus.c
@@ -280,18 +280,24 @@ static char *unit_names[][3] = {
 static double pow10_table[8] = { 0.001, 0.01, 0.1, 1, 10, 100, 1000, 10000 };
 
 
-static data_t *append_str(data_t *data, enum UnitType unit_type, uint8_t value_type, uint8_t sn, char const *extra, char const *value)
+static data_t *append_str(data_t *data, enum UnitType unit_type, uint8_t value_type, uint8_t sn,
+    char const *key_extra, char const *pretty_extra, char const *value)
 {
     char key[100] = {0};
     char pretty[100] = {0};
 
     value_type &= 0x3;
 
-    snprintf(key, sizeof(key), "%s_%s_%d", value_types_tab[value_type][0], unit_names[unit_type][0], sn);
-    if (extra[0] == '\0') {
+    if (!key_extra || !*key_extra) {
+        snprintf(key, sizeof(key), "%s_%s_%d", value_types_tab[value_type][0], unit_names[unit_type][0], sn);
+    } else {
+        snprintf(key, sizeof(key), "%s_%s_%s_%d", value_types_tab[value_type][0], unit_names[unit_type][0], key_extra, sn);
+    }
+
+    if (!pretty_extra || !*pretty_extra) {
         snprintf(pretty, sizeof(pretty), "%s %s[%d]", value_types_tab[value_type][1], unit_names[unit_type][1], sn);
     } else {
-        snprintf(pretty, sizeof(pretty), "%s %s %s", value_types_tab[value_type][1], unit_names[unit_type][1], extra);
+        snprintf(pretty, sizeof(pretty), "%s %s %s", value_types_tab[value_type][1], unit_names[unit_type][1], pretty_extra);
     }
 
     return data_append(data,
@@ -299,7 +305,8 @@ static data_t *append_str(data_t *data, enum UnitType unit_type, uint8_t value_t
 
 }
 
-static data_t *append_val(data_t *data, enum UnitType unit_type, uint8_t value_type, uint8_t sn, char const *extra, int64_t val, int exp)
+static data_t *append_val(data_t *data, enum UnitType unit_type, uint8_t value_type, uint8_t sn,
+    char const *key_extra, char const *pretty_extra, int64_t val, int exp)
 {
     char const *prefix = "";
     char buffer_val[256] = {0};
@@ -332,7 +339,7 @@ static data_t *append_val(data_t *data, enum UnitType unit_type, uint8_t value_t
 
     snprintf(buffer_val, sizeof(buffer_val), "%.03f %s%s", fvalue, prefix, unit_names[unit_type][2]);
 
-    return append_str(data, unit_type, value_type, sn, extra, buffer_val);
+    return append_str(data, unit_type, value_type, sn, key_extra, pretty_extra, buffer_val);
 }
 
 static size_t m_bus_tm_decode(const uint8_t *data, size_t data_size, char *output, size_t output_size)
@@ -516,96 +523,97 @@ static int m_bus_decode_records(data_t *data, const uint8_t *b, uint8_t dif_codi
         case 0:
             if ((vif_uam&0xF8) == 0) {
                 // E000 0nnn Energy 10nnn-3 Wh  0.001Wh to 10000Wh
-                data = append_val(data, kEnergy_Wh, dif_ff, dif_sn, "", val, -3 + (vif_uam&0x7));
+                data = append_val(data, kEnergy_Wh, dif_ff, dif_sn, "", "", val, -3 + (vif_uam&0x7));
             } else if ((vif_uam&0xF8) == 0x08) {
                 // E000 1nnn    Energy  10nnn J 0.001kJ to 10000kJ
-                data = append_val(data, kEnergy_J, dif_ff, dif_sn, "", val, vif_uam&0x7);
+                data = append_val(data, kEnergy_J, dif_ff, dif_sn, "", "", val, vif_uam&0x7);
             } else if ((vif_uam&0xF8) == 0x10) {
                 // E001 0nnn    Volume  10nnn-6 m3  0.001l to 10000l
 
                 if (dif_sn == 0) {
-                    data = append_val(data, kVolume, dif_ff, dif_sn, "", val, -6 + (vif_uam&0x7));
+                    data = append_val(data, kVolume, dif_ff, dif_sn, "", "", val, -6 + (vif_uam&0x7));
                 } else
                 if (dif_sn >= 8 && dif_sn <= 19) {
                     dif_sn -= 8;
-                    data = append_val(data, kVolume, dif_ff, dif_sn, history_months[dif_sn][1], val, -6 + (vif_uam&0x7));
+                    data = append_val(data, kVolume, dif_ff, dif_sn,
+                        history_months[dif_sn][0], history_months[dif_sn][1], val, -6 + (vif_uam&0x7));
                 }
 
             } else if ((vif_uam&0xF8) == 0x18) {
                 // E001 1nnn    Mass    10nnn-3 kg  0.001kg to 10000kg
-                data = append_val(data, kEnergy_J, dif_ff, dif_sn, "", val, -3 + (vif_uam&0x7));
+                data = append_val(data, kEnergy_J, dif_ff, dif_sn, "", "", val, -3 + (vif_uam&0x7));
             } else if ((vif_uam&0xFC) == 0x20) {
                 /* E010 00nn    On Time nn = 00 seconds
                                         nn = 01 minutes
                                         nn = 10 hours
                                         nn = 11 days */
                 switch (vif_uam&3) {
-                    case 0: data = append_val(data, kOnTimeSec, dif_ff, dif_sn, "", val, 0); break;
-                    case 1: data = append_val(data, kOnTimeMin, dif_ff, dif_sn, "", val, 0); break;
-                    case 2: data = append_val(data, kOnTimeHours, dif_ff, dif_sn, "", val, 0); break;
-                    case 3: data = append_val(data, kOnTimeDays, dif_ff, dif_sn, "", val, 0); break;
+                    case 0: data = append_val(data, kOnTimeSec, dif_ff, dif_sn, "", "", val, 0); break;
+                    case 1: data = append_val(data, kOnTimeMin, dif_ff, dif_sn, "", "", val, 0); break;
+                    case 2: data = append_val(data, kOnTimeHours, dif_ff, dif_sn, "", "", val, 0); break;
+                    case 3: data = append_val(data, kOnTimeDays, dif_ff, dif_sn, "", "", val, 0); break;
                     default: break;
                 }
             } else if ((vif_uam&0xFC) == 0x24) {
                 // E010 01nn    Operating Time  coded like OnTime
                 switch (vif_uam&3) {
-                    case 0: data = append_val(data, kOperTimeSec, dif_ff, dif_sn, "", val, 0); break;
-                    case 1: data = append_val(data, kOperTimeMin, dif_ff, dif_sn, "", val, 0); break;
-                    case 2: data = append_val(data, kOperTimeHours, dif_ff, dif_sn, "", val, 0); break;
-                    case 3: data = append_val(data, kOperTimeDays, dif_ff, dif_sn, "", val, 0); break;
+                    case 0: data = append_val(data, kOperTimeSec, dif_ff, dif_sn, "", "", val, 0); break;
+                    case 1: data = append_val(data, kOperTimeMin, dif_ff, dif_sn, "", "", val, 0); break;
+                    case 2: data = append_val(data, kOperTimeHours, dif_ff, dif_sn, "", "", val, 0); break;
+                    case 3: data = append_val(data, kOperTimeDays, dif_ff, dif_sn, "", "", val, 0); break;
                     default: break;
                 }
             } else if ((vif_uam&0xF8) == 0x28) {
                 // E010 1nnn    Power  10nnn-3 W    0.001W to 10000W
-                data = append_val(data, kPower_W, dif_ff, dif_sn, "", val, -3 + (vif_uam&0x7));
+                data = append_val(data, kPower_W, dif_ff, dif_sn, "", "", val, -3 + (vif_uam&0x7));
             } else if ((vif_uam&0xF8) == 0x30) {
                 // E011 0nnn    Power   10nnn J/h   0.001kJ/h to 10000kJ/h
-                data = append_val(data, kPower_Jh, dif_ff, dif_sn, "", val, vif_uam&0x7);
+                data = append_val(data, kPower_Jh, dif_ff, dif_sn, "", "", val, vif_uam&0x7);
             } else if ((vif_uam&0xF8) == 0x38) {
                 // E011 1nnn    Volume Flow 10nnn-6 m3/h   0.001l/h to 10000l/h
-                data = append_val(data, kVolumeFlow_h, dif_ff, dif_sn, "", val, -6 + (vif_uam&0x7));
+                data = append_val(data, kVolumeFlow_h, dif_ff, dif_sn, "", "", val, -6 + (vif_uam&0x7));
             } else if ((vif_uam&0xF8) == 0x40) {
                 // E100 0nnn    Volume Flow ext.    10nnn-7 m3/min  0.0001l/min to 1000l/min
-                data = append_val(data, kVolumeFlow_min, dif_ff, dif_sn, "", val, -7 + (vif_uam&0x7));
+                data = append_val(data, kVolumeFlow_min, dif_ff, dif_sn, "", "", val, -7 + (vif_uam&0x7));
             } else if ((vif_uam&0xF8) == 0x48) {
                 // E100 1nnn    Volume Flow ext.   10nnn-9 m³/s    0.001ml/s to 10000ml/s
                 // in litres so exp -3
-                data = append_val(data, kVolumeFlow_s, dif_ff, dif_sn, "", val, -3 + (vif_uam&0x7));
+                data = append_val(data, kVolumeFlow_s, dif_ff, dif_sn, "", "", val, -3 + (vif_uam&0x7));
             } else if ((vif_uam&0xF8) == 0x50) {
                 // E101 0nnn    Mass flow   10nnn-3 kg/h    0.001kg/h to 10000kg/h
-                data = append_val(data, kMassFlow, dif_ff, dif_sn, "", val, -3 + (vif_uam&0x7));
+                data = append_val(data, kMassFlow, dif_ff, dif_sn, "", "", val, -3 + (vif_uam&0x7));
             } else if ((vif_uam&0xFC) == 0x58) {
                 // E101 10nn    Flow Temperature 10nn-3 °C 0.001°C to 1°C
-                data = append_val(data, kTemperatureFlow, dif_ff, dif_sn, "", val, -3 + (vif_uam&0x3));
+                data = append_val(data, kTemperatureFlow, dif_ff, dif_sn, "", "", val, -3 + (vif_uam&0x3));
             } else if ((vif_uam&0xFC) == 0x5C) {
                 // E101 11nn    Return Temperature 10nn-3 °C    0.001°C to 1°C
-                data = append_val(data, kTemperatureReturn, dif_ff, dif_sn, "", val, -3 + (vif_uam&0x3));
+                data = append_val(data, kTemperatureReturn, dif_ff, dif_sn, "", "", val, -3 + (vif_uam&0x3));
             } else if ((vif_uam&0xFC) == 0x60) {
                 // E110 00nn    Temperature Difference  10nn-3 K    1mK to 1000mK
-                data = append_val(data, kTemperatureDiff, dif_ff, dif_sn, "", val, -3 + (vif_uam&0x3));
+                data = append_val(data, kTemperatureDiff, dif_ff, dif_sn, "", "", val, -3 + (vif_uam&0x3));
             } else if ((vif_uam&0xFC) == 0x64) {
                 // E110 01nn    External temperature    10 nn-3 ° C 0.001 ° C to 1 ° C
-                data = append_val(data, kTemperatureExtern, dif_ff, dif_sn, history_hours[dif_sn&0x3], val, -3 + (vif_uam&0x3));
+                data = append_val(data, kTemperatureExtern, dif_ff, dif_sn, "", history_hours[dif_sn&0x3], val, -3 + (vif_uam&0x3));
             } else if ((vif_uam&0xFC) == 0x68) {
                 // E110 10nn    Pressure    10nn-3 bar 1mbar to 1000mbar
-                data = append_val(data, kPressure, dif_ff, dif_sn, "", val, -3 + (vif_uam&0x3));
+                data = append_val(data, kPressure, dif_ff, dif_sn, "", "", val, -3 + (vif_uam&0x3));
             } else if ((vif_uam&0xFE) == 0x6C) {
                 // E110 110n    Time Point  n = 0 date, n = 1 time & date
                 char buff_time[256] = {0};
 
                 if (vif_uam&1) {
                     if (m_bus_tm_decode(b, dif_coding, buff_time, sizeof(buff_time))) {
-                        data = append_str(data, kTimeDate, dif_ff, dif_sn, "", buff_time);
+                        data = append_str(data, kTimeDate, dif_ff, dif_sn, "", "", buff_time);
                     }
                 } else {
                     if (m_bus_tm_decode(b, dif_coding, buff_time, sizeof(buff_time))) {
-                        data = append_str(data, kDate, dif_ff, dif_sn, "", buff_time);
+                        data = append_str(data, kDate, dif_ff, dif_sn, "", "", buff_time);
                     }
                 }
 
             } else if (vif_uam == 0x6E) {
                 // E110 1110    Units for H.C.A.        dimensionless
-                data = append_val(data, kHca, dif_ff, dif_sn, "", val, 0);
+                data = append_val(data, kHca, dif_ff, dif_sn, "", "", val, 0);
             } else if ((vif_uam&0xFC) == 0x70) {
                 // E111 00nn    Averaging Duration coded like OnTime
             } else if ((vif_uam&0xFC) == 0x74) {


### PR DESCRIPTION
* Key inst_volume_0 is now unique

Fast fix. Will be nice to find a better solution to provide variable arguments to the append_str.

Previous keys:
"inst_volume_0" : "6.257 m3", "inst_volume_0" : "6.116 m3", "inst_volume_1" : "5.764 m3", "inst_volume_2" : "5.494 m3", 
...

New keys:
"inst_volume_0" : "6.257 m3", "inst_volume_m1_0" : "6.116 m3", "inst_volume_m2_1" : "5.764 m3", "inst_volume_m3_2" : 
...