### PR TITLE
Fix out-of-bounds access in klimalogg, which causes frequent segfaults

### DIFF
--- a/src/devices/klimalogg.c
+++ b/src/devices/klimalogg.c
@@ -60,7 +60,7 @@ static int klimalogg_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     if (b[7] != 0x6a) // 0x56 bit reflected
         return DECODE_FAIL_SANITY;
 
-    reflect_bytes(b, 11);
+    reflect_bytes(b, 9);
 
     int crc = crc8(b, 9, 0x31, 0);
     if (crc)


### PR DESCRIPTION
A better fix would have been to write _reflect_bytes(b, sizeof(b))_ but this should then also be done in the next line with _crc8_, and since that isn't related to the fix, I went for minimalism and consistency.