### PR TITLE
It's really the gcc compiler that defines __restrict, not the fact that it is used to target a particular platform

### DIFF
--- a/include/r_util.h
+++ b/include/r_util.h
@@ -17,8 +17,8 @@
 #include <time.h>
 #include "compat_time.h"
 
-#if defined _MSC_VER || defined ESP32 // Microsoft Visual Studio or ESP32
-    // MSC and ESP32 have something like C99 restrict as __restrict
+#if defined _MSC_VER || defined __cplusplus // Microsoft Visual Studio or C++ compilers (G++ is used by ESP32, ESP8266...)
+    // MSC and C++ compilers have something like C99 restrict as __restrict
     #ifndef restrict
     #define restrict  __restrict
     #endif


### PR DESCRIPTION
Before this change, any other platform than ESP32 that uses GCC would fail compiling because of the `restrict` keyword being undefined.
I found it while working on the RFLink32 project that also happens to target the D1 mini (ESP8266)