### PR TITLE
Fix mongoose poll call so influx output works even in replay mode.

### DIFF
--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -372,7 +372,13 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx)
         raw_output_t *output = *iter;
         raw_output_frame(output, iq_buf, len);
     }
-
+    
+    // do the mongoose polling here so that influx output works even in replay mode.
+    if (cfg->mgr) {
+        int max_polls = 16;
+        while (max_polls-- && mg_mgr_poll(cfg->mgr, 0));
+    }
+    
     if ((cfg->bytes_to_read > 0) && (cfg->bytes_to_read <= len)) {
         len = cfg->bytes_to_read;
         cfg->exit_async = 1;
@@ -1362,11 +1368,6 @@ static void sdr_handler(sdr_event_t *ev, void *ctx)
     }
 
     if (ev->ev == SDR_EV_DATA) {
-        if (cfg->mgr) {
-            int max_polls = 16;
-            while (max_polls-- && mg_mgr_poll(cfg->mgr, 0));
-        }
-
         if (!cfg->exit_async)
             sdr_callback((unsigned char *)ev->buf, ev->len, ctx);
     }

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -372,13 +372,13 @@ static void sdr_callback(unsigned char *iq_buf, uint32_t len, void *ctx)
         raw_output_t *output = *iter;
         raw_output_frame(output, iq_buf, len);
     }
-    
+
     // do the mongoose polling here so that influx output works even in replay mode.
     if (cfg->mgr) {
         int max_polls = 16;
         while (max_polls-- && mg_mgr_poll(cfg->mgr, 0));
     }
-    
+
     if ((cfg->bytes_to_read > 0) && (cfg->bytes_to_read <= len)) {
         len = cfg->bytes_to_read;
         cfg->exit_async = 1;


### PR DESCRIPTION
When I used "replay" mode (`-r filename`) to read in processed data from my HackRF (with my wiki page https://github.com/merbanan/rtl_433/wiki/Signal-Preprocessing), I was able to get decoded data to show up in STDOUT. However, when I used the 'influx' output option, `rtl_433` said it would connect to the influxdb server, but it never made any requests. Inspecting the traffic confirmed this. After looking into the issue, it appears that we are not calling `mg_mgr_poll` when in replay mode because the `sdr_handler` function is not called in replay mode. I found a comment in the `sdr_callback` function (//do this here and not in sdr_handler so realtime replay can use rtl_tcp output), which suggested moving the `mg_mgr_poll` call up there instead. I did this and it fixed the issue. I also retested using an RTL SDR device directly (no GNU Radio sending in processed data) and that also seems to still work with the influx output. 

I believe that the influx output option should still work in replay mode because that could be a useful way to debug things and `rtl_433` makes no mention that this shouldn't work. Hence, I made this pull request. Let me know if you have any questions or suggestions for improvement or if you are OK with these changes.