### PR TITLE
fix: make sure that char* declarations with a direct assignment of a constant are no longer valid in plugins

### DIFF
--- a/tests/symbolizer.py
+++ b/tests/symbolizer.py
@@ -150,6 +150,11 @@ def process_source(path, name):
                 doc = ''
                 continue
 
+            # look for char * variable = "" declarations that should really be char const *
+            m = re.match(r'(?:static)?\s?char\s?\*\s?[^\*\s]+\s?=\s?(?:{|")', line)
+            if m:
+                err(f"::error file={name},line={i}::char * variable should be char const * when being given a constant value")
+
             # look for r_device with decode_fn
             m = re.match(r'\s*r_device\s+const\s+([^\*]*?)\s*=', line)
             if m:


### PR DESCRIPTION
They must be char const * because string literals are "const" with newest compilers

As requested here: https://github.com/merbanan/rtl_433/pull/2379#issuecomment-1432044311