### PR TITLE
Add restartable SDR device

### DIFF
--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -70,6 +70,11 @@ ppm_error     0
 # default is "250k", other valid settings are 1024k, 2048k, 3200k
 sample_rate   250k
 
+# as command line option:
+#   [-D restart | pause | quit | manual] Input device run mode options.
+# default is "quit"
+device_mode   quit
+
 ## Demodulator options
 
 # as command line option:

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -31,7 +31,7 @@ struct mg_mgr;
 typedef enum {
     CONVERT_NATIVE,
     CONVERT_SI,
-    CONVERT_CUSTOMARY
+    CONVERT_CUSTOMARY,
 } conversion_mode_t;
 
 typedef enum {
@@ -43,7 +43,23 @@ typedef enum {
     REPORT_TIME_OFF,
 } time_mode_t;
 
+typedef enum {
+    DEVICE_MODE_QUIT,
+    DEVICE_MODE_RESTART,
+    DEVICE_MODE_PAUSE,
+    DEVICE_MODE_MANUAL,
+} device_mode_t;
+
+typedef enum {
+    DEVICE_STATE_STOPPED,
+    DEVICE_STATE_STARTING,
+    DEVICE_STATE_GRACE,
+    DEVICE_STATE_STARTED,
+} device_state_t;
+
 typedef struct r_cfg {
+    device_mode_t dev_mode; ///< Input device run mode
+    device_state_t dev_state; ///< Input device run state
     char *dev_query;
     char const *dev_info;
     char *gain_str;


### PR DESCRIPTION
This adds a new option to select the input device run mode:
`[-D restart | pause | quit | manual] Input device run mode options.`

Supported input device run modes:
- `restart`: Restart the input device on errors
- `pause`: Pause the input device on errors, waits for e.g. HTTP-API control
- `quit`: Quit on input device errors (default)
- `manual`: Don't start an input device, waits for e.g. HTTP-API control

Without this option the default is to start the SDR and quit on errors, as usual.

Thoughts and comments much welcome!