### PR TITLE
Add conf-file for SWETUP garage door remote

### DIFF
--- a/conf/SWETUP-garage-opener.conf
+++ b/conf/SWETUP-garage-opener.conf
@@ -1,0 +1,29 @@
+# SWETUP garage door opener
+# (c) FoxWhiskey 2023
+#
+# A four-button remote control device most likely based on EV1527 chip.
+# The device is available on AMAZON and a no-name-product branded for the german market.
+# See https://www.amazon.de/-/en/Handheld-Transmitter-Control-Universal-Wireless/dp/B09HWY1KH7
+#
+# The package includes a set of two devices. Each device, however, transmits identical signals, which suggests
+# that no ID is present and all devices are indistinguishable (if not trained to a specific code...)
+# When a button is pressed, the device transmits a 25bit code with following pattern:
+#
+# Bit 1-20  : constant
+# Bit 21-24 : BUTTON
+# Bit 25    : constant
+#
+# The pattern is being repeated as long as the button is held down. So, postprocessing is necessary if duplicates are unwanted.
+#
+#
+decoder {
+        n=SWETUP-remote-4btn,
+        m=OOK_PWM,
+        s=264,
+        l=788,
+        r=945,
+        bits=25,
+        preamble={20}57ba1,
+        get=@0:{4}:button:[0x7:A 0xd:E 0xB:C 0xD:D],
+        unique
+}


### PR DESCRIPTION
Here's a conf-file to decode the "SWETUP" garage door remote, available on AMAZON.
Please note [PR #488](https://github.com/merbanan/rtl_433_tests/pull/448) for test data