### PR TITLE
Change LaCrosse TX invalid humidity handling (#2329)

### DIFF
--- a/src/devices/lacrosse.c
+++ b/src/devices/lacrosse.c
@@ -118,10 +118,11 @@ static int lacrossetx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
         // TODO: check if message length is a valid value
         //uint8_t msg_len      = msg_nybbles[1];
-        uint8_t msg_type     = msg_nybbles[2];
-        uint8_t sensor_id    = (msg_nybbles[3] << 3) + (msg_nybbles[4] >> 1);
-        float msg_value      = msg_nybbles[5] * 10 + msg_nybbles[6] + msg_nybbles[7] * 0.1f;
-        int msg_value_int    = msg_nybbles[8] * 10 + msg_nybbles[9];
+        uint8_t msg_type       = msg_nybbles[2];
+        uint8_t sensor_id      = (msg_nybbles[3] << 3) + (msg_nybbles[4] >> 1);
+        uint16_t msg_value_raw = (msg_nybbles[5] << 8) | (msg_nybbles[6] << 4) | msg_nybbles[7];
+        float msg_value        = msg_nybbles[5] * 10 + msg_nybbles[6] + msg_nybbles[7] * 0.1f;
+        int msg_value_int      = msg_nybbles[8] * 10 + msg_nybbles[9];
 
         // Check Repeated data values as another way of verifying
         // message integrity.
@@ -152,7 +153,7 @@ static int lacrossetx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             data_t *data = data_make(
                     "model",            "",             DATA_STRING, "LaCrosse-TX",
                     "id",               "",             DATA_INT,    sensor_id,
-                    "humidity",         "Humidity",     DATA_FORMAT, "%.1f %%", DATA_DOUBLE, msg_value,
+                    "humidity",         "Humidity",     DATA_COND,   msg_value_raw != 0xff, DATA_FORMAT, "%.1f %%", DATA_DOUBLE, msg_value,
                     "mic",              "Integrity",    DATA_STRING, "PARITY",
                     NULL);
             /* clang-format on */


### PR DESCRIPTION
Invalid sensor data (0x0ff) will be suppressed from the output.