### PR TITLE
Make all r_device declarations const to place them in the readonly section of the final image

### DIFF
--- a/include/decoder_util.h
+++ b/include/decoder_util.h
@@ -29,7 +29,7 @@
 #endif
 
 /// Create a new r_device, copy from dev_template if not NULL.
-r_device *create_device(r_device *dev_template);
+r_device *create_device(r_device const *dev_template);
 
 /// Output data.
 void decoder_output_data(r_device *decoder, data_t *data);

--- a/src/decoder_util.c
+++ b/src/decoder_util.c
@@ -16,7 +16,7 @@
 
 // create decoder functions
 
-r_device *create_device(r_device *dev_template)
+r_device *create_device(r_device const *dev_template)
 {
     r_device *r_dev = malloc(sizeof (*r_dev));
     if (!r_dev) {

--- a/src/devices/abmt.c
+++ b/src/devices/abmt.c
@@ -88,7 +88,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device abmt = {
+r_device const abmt = {
         .name        = "Amazon Basics Meat Thermometer",
         .modulation  = OOK_PULSE_PCM,
         .short_width = 550,

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -1869,7 +1869,7 @@ static char *acurite_rain_gauge_output_fields[] = {
         NULL,
 };
 
-r_device acurite_rain_896 = {
+r_device const acurite_rain_896 = {
         .name        = "Acurite 896 Rain Gauge",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 1000,
@@ -1892,7 +1892,7 @@ static char *acurite_th_output_fields[] = {
         NULL,
 };
 
-r_device acurite_th = {
+r_device const acurite_th = {
         .name        = "Acurite 609TXC Temperature and Humidity Sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 1000,
@@ -1936,7 +1936,7 @@ static char *acurite_txr_output_fields[] = {
         NULL,
 };
 
-r_device acurite_txr = {
+r_device const acurite_txr = {
         .name        = "Acurite 592TXR Temp/Humidity, 5n1 Weather Station, 6045 Lightning, 899 Rain, 3N1, Atlas",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 220,  // short pulse is 220 us + 392 us gap
@@ -1969,7 +1969,7 @@ static char *acurite_986_output_fields[] = {
         NULL,
 };
 
-r_device acurite_986 = {
+r_device const acurite_986 = {
         .name        = "Acurite 986 Refrigerator / Freezer Thermometer",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 520,
@@ -2013,7 +2013,7 @@ static char *acurite_590_output_fields[] = {
 //.long_width     = 1076,
 //.gap_limit      = 1200,
 //.reset_limit    = 12000,
-r_device acurite_606 = {
+r_device const acurite_606 = {
         .name        = "Acurite 606TX Temperature Sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 2000,
@@ -2038,7 +2038,7 @@ static char *acurite_00275rm_output_fields[] = {
         NULL,
 };
 
-r_device acurite_00275rm = {
+r_device const acurite_00275rm = {
         .name        = "Acurite 00275rm,00276rm Temp/Humidity with optional probe",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 232, // short pulse is 232 us
@@ -2050,7 +2050,7 @@ r_device acurite_00275rm = {
         .fields      = acurite_00275rm_output_fields,
 };
 
-r_device acurite_590tx = {
+r_device const acurite_590tx = {
         .name        = "Acurite 590TX Temperature with optional Humidity",
         .modulation  = OOK_PULSE_PPM, // OOK_PULSE_PWM,
         .short_width = 500,           // short pulse is 232 us

--- a/src/devices/acurite_01185m.c
+++ b/src/devices/acurite_01185m.c
@@ -125,7 +125,7 @@ static char *acurite_01185m_output_fields[] = {
         NULL,
 };
 
-r_device acurite_01185m = {
+r_device const acurite_01185m = {
         .name        = "Acurite Grill/Meat Thermometer 01185M",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 840,  // short pulse is 840 us

--- a/src/devices/akhan_100F14.c
+++ b/src/devices/akhan_100F14.c
@@ -69,7 +69,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device akhan_100F14 = {
+r_device const akhan_100F14 = {
         .name        = "Akhan 100F14 remote keyless entry",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 316,

--- a/src/devices/alecto.c
+++ b/src/devices/alecto.c
@@ -223,7 +223,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device alectov1 = {
+r_device const alectov1 = {
         .name        = "AlectoV1 Weather Sensor (Alecto WS3500 WS4500 Ventus W155/W044 Oregon)",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 2000,

--- a/src/devices/ambient_weather.c
+++ b/src/devices/ambient_weather.c
@@ -168,7 +168,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device ambient_weather = {
+r_device const ambient_weather = {
         .name        = "Ambient Weather F007TH, TFA 30.3208.02, SwitchDocLabs F016TH temperature sensor",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 500,

--- a/src/devices/ambientweather_tx8300.c
+++ b/src/devices/ambientweather_tx8300.c
@@ -129,7 +129,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device ambientweather_tx8300 = {
+r_device const ambientweather_tx8300 = {
         .name        = "Ambient Weather TX-8300 Temperature/Humidity Sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 2000,

--- a/src/devices/ambientweather_wh31e.c
+++ b/src/devices/ambientweather_wh31e.c
@@ -374,7 +374,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device ambientweather_wh31e = {
+r_device const ambientweather_wh31e = {
         .name        = "Ambient Weather WH31E Thermo-Hygrometer Sensor, EcoWitt WH40 rain gauge",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 56,

--- a/src/devices/ant_antplus.c
+++ b/src/devices/ant_antplus.c
@@ -151,7 +151,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device ant_antplus = {
+r_device const ant_antplus = {
         .name        = "ANT and ANT+ devices",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 1,

--- a/src/devices/archos_tbh.c
+++ b/src/devices/archos_tbh.c
@@ -225,7 +225,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device archos_tbh = {
+r_device const archos_tbh = {
         .name        = "TBH weather sensor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 212,

--- a/src/devices/atech_ws308.c
+++ b/src/devices/atech_ws308.c
@@ -127,7 +127,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device atech_ws308 = {
+r_device const atech_ws308 = {
         .name        = "Atech-WS308 temperature sensor",
         .modulation  = OOK_PULSE_RZ,
         .short_width = 1600,

--- a/src/devices/auriol_4ld5661.c
+++ b/src/devices/auriol_4ld5661.c
@@ -86,7 +86,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device auriol_4ld5661 = {
+r_device const auriol_4ld5661 = {
         .name        = "Auriol 4-LD5661 temperature/rain sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 1000,

--- a/src/devices/auriol_aft77b2.c
+++ b/src/devices/auriol_aft77b2.c
@@ -145,7 +145,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device auriol_aft77b2 = {
+r_device const auriol_aft77b2 = {
         .name        = "Auriol AFT 77 B2 temperature sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 500,

--- a/src/devices/auriol_afw2a1.c
+++ b/src/devices/auriol_afw2a1.c
@@ -117,7 +117,7 @@ static char *output_fields[] = {
 };
 
 // ToDo: The timings have come about through trial and error. Audit this against weak signals!
-r_device auriol_afw2a1 = {
+r_device const auriol_afw2a1 = {
         .name        = "Auriol AFW2A1 temperature/humidity sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 576,

--- a/src/devices/auriol_ahfl.c
+++ b/src/devices/auriol_ahfl.c
@@ -108,7 +108,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device auriol_ahfl = {
+r_device const auriol_ahfl = {
         .name        = "Auriol AHFL temperature/humidity sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 2100,

--- a/src/devices/auriol_hg02832.c
+++ b/src/devices/auriol_hg02832.c
@@ -101,7 +101,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device auriol_hg02832 = {
+r_device const auriol_hg02832 = {
         .name        = "Auriol HG02832, HG05124A-DCF, Rubicson 48957 temperature/humidity sensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 252,

--- a/src/devices/badger_water.c
+++ b/src/devices/badger_water.c
@@ -150,7 +150,7 @@ static char *badger_output_fields[] = {
 
 // Badger ORION water meter,
 // Frequency 916.45 MHz, Bitrate 100 kbps, Modulation NRZ FSK
-r_device badger_orion = {
+r_device const badger_orion = {
         .name        = "Badger ORION water meter, 100kbps (-f 916.45M -s 1200k)", // Minimum samplerate = 1.2 MHz (12 samples of 100kb/s)
         .modulation  = FSK_PULSE_PCM,
         .short_width = 10,   // Bit rate: 100 kb/s

--- a/src/devices/blueline.c
+++ b/src/devices/blueline.c
@@ -396,7 +396,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device blueline;
+r_device const blueline;
 
 static r_device *blueline_create(char *arg)
 {
@@ -430,7 +430,7 @@ static r_device *blueline_create(char *arg)
     return r_dev;
 }
 
-r_device blueline = {
+r_device const blueline = {
         .name        = "BlueLine Innovations Power Cost Monitor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 500,

--- a/src/devices/blyss.c
+++ b/src/devices/blyss.c
@@ -62,7 +62,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device blyss = {
+r_device const blyss = {
         .name        = "Blyss DC5-UK-WH",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 500,

--- a/src/devices/brennenstuhl_rcs_2044.c
+++ b/src/devices/brennenstuhl_rcs_2044.c
@@ -120,7 +120,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device brennenstuhl_rcs_2044 = {
+r_device const brennenstuhl_rcs_2044 = {
         .name        = "Brennenstuhl RCS 2044",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 320,

--- a/src/devices/bresser_3ch.c
+++ b/src/devices/bresser_3ch.c
@@ -106,7 +106,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device bresser_3ch = {
+r_device const bresser_3ch = {
         .name        = "Bresser Thermo-/Hygro-Sensor 3CH",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 250,  // short pulse is ~250 us

--- a/src/devices/bresser_5in1.c
+++ b/src/devices/bresser_5in1.c
@@ -174,7 +174,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device bresser_5in1 = {
+r_device const bresser_5in1 = {
         .name        = "Bresser Weather Center 5-in-1",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 124,

--- a/src/devices/bresser_6in1.c
+++ b/src/devices/bresser_6in1.c
@@ -238,7 +238,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device bresser_6in1 = {
+r_device const bresser_6in1 = {
         .name        = "Bresser Weather Center 6-in-1, 7-in-1 indoor, soil, new 5-in-1, 3-in-1 wind gauge, Froggit WH6000, Ventus C8488A",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 124,

--- a/src/devices/bresser_7in1.c
+++ b/src/devices/bresser_7in1.c
@@ -151,7 +151,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device bresser_7in1 = {
+r_device const bresser_7in1 = {
         .name        = "Bresser Weather Center 7-in-1",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 124,

--- a/src/devices/bt_rain.c
+++ b/src/devices/bt_rain.c
@@ -96,7 +96,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device bt_rain = {
+r_device const bt_rain = {
         .name        = "Biltema rain gauge",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 1940,

--- a/src/devices/burnhardbbq.c
+++ b/src/devices/burnhardbbq.c
@@ -134,7 +134,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device burnhardbbq = {
+r_device const burnhardbbq = {
         .name        = "Burnhard BBQ thermometer",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 240,

--- a/src/devices/calibeur.c
+++ b/src/devices/calibeur.c
@@ -125,7 +125,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device calibeur_RF104 = {
+r_device const calibeur_RF104 = {
         .name        = "Calibeur RF-104 Sensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 760,  // Short pulse 760µs

--- a/src/devices/cardin.c
+++ b/src/devices/cardin.c
@@ -114,7 +114,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device cardin = {
+r_device const cardin = {
         .name        = "Cardin S466-TX2",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 730,

--- a/src/devices/cavius.c
+++ b/src/devices/cavius.c
@@ -129,7 +129,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device cavius = {
+r_device const cavius = {
         .name        = "Cavius smoke, heat and water detector",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 206,

--- a/src/devices/ced7000.c
+++ b/src/devices/ced7000.c
@@ -102,7 +102,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device ced7000 = {
+r_device const ced7000 = {
         .name        = "CED7000 Shot Timer",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 1300,

--- a/src/devices/chuango.c
+++ b/src/devices/chuango.c
@@ -95,7 +95,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device chuango = {
+r_device const chuango = {
         .name        = "Chuango Security Technology",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 568,  // Pulse: Short 568µs, Long 1704µs

--- a/src/devices/cmr113.c
+++ b/src/devices/cmr113.c
@@ -118,7 +118,7 @@ static char *output_fields[] = {
 };
 
 // Short high and low pulses are quite different in length so we have a high tolerance of 200
-r_device cmr113 = {
+r_device const cmr113 = {
         .name        = "Clipsal CMR113 Cent-a-meter power meter",
         .modulation  = OOK_PULSE_PIWM_DC,
         .short_width = 480,

--- a/src/devices/companion_wtr001.c
+++ b/src/devices/companion_wtr001.c
@@ -134,7 +134,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device companion_wtr001 = {
+r_device const companion_wtr001 = {
         .name        = "Companion WTR001 Temperature Sensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 732,  // 732 us pulse + 2196 us gap is 1 (will be inverted in code)

--- a/src/devices/cotech_36_7959.c
+++ b/src/devices/cotech_36_7959.c
@@ -150,7 +150,7 @@ static char *cotech_36_7959_output_fields[] = {
         NULL,
 };
 
-r_device cotech_36_7959 = {
+r_device const cotech_36_7959 = {
         .name        = "Cotech 36-7959, SwitchDocLabs FT020T wireless weather station with USB",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 500,

--- a/src/devices/current_cost.c
+++ b/src/devices/current_cost.c
@@ -125,7 +125,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device current_cost = {
+r_device const current_cost = {
         .name        = "CurrentCost Current Sensor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 250,

--- a/src/devices/danfoss.c
+++ b/src/devices/danfoss.c
@@ -157,7 +157,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device danfoss_CFR = {
+r_device const danfoss_CFR = {
         .name        = "Danfoss CFR Thermostat",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 100, // NRZ decoding

--- a/src/devices/digitech_xc0324.c
+++ b/src/devices/digitech_xc0324.c
@@ -218,7 +218,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device digitech_xc0324 = {
+r_device const digitech_xc0324 = {
         .name        = "Digitech XC-0324 / AmbientWeather FT005TH temp/hum sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 520,  // = 130 * 4

--- a/src/devices/directv.c
+++ b/src/devices/directv.c
@@ -370,7 +370,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device directv = {
+r_device const directv = {
         .name        = "DirecTV RC66RX Remote Control",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 600,  // 150 samples @250k

--- a/src/devices/dish_remote_6_3.c
+++ b/src/devices/dish_remote_6_3.c
@@ -139,7 +139,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device dish_remote_6_3 = {
+r_device const dish_remote_6_3 = {
         .name        = "Dish remote 6.3",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 1692,

--- a/src/devices/dsc.c
+++ b/src/devices/dsc.c
@@ -262,7 +262,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device dsc_security = {
+r_device const dsc_security = {
         .name        = "DSC Security Contact",
         .modulation  = OOK_PULSE_RZ,
         .short_width = 250,  // Pulse length, 250 µs
@@ -272,7 +272,7 @@ r_device dsc_security = {
         .fields      = output_fields,
 };
 
-r_device dsc_security_ws4945 = {
+r_device const dsc_security_ws4945 = {
         // Used for EV-DW4927, WS4975 and WS4945.
         .name        = "DSC Security Contact (WS4945)",
         .modulation  = OOK_PULSE_RZ,

--- a/src/devices/ecodhome.c
+++ b/src/devices/ecodhome.c
@@ -182,7 +182,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device ecodhome = {
+r_device const ecodhome = {
         .name        = "EcoDHOME Smart Socket and MCEE Solar monitor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 250,

--- a/src/devices/ecowitt.c
+++ b/src/devices/ecowitt.c
@@ -115,7 +115,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device ecowitt = {
+r_device const ecowitt = {
         .name        = "Ecowitt Wireless Outdoor Thermometer WH53/WH0280/WH0281A",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 500,  // 500 us nominal short pulse

--- a/src/devices/efergy_e2_classic.c
+++ b/src/devices/efergy_e2_classic.c
@@ -121,7 +121,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device efergy_e2_classic = {
+r_device const efergy_e2_classic = {
         .name        = "Efergy e2 classic",
         .modulation  = FSK_PULSE_PWM,
         .short_width = 64,

--- a/src/devices/efergy_optical.c
+++ b/src/devices/efergy_optical.c
@@ -134,7 +134,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device efergy_optical = {
+r_device const efergy_optical = {
         .name        = "Efergy Optical",
         .modulation  = FSK_PULSE_PWM,
         .short_width = 64,

--- a/src/devices/efth800.c
+++ b/src/devices/efth800.c
@@ -140,7 +140,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device eurochron_efth800 = {
+r_device const eurochron_efth800 = {
         .name        = "Eurochron EFTH-800 temperature and humidity sensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 250,

--- a/src/devices/elro_db286a.c
+++ b/src/devices/elro_db286a.c
@@ -55,7 +55,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device elro_db286a = {
+r_device const elro_db286a = {
         .name        = "Elro DB286A Doorbell",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 456,

--- a/src/devices/elv.c
+++ b/src/devices/elv.c
@@ -105,7 +105,7 @@ static char *elv_em1000_output_fields[] = {
         NULL,
 };
 
-r_device elv_em1000 = {
+r_device const elv_em1000 = {
         .name        = "ELV EM 1000",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 500,  // guessed, no samples available
@@ -279,7 +279,7 @@ static char *elv_ws2000_output_fields[] = {
         NULL,
 };
 
-r_device elv_ws2000 = {
+r_device const elv_ws2000 = {
         .name        = "ELV WS 2000",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 366,  // 0 => 854us, 1 => 366us according to link in top

--- a/src/devices/emax.c
+++ b/src/devices/emax.c
@@ -227,7 +227,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device emax = {
+r_device const emax = {
         .name        = "Emax W6, rebrand Altronics x7063/4, Optex 990040/50/51, Orium 13093/13123, Infactory FWS-1200, Newentor Q9, Otio 810025, Protmex PT3390A, Jula Marquant 014331/32, Weather Station or temperature/humidity sensor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 90,

--- a/src/devices/emontx.c
+++ b/src/devices/emontx.c
@@ -157,7 +157,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device emontx = {
+r_device const emontx = {
         .name        = "emonTx OpenEnergyMonitor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 2000000.0f / (49230 + 49261), // 49261kHz for RFM69, 49230kHz for RFM12B

--- a/src/devices/emos_e6016.c
+++ b/src/devices/emos_e6016.c
@@ -138,7 +138,7 @@ static char *output_fields[] = {
         NULL,
 };
 // n=EMOS-E6016,m=OOK_PWM,s=280,l=796,r=804,g=0,t=0,y=1836,rows>=3,bits=120
-r_device emos_e6016 = {
+r_device const emos_e6016 = {
         .name        = "EMOS E6016 weatherstation with DCF77",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 280,

--- a/src/devices/emos_e6016_rain.c
+++ b/src/devices/emos_e6016_rain.c
@@ -109,7 +109,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device emos_e6016_rain = {
+r_device const emos_e6016_rain = {
         .name        = "EMOS E6016 rain gauge",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 300,

--- a/src/devices/enocean_erp1.c
+++ b/src/devices/enocean_erp1.c
@@ -97,7 +97,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device enocean_erp1 = {
+r_device const enocean_erp1 = {
         .name        = "EnOcean ERP1",
         .modulation  = OOK_PULSE_PCM,
         .short_width = 8,

--- a/src/devices/ert_idm.c
+++ b/src/devices/ert_idm.c
@@ -618,7 +618,7 @@ static char *output_fields[] = {
 //      Freq 912600155
 //     -X n=L58,m=OOK_MC_ZEROBIT,s=30,l=30,g=20000,r=20000,match={24}0x16a31e,preamble={1}0x00
 
-r_device ert_idm = {
+r_device const ert_idm = {
         .name        = "ERT Interval Data Message (IDM)",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 30,
@@ -631,7 +631,7 @@ r_device ert_idm = {
         .fields    = output_fields,
 };
 
-r_device ert_netidm = {
+r_device const ert_netidm = {
         .name        = "ERT Interval Data Message (IDM) for Net Meters",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 30,

--- a/src/devices/ert_scm.c
+++ b/src/devices/ert_scm.c
@@ -106,7 +106,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device ert_scm = {
+r_device const ert_scm = {
         .name        = "ERT Standard Consumption Message (SCM)",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 30,

--- a/src/devices/esa.c
+++ b/src/devices/esa.c
@@ -101,7 +101,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device esa_energy = {
+r_device const esa_energy = {
         .name        = "ESA1000 / ESA2000 Energy Monitor",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 260,

--- a/src/devices/esic_emt7110.c
+++ b/src/devices/esic_emt7110.c
@@ -104,7 +104,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device esic_emt7110 = {
+r_device const esic_emt7110 = {
         .name        = "ESIC EMT7110 power meter",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 104,

--- a/src/devices/esperanza_ews.c
+++ b/src/devices/esperanza_ews.c
@@ -123,7 +123,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device esperanza_ews = {
+r_device const esperanza_ews = {
         .name        = "Esperanza EWS",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 2000,

--- a/src/devices/eurochron.c
+++ b/src/devices/eurochron.c
@@ -93,7 +93,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device eurochron = {
+r_device const eurochron = {
         .name        = "Eurochron temperature and humidity sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 1016,

--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -15,7 +15,7 @@
 #include "fatal.h"
 #include <stdlib.h>
 
-r_device fineoffset_WH2;
+r_device const fineoffset_WH2;
 
 static r_device *fineoffset_WH2_create(char *arg)
 {
@@ -1007,7 +1007,7 @@ static char *output_fields_WH0530[] = {
         NULL,
 };
 
-r_device fineoffset_WH2 = {
+r_device const fineoffset_WH2 = {
         .name        = "Fine Offset Electronics, WH2, WH5, Telldus Temperature/Humidity/Rain Sensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 500,  // Short pulse 544µs, long pulse 1524µs, fixed gap 1036µs
@@ -1019,7 +1019,7 @@ r_device fineoffset_WH2 = {
         .fields      = output_fields,
 };
 
-r_device fineoffset_WH25 = {
+r_device const fineoffset_WH25 = {
         .name        = "Fine Offset Electronics, WH25, WH32B, WH24, WH65B, HP1000, Misol WS2320 Temperature/Humidity/Pressure Sensor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 58,    // Bit width = 58µs (measured across 580 samples / 40 bits / 250 kHz )
@@ -1029,7 +1029,7 @@ r_device fineoffset_WH25 = {
         .fields      = output_fields_WH25,
 };
 
-r_device fineoffset_WH51 = {
+r_device const fineoffset_WH51 = {
         .name        = "Fine Offset Electronics/ECOWITT WH51, SwitchDoc Labs SM23 Soil Moisture Sensor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 58, // Bit width = 58µs (measured across 580 samples / 40 bits / 250 kHz )
@@ -1039,7 +1039,7 @@ r_device fineoffset_WH51 = {
         .fields      = output_fields_WH51,
 };
 
-r_device fineoffset_WH0530 = {
+r_device const fineoffset_WH0530 = {
         .name        = "Fine Offset Electronics, WH0530 Temperature/Rain Sensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 504,  // Short pulse 504µs

--- a/src/devices/fineoffset_wh1050.c
+++ b/src/devices/fineoffset_wh1050.c
@@ -133,7 +133,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device fineoffset_wh1050 = {
+r_device const fineoffset_wh1050 = {
         .name        = "Fine Offset WH1050 Weather Station",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 544,

--- a/src/devices/fineoffset_wh1080.c
+++ b/src/devices/fineoffset_wh1080.c
@@ -349,7 +349,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device fineoffset_wh1080 = {
+r_device const fineoffset_wh1080 = {
         .name        = "Fine Offset Electronics WH1080/WH3080 Weather Station",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 544,  // Short pulse 544µs, long pulse 1524µs, fixed gap 1036µs
@@ -359,7 +359,7 @@ r_device fineoffset_wh1080 = {
         .fields      = output_fields,
 };
 
-r_device fineoffset_wh1080_fsk = {
+r_device const fineoffset_wh1080_fsk = {
         .name        = "Fine Offset Electronics WH1080/WH3080 Weather Station (FSK)",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 58,

--- a/src/devices/fineoffset_wh31l.c
+++ b/src/devices/fineoffset_wh31l.c
@@ -166,7 +166,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device fineoffset_wh31l = {
+r_device const fineoffset_wh31l = {
         .name        = "Ambient Weather WH31L (FineOffset WH57) Lightning-Strike sensor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 56,

--- a/src/devices/fineoffset_wh45.c
+++ b/src/devices/fineoffset_wh45.c
@@ -142,7 +142,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device fineoffset_wh45 = {
+r_device const fineoffset_wh45 = {
         .name        = "Fine Offset Electronics WH45 air quality sensor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 58,

--- a/src/devices/fineoffset_wn34.c
+++ b/src/devices/fineoffset_wn34.c
@@ -120,7 +120,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device fineoffset_wn34 = {
+r_device const fineoffset_wn34 = {
         .name        = "Fine Offset Electronics WN34 temperature sensor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 58,

--- a/src/devices/fineoffset_ws80.c
+++ b/src/devices/fineoffset_ws80.c
@@ -131,7 +131,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device fineoffset_ws80 = {
+r_device const fineoffset_ws80 = {
         .name        = "Fine Offset Electronics WS80 weather station",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 58,

--- a/src/devices/fordremote.c
+++ b/src/devices/fordremote.c
@@ -69,7 +69,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device fordremote = {
+r_device const fordremote = {
         .name        = "Ford Car Key",
         .modulation  = OOK_PULSE_DMC,
         .short_width = 250,  // half-bit width is 250 us

--- a/src/devices/fs20.c
+++ b/src/devices/fs20.c
@@ -128,7 +128,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device fs20 = {
+r_device const fs20 = {
         .name        = "FS20",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 400,

--- a/src/devices/ft004b.c
+++ b/src/devices/ft004b.c
@@ -71,7 +71,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device ft004b = {
+r_device const ft004b = {
         .name        = "FT-004-B Temperature Sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 1956,

--- a/src/devices/funkbus.c
+++ b/src/devices/funkbus.c
@@ -173,7 +173,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device funkbus_remote = {
+r_device const funkbus_remote = {
         .name        = "Funkbus / Instafunk (Berker, Gira, Jung)",
         .modulation  = OOK_PULSE_DMC,
         .short_width = 500,

--- a/src/devices/ge_coloreffects.c
+++ b/src/devices/ge_coloreffects.c
@@ -164,7 +164,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device ge_coloreffects = {
+r_device const ge_coloreffects = {
         .name        = "GE Color Effects",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 52,

--- a/src/devices/generic_motion.c
+++ b/src/devices/generic_motion.c
@@ -68,7 +68,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device generic_motion = {
+r_device const generic_motion = {
         .name        = "Generic wireless motion sensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 888,

--- a/src/devices/generic_remote.c
+++ b/src/devices/generic_remote.c
@@ -79,7 +79,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device generic_remote = {
+r_device const generic_remote = {
         .name        = "Generic Remote SC226x EV1527",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 464,

--- a/src/devices/generic_temperature_sensor.c
+++ b/src/devices/generic_temperature_sensor.c
@@ -68,7 +68,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device generic_temperature_sensor = {
+r_device const generic_temperature_sensor = {
         .name        = "Generic temperature sensor 1",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 2000,

--- a/src/devices/geo_minim.c
+++ b/src/devices/geo_minim.c
@@ -337,7 +337,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device geo_minim = {
+r_device const geo_minim = {
         .name           = "GEO minim+ energy monitor",
         .modulation     = FSK_PULSE_PCM,
         .short_width    = 24,

--- a/src/devices/govee.c
+++ b/src/devices/govee.c
@@ -249,7 +249,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device govee = {
+r_device const govee = {
         .name        = "Govee Water Leak Detector H5054, Door Contact Sensor B5023",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 440,  // Threshold between short and long pulse [us]
@@ -389,7 +389,7 @@ static int govee_h5054_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-r_device govee_h5054 = {
+r_device const govee_h5054 = {
         .name        = "Govee Water Leak Detector H5054",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 440,  // Threshold between short and long pulse [us]

--- a/src/devices/gt_tmbbq05.c
+++ b/src/devices/gt_tmbbq05.c
@@ -135,7 +135,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device gt_tmbbq05 = {
+r_device const gt_tmbbq05 = {
         .name        = "Globaltronics QUIGG GT-TMBBQ-05",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 2000,

--- a/src/devices/gt_wt_02.c
+++ b/src/devices/gt_wt_02.c
@@ -126,7 +126,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device gt_wt_02 = {
+r_device const gt_wt_02 = {
         .name        = "Globaltronics GT-WT-02 Sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 2500, // 3ms (old) / 2ms (new)

--- a/src/devices/gt_wt_03.c
+++ b/src/devices/gt_wt_03.c
@@ -158,7 +158,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device gt_wt_03 = {
+r_device const gt_wt_03 = {
         .name        = "Globaltronics GT-WT-03 Sensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 256,

--- a/src/devices/hcs200.c
+++ b/src/devices/hcs200.c
@@ -97,7 +97,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device hcs200 = {
+r_device const hcs200 = {
         .name        = "Microchip HCS200/HCS300 KeeLoq Hopping Encoder based remotes",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 370,
@@ -109,7 +109,7 @@ r_device hcs200 = {
         .fields      = output_fields,
 };
 
-r_device hcs200_fsk = {
+r_device const hcs200_fsk = {
         .name        = "Microchip HCS200/HCS300 KeeLoq Hopping Encoder based remotes (FSK)",
         .modulation  = FSK_PULSE_PWM,
         .short_width = 370,

--- a/src/devices/hideki.c
+++ b/src/devices/hideki.c
@@ -242,7 +242,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device hideki_ts04 = {
+r_device const hideki_ts04 = {
         .name        = "HIDEKI TS04 Temperature, Humidity, Wind and Rain Sensor",
         .modulation  = OOK_PULSE_DMC,
         .short_width = 520,  // half-bit width 520 us

--- a/src/devices/holman_ws5029.c
+++ b/src/devices/holman_ws5029.c
@@ -131,7 +131,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device holman_ws5029pcm = {
+r_device const holman_ws5029pcm = {
         .name        = "Holman Industries iWeather WS5029 weather station (newer PCM)",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 100,
@@ -212,7 +212,7 @@ static int holman_ws5029pwm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-r_device holman_ws5029pwm = {
+r_device const holman_ws5029pwm = {
         .name        = "Holman Industries iWeather WS5029 weather station (older PWM)",
         .modulation  = FSK_PULSE_PWM,
         .short_width = 488,

--- a/src/devices/hondaremote.c
+++ b/src/devices/hondaremote.c
@@ -68,7 +68,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device hondaremote = {
+r_device const hondaremote = {
         .name        = "Honda Car Key",
         .modulation  = FSK_PULSE_PWM,
         .short_width = 250,

--- a/src/devices/honeywell.c
+++ b/src/devices/honeywell.c
@@ -139,7 +139,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device honeywell = {
+r_device const honeywell = {
         .name        = "Honeywell Door/Window Sensor, 2Gig DW10/DW11, RE208 repeater",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 156,

--- a/src/devices/honeywell_cm921.c
+++ b/src/devices/honeywell_cm921.c
@@ -458,7 +458,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device honeywell_cm921 = {
+r_device const honeywell_cm921 = {
         .name        = "Honeywell CM921 Wireless Programmable Room Thermostat",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 26,

--- a/src/devices/honeywell_wdb.c
+++ b/src/devices/honeywell_wdb.c
@@ -125,7 +125,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device honeywell_wdb = {
+r_device const honeywell_wdb = {
         .name        = "Honeywell ActivLink, Wireless Doorbell",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 175,
@@ -137,7 +137,7 @@ r_device honeywell_wdb = {
         .fields      = output_fields,
 };
 
-r_device honeywell_wdb_fsk = {
+r_device const honeywell_wdb_fsk = {
         .name        = "Honeywell ActivLink, Wireless Doorbell (FSK)",
         .modulation  = FSK_PULSE_PWM,
         .short_width = 160,

--- a/src/devices/ht680.c
+++ b/src/devices/ht680.c
@@ -90,7 +90,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device ht680 = {
+r_device const ht680 = {
         .name        = "HT680 Remote control",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 200,

--- a/src/devices/ibis_beacon.c
+++ b/src/devices/ibis_beacon.c
@@ -89,7 +89,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device ibis_beacon = {
+r_device const ibis_beacon = {
         .name        = "IBIS beacon",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 30,  // Nominal width of clock half period [us]

--- a/src/devices/ikea_sparsnas.c
+++ b/src/devices/ikea_sparsnas.c
@@ -288,7 +288,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device ikea_sparsnas = {
+r_device const ikea_sparsnas = {
         .name        = "IKEA Sparsnas Energy Meter Monitor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 27,

--- a/src/devices/infactory.c
+++ b/src/devices/infactory.c
@@ -130,7 +130,7 @@ This analysis is the reason for the new r_device definitions below.
 NB: pulse_slicer_ppm does not use .gap_limit if .tolerance is set.
 */
 
-r_device infactory = {
+r_device const infactory = {
         .name        = "inFactory, nor-tec, FreeTec NC-3982-913 temperature humidity sensor",
         .modulation  = OOK_PULSE_PPM,
         .sync_width  = 500,  // Sync pulse width (recognized, but not used)

--- a/src/devices/inkbird_ith20r.c
+++ b/src/devices/inkbird_ith20r.c
@@ -140,7 +140,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device inkbird_ith20r = {
+r_device const inkbird_ith20r = {
         .name        = "Inkbird ITH-20R temperature humidity sensor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 100,  // Width of a '0' gap

--- a/src/devices/inovalley-kw9015b.c
+++ b/src/devices/inovalley-kw9015b.c
@@ -84,7 +84,7 @@ static char *kw9015b_csv_output_fields[] = {
         NULL,
 };
 
-r_device kw9015b = {
+r_device const kw9015b = {
         .name        = "Inovalley kw9015b, TFA Dostmann 30.3161 (Rain and temperature sensor)",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 2000,

--- a/src/devices/insteon.c
+++ b/src/devices/insteon.c
@@ -484,7 +484,7 @@ static char *output_fields[] = {
 
 //     -X 'n=Insteon_F16,m=FSK_PCM,s=110,l=110,t=15,g=20000,r=20000,invert,match={16}0x6666'
 
-r_device insteon = {
+r_device const insteon = {
         .name        = "Insteon",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 110, // short gap is 132 us

--- a/src/devices/interlogix.c
+++ b/src/devices/interlogix.c
@@ -237,7 +237,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device interlogix = {
+r_device const interlogix = {
         .name        = "Interlogix GE UTC Security Devices",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 122,

--- a/src/devices/intertechno.c
+++ b/src/devices/intertechno.c
@@ -61,7 +61,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device intertechno = {
+r_device const intertechno = {
         .name        = "Intertechno 433",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 330,

--- a/src/devices/jasco.c
+++ b/src/devices/jasco.c
@@ -77,7 +77,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device jasco = {
+r_device const jasco = {
         .name        = "Jasco/GE Choice Alert Security Devices",
         .modulation  = OOK_PULSE_PCM,
         .short_width = 250,

--- a/src/devices/kedsum.c
+++ b/src/devices/kedsum.c
@@ -105,7 +105,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device kedsum = {
+r_device const kedsum = {
         .name        = "Kedsum Temperature & Humidity Sensor, Pearl NC-7415",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 2000,

--- a/src/devices/kerui.c
+++ b/src/devices/kerui.c
@@ -103,7 +103,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device kerui = {
+r_device const kerui = {
         .name        = "Kerui PIR / Contact Sensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 420,

--- a/src/devices/klimalogg.c
+++ b/src/devices/klimalogg.c
@@ -101,7 +101,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device klimalogg = {
+r_device const klimalogg = {
         .name        = "Klimalogg",
         .modulation  = OOK_PULSE_NRZS,
         .short_width = 26,

--- a/src/devices/lacrosse.c
+++ b/src/devices/lacrosse.c
@@ -184,7 +184,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device lacrossetx = {
+r_device const lacrossetx = {
         .name        = "LaCrosse TX Temperature / Humidity Sensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 550,  // 550 us pulse + 1000 us gap is 1

--- a/src/devices/lacrosse_breezepro.c
+++ b/src/devices/lacrosse_breezepro.c
@@ -166,7 +166,7 @@ static char *output_fields[] = {
 };
 
 // flex decoder m=FSK_PCM, s=107, l=107, r=5900
-r_device lacrosse_breezepro = {
+r_device const lacrosse_breezepro = {
         .name        = "LaCrosse Technology View LTV-WSDTH01 Breeze Pro Wind Sensor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 107,

--- a/src/devices/lacrosse_r1.c
+++ b/src/devices/lacrosse_r1.c
@@ -193,7 +193,7 @@ static char *output_fields[] = {
 };
 
 // flex decoder m=FSK_PCM, s=104, l=104, r=9600
-r_device lacrosse_r1 = {
+r_device const lacrosse_r1 = {
         .name        = "LaCrosse Technology View LTV-R1, LTV-R3 Rainfall Gauge, LTV-W1/W2 Wind Sensor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 104,

--- a/src/devices/lacrosse_th3.c
+++ b/src/devices/lacrosse_th3.c
@@ -151,7 +151,7 @@ static char *output_fields[] = {
 // flex decoder n=TH3, m=FSK_PCM, s=104, l=104, r=9600
 // flex decoder n=TH2, m=FSK_PCM, s=107, l=107, r=5900
 // TH3 parameters should be good enough for both sensors
-r_device lacrosse_th3 = {
+r_device const lacrosse_th3 = {
         .name        = "LaCrosse Technology View LTV-TH Thermo/Hygro Sensor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 104,

--- a/src/devices/lacrosse_tx141x.c
+++ b/src/devices/lacrosse_tx141x.c
@@ -302,7 +302,7 @@ static char *output_fields[] = {
 };
 
 // note TX141W, TX145wsdth: m=OOK_PWM, s=256, l=500, r=1888, y=748
-r_device lacrosse_tx141x = {
+r_device const lacrosse_tx141x = {
         .name        = "LaCrosse TX141-Bv2, TX141TH-Bv2, TX141-Bv3, TX141W, TX145wsdth, (TFA, ORIA) sensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 208,  // short pulse is 208 us + 417 us gap

--- a/src/devices/lacrosse_tx34.c
+++ b/src/devices/lacrosse_tx34.c
@@ -114,7 +114,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device lacrosse_tx34 = {
+r_device const lacrosse_tx34 = {
         .name        = "LaCrosse TX34-IT rain gauge",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 58,

--- a/src/devices/lacrosse_tx35.c
+++ b/src/devices/lacrosse_tx35.c
@@ -181,7 +181,7 @@ static char *output_fields[] = {
 };
 
 // Receiver for the TX29 and TX25U device
-r_device lacrosse_tx29 = {
+r_device const lacrosse_tx29 = {
         .name        = "LaCrosse TX29IT, TFA Dostmann 30.3159.IT Temperature sensor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 55, // 58 us for TX34-IT
@@ -192,7 +192,7 @@ r_device lacrosse_tx29 = {
 };
 
 // Receiver for the TX35 device
-r_device lacrosse_tx35 = {
+r_device const lacrosse_tx35 = {
         .name        = "LaCrosse TX35DTH-IT, TFA Dostmann 30.3155 Temperature/Humidity sensor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 105,

--- a/src/devices/lacrosse_wr1.c
+++ b/src/devices/lacrosse_wr1.c
@@ -136,7 +136,7 @@ static char *output_fields[] = {
 };
 
 // flex decoder m=FSK_PCM, s=104, l=104, r=9600
-r_device lacrosse_wr1 = {
+r_device const lacrosse_wr1 = {
         .name        = "LaCrosse Technology View LTV-WR1 Multi Sensor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 104,

--- a/src/devices/lacrosse_ws7000.c
+++ b/src/devices/lacrosse_ws7000.c
@@ -230,7 +230,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device lacrosse_ws7000 = {
+r_device const lacrosse_ws7000 = {
         .name        = "LaCrosse/ELV/Conrad WS7000/WS2500 weather sensors",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 400,

--- a/src/devices/lacrossews.c
+++ b/src/devices/lacrossews.c
@@ -213,7 +213,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device lacrossews = {
+r_device const lacrossews = {
         .name        = "LaCrosse WS-2310 / WS-3600 Weather Station",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 368,

--- a/src/devices/lightwave_rf.c
+++ b/src/devices/lightwave_rf.c
@@ -145,7 +145,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device lightwave_rf = {
+r_device const lightwave_rf = {
         .name        = "LightwaveRF",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 250,  // Short gap 250µs, long gap 1250µs, (Pulse width is 250µs)

--- a/src/devices/m_bus.c
+++ b/src/devices/m_bus.c
@@ -1189,7 +1189,7 @@ static char *output_fields[] = {
 
 // Mode C1, C2 (Meter TX), T1, T2 (Meter TX),
 // Frequency 868.95 MHz, Bitrate 100 kbps, Modulation NRZ FSK
-r_device m_bus_mode_c_t = {
+r_device const m_bus_mode_c_t = {
         .name        = "Wireless M-Bus, Mode C&T, 100kbps (-f 868.95M -s 1200k)", // Minimum samplerate = 1.2 MHz (12 samples of 100kb/s)
         .modulation  = FSK_PULSE_PCM,
         .short_width = 10,  // Bit rate: 100 kb/s
@@ -1201,7 +1201,7 @@ r_device m_bus_mode_c_t = {
 
 // Mode S1, S1-m, S2, T2 (Meter RX),    (Meter RX not so interesting)
 // Frequency 868.3 MHz, Bitrate 32.768 kbps, Modulation Manchester FSK
-r_device m_bus_mode_s = {
+r_device const m_bus_mode_s = {
         .name        = "Wireless M-Bus, Mode S, 32.768kbps (-f 868.3M -s 1000k)", // Minimum samplerate = 1 MHz (15 samples of 32kb/s manchester coded)
         .modulation  = FSK_PULSE_PCM,
         .short_width = (1000.0 / 32.768), // ~31 us per bit
@@ -1219,7 +1219,7 @@ r_device m_bus_mode_s = {
 // Frequency 868.33 MHz, Bitrate 4.8 kbps, Modulation Manchester FSK
 //      Preamble {0x55, 0x54, 0x76, 0x96} (Format A) (B not supported)
 // Untested stub!!! (Need samples)
-r_device m_bus_mode_r = {
+r_device const m_bus_mode_r = {
         .name        = "Wireless M-Bus, Mode R, 4.8kbps (-f 868.33M)",
         .modulation  = FSK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = (1000.0f / 4.8f / 2),    // ~208 us per bit -> clock half period ~104 us
@@ -1243,7 +1243,7 @@ r_device m_bus_mode_r = {
 //      Preamble {0x55, 0xF6, 0x8D} (Format A)
 //      Preamble {0x55, 0xF6, 0x72} (Format B)
 // Untested stub!!! (Need samples)
-r_device m_bus_mode_f = {
+r_device const m_bus_mode_f = {
         .name        = "Wireless M-Bus, Mode F, 2.4kbps",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 1000.0f / 2.4f, // ~417 us

--- a/src/devices/markisol.c
+++ b/src/devices/markisol.c
@@ -122,7 +122,7 @@ static char *output_fields[] = {
 
 // rtl_433 -f 433900000 -X 'n=name,m=OOK_PWM,s=368,l=704,r=10000,g=10000,t=0,y=5628'
 
-r_device markisol = {
+r_device const markisol = {
         .name        = "Markisol, E-Motion, BOFU, Rollerhouse, BF-30x, BF-415 curtain remote",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 368,

--- a/src/devices/marlec_solar.c
+++ b/src/devices/marlec_solar.c
@@ -105,7 +105,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device marlec_solar = {
+r_device const marlec_solar = {
         .name        = "Marlec Solar iBoost+ sensors",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 20,

--- a/src/devices/maverick_et73.c
+++ b/src/devices/maverick_et73.c
@@ -98,7 +98,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device maverick_et73 = {
+r_device const maverick_et73 = {
         .name        = "Maverick et73",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 1050,

--- a/src/devices/maverick_et73x.c
+++ b/src/devices/maverick_et73x.c
@@ -113,7 +113,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device maverick_et73x = {
+r_device const maverick_et73x = {
         .name        = "Maverick ET-732/733 BBQ Sensor",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 230,

--- a/src/devices/maverick_xr30.c
+++ b/src/devices/maverick_xr30.c
@@ -103,7 +103,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device maverick_xr30 = {
+r_device const maverick_xr30 = {
         .name        = "Maverick XR-30 BBQ Sensor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 360,

--- a/src/devices/mebus.c
+++ b/src/devices/mebus.c
@@ -79,7 +79,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device mebus433 = {
+r_device const mebus433 = {
         .name        = "Mebus 433",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 800,  // guessed, no samples available

--- a/src/devices/megacode.c
+++ b/src/devices/megacode.c
@@ -90,7 +90,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device megacode = {
+r_device const megacode = {
         .name        = "Linear Megacode Garage/Gate Remotes",
         .modulation  = OOK_PULSE_PCM,
         .short_width = 1000,

--- a/src/devices/missil_ml0757.c
+++ b/src/devices/missil_ml0757.c
@@ -140,7 +140,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device missil_ml0757 = {
+r_device const missil_ml0757 = {
         .name        = "Missil ML0757 weather station",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 975,

--- a/src/devices/neptune_r900.c
+++ b/src/devices/neptune_r900.c
@@ -233,7 +233,7 @@ static char *output_fields[] = {
 /*
  * r_device - registers device/callback. see rtl_433_devices.h
  */
-r_device neptune_r900 = {
+r_device const neptune_r900 = {
         .name        = "Neptune R900 flow meters",
         .modulation  = OOK_PULSE_PCM,
         .short_width = 30,

--- a/src/devices/new_template.c
+++ b/src/devices/new_template.c
@@ -283,7 +283,7 @@ static char *output_fields[] = {
  * and sort it into src/CMakeLists.txt or run ./maintainer_update.py
  *
  */
-r_device new_template = {
+r_device const new_template = {
         .name        = "Template decoder",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 132,  // short gap is 132 us

--- a/src/devices/newkaku.c
+++ b/src/devices/newkaku.c
@@ -84,7 +84,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device newkaku = {
+r_device const newkaku = {
         .name        = "KlikAanKlikUit Wireless Switch",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 300,  // 1:1

--- a/src/devices/nexa.c
+++ b/src/devices/nexa.c
@@ -79,7 +79,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device nexa = {
+r_device const nexa = {
         .name        = "Nexa",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 270,  // 1:1

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -112,7 +112,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device nexus = {
+r_device const nexus = {
         .name        = "Nexus, FreeTec NC-7345, NX-3980, Solight TE82S, TFA 30.3209 temperature/humidity sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 1000,

--- a/src/devices/nice_flor_s.c
+++ b/src/devices/nice_flor_s.c
@@ -75,7 +75,7 @@ static char *output_fields[] = {
 // model     : Nice Flor-s  Button ID : 1             Serial (enc.): 56bc8d1    Code (enc.): 89f4
 // count     : 6
 
-r_device nice_flor_s = {
+r_device const nice_flor_s = {
         .name        = "Nice Flor-s remote control for gates",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 500,  // short pulse is ~500 us + ~1000 us gap

--- a/src/devices/norgo.c
+++ b/src/devices/norgo.c
@@ -219,7 +219,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device norgo = {
+r_device const norgo = {
         .name        = "Norgo NGE101",
         .modulation  = OOK_PULSE_DMC,
         .short_width = 486,

--- a/src/devices/oil_standard.c
+++ b/src/devices/oil_standard.c
@@ -137,7 +137,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device oil_standard = {
+r_device const oil_standard = {
         .name        = "Oil Ultrasonic STANDARD FSK",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 500,
@@ -147,7 +147,7 @@ r_device oil_standard = {
         .fields      = output_fields,
 };
 
-r_device oil_standard_ask = {
+r_device const oil_standard_ask = {
         .name        = "Oil Ultrasonic STANDARD ASK",
         .modulation  = OOK_PULSE_PCM,
         .short_width = 500,

--- a/src/devices/oil_watchman.c
+++ b/src/devices/oil_watchman.c
@@ -110,7 +110,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device oil_watchman = {
+r_device const oil_watchman = {
         .name        = "Watchman Sonic / Apollo Ultrasonic / Beckett Rocket oil tank monitor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 1000,

--- a/src/devices/oil_watchman_advanced.c
+++ b/src/devices/oil_watchman_advanced.c
@@ -92,7 +92,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device oil_watchman_advanced = {
+r_device const oil_watchman_advanced = {
         .name        = "Watchman Sonic Advanced / Plus",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 500,

--- a/src/devices/opus_xt300.c
+++ b/src/devices/opus_xt300.c
@@ -104,7 +104,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device opus_xt300 = {
+r_device const opus_xt300 = {
         .name        = "Opus/Imagintronix XT300 Soil Moisture",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 544,

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -929,7 +929,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device oregon_scientific = {
+r_device const oregon_scientific = {
         .name        = "Oregon Scientific Weather Sensor",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 440, // Nominal 1024Hz (488us), but pulses are shorter than pauses

--- a/src/devices/oregon_scientific_sl109h.c
+++ b/src/devices/oregon_scientific_sl109h.c
@@ -115,7 +115,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device oregon_scientific_sl109h = {
+r_device const oregon_scientific_sl109h = {
         .name        = "Oregon Scientific SL109H Remote Thermal Hygro Sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 2000,

--- a/src/devices/oregon_scientific_v1.c
+++ b/src/devices/oregon_scientific_v1.c
@@ -95,7 +95,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device oregon_scientific_v1 = {
+r_device const oregon_scientific_v1 = {
         .name        = "OSv1 Temperature Sensor",
         .modulation  = OOK_PULSE_PWM_OSV1,
         .short_width = 1465, // nominal half-bit width

--- a/src/devices/philips_aj3650.c
+++ b/src/devices/philips_aj3650.c
@@ -142,7 +142,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device philips_aj3650 = {
+r_device const philips_aj3650 = {
         .name        = "Philips outdoor temperature sensor (type AJ3650)",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 2000,

--- a/src/devices/philips_aj7010.c
+++ b/src/devices/philips_aj7010.c
@@ -121,7 +121,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device philips_aj7010 = {
+r_device const philips_aj7010 = {
         .name        = "Philips outdoor temperature sensor (type AJ7010)",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 2000,

--- a/src/devices/proflame2.c
+++ b/src/devices/proflame2.c
@@ -152,7 +152,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device proflame2 = {
+r_device const proflame2 = {
         .name        = "SmartFire Proflame 2 remote control",
         .modulation  = OOK_PULSE_PCM,
         .short_width = 417, // 2400 baud

--- a/src/devices/prologue.c
+++ b/src/devices/prologue.c
@@ -98,7 +98,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device prologue = {
+r_device const prologue = {
         .name        = "Prologue, FreeTec NC-7104, NC-7159-675 temperature sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 2000,

--- a/src/devices/proove.c
+++ b/src/devices/proove.c
@@ -104,7 +104,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device proove = {
+r_device const proove = {
         .name        = "Proove / Nexa / KlikAanKlikUit Wireless Switch",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 270,  // 1:1

--- a/src/devices/quhwa.c
+++ b/src/devices/quhwa.c
@@ -61,7 +61,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device quhwa = {
+r_device const quhwa = {
         .name        = "Quhwa",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 360,  // Pulse: Short 360µs, Long 1070µs

--- a/src/devices/radiohead_ask.c
+++ b/src/devices/radiohead_ask.c
@@ -248,7 +248,7 @@ static char *sensible_living_output_fields[] = {
         NULL,
 };
 
-r_device radiohead_ask = {
+r_device const radiohead_ask = {
         .name        = "Radiohead ASK",
         .modulation  = OOK_PULSE_PCM,
         .short_width = 500,
@@ -258,7 +258,7 @@ r_device radiohead_ask = {
         .fields      = radiohead_ask_output_fields,
 };
 
-r_device sensible_living = {
+r_device const sensible_living = {
         .name        = "Sensible Living Mini-Plant Moisture Sensor",
         .modulation  = OOK_PULSE_PCM,
         .short_width = 1000,

--- a/src/devices/rainpoint.c
+++ b/src/devices/rainpoint.c
@@ -131,7 +131,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device rainpoint = {
+r_device const rainpoint = {
         .name        = "RainPoint soil temperature and moisture sensor",
         .modulation  = OOK_PULSE_PCM,
         .short_width = 500,

--- a/src/devices/regency_fan.c
+++ b/src/devices/regency_fan.c
@@ -170,7 +170,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device regency_fan = {
+r_device const regency_fan = {
         .name        = "Regency Ceiling Fan Remote (-f 303.75M to 303.96M)",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 580,

--- a/src/devices/rftech.c
+++ b/src/devices/rftech.c
@@ -78,7 +78,7 @@ static char *csv_output_fields[] = {
         NULL,
 };
 
-r_device rftech = {
+r_device const rftech = {
         .name        = "RF-tech",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 2000,

--- a/src/devices/rojaflex.c
+++ b/src/devices/rojaflex.c
@@ -296,7 +296,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device rojaflex = {
+r_device const rojaflex = {
         .name        = "RojaFlex shutter and remote devices",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 100,

--- a/src/devices/rubicson.c
+++ b/src/devices/rubicson.c
@@ -106,7 +106,7 @@ static char *output_fields[] = {
 };
 
 // timings based on samp_rate=1024000
-r_device rubicson = {
+r_device const rubicson = {
         .name        = "Rubicson, TFA 30.3197 or InFactory PT-310 Temperature Sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 1000, // Gaps:  Short 976us, Long 1940us, Sync 4000us

--- a/src/devices/rubicson_48659.c
+++ b/src/devices/rubicson_48659.c
@@ -190,7 +190,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device rubicson_48659 = {
+r_device const rubicson_48659 = {
         .name        = "Rubicson 48659 Thermometer",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 940,

--- a/src/devices/rubicson_pool_48942.c
+++ b/src/devices/rubicson_pool_48942.c
@@ -97,7 +97,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device rubicson_pool_48942 = {
+r_device const rubicson_pool_48942 = {
         .name        = "Rubicson Pool Thermometer 48942",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 280,

--- a/src/devices/s3318p.c
+++ b/src/devices/s3318p.c
@@ -124,7 +124,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device s3318p = {
+r_device const s3318p = {
         .name        = "Conrad S3318P, FreeTec NC-5849-913 temperature humidity sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 1900,

--- a/src/devices/schraeder.c
+++ b/src/devices/schraeder.c
@@ -277,7 +277,7 @@ static char *output_fields_SMD3MA4[] = {
         NULL,
 };
 
-r_device schraeder = {
+r_device const schraeder = {
         .name        = "Schrader TPMS",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 120,
@@ -287,7 +287,7 @@ r_device schraeder = {
         .fields      = output_fields,
 };
 
-r_device schrader_EG53MA4 = {
+r_device const schrader_EG53MA4 = {
         .name        = "Schrader TPMS EG53MA4, PA66GF35",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 123,
@@ -297,7 +297,7 @@ r_device schrader_EG53MA4 = {
         .fields      = output_fields_EG53MA4,
 };
 
-r_device schrader_SMD3MA4 = {
+r_device const schrader_SMD3MA4 = {
         .name        = "Schrader TPMS SMD3MA4 (Subaru)",
         .modulation  = OOK_PULSE_PCM,
         .short_width = 120,

--- a/src/devices/scmplus.c
+++ b/src/devices/scmplus.c
@@ -173,7 +173,7 @@ static char *output_fields[] = {
 //      Freq 912600155
 //     -X n=L58,m=OOK_MC_ZEROBIT,s=30,l=30,g=20000,r=20000,match={24}0x16a31e,preamble={1}0x00
 
-r_device scmplus = {
+r_device const scmplus = {
         .name        = "Standard Consumption Message Plus (SCMplus)",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 30,

--- a/src/devices/secplus_v1.c
+++ b/src/devices/secplus_v1.c
@@ -395,7 +395,7 @@ static char *output_fields[] = {
 //      Freq 310.01M
 //   -X "n=v1,m=OOK_PCM,s=500,l=500,t=40,r=10000,g=7400"
 
-r_device secplus_v1 = {
+r_device const secplus_v1 = {
         .name        = "Security+ (Keyfob)",
         .modulation  = OOK_PULSE_PCM,
         .short_width = 500,

--- a/src/devices/secplus_v2.c
+++ b/src/devices/secplus_v2.c
@@ -394,7 +394,7 @@ static char *output_fields[] = {
 //      Freq 310.01M
 //  -X "n=vI3,m=OOK_PCM,s=230,l=230,t=40,r=10000,g=7400,match={24}0xaaaa9560"
 
-r_device secplus_v2 = {
+r_device const secplus_v2 = {
         .name        = "Security+ 2.0 (Keyfob)",
         .modulation  = OOK_PULSE_PCM,
         .short_width = 250,

--- a/src/devices/sharp_spc775.c
+++ b/src/devices/sharp_spc775.c
@@ -99,7 +99,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device sharp_spc775 = {
+r_device const sharp_spc775 = {
         .name        = "Sharp SPC775 weather station",
         .modulation  = FSK_PULSE_PWM,
         .short_width = 225,

--- a/src/devices/silvercrest.c
+++ b/src/devices/silvercrest.c
@@ -55,7 +55,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device silvercrest = {
+r_device const silvercrest = {
         .name        = "Silvercrest Remote Control",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 264,

--- a/src/devices/simplisafe.c
+++ b/src/devices/simplisafe.c
@@ -203,7 +203,7 @@ static char *sensor_output_fields[] = {
         NULL,
 };
 
-r_device ss_sensor = {
+r_device const ss_sensor = {
         .name        = "SimpliSafe Home Security System (May require disabling automatic gain for KeyPad decodes)",
         .modulation  = OOK_PULSE_PIWM_DC,
         .short_width = 500,  // half-bit width 500 us

--- a/src/devices/simplisafe_gen3.c
+++ b/src/devices/simplisafe_gen3.c
@@ -97,7 +97,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device simplisafe_gen3 = {
+r_device const simplisafe_gen3 = {
         .name        = "SimpliSafe Gen 3 Home Security System",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 208, // 4800 baud

--- a/src/devices/smoke_gs558.c
+++ b/src/devices/smoke_gs558.c
@@ -126,7 +126,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device smoke_gs558 = {
+r_device const smoke_gs558 = {
         .name        = "Wireless Smoke and Heat Detector GS 558",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 436,          // Threshold between short and long pulse [us]

--- a/src/devices/solight_te44.c
+++ b/src/devices/solight_te44.c
@@ -93,7 +93,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device solight_te44 = {
+r_device const solight_te44 = {
         .name        = "Solight TE44/TE66, EMOS E0107T, NX-6876-917",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 972,  // short gap = 972 us

--- a/src/devices/somfy_iohc.c
+++ b/src/devices/somfy_iohc.c
@@ -216,7 +216,7 @@ static char *output_fields[] = {
 };
 
 // rtl_433 -c 0 -R 0 -g 40 -X "n=uart,m=FSK_PCM,s=26,l=26,r=300,preamble={24}0x57fd99,decode_uart" -f 868.89M
-r_device somfy_iohc = {
+r_device const somfy_iohc = {
         .name        = "Somfy io-homecontrol",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 26,

--- a/src/devices/somfy_rts.c
+++ b/src/devices/somfy_rts.c
@@ -193,7 +193,7 @@ static char *output_fields[] = {
 // rtl_433 -r g001_433.414M_250k.cu8 -X "n=somfy-test,m=OOK_PCM,s=604,l=604,t=40,r=10000,g=3000,y=2416"
 // Nominal bit width is ~604 us, RZ, short=long
 
-r_device somfy_rts = {
+r_device const somfy_rts = {
         .name        = "Somfy RTS",
         .modulation  = OOK_PULSE_PCM,
         .short_width = 604,   // each pulse is ~604 us (nominal bit width)

--- a/src/devices/springfield.c
+++ b/src/devices/springfield.c
@@ -102,7 +102,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device springfield = {
+r_device const springfield = {
         .name        = "Springfield Temperature and Soil Moisture",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 2000,

--- a/src/devices/srsmith_pool_srs_2c_tx.c
+++ b/src/devices/srsmith_pool_srs_2c_tx.c
@@ -158,7 +158,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device srsmith_pool_srs_2c_tx = {
+r_device const srsmith_pool_srs_2c_tx = {
         .name        = "SRSmith Pool Light Remote Control SRS-2C-TX (-f 915M)",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 100,

--- a/src/devices/steelmate.c
+++ b/src/devices/steelmate.c
@@ -109,7 +109,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device steelmate = {
+r_device const steelmate = {
         .name        = "Steelmate TPMS",
         .modulation  = FSK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 12 * 4,

--- a/src/devices/telldus_ft0385r.c
+++ b/src/devices/telldus_ft0385r.c
@@ -206,7 +206,7 @@ static char *telldus_ft0385r_output_fields[] = {
         NULL,
 };
 
-r_device telldus_ft0385r = {
+r_device const telldus_ft0385r = {
         .name        = "Telldus weather station FT0385R sensors",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 500,

--- a/src/devices/tfa_14_1504_v2.c
+++ b/src/devices/tfa_14_1504_v2.c
@@ -125,7 +125,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tfa_14_1504_v2 = {
+r_device const tfa_14_1504_v2 = {
         .name        = "TFA Dostmann 14.1504.V2 Radio-controlled grill and meat thermometer",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 360,

--- a/src/devices/tfa_30_3196.c
+++ b/src/devices/tfa_30_3196.c
@@ -114,7 +114,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tfa_303196 = {
+r_device const tfa_303196 = {
         .name        = "TFA Dostmann 30.3196 T/H outdoor sensor",
         .modulation  = FSK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 245,

--- a/src/devices/tfa_30_3221.c
+++ b/src/devices/tfa_30_3221.c
@@ -102,7 +102,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tfa_30_3221 = {
+r_device const tfa_30_3221 = {
         .name        = "TFA Dostmann 30.3221.02 T/H Outdoor Sensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 235,

--- a/src/devices/tfa_drop_30.3233.c
+++ b/src/devices/tfa_drop_30.3233.c
@@ -185,7 +185,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tfa_drop_303233 = {
+r_device const tfa_drop_303233 = {
         .name        = "TFA Drop Rain Gauge 30.3233.01",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 255,

--- a/src/devices/tfa_marbella.c
+++ b/src/devices/tfa_marbella.c
@@ -96,7 +96,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tfa_marbella = {
+r_device const tfa_marbella = {
         .name        = "TFA Marbella Pool Thermometer",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 105,

--- a/src/devices/tfa_pool_thermometer.c
+++ b/src/devices/tfa_pool_thermometer.c
@@ -88,7 +88,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tfa_pool_thermometer = {
+r_device const tfa_pool_thermometer = {
         .name        = "TFA pool temperature sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 2000,

--- a/src/devices/tfa_twin_plus_30.3049.c
+++ b/src/devices/tfa_twin_plus_30.3049.c
@@ -117,7 +117,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tfa_twin_plus_303049 = {
+r_device const tfa_twin_plus_303049 = {
         .name        = "TFA-Twin-Plus-30.3049, Conrad KW9010, Ea2 BL999",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 2000,

--- a/src/devices/thermopro_tp11.c
+++ b/src/devices/thermopro_tp11.c
@@ -68,7 +68,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device thermopro_tp11 = {
+r_device const thermopro_tp11 = {
         .name        = "Thermopro TP11 Thermometer",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 500,

--- a/src/devices/thermopro_tp12.c
+++ b/src/devices/thermopro_tp12.c
@@ -111,7 +111,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device thermopro_tp12 = {
+r_device const thermopro_tp12 = {
         .name        = "Thermopro TP08/TP12/TP20 thermometer",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 500,

--- a/src/devices/thermopro_tx2.c
+++ b/src/devices/thermopro_tx2.c
@@ -105,7 +105,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device thermopro_tx2 = {
+r_device const thermopro_tx2 = {
         .name        = "ThermoPro-TX2 temperature sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 2000,

--- a/src/devices/tpms_abarth124.c
+++ b/src/devices/tpms_abarth124.c
@@ -121,7 +121,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tpms_abarth124 = {
+r_device const tpms_abarth124 = {
         .name        = "Abarth 124 Spider TPMS",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 52,  // 12-13 samples @250k

--- a/src/devices/tpms_ave.c
+++ b/src/devices/tpms_ave.c
@@ -154,7 +154,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tpms_ave = {
+r_device const tpms_ave = {
         .name        = "AVE TPMS",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 100,

--- a/src/devices/tpms_citroen.c
+++ b/src/devices/tpms_citroen.c
@@ -132,7 +132,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tpms_citroen = {
+r_device const tpms_citroen = {
         .name        = "Citroen TPMS",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 52,  // 12-13 samples @250k

--- a/src/devices/tpms_elantra2012.c
+++ b/src/devices/tpms_elantra2012.c
@@ -148,7 +148,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tpms_elantra2012 = {
+r_device const tpms_elantra2012 = {
         .name        = "Elantra2012 TPMS",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 49,  // 12-13 samples @250k

--- a/src/devices/tpms_ford.c
+++ b/src/devices/tpms_ford.c
@@ -224,7 +224,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tpms_ford = {
+r_device const tpms_ford = {
         .name        = "Ford TPMS",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 52,  // 12-13 samples @250k

--- a/src/devices/tpms_hyundai_vdo.c
+++ b/src/devices/tpms_hyundai_vdo.c
@@ -142,7 +142,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tpms_hyundai_vdo = {
+r_device const tpms_hyundai_vdo = {
         .name        = "Hyundai TPMS (VDO)",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 52,  // in the FCC test protocol is actually 42us, but works with 52 also

--- a/src/devices/tpms_jansite.c
+++ b/src/devices/tpms_jansite.c
@@ -113,7 +113,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tpms_jansite = {
+r_device const tpms_jansite = {
         .name        = "Jansite TPMS Model TY02S",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 52,  // 12-13 samples @250k

--- a/src/devices/tpms_jansite_solar.c
+++ b/src/devices/tpms_jansite_solar.c
@@ -130,7 +130,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tpms_jansite_solar = {
+r_device const tpms_jansite_solar = {
         .name        = "Jansite TPMS Model Solar",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 51,

--- a/src/devices/tpms_kia.c
+++ b/src/devices/tpms_kia.c
@@ -144,7 +144,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tpms_kia = {
+r_device const tpms_kia = {
         .name        = "Kia TPMS (-s 1000k)",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 50,

--- a/src/devices/tpms_pmv107j.c
+++ b/src/devices/tpms_pmv107j.c
@@ -122,7 +122,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tpms_pmv107j = {
+r_device const tpms_pmv107j = {
         .name        = "PMV-107J (Toyota) TPMS",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 100, // 25 samples @250k

--- a/src/devices/tpms_porsche.c
+++ b/src/devices/tpms_porsche.c
@@ -113,7 +113,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tpms_porsche = {
+r_device const tpms_porsche = {
         .name        = "Porsche Boxster/Cayman TPMS",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 52,  // 12-13 samples @250k

--- a/src/devices/tpms_renault.c
+++ b/src/devices/tpms_renault.c
@@ -119,7 +119,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tpms_renault = {
+r_device const tpms_renault = {
         .name        = "Renault TPMS",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 52,  // 12-13 samples @250k

--- a/src/devices/tpms_renault_0435r.c
+++ b/src/devices/tpms_renault_0435r.c
@@ -174,7 +174,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tpms_renault_0435r = {
+r_device const tpms_renault_0435r = {
         .name        = "Renault 0435R TPMS",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 52,  // 12-13 samples @250k

--- a/src/devices/tpms_toyota.c
+++ b/src/devices/tpms_toyota.c
@@ -114,7 +114,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tpms_toyota = {
+r_device const tpms_toyota = {
         .name        = "Toyota TPMS",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 52,  // 12-13 samples @250k

--- a/src/devices/tpms_truck.c
+++ b/src/devices/tpms_truck.c
@@ -127,7 +127,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tpms_truck = {
+r_device const tpms_truck = {
         .name        = "Unbranded SolarTPMS for trucks",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 52,

--- a/src/devices/tpms_tyreguard400.c
+++ b/src/devices/tpms_tyreguard400.c
@@ -191,7 +191,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device tpms_tyreguard400 = {
+r_device const tpms_tyreguard400 = {
         .name        = "TyreGuard 400 TPMS",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 100,

--- a/src/devices/ts_ft002.c
+++ b/src/devices/ts_ft002.c
@@ -115,7 +115,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device ts_ft002 = {
+r_device const ts_ft002 = {
         .name        = "TS-FT002 Wireless Ultrasonic Tank Liquid Level Meter With Temperature Sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 464,

--- a/src/devices/ttx201.c
+++ b/src/devices/ttx201.c
@@ -216,7 +216,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device ttx201 = {
+r_device const ttx201 = {
         .name        = "Emos TTX201 Temperature Sensor",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 510,

--- a/src/devices/vaillant_vrt340f.c
+++ b/src/devices/vaillant_vrt340f.c
@@ -147,7 +147,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device vaillant_vrt340f = {
+r_device const vaillant_vrt340f = {
         .name        = "Vaillant calorMatic VRT340f Central Heating Control",
         .modulation  = OOK_PULSE_DMC,
         .short_width = 836,  // half-bit width 836 us

--- a/src/devices/vauno_en8822c.c
+++ b/src/devices/vauno_en8822c.c
@@ -94,7 +94,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device vauno_en8822c = {
+r_device const vauno_en8822c = {
         .name        = "Vauno EN8822C",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 2000,

--- a/src/devices/visonic_powercode.c
+++ b/src/devices/visonic_powercode.c
@@ -120,7 +120,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device visonic_powercode = {
+r_device const visonic_powercode = {
         .name        = "Visonic powercode",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 400,

--- a/src/devices/waveman.c
+++ b/src/devices/waveman.c
@@ -88,7 +88,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device waveman = {
+r_device const waveman = {
         .name        = "Waveman Switch Transmitter",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 357,

--- a/src/devices/wec2103.c
+++ b/src/devices/wec2103.c
@@ -83,7 +83,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device wec2103 = {
+r_device const wec2103 = {
         .name           = "WEC-2103 temperature/humidity sensor",
         .modulation     = OOK_PULSE_PPM,
         .short_width    = 1900,

--- a/src/devices/wg_pb12v1.c
+++ b/src/devices/wg_pb12v1.c
@@ -91,7 +91,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device wg_pb12v1 = {
+r_device const wg_pb12v1 = {
         .name        = "WG-PB12V1 Temperature Sensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 564,  // Short pulse 564µs, long pulse 1476µs, fixed gap 960µs

--- a/src/devices/ws2032.c
+++ b/src/devices/ws2032.c
@@ -115,7 +115,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device ws2032 = {
+r_device const ws2032 = {
         .name        = "WS2032 weather station",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 500,

--- a/src/devices/wssensor.c
+++ b/src/devices/wssensor.c
@@ -92,7 +92,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device wssensor = {
+r_device const wssensor = {
         .name        = "Hyundai WS SENZOR Remote Temperature Sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 1000,

--- a/src/devices/wt0124.c
+++ b/src/devices/wt0124.c
@@ -106,7 +106,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device wt1024 = {
+r_device const wt1024 = {
         .name        = "WT0124 Pool Thermometer",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 680,

--- a/src/devices/wt450.c
+++ b/src/devices/wt450.c
@@ -126,7 +126,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device wt450 = {
+r_device const wt450 = {
         .name        = "WT450, WT260H, WT405H",
         .modulation  = OOK_PULSE_DMC,
         .short_width = 976,  // half-bit width 976 us

--- a/src/devices/x10_rf.c
+++ b/src/devices/x10_rf.c
@@ -159,7 +159,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device X10_RF = {
+r_device const X10_RF = {
         .name        = "X10 RF",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 562,  // Short gap 562.5 µs

--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -199,7 +199,7 @@ static char *output_fields[] = {
 };
 
 /* r_device definition */
-r_device x10_sec = {
+r_device const x10_sec = {
         .name        = "X10 Security",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 562,  // Short gap 562us

--- a/src/devices/yale_hsa.c
+++ b/src/devices/yale_hsa.c
@@ -131,7 +131,7 @@ static char *output_fields[] = {
         NULL,
 };
 
-r_device yale_hsa = {
+r_device const yale_hsa = {
         .name        = "Yale HSA (Home Security Alarm), YES-Alarmkit",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 850,

--- a/tests/symbolizer.py
+++ b/tests/symbolizer.py
@@ -151,7 +151,7 @@ def process_source(path, name):
                 continue
 
             # look for r_device with decode_fn
-            m = re.match(r'\s*r_device\s+([^\*]*?)\s*=', line)
+            m = re.match(r'\s*r_device\s+const\s+([^\*]*?)\s*=', line)
             if m:
                 rName = m.group(1)
                 if rName in links:


### PR DESCRIPTION
When encountering global variables, the compiler places them in different sections of the MAP file for the linker to assemble into the final image. It merges all declarations of the same type into one single "segment" that then gets placed into RAM upon starting the image.
On the ESP32, there is very limited RAM (320KiB) and what's even more limiting is that only 120KiB are contiguous. This means that should the linker produce a segment of RAM that is bigger than those 120KiB, the build process will fail.
Up until 2021, this wasn't much of a problem, but with the devices added since then, I have reached a state where I can't build rtl_433 anymore for this device.
Looking a the map file, I saw that all global `r_devices` declarations, those at the end of each device file, were placed in the `.bss` segment, which takes up a lot of RAM.
But if I add a `const` modifier to all `r_devices` declarations, they end up in the `.rodata` section which is a different segment, not even in the preciously rare RAM, and I can now build again and it runs just fine.
I have also tested under Windows, I could not see any ill effect of that change there.

To me, it even makes more sense to have those declarations `const` because they are not meant to be modified at runtime anyway.