### PR TITLE
Manchester decoding should work on bitrow not entire bitbuffer

### DIFF
--- a/include/bitbuffer.h
+++ b/include/bitbuffer.h
@@ -161,7 +161,11 @@ static inline uint8_t bitrow_get_byte(uint8_t const *bitrow, unsigned bit_idx)
 /// Clear the content of the bitrow and sets bitrow_num_bits to 0.
 void bitrow_clear(bitrow_t bitrow, uint16_t *bitrow_num_bits);
 
-/// Add the given bit into the bitrow, at the bit_idx position and increments the position upon return
+/// Add the given bit into the bitrow, at the bit_idx position and increments the position upon return.
+/// free_row and max_rows are used when called via bitbuffer_add_bit to allow row spilling.
+void bitrow_add_bit_spillable(bitrow_t bitrow, uint16_t *bitrow_num_bits, int bit, uint16_t *free_row, int max_rows);
+
+/// Add the given bit into the bitrow, at the bit_idx position and increments the position upon return.
 void bitrow_add_bit(bitrow_t bitrow, uint16_t *bitrow_num_bits, int bit);
 
 /// Extract (potentially unaligned) bytes from the bit row. Len is bits.

--- a/include/bitbuffer.h
+++ b/include/bitbuffer.h
@@ -109,13 +109,13 @@ void bitbuffer_parse(bitbuffer_t *bits, const char *code);
 unsigned bitbuffer_search(bitbuffer_t *bitbuffer, unsigned row, unsigned start,
         const uint8_t *pattern, unsigned pattern_bits_len);
 
-/// Manchester decoding from one bitbuffer into another, starting at the
+/// Manchester decoding from one bitbuffer into a bitrow, starting at the
 /// specified row and start bit. Decode at most 'max' data bits (i.e. 2*max)
 /// bits from the input buffer). Return the bit position in the input row
 /// (i.e. returns start + 2*outbuf->bits_per_row[0]).
 /// per IEEE 802.3 conventions, i.e. high-low is a 0 bit, low-high is a 1 bit.
 unsigned bitbuffer_manchester_decode(bitbuffer_t *inbuf, unsigned row, unsigned start,
-        bitbuffer_t *outbuf, unsigned max);
+        uint8_t *outrow, uint16_t *outrow_num_bits, unsigned max);
 
 /// Differential Manchester decoding from one bitbuffer into another, starting at the
 /// specified row and start bit. Decode at most 'max' data bits (i.e. 2*max)
@@ -157,5 +157,25 @@ static inline uint8_t bitrow_get_byte(uint8_t const *bitrow, unsigned bit_idx)
     return (uint8_t)((bitrow[(bit_idx >> 3)] << (bit_idx & 7)) |
                      (bitrow[(bit_idx >> 3) + 1] >> (8 - (bit_idx & 7))));
 }
+
+/// Clear the content of the bitrow and sets bitrow_num_bits to 0.
+void bitrow_clear(bitrow_t bitrow, uint16_t *bitrow_num_bits);
+
+/// Add the given bit into the bitrow, at the bit_idx position and increments the position upon return
+void bitrow_add_bit(bitrow_t bitrow, uint16_t *bitrow_num_bits, int bit);
+
+/// Extract (potentially unaligned) bytes from the bit row. Len is bits.
+void bitrow_extract_bytes(bitrow_t const bitrow, unsigned pos, uint8_t *out, unsigned len);
+
+/// Invert all bits in the bitrow (do not invert the empty bits).
+void bitrow_invert(bitrow_t bitrow, uint16_t bitrow_num_bits);
+
+/// Manchester decoding from one bitrow into another, starting at the
+/// specified start bit. Decode at most 'max' data bits (i.e. 2*max)
+/// bits from the input buffer). Return the bit position in the input row
+/// (i.e. returns start + 2*outbuf->bits_per_row[0]).
+/// per IEEE 802.3 conventions, i.e. high-low is a 0 bit, low-high is a 1 bit.
+unsigned bitrow_manchester_decode(bitrow_t const inrow, uint16_t inrow_num_bits, unsigned start,
+        bitrow_t outrow, uint16_t *outrow_num_bits, unsigned max);
 
 #endif /* INCLUDE_BITBUFFER_H_ */

--- a/include/bitbuffer.h
+++ b/include/bitbuffer.h
@@ -112,17 +112,17 @@ unsigned bitbuffer_search(bitbuffer_t *bitbuffer, unsigned row, unsigned start,
 /// Manchester decoding from one bitbuffer into a bitrow, starting at the
 /// specified row and start bit. Decode at most 'max' data bits (i.e. 2*max)
 /// bits from the input buffer). Return the bit position in the input row
-/// (i.e. returns start + 2*outbuf->bits_per_row[0]).
+/// (i.e. returns start + 2 * *outrow_num_bits).
 /// per IEEE 802.3 conventions, i.e. high-low is a 0 bit, low-high is a 1 bit.
 unsigned bitbuffer_manchester_decode(bitbuffer_t *inbuf, unsigned row, unsigned start,
         uint8_t *outrow, uint16_t *outrow_num_bits, unsigned max);
 
-/// Differential Manchester decoding from one bitbuffer into another, starting at the
+/// Differential Manchester decoding from one bitbuffer into a bitrow, starting at the
 /// specified row and start bit. Decode at most 'max' data bits (i.e. 2*max)
 /// bits from the input buffer). Return the bit position in the input row
-/// (i.e. returns start + 2*outbuf->bits_per_row[0]).
+/// (i.e. returns start + 2 * *outrow_num_bits).
 unsigned bitbuffer_differential_manchester_decode(bitbuffer_t *inbuf, unsigned row, unsigned start,
-        bitbuffer_t *outbuf, unsigned max);
+        uint8_t *outrow, uint16_t *outrow_num_bits, unsigned max);
 
 /// Compares two given rows of a bitbuffer.
 ///
@@ -173,9 +173,16 @@ void bitrow_invert(bitrow_t bitrow, uint16_t bitrow_num_bits);
 /// Manchester decoding from one bitrow into another, starting at the
 /// specified start bit. Decode at most 'max' data bits (i.e. 2*max)
 /// bits from the input buffer). Return the bit position in the input row
-/// (i.e. returns start + 2*outbuf->bits_per_row[0]).
+/// (i.e. returns start + 2 * *outrow_num_bits).
 /// per IEEE 802.3 conventions, i.e. high-low is a 0 bit, low-high is a 1 bit.
 unsigned bitrow_manchester_decode(bitrow_t const inrow, uint16_t inrow_num_bits, unsigned start,
+        bitrow_t outrow, uint16_t *outrow_num_bits, unsigned max);
+
+/// Differential Manchester decoding from one bitrow into another, starting at the
+/// specified start bit. Decode at most 'max' data bits (i.e. 2*max)
+/// bits from the input buffer). Return the bit position in the input row
+/// (i.e. returns start + 2 * *outrow_num_bits).
+unsigned bitrow_differential_manchester_decode(bitrow_t const inrow, uint16_t inrow_num_bits, unsigned start,
         bitrow_t outrow, uint16_t *outrow_num_bits, unsigned max);
 
 #endif /* INCLUDE_BITBUFFER_H_ */

--- a/include/bitbuffer.h
+++ b/include/bitbuffer.h
@@ -14,6 +14,9 @@
 
 #include <stdint.h>
 
+// Round up (NUM_BITS / 8)
+#define NUM_BYTES(NUM_BITS) (((NUM_BITS) + 7) >> 3)
+
 // NOTE: Wireless mbus protocol needs at least ((256+16*2+3)*12)/8 => 437 bytes
 //       which fits even if RTL_433_REDUCE_STACK_USE is defined because of row spilling
 #ifdef RTL_433_REDUCE_STACK_USE

--- a/include/bitbuffer.h
+++ b/include/bitbuffer.h
@@ -162,7 +162,8 @@ static inline uint8_t bitrow_get_byte(uint8_t const *bitrow, unsigned bit_idx)
 }
 
 /// Clear the content of the bitrow and sets bitrow_num_bits to 0.
-void bitrow_clear(bitrow_t bitrow, uint16_t *bitrow_num_bits);
+/// bitrow_num_bytes is the number of bytes allocated for the bitrow
+void bitrow_clear(bitrow_t bitrow, uint16_t *bitrow_num_bits, uint16_t bitrow_num_bytes);
 
 /// Add the given bit into the bitrow, at the bit_idx position and increments the position upon return.
 /// free_row and max_rows are used when called via bitbuffer_add_bit to allow row spilling.

--- a/include/bitbuffer.h
+++ b/include/bitbuffer.h
@@ -163,34 +163,34 @@ static inline uint8_t bitrow_get_byte(uint8_t const *bitrow, unsigned bit_idx)
 
 /// Clear the content of the bitrow and sets bitrow_num_bits to 0.
 /// bitrow_num_bytes is the number of bytes allocated for the bitrow
-void bitrow_clear(bitrow_t bitrow, uint16_t *bitrow_num_bits, uint16_t bitrow_num_bytes);
+void bitrow_clear(uint8_t *bitrow, uint16_t *bitrow_num_bits, uint16_t bitrow_num_bytes);
 
 /// Add the given bit into the bitrow, at the bit_idx position and increments the position upon return.
 /// free_row and max_rows are used when called via bitbuffer_add_bit to allow row spilling.
-void bitrow_add_bit_spillable(bitrow_t bitrow, uint16_t *bitrow_num_bits, int bit, uint16_t *free_row, int max_rows);
+void bitrow_add_bit_spillable(uint8_t *bitrow, uint16_t *bitrow_num_bits, int bit, uint16_t *free_row, int max_rows);
 
 /// Add the given bit into the bitrow, at the bit_idx position and increments the position upon return.
-void bitrow_add_bit(bitrow_t bitrow, uint16_t *bitrow_num_bits, int bit);
+void bitrow_add_bit(uint8_t *bitrow, uint16_t *bitrow_num_bits, int bit);
 
 /// Extract (potentially unaligned) bytes from the bit row. Len is bits.
-void bitrow_extract_bytes(bitrow_t const bitrow, unsigned pos, uint8_t *out, unsigned len);
+void bitrow_extract_bytes(uint8_t const *bitrow, unsigned pos, uint8_t *out, unsigned len);
 
 /// Invert all bits in the bitrow (do not invert the empty bits).
-void bitrow_invert(bitrow_t bitrow, uint16_t bitrow_num_bits);
+void bitrow_invert(uint8_t *bitrow, uint16_t bitrow_num_bits);
 
 /// Manchester decoding from one bitrow into another, starting at the
 /// specified start bit. Decode at most 'max' data bits (i.e. 2*max)
 /// bits from the input buffer). Return the bit position in the input row
 /// (i.e. returns start + 2 * *outrow_num_bits).
 /// per IEEE 802.3 conventions, i.e. high-low is a 0 bit, low-high is a 1 bit.
-unsigned bitrow_manchester_decode(bitrow_t const inrow, uint16_t inrow_num_bits, unsigned start,
-        bitrow_t outrow, uint16_t *outrow_num_bits, unsigned max);
+unsigned bitrow_manchester_decode(uint8_t const *inrow, uint16_t inrow_num_bits, unsigned start,
+        uint8_t *outrow, uint16_t *outrow_num_bits, unsigned max);
 
 /// Differential Manchester decoding from one bitrow into another, starting at the
 /// specified start bit. Decode at most 'max' data bits (i.e. 2*max)
 /// bits from the input buffer). Return the bit position in the input row
 /// (i.e. returns start + 2 * *outrow_num_bits).
-unsigned bitrow_differential_manchester_decode(bitrow_t const inrow, uint16_t inrow_num_bits, unsigned start,
-        bitrow_t outrow, uint16_t *outrow_num_bits, unsigned max);
+unsigned bitrow_differential_manchester_decode(uint8_t const *inrow, uint16_t inrow_num_bits, unsigned start,
+        uint8_t *outrow, uint16_t *outrow_num_bits, unsigned max);
 
 #endif /* INCLUDE_BITBUFFER_H_ */

--- a/src/bitbuffer.c
+++ b/src/bitbuffer.c
@@ -391,9 +391,9 @@ int bitbuffer_find_repeated_prefix(bitbuffer_t *bits, unsigned min_repeats, unsi
     return -1;
 }
 
-void bitrow_clear(bitrow_t bitrow, uint16_t *bitrow_num_bits)
+void bitrow_clear(bitrow_t bitrow, uint16_t *bitrow_num_bits, uint16_t bitrow_num_bytes)
 {
-    memset(&bitrow[0], 0, BITBUF_COLS);
+    memset(&bitrow[0], 0, bitrow_num_bytes);
     *bitrow_num_bits = 0;
 }
 

--- a/src/bitbuffer.c
+++ b/src/bitbuffer.c
@@ -391,13 +391,13 @@ int bitbuffer_find_repeated_prefix(bitbuffer_t *bits, unsigned min_repeats, unsi
     return -1;
 }
 
-void bitrow_clear(bitrow_t bitrow, uint16_t *bitrow_num_bits, uint16_t bitrow_num_bytes)
+void bitrow_clear(uint8_t *bitrow, uint16_t *bitrow_num_bits, uint16_t bitrow_num_bytes)
 {
     memset(&bitrow[0], 0, bitrow_num_bytes);
     *bitrow_num_bits = 0;
 }
 
-void bitrow_add_bit_spillable(bitrow_t bitrow, uint16_t *bitrow_num_bits, int bit, uint16_t *free_row, int max_rows)
+void bitrow_add_bit_spillable(uint8_t *bitrow, uint16_t *bitrow_num_bits, int bit, uint16_t *free_row, int max_rows)
 {
     uint16_t col_index = *bitrow_num_bits / 8;
     uint16_t bit_index = *bitrow_num_bits % 8;
@@ -436,13 +436,13 @@ void bitrow_add_bit_spillable(bitrow_t bitrow, uint16_t *bitrow_num_bits, int bi
 */
 }
 
-void bitrow_add_bit(bitrow_t bitrow, uint16_t *bitrow_num_bits, int bit)
+void bitrow_add_bit(uint8_t *bitrow, uint16_t *bitrow_num_bits, int bit)
 {
     uint16_t free_row = 0;
     bitrow_add_bit_spillable(bitrow, bitrow_num_bits, bit, &free_row, 0);
 }
 
-void bitrow_extract_bytes(bitrow_t const bits, unsigned pos, uint8_t *out, unsigned len)
+void bitrow_extract_bytes(uint8_t const *const bits, unsigned pos, uint8_t *out, unsigned len)
 {
     if (len == 0)
         return;
@@ -468,7 +468,7 @@ void bitrow_extract_bytes(bitrow_t const bits, unsigned pos, uint8_t *out, unsig
         out[(len - 1) / 8] &= 0xff00 >> (len & 7); // mask off bottom bits
 }
 
-void bitrow_invert(bitrow_t bitrow, uint16_t bitrow_num_bits)
+void bitrow_invert(uint8_t *bitrow, uint16_t bitrow_num_bits)
 {
     if (bitrow_num_bits > 0) {
         const unsigned last_col  = (bitrow_num_bits - 1) / 8;
@@ -480,8 +480,8 @@ void bitrow_invert(bitrow_t bitrow, uint16_t bitrow_num_bits)
     }
 }
 
-unsigned bitrow_manchester_decode(bitrow_t const inrow, uint16_t inrow_num_bits, unsigned start,
-        bitrow_t outrow, uint16_t *outrow_num_bits, unsigned max)
+unsigned bitrow_manchester_decode(uint8_t const *inrow, uint16_t inrow_num_bits, unsigned start,
+        uint8_t *outrow, uint16_t *outrow_num_bits, unsigned max)
 {
     uint8_t const *bits     = inrow;
     unsigned int len  = inrow_num_bits;
@@ -505,10 +505,10 @@ unsigned bitrow_manchester_decode(bitrow_t const inrow, uint16_t inrow_num_bits,
     return ipos;
 }
 
-unsigned bitrow_differential_manchester_decode(bitrow_t const inrow, uint16_t inrow_num_bits, unsigned start,
-        bitrow_t outrow, uint16_t *outrow_num_bits, unsigned max)
+unsigned bitrow_differential_manchester_decode(uint8_t const *inrow, uint16_t inrow_num_bits, unsigned start,
+        uint8_t *outrow, uint16_t *outrow_num_bits, unsigned max)
 {
-    uint8_t *bits     = inrow;
+    uint8_t const *bits = inrow;
     unsigned int len  = inrow_num_bits;
     unsigned int ipos = start;
     uint8_t bit1, bit2 = 0;

--- a/src/bitbuffer.c
+++ b/src/bitbuffer.c
@@ -186,53 +186,9 @@ unsigned bitbuffer_manchester_decode(bitbuffer_t *inbuf, unsigned row, unsigned 
 }
 
 unsigned bitbuffer_differential_manchester_decode(bitbuffer_t *inbuf, unsigned row, unsigned start,
-        bitbuffer_t *outbuf, unsigned max)
+        uint8_t *outrow, uint16_t *outrow_num_bits, unsigned max)
 {
-    uint8_t *bits     = inbuf->bb[row];
-    unsigned int len  = inbuf->bits_per_row[row];
-    unsigned int ipos = start;
-    uint8_t bit1, bit2 = 0;
-
-    if (max && len > start + (max * 2))
-        len = start + (max * 2);
-
-    // the first long pulse will determine the clock
-    // if needed skip one short pulse to get in synch
-    while (ipos < len) {
-        bit1 = bit_at(bits, ipos++);
-        bit2 = bit_at(bits, ipos++);
-        uint8_t bit3 = bit_at(bits, ipos);
-
-        if (bit1 != bit2) {
-            if (bit2 != bit3) {
-                bitbuffer_add_bit(outbuf, 0);
-            }
-            else {
-                bit2 = bit1;
-                ipos -= 1;
-                break;
-            }
-        }
-        else {
-            bit2 = 1 - bit1;
-            ipos -= 2;
-            break;
-        }
-    }
-
-    while (ipos < len) {
-        bit1 = bit_at(bits, ipos++);
-        if (bit1 == bit2)
-            break; // clock missing, abort
-        bit2 = bit_at(bits, ipos++);
-
-        if (bit1 == bit2)
-            bitbuffer_add_bit(outbuf, 1);
-        else
-            bitbuffer_add_bit(outbuf, 0);
-    }
-
-    return ipos;
+    return bitrow_differential_manchester_decode(inbuf->bb[row], inbuf->bits_per_row[row], start, outrow, outrow_num_bits, max);
 }
 
 static void print_bitrow(uint8_t const *bitrow, unsigned bit_len, unsigned highest_indent, int always_binary)
@@ -527,6 +483,56 @@ unsigned bitrow_manchester_decode(bitrow_t const inrow, uint16_t inrow_num_bits,
             break;
 
         bitrow_add_bit(outrow, outrow_num_bits, bit2);
+    }
+
+    return ipos;
+}
+
+unsigned bitrow_differential_manchester_decode(bitrow_t const inrow, uint16_t inrow_num_bits, unsigned start,
+        bitrow_t outrow, uint16_t *outrow_num_bits, unsigned max)
+{
+    uint8_t *bits     = inrow;
+    unsigned int len  = inrow_num_bits;
+    unsigned int ipos = start;
+    uint8_t bit1, bit2 = 0;
+
+    if (max && len > start + (max * 2))
+        len = start + (max * 2);
+
+    // the first long pulse will determine the clock
+    // if needed skip one short pulse to get in synch
+    while (ipos < len) {
+        bit1         = bit_at(bits, ipos++);
+        bit2         = bit_at(bits, ipos++);
+        uint8_t bit3 = bit_at(bits, ipos);
+
+        if (bit1 != bit2) {
+            if (bit2 != bit3) {
+                bitrow_add_bit(outrow, outrow_num_bits, 0);
+            }
+            else {
+                bit2 = bit1;
+                ipos -= 1;
+                break;
+            }
+        }
+        else {
+            bit2 = 1 - bit1;
+            ipos -= 2;
+            break;
+        }
+    }
+
+    while (ipos < len) {
+        bit1 = bit_at(bits, ipos++);
+        if (bit1 == bit2)
+            break; // clock missing, abort
+        bit2 = bit_at(bits, ipos++);
+
+        if (bit1 == bit2)
+            bitrow_add_bit(outrow, outrow_num_bits, 1);
+        else
+            bitrow_add_bit(outrow, outrow_num_bits, 0);
     }
 
     return ipos;

--- a/src/bitbuffer.c
+++ b/src/bitbuffer.c
@@ -33,42 +33,7 @@ void bitbuffer_add_bit(bitbuffer_t *bits, int bit)
         fprintf(stderr, "%s: Warning: row length limit (%u bits) reached\n", __func__, UINT16_MAX);
     }
 
-    uint16_t col_index = bits->bits_per_row[bits->num_rows - 1] / 8;
-    uint16_t bit_index = bits->bits_per_row[bits->num_rows - 1] % 8;
-    if (bits->bits_per_row[bits->num_rows - 1] > 0
-            && bits->bits_per_row[bits->num_rows - 1] % (BITBUF_COLS * 8) == 0) {
-        // spill into next row
-        // fprintf(stderr, "%s: row spill [%d] to %d (%d)\n", __func__, bits->num_rows - 1, col_index, bits->free_row);
-        if (bits->free_row == BITBUF_ROWS - 1) {
-            //print_logf(LOG_WARNING, __func__, "Warning: row count limit (%d rows) reached", BITBUF_ROWS);
-            fprintf(stderr, "%s: Warning: row count limit (%d rows) reached\n", __func__, BITBUF_ROWS);
-        }
-        if (bits->free_row < BITBUF_ROWS) {
-            bits->free_row++;
-        }
-        else {
-            // fprintf(stderr, "%s: Could not add more rows\n", __func__);
-            return;
-        }
-    }
-    uint8_t *b = bits->bb[bits->num_rows - 1];
-    b[col_index] |= (bit << (7 - bit_index));
-    bits->bits_per_row[bits->num_rows - 1]++;
-
-/*
-    // preamble compression
-    if (bits->bits_per_row[bits->num_rows - 1] == 60 * 8) {
-        uint8_t *b = bits->bb[bits->num_rows - 1];
-        for (int i = 21; i < 60; ++i) {
-            if (b[20] != b[i]) {
-                return;
-            }
-        }
-        // fprintf(stderr, "%s: preamble compression\n", __func__);
-        memset(&b[30], 0, 30);
-        bits->bits_per_row[bits->num_rows - 1] = 30 * 8;
-    }
-*/
+    bitrow_add_bit(bits->bb[bits->num_rows - 1], &bits->bits_per_row[bits->num_rows - 1], bit);
 }
 
 /// Set the width of the current (last) row by expanding or truncating as needed.
@@ -131,16 +96,7 @@ void bitbuffer_add_sync(bitbuffer_t *bits)
 void bitbuffer_invert(bitbuffer_t *bits)
 {
     for (unsigned row = 0; row < bits->num_rows; ++row) {
-        if (bits->bits_per_row[row] > 0) {
-            uint8_t *b = bits->bb[row];
-
-            const unsigned last_col  = (bits->bits_per_row[row] - 1) / 8;
-            const unsigned last_bits = ((bits->bits_per_row[row] - 1) % 8) + 1;
-            for (unsigned col = 0; col <= last_col; ++col) {
-                b[col] = ~b[col]; // Invert
-            }
-            b[last_col] ^= 0xFF >> last_bits; // Re-invert unused bits in last byte
-        }
+        bitrow_invert(bits->bb[row], bits->bits_per_row[row]);
     }
 }
 
@@ -187,29 +143,7 @@ void bitbuffer_nrzm_decode(bitbuffer_t *bits)
 void bitbuffer_extract_bytes(bitbuffer_t *bitbuffer, unsigned row,
         unsigned pos, uint8_t *out, unsigned len)
 {
-    uint8_t *bits = bitbuffer->bb[row];
-    if (len == 0)
-        return;
-    if ((pos & 7) == 0) {
-        memcpy(out, bits + (pos / 8), (len + 7) / 8);
-    }
-    else {
-        unsigned shift = 8 - (pos & 7);
-        unsigned bytes = (len + 7) >> 3;
-        uint8_t *p = out;
-        uint16_t word;
-        pos = pos >> 3; // Convert to bytes
-
-        word = bits[pos];
-
-        while (bytes--) {
-            word <<= 8;
-            word |= bits[++pos];
-            *(p++) = word >> shift;
-        }
-    }
-    if (len & 7)
-        out[(len - 1) / 8] &= 0xff00 >> (len & 7); // mask off bottom bits
+    bitrow_extract_bytes(bitbuffer->bb[row], pos, out, len);
 }
 
 // If we make this an inline function instead of a macro, it means we don't
@@ -246,28 +180,9 @@ unsigned bitbuffer_search(bitbuffer_t *bitbuffer, unsigned row, unsigned start,
 }
 
 unsigned bitbuffer_manchester_decode(bitbuffer_t *inbuf, unsigned row, unsigned start,
-        bitbuffer_t *outbuf, unsigned max)
+        uint8_t *outrow, uint16_t *outrow_num_bits, unsigned max)
 {
-    uint8_t *bits     = inbuf->bb[row];
-    unsigned int len  = inbuf->bits_per_row[row];
-    unsigned int ipos = start;
-
-    if (max && len > start + (max * 2))
-        len = start + (max * 2);
-
-    while (ipos < len) {
-        uint8_t bit1, bit2;
-
-        bit1 = bit_at(bits, ipos++);
-        bit2 = bit_at(bits, ipos++);
-
-        if (bit1 == bit2)
-            break;
-
-        bitbuffer_add_bit(outbuf, bit2);
-    }
-
-    return ipos;
+    return bitrow_manchester_decode(inbuf->bb[row], inbuf->bits_per_row[row], start, outrow, outrow_num_bits, max);
 }
 
 unsigned bitbuffer_differential_manchester_decode(bitbuffer_t *inbuf, unsigned row, unsigned start,
@@ -518,6 +433,103 @@ int bitbuffer_find_repeated_prefix(bitbuffer_t *bits, unsigned min_repeats, unsi
         }
     }
     return -1;
+}
+
+void bitrow_clear(bitrow_t bitrow, uint16_t *bitrow_num_bits)
+{
+    memset(&bitrow[0], 0, BITBUF_COLS);
+    *bitrow_num_bits = 0;
+}
+
+void bitrow_add_bit(bitrow_t bitrow, uint16_t *bitrow_num_bits, int bit)
+{
+    uint16_t col_index = bits->bits_per_row[bits->num_rows - 1] / 8;
+    uint16_t bit_index = bits->bits_per_row[bits->num_rows - 1] % 8;
+    if (bits->bits_per_row[bits->num_rows - 1] > 0
+            && bits->bits_per_row[bits->num_rows - 1] % (BITBUF_COLS * 8) == 0) {
+        // spill into next row
+        // fprintf(stderr, "%s: row spill [%d] to %d (%d)\n", __func__, bits->num_rows - 1, col_index, bits->free_row);
+        if (bits->free_row == BITBUF_ROWS - 1) {
+            //print_logf(LOG_WARNING, __func__, "Warning: row count limit (%d rows) reached", BITBUF_ROWS);
+            fprintf(stderr, "%s: Warning: row count limit (%d rows) reached\n", __func__, BITBUF_ROWS);
+        }
+        if (bits->free_row < BITBUF_ROWS) {
+            bits->free_row++;
+        }
+        else {
+            // fprintf(stderr, "%s: Could not add more rows\n", __func__);
+            return;
+        }
+    }
+    else {
+        // fprintf(stderr, "ERROR: bitbuffer:: Could not add more columns\n");    // Some decoders may add many columns...
+    uint8_t *b = bits->bb[bits->num_rows - 1];
+    b[col_index] |= (bit << (7 - bit_index));
+    bits->bits_per_row[bits->num_rows - 1]++;
+    }
+}
+
+void bitrow_extract_bytes(bitrow_t const bits, unsigned pos, uint8_t *out, unsigned len)
+{
+    if (len == 0)
+        return;
+    if ((pos & 7) == 0) {
+        memcpy(out, bits + (pos / 8), (len + 7) / 8);
+    }
+    else {
+        unsigned shift = 8 - (pos & 7);
+        unsigned bytes = (len + 7) >> 3;
+        uint8_t *p     = out;
+        uint16_t word;
+        pos = pos >> 3; // Convert to bytes
+
+        word = bits[pos];
+
+        while (bytes--) {
+            word <<= 8;
+            word |= bits[++pos];
+            *(p++) = word >> shift;
+        }
+    }
+    if (len & 7)
+        out[(len - 1) / 8] &= 0xff00 >> (len & 7); // mask off bottom bits
+}
+
+void bitrow_invert(bitrow_t bitrow, uint16_t bitrow_num_bits)
+{
+    if (bitrow_num_bits > 0) {
+        const unsigned last_col  = (bitrow_num_bits - 1) / 8;
+        const unsigned last_bits = ((bitrow_num_bits - 1) % 8) + 1;
+        for (unsigned col = 0; col <= last_col; ++col) {
+            bitrow[col] = ~bitrow[col]; // Invert
+        }
+        bitrow[last_col] ^= 0xFF >> last_bits; // Re-invert unused bits in last byte
+    }
+}
+
+unsigned bitrow_manchester_decode(bitrow_t const inrow, uint16_t inrow_num_bits, unsigned start,
+        bitrow_t outrow, uint16_t *outrow_num_bits, unsigned max)
+{
+    uint8_t const *bits     = inrow;
+    unsigned int len  = inrow_num_bits;
+    unsigned int ipos = start;
+
+    if (max && len > start + (max * 2))
+        len = start + (max * 2);
+
+    while (ipos < len) {
+        uint8_t bit1, bit2;
+
+        bit1 = bit_at(bits, ipos++);
+        bit2 = bit_at(bits, ipos++);
+
+        if (bit1 == bit2)
+            break;
+
+        bitrow_add_bit(outrow, outrow_num_bits, bit2);
+    }
+
+    return ipos;
 }
 
 // Unit testing

--- a/src/devices/abmt.c
+++ b/src/devices/abmt.c
@@ -28,6 +28,7 @@ F - ones
 #include "decoder.h"
 
 #define SYNC_PATTERN_START_OFF 72
+#define EXPECTED_NUM_BITS 48
 
 // Convert two BCD encoded nibbles to an integer
 static unsigned bcd2int(uint8_t bcd)
@@ -39,7 +40,7 @@ static int abmt_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     int row;
     float temp_c;
-    bitrow_t packet_bits = {0};
+    uint8_t packet_bits[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t packet_bits_num_bits = 0;
     unsigned int id;
     data_t *data;
@@ -63,7 +64,7 @@ static int abmt_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_FAIL_SANITY;
 
     // sync bitstream
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos - SYNC_PATTERN_START_OFF, packet_bits, &packet_bits_num_bits, 48);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos - SYNC_PATTERN_START_OFF, packet_bits, &packet_bits_num_bits, EXPECTED_NUM_BITS);
     bitrow_invert(packet_bits, packet_bits_num_bits);
 
     b      = packet_bits;

--- a/src/devices/abmt.c
+++ b/src/devices/abmt.c
@@ -39,7 +39,8 @@ static int abmt_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     int row;
     float temp_c;
-    bitbuffer_t packet_bits = {0};
+    bitrow_t packet_bits = {0};
+    uint16_t packet_bits_num_bits = 0;
     unsigned int id;
     data_t *data;
     unsigned bitpos = 0;
@@ -62,10 +63,10 @@ static int abmt_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_FAIL_SANITY;
 
     // sync bitstream
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos - SYNC_PATTERN_START_OFF, &packet_bits, 48);
-    bitbuffer_invert(&packet_bits);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos - SYNC_PATTERN_START_OFF, packet_bits, &packet_bits_num_bits, 48);
+    bitrow_invert(packet_bits, packet_bits_num_bits);
 
-    b      = packet_bits.bb[0];
+    b      = packet_bits;
     id     = b[0];
     temp   = bcd2int(b[3]) * 10 + bcd2int(b[4] >> 4);
     temp_c = (float)temp;

--- a/src/devices/cavius.c
+++ b/src/devices/cavius.c
@@ -59,17 +59,18 @@ static int cavius_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
     bit_offset += sizeof(preamble) * 8; // skip sync
 
-    bitbuffer_t databits = {0};
+    bitrow_t databits = {0};
+    uint16_t databits_num_bits = 0;
 
-    bitbuffer_manchester_decode(bitbuffer, 0, bit_offset, &databits, 11 * 8);
-    bitbuffer_invert(&databits);
+    bitbuffer_manchester_decode(bitbuffer, 0, bit_offset, databits, &databits_num_bits, 11 * 8);
+    bitrow_invert(databits, databits_num_bits);
 
     // we require 11 bytes
-    if (databits.bits_per_row[0] < 11 * 8) {
+    if (databits_num_bits < 11 * 8) {
         return DECODE_FAIL_SANITY; // manchester_decode fail
     }
 
-    uint8_t *b = databits.bb[0];
+    uint8_t *b = databits;
 
     int crc = crc8le(b, 7, 0x31, 0x0);
     if (crc != 0) {

--- a/src/devices/cavius.c
+++ b/src/devices/cavius.c
@@ -36,6 +36,7 @@ Sometimes the receiver samplerate has to be at 250ksps to decode properly.
 */
 
 #include "decoder.h"
+#define EXPECTED_NUM_BYTES 11
 
 static int cavius_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
@@ -59,14 +60,14 @@ static int cavius_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
     bit_offset += sizeof(preamble) * 8; // skip sync
 
-    bitrow_t databits = {0};
+    uint8_t databits[EXPECTED_NUM_BYTES] = {0};
     uint16_t databits_num_bits = 0;
 
-    bitbuffer_manchester_decode(bitbuffer, 0, bit_offset, databits, &databits_num_bits, 11 * 8);
+    bitbuffer_manchester_decode(bitbuffer, 0, bit_offset, databits, &databits_num_bits, EXPECTED_NUM_BYTES * 8);
     bitrow_invert(databits, databits_num_bits);
 
     // we require 11 bytes
-    if (databits_num_bits < 11 * 8) {
+    if (databits_num_bits < EXPECTED_NUM_BYTES * 8) {
         return DECODE_FAIL_SANITY; // manchester_decode fail
     }
 

--- a/src/devices/ced7000.c
+++ b/src/devices/ced7000.c
@@ -36,7 +36,8 @@ Data layout:
 
 static int ced7000_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    bitbuffer_t decoded = { 0 };
+    uint8_t decoded[NUM_BYTES(NUM_BITS_DATA)] = { 0 };
+    uint16_t decoded_num_bits = 0;
     int ret = 0;
     int bitpos = 0;
     uint8_t *b;
@@ -58,7 +59,7 @@ static int ced7000_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     bitbuffer_invert(bitbuffer);
 
     /* Check and decode the Manchester bits */
-    ret = bitbuffer_manchester_decode(bitbuffer, row, bitpos, &decoded, NUM_BITS_DATA);
+    ret = bitbuffer_manchester_decode(bitbuffer, row, bitpos, decoded, &decoded_num_bits, NUM_BITS_DATA);
     if (ret != NUM_BITS_TOTAL + 1) {
         decoder_log(decoder, 2, __func__, "invalid Manchester data");
         return DECODE_FAIL_MIC;
@@ -68,7 +69,7 @@ static int ced7000_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     /* IIIIIIII IIIIIIII CCCCCCCC FFFFFFFF FFFFFFFF FFFFSSSS
        SSSSSSSS SSSSSSSS UUUUUUUU UUUUUUUU UUUUxxxx*/
 
-    b = decoded.bb[0];
+    b = decoded;
 
     /* Reverse the bit order per nibble */
     reflect_nibbles(b, ret / 8);

--- a/src/devices/current_cost.c
+++ b/src/devices/current_cost.c
@@ -11,6 +11,7 @@
 */
 
 #include "decoder.h"
+#define EXPECTED_NUM_BITS 64
 
 /**
 CurrentCost TX, CurrentCost EnviR current sensors.
@@ -20,7 +21,7 @@ CurrentCost TX, CurrentCost EnviR current sensors.
 static int current_cost_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
-    bitrow_t packet = {0};
+    uint8_t packet [NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t packet_num_bits = 0;
     uint8_t *b;
     int is_envir = 0;
@@ -36,7 +37,7 @@ static int current_cost_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     // 1 bit so that the decoder starts with a high bit.
     uint8_t init_pattern_envir[] = {0x55, 0x55, 0x55, 0x55, 0xa4, 0x57};
 
-    start_pos = bitbuffer_search(bitbuffer, 0, 0, init_pattern_envir, 48);
+    start_pos = bitbuffer_search(bitbuffer, 0, 0, init_pattern_envir, EXPECTED_NUM_BITS);
 
     if (start_pos + 47 + 112 <= bitbuffer->bits_per_row[0]) {
         is_envir = 1;
@@ -56,7 +57,7 @@ static int current_cost_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         start_pos += 45;
     }
 
-    start_pos = bitbuffer_manchester_decode(bitbuffer, 0, start_pos, packet, &packet_num_bits, 0);
+    start_pos = bitbuffer_manchester_decode(bitbuffer, 0, start_pos, packet, &packet_num_bits, EXPECTED_NUM_BITS);
 
     if (packet_num_bits < 64) {
         return DECODE_ABORT_EARLY;

--- a/src/devices/current_cost.c
+++ b/src/devices/current_cost.c
@@ -20,7 +20,8 @@ CurrentCost TX, CurrentCost EnviR current sensors.
 static int current_cost_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
-    bitbuffer_t packet = {0};
+    bitrow_t packet = {0};
+    uint16_t packet_num_bits = 0;
     uint8_t *b;
     int is_envir = 0;
     unsigned int start_pos;
@@ -55,13 +56,13 @@ static int current_cost_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         start_pos += 45;
     }
 
-    start_pos = bitbuffer_manchester_decode(bitbuffer, 0, start_pos, &packet, 0);
+    start_pos = bitbuffer_manchester_decode(bitbuffer, 0, start_pos, packet, &packet_num_bits, 0);
 
-    if (packet.bits_per_row[0] < 64) {
+    if (packet_num_bits < 64) {
         return DECODE_ABORT_EARLY;
     }
 
-    b = packet.bb[0];
+    b = packet;
     // Read data
     // Meter (b[0] = 0000xxxx) bits 5 and 4 are "unknown", but always 0 to date.
     if ((b[0] & 0xf0) == 0) {

--- a/src/devices/danfoss.c
+++ b/src/devices/danfoss.c
@@ -47,7 +47,7 @@ Nibble content:
 
 #include "decoder.h"
 
-#define NUM_BYTES 10    // Output contains 21 nibbles, but skip first nibble 0xE, as it is not part of CRC and to get byte alignment
+#define DANFOSS_NUM_BYTES 10    // Output contains 21 nibbles, but skip first nibble 0xE, as it is not part of CRC and to get byte alignment
 static const uint8_t HEADER[] = { 0x36, 0x5c }; // Encoded prefix. Full prefix is 3 nibbles => 18 bits (but checking 16 is ok)
 
 // Mapping from 6 bits to 4 bits
@@ -78,7 +78,7 @@ static uint8_t danfoss_decode_nibble(uint8_t byte)
 
 static int danfoss_cfr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    uint8_t bytes[NUM_BYTES]; // Decoded bytes with two 4 bit nibbles in each
+    uint8_t bytes[DANFOSS_NUM_BYTES]; // Decoded bytes with two 4 bit nibbles in each
     data_t *data;
 
     // Validate package
@@ -93,7 +93,7 @@ static int danfoss_cfr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         bit_offset += 6; // Skip first nibble 0xE to get byte alignment and remove from CRC calculation
 
         // Decode input 6 bit nibbles to output 4 bit nibbles (packed in bytes)
-        for (unsigned n = 0; n < NUM_BYTES; ++n) {
+        for (unsigned n = 0; n < DANFOSS_NUM_BYTES; ++n) {
             uint8_t nibble_h = danfoss_decode_nibble(bitrow_get_byte(bitbuffer->bb[0], n * 12 + bit_offset) >> 2);
             uint8_t nibble_l = danfoss_decode_nibble(bitrow_get_byte(bitbuffer->bb[0], n * 12 + bit_offset + 6) >> 2);
             if (nibble_h > 0xF || nibble_l > 0xF) {
@@ -104,10 +104,10 @@ static int danfoss_cfr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         }
 
         // Output raw decoded data for debug
-        decoder_log_bitrow(decoder, 1, __func__, bytes, NUM_BYTES * 8, "Danfoss: Raw 6b/4b decoded");
+        decoder_log_bitrow(decoder, 1, __func__, bytes, DANFOSS_NUM_BYTES * 8, "Danfoss: Raw 6b/4b decoded");
 
         // Validate Prefix and CRC
-        uint16_t crc_calc = crc16(bytes, NUM_BYTES-2, 0x1021, 0x0000);
+        uint16_t crc_calc = crc16(bytes, DANFOSS_NUM_BYTES-2, 0x1021, 0x0000);
         if (bytes[0] != 0x02        // Somewhat redundant to header search, but checks last bits
          || crc_calc != (((uint16_t)bytes[8] << 8) | bytes[9])
         ) {

--- a/src/devices/ge_coloreffects.c
+++ b/src/devices/ge_coloreffects.c
@@ -61,7 +61,7 @@ static unsigned ge_decode(bitbuffer_t *inbuf, unsigned row, unsigned start, bitr
 static int ge_coloreffects_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned start_pos)
 {
     data_t *data;
-    bitrow_t packet_bits = {0};
+    uint8_t packet_bits[3] = {0};
     uint16_t packet_bits_num_bits = 0;
 
     ge_decode(bitbuffer, row, start_pos, packet_bits, &packet_bits_num_bits);

--- a/src/devices/ge_coloreffects.c
+++ b/src/devices/ge_coloreffects.c
@@ -29,7 +29,7 @@ Decodes the following encoding scheme:
 - 10 = 0
 - 1100 = 1
 */
-static unsigned ge_decode(bitbuffer_t *inbuf, unsigned row, unsigned start, bitrow_t outrow, uint16_t *outrow_num_bits)
+static unsigned ge_decode(bitbuffer_t *inbuf, unsigned row, unsigned start, uint8_t *outrow, uint16_t *outrow_num_bits)
 {
     uint8_t *bits = inbuf->bb[row];
     unsigned int len = inbuf->bits_per_row[row];

--- a/src/devices/honeywell_cm921.c
+++ b/src/devices/honeywell_cm921.c
@@ -266,7 +266,7 @@ static uint8_t next(const uint8_t *bb, unsigned *ipos, unsigned num_bytes)
     return r;
 }
 
-static int parse_msg(bitrow_t bmsg, uint16_t bmsg_num_bits, message_t *msg)
+static int parse_msg(uint8_t const *bmsg, uint16_t bmsg_num_bits, message_t *msg)
 {
     if (bmsg_num_bits < 8)
         return DECODE_ABORT_LENGTH;

--- a/src/devices/insteon.c
+++ b/src/devices/insteon.c
@@ -115,8 +115,10 @@ static int parse_insteon_pkt(r_device *decoder, bitbuffer_t *bits, unsigned int 
 {
     uint8_t results[35]   = {0};
     uint8_t results_len   = 0;
-    bitbuffer_t i_bits    = {0};
-    bitbuffer_t d_bits    = {0};
+    bitrow_t i_bits    = {0};
+    uint16_t i_bits_num_bits = 0;
+    bitrow_t d_bits    = {0};
+    uint16_t d_bits_num_bits = 0;
     unsigned int next_pos = 0;
     uint8_t i             = 0;
     uint8_t pkt_i, pkt_d;
@@ -154,11 +156,11 @@ static int parse_insteon_pkt(r_device *decoder, bitbuffer_t *bits, unsigned int 
 
     */
 
-    next_pos = bitbuffer_manchester_decode(bits, row, start_pos, &i_bits, 5);
-    pkt_i    = reverse8(i_bits.bb[0][0]);
+    next_pos = bitbuffer_manchester_decode(bits, row, start_pos, i_bits, &i_bits_num_bits, 5);
+    pkt_i    = reverse8(i_bits[0]);
 
-    next_pos               = bitbuffer_manchester_decode(bits, row, next_pos, &d_bits, 8);
-    pkt_d                  = reverse8(d_bits.bb[0][0]);
+    next_pos               = bitbuffer_manchester_decode(bits, row, next_pos, d_bits, &d_bits_num_bits, 8);
+    pkt_d                  = reverse8(d_bits[0]);
     results[results_len++] = pkt_d;
 
     if (pkt_i != 31) { // should always be 31 (0b11111) in first block of packet
@@ -217,10 +219,10 @@ static int parse_insteon_pkt(r_device *decoder, bitbuffer_t *bits, unsigned int 
     for (int j = 1; j < max_pkt_len; j++) {
         unsigned y;
         start_pos += 28;
-        bitbuffer_clear(&i_bits);
-        bitbuffer_clear(&d_bits);
-        next_pos = bitbuffer_manchester_decode(bits, row, start_pos, &i_bits, 5);
-        next_pos = bitbuffer_manchester_decode(bits, row, next_pos, &d_bits, 8);
+        bitrow_clear(i_bits, &i_bits_num_bits);
+        bitrow_clear(d_bits, &d_bits_num_bits);
+        next_pos = bitbuffer_manchester_decode(bits, row, start_pos, i_bits, &i_bits_num_bits, 5);
+        next_pos = bitbuffer_manchester_decode(bits, row, next_pos, d_bits, &d_bits_num_bits, 8);
 
         y = (next_pos - start_pos);
         if (y != 26) {
@@ -231,8 +233,8 @@ static int parse_insteon_pkt(r_device *decoder, bitbuffer_t *bits, unsigned int 
         // bitbuffer_extract_bytes(bits, row, start_pos -2, buff, 8);
         // printBits(sizeof(buff), buff);
 
-        pkt_i = reverse8(i_bits.bb[0][0]);
-        pkt_d = reverse8(d_bits.bb[0][0]);
+        pkt_i = reverse8(i_bits[0]);
+        pkt_d = reverse8(d_bits[0]);
 
         results[results_len++] = pkt_d;
 

--- a/src/devices/insteon.c
+++ b/src/devices/insteon.c
@@ -222,8 +222,8 @@ static int parse_insteon_pkt(r_device *decoder, bitbuffer_t *bits, unsigned int 
     for (int j = 1; j < max_pkt_len; j++) {
         unsigned y;
         start_pos += 28;
-        bitrow_clear(i_bits, &i_bits_num_bits);
-        bitrow_clear(d_bits, &d_bits_num_bits);
+        bitrow_clear(i_bits, &i_bits_num_bits, sizeof(i_bits));
+        bitrow_clear(d_bits, &d_bits_num_bits, sizeof(d_bits));
         next_pos = bitbuffer_manchester_decode(bits, row, start_pos, i_bits, &i_bits_num_bits, I_EXPECTED_NUM_BITS);
         next_pos = bitbuffer_manchester_decode(bits, row, next_pos, d_bits, &d_bits_num_bits, D_EXPECTED_NUM_BITS);
 

--- a/src/devices/insteon.c
+++ b/src/devices/insteon.c
@@ -111,13 +111,16 @@ static uint8_t gen_crc(uint8_t *dat)
     return (r);
 }
 
+#define I_EXPECTED_NUM_BITS 5
+#define D_EXPECTED_NUM_BITS 8
+
 static int parse_insteon_pkt(r_device *decoder, bitbuffer_t *bits, unsigned int row, unsigned int start_pos)
 {
     uint8_t results[35]   = {0};
     uint8_t results_len   = 0;
-    bitrow_t i_bits    = {0};
+    uint8_t i_bits[NUM_BYTES(I_EXPECTED_NUM_BITS)] = {0};
     uint16_t i_bits_num_bits = 0;
-    bitrow_t d_bits    = {0};
+    uint8_t d_bits[NUM_BYTES(D_EXPECTED_NUM_BITS)] = {0};
     uint16_t d_bits_num_bits = 0;
     unsigned int next_pos = 0;
     uint8_t i             = 0;
@@ -156,10 +159,10 @@ static int parse_insteon_pkt(r_device *decoder, bitbuffer_t *bits, unsigned int 
 
     */
 
-    next_pos = bitbuffer_manchester_decode(bits, row, start_pos, i_bits, &i_bits_num_bits, 5);
+    next_pos = bitbuffer_manchester_decode(bits, row, start_pos, i_bits, &i_bits_num_bits, I_EXPECTED_NUM_BITS);
     pkt_i    = reverse8(i_bits[0]);
 
-    next_pos               = bitbuffer_manchester_decode(bits, row, next_pos, d_bits, &d_bits_num_bits, 8);
+    next_pos               = bitbuffer_manchester_decode(bits, row, next_pos, d_bits, &d_bits_num_bits, D_EXPECTED_NUM_BITS);
     pkt_d                  = reverse8(d_bits[0]);
     results[results_len++] = pkt_d;
 
@@ -221,8 +224,8 @@ static int parse_insteon_pkt(r_device *decoder, bitbuffer_t *bits, unsigned int 
         start_pos += 28;
         bitrow_clear(i_bits, &i_bits_num_bits);
         bitrow_clear(d_bits, &d_bits_num_bits);
-        next_pos = bitbuffer_manchester_decode(bits, row, start_pos, i_bits, &i_bits_num_bits, 5);
-        next_pos = bitbuffer_manchester_decode(bits, row, next_pos, d_bits, &d_bits_num_bits, 8);
+        next_pos = bitbuffer_manchester_decode(bits, row, start_pos, i_bits, &i_bits_num_bits, I_EXPECTED_NUM_BITS);
+        next_pos = bitbuffer_manchester_decode(bits, row, next_pos, d_bits, &d_bits_num_bits, D_EXPECTED_NUM_BITS);
 
         y = (next_pos - start_pos);
         if (y != 26) {

--- a/src/devices/m_bus.c
+++ b/src/devices/m_bus.c
@@ -1128,10 +1128,11 @@ static int m_bus_mode_s_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     static const uint8_t PREAMBLE_S[]  = {0x54, 0x76, 0x96};  // Mode S Preamble
     static const uint8_t PREAMBLE_T_DN[] = {0xaa, 0xab, 0x32};  // Mode T Downlink Preamble
-    bitbuffer_t packet_bits = {0};
-    m_bus_data_t    data_in     = {0};  // Data from Physical layer decoded to bytes
-    m_bus_data_t    data_out    = {0};  // Data from Data Link layer
-    m_bus_block1_t  block1      = {0};  // Block1 fields from Data Link layer
+    bitrow_t packet_bits          = {0};
+    uint16_t packet_bits_num_bits = 0;
+    m_bus_data_t    data_in       = {0};  // Data from Physical layer decoded to bytes
+    m_bus_data_t    data_out      = {0};  // Data from Data Link layer
+    m_bus_block1_t  block1        = {0};  // Block1 fields from Data Link layer
 
     // Validate package length
     if (bitbuffer->bits_per_row[0] < (32+13*8) || bitbuffer->bits_per_row[0] > (64+256*8)) {
@@ -1153,9 +1154,9 @@ static int m_bus_mode_s_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (bit_offset >= bitbuffer->bits_per_row[0]) { // Did not find a big enough package
         return DECODE_ABORT_EARLY;
     }
-    bitbuffer_manchester_decode(bitbuffer, 0, bit_offset, &packet_bits, 800);
+    bitbuffer_manchester_decode(bitbuffer, 0, bit_offset, packet_bits, &packet_bits_num_bits, 800);
     data_in.length = (bitbuffer->bits_per_row[0]);
-    bitbuffer_extract_bytes(&packet_bits, 0, 0, data_in.data, data_in.length);
+    bitrow_extract_bytes(packet_bits, 0, data_in.data, data_in.length);
 
     if (!m_bus_decode_format_a(decoder, &data_in, &data_out, &block1))    return 0;
 

--- a/src/devices/m_bus.c
+++ b/src/devices/m_bus.c
@@ -1124,11 +1124,14 @@ static int m_bus_mode_f_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 Wireless M-Bus, Mode S.
 @sa m_bus_output_data()
 */
+
+#define EXPECTED_NUM_BITS 800
+
 static int m_bus_mode_s_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     static const uint8_t PREAMBLE_S[]  = {0x54, 0x76, 0x96};  // Mode S Preamble
     static const uint8_t PREAMBLE_T_DN[] = {0xaa, 0xab, 0x32};  // Mode T Downlink Preamble
-    bitrow_t packet_bits          = {0};
+    uint8_t packet_bits[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t packet_bits_num_bits = 0;
     m_bus_data_t    data_in       = {0};  // Data from Physical layer decoded to bytes
     m_bus_data_t    data_out      = {0};  // Data from Data Link layer
@@ -1154,7 +1157,7 @@ static int m_bus_mode_s_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (bit_offset >= bitbuffer->bits_per_row[0]) { // Did not find a big enough package
         return DECODE_ABORT_EARLY;
     }
-    bitbuffer_manchester_decode(bitbuffer, 0, bit_offset, packet_bits, &packet_bits_num_bits, 800);
+    bitbuffer_manchester_decode(bitbuffer, 0, bit_offset, packet_bits, &packet_bits_num_bits, EXPECTED_NUM_BITS);
     data_in.length = (bitbuffer->bits_per_row[0]);
     bitrow_extract_bytes(packet_bits, 0, data_in.data, data_in.length);
 

--- a/src/devices/maverick_et73x.c
+++ b/src/devices/maverick_et73x.c
@@ -40,10 +40,12 @@ note that the mentioned quaternary conversion is actually manchester code.
 
 #include "decoder.h"
 
+#define EXPECTED_NUM_BITS 104
+
 static int maverick_et73x_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
-    bitrow_t mc = {0};
+    uint8_t mc[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t mc_num_bits = 0;
 
     if (bitbuffer->num_rows != 1)
@@ -58,7 +60,7 @@ static int maverick_et73x_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_ABORT_EARLY; // preamble missing
 
     // decode the inner manchester encoding
-    bitbuffer_manchester_decode(bitbuffer, 0, 0, mc, &mc_num_bits, 104);
+    bitbuffer_manchester_decode(bitbuffer, 0, 0, mc, &mc_num_bits, EXPECTED_NUM_BITS);
 
     // we require 7 bytes 13 nibble rounded up (b[6] highest reference below)
     if (mc_num_bits < 52) {

--- a/src/devices/maverick_et73x.c
+++ b/src/devices/maverick_et73x.c
@@ -43,7 +43,8 @@ note that the mentioned quaternary conversion is actually manchester code.
 static int maverick_et73x_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
-    bitbuffer_t mc = {0};
+    bitrow_t mc = {0};
+    uint16_t mc_num_bits = 0;
 
     if (bitbuffer->num_rows != 1)
         return DECODE_ABORT_EARLY;
@@ -57,14 +58,14 @@ static int maverick_et73x_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_ABORT_EARLY; // preamble missing
 
     // decode the inner manchester encoding
-    bitbuffer_manchester_decode(bitbuffer, 0, 0, &mc, 104);
+    bitbuffer_manchester_decode(bitbuffer, 0, 0, mc, &mc_num_bits, 104);
 
     // we require 7 bytes 13 nibble rounded up (b[6] highest reference below)
-    if (mc.bits_per_row[0] < 52) {
+    if (mc_num_bits < 52) {
         return DECODE_FAIL_SANITY; // manchester_decode fail
     }
 
-    uint8_t *b = mc.bb[0];
+    uint8_t *b = mc;
     int pre    = (b[0] << 4) | (b[1] & 0xf0) >> 4;
     int flags  = b[1] & 0x0f;
     int temp1  = (b[2] << 2) | (b[3] & 0xc0) >> 6;
@@ -81,7 +82,7 @@ static int maverick_et73x_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         status = "init";
 
     uint8_t chk[3];
-    bitbuffer_extract_bytes(&mc, 0, 12, chk, 24);
+    bitrow_extract_bytes(mc, 12, chk, 24);
 
     //digest is used to represent a session. This means, we get a new id if a reset or battery exchange is done.
     int id = lfsr_digest16(chk, 3, 0x8810, 0xdd38) ^ digest;

--- a/src/devices/newkaku.c
+++ b/src/devices/newkaku.c
@@ -19,6 +19,8 @@ start pulse: 1T high, 10.44T low
 
 #include "decoder.h"
 
+#define EXPECTED_NUM_BITS 80
+
 static int newkaku_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     uint8_t *b = bitbuffer->bb[0];
@@ -40,10 +42,10 @@ static int newkaku_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         b[6] &= 0xfe; // change DIM to ON to use Manchester
     }
 
-    bitrow_t databits = {0};
+    uint8_t databits[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t databits_num_bits = 0;
     // note: not manchester encoded but actually ternary
-    unsigned pos = bitbuffer_manchester_decode(bitbuffer, 0, 0, databits, &databits_num_bits, 80);
+    unsigned pos = bitbuffer_manchester_decode(bitbuffer, 0, 0, databits, &databits_num_bits, EXPECTED_NUM_BITS);
     bitrow_invert(databits, databits_num_bits);
 
     /* Reject codes when Manchester decoding fails */

--- a/src/devices/newkaku.c
+++ b/src/devices/newkaku.c
@@ -50,7 +50,7 @@ static int newkaku_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (pos != 64 && pos != 72)
         return DECODE_ABORT_LENGTH;
 
-    b = databits.bb[0];
+    b = &databits[0];
 
     uint32_t id        = (b[0] << 18) | (b[1] << 10) | (b[2] << 2) | (b[3] >> 6); // ID 26 bits
     uint32_t group_cmd = (b[3] >> 5) & 1;

--- a/src/devices/newkaku.c
+++ b/src/devices/newkaku.c
@@ -50,7 +50,7 @@ static int newkaku_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (pos != 64 && pos != 72)
         return DECODE_ABORT_LENGTH;
 
-    b = &databits[0];
+    b = databits;
 
     uint32_t id        = (b[0] << 18) | (b[1] << 10) | (b[2] << 2) | (b[3] >> 6); // ID 26 bits
     uint32_t group_cmd = (b[3] >> 5) & 1;

--- a/src/devices/newkaku.c
+++ b/src/devices/newkaku.c
@@ -40,10 +40,11 @@ static int newkaku_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         b[6] &= 0xfe; // change DIM to ON to use Manchester
     }
 
-    bitbuffer_t databits = {0};
+    bitrow_t databits = {0};
+    uint16_t databits_num_bits = 0;
     // note: not manchester encoded but actually ternary
-    unsigned pos = bitbuffer_manchester_decode(bitbuffer, 0, 0, &databits, 80);
-    bitbuffer_invert(&databits);
+    unsigned pos = bitbuffer_manchester_decode(bitbuffer, 0, 0, databits, &databits_num_bits, 80);
+    bitrow_invert(databits, databits_num_bits);
 
     /* Reject codes when Manchester decoding fails */
     if (pos != 64 && pos != 72)

--- a/src/devices/nexa.c
+++ b/src/devices/nexa.c
@@ -37,16 +37,17 @@ static int nexa_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (bitbuffer->bits_per_row[0] != 64 && bitbuffer->bits_per_row[0] != 72)
         return DECODE_ABORT_LENGTH;
 
-    bitbuffer_t databits = {0};
+    bitrow_t databits = {0};
+    uint16_t databits_num_bits = 0;
     // note: not manchester encoded but actually ternary
-    unsigned pos = bitbuffer_manchester_decode(bitbuffer, 0, 0, &databits, 80);
-    bitbuffer_invert(&databits);
+    unsigned pos = bitbuffer_manchester_decode(bitbuffer, 0, 0, databits, &databits_num_bits, 80);
+    bitrow_invert(databits, databits_num_bits);
 
     /* Reject codes when Manchester decoding fails */
     if (pos != 64 && pos != 72)
         return DECODE_ABORT_LENGTH;
 
-    uint8_t *b = databits.bb[0];
+    uint8_t *b = databits;
 
     uint32_t id        = (b[0] << 18) | (b[1] << 10) | (b[2] << 2) | (b[3] >> 6); // ID 26 bits
     uint32_t group_cmd = (b[3] >> 5) & 1;

--- a/src/devices/nexa.c
+++ b/src/devices/nexa.c
@@ -25,6 +25,8 @@ since the Nexa uses two different bit lengths for ON and OFF.
 
 #include "decoder.h"
 
+#define EXPECTED_NUM_BITS 80
+
 static int nexa_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
@@ -37,10 +39,10 @@ static int nexa_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (bitbuffer->bits_per_row[0] != 64 && bitbuffer->bits_per_row[0] != 72)
         return DECODE_ABORT_LENGTH;
 
-    bitrow_t databits = {0};
+    uint8_t databits[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t databits_num_bits = 0;
     // note: not manchester encoded but actually ternary
-    unsigned pos = bitbuffer_manchester_decode(bitbuffer, 0, 0, databits, &databits_num_bits, 80);
+    unsigned pos = bitbuffer_manchester_decode(bitbuffer, 0, 0, databits, &databits_num_bits, EXPECTED_NUM_BITS);
     bitrow_invert(databits, databits_num_bits);
 
     /* Reject codes when Manchester decoding fails */

--- a/src/devices/oil_smart.c
+++ b/src/devices/oil_smart.c
@@ -55,16 +55,19 @@ Start of frame full preamble is depending on first data bit either
     0101 0101 0101 0101 0101 0111 01
     0101 0101 0101 0101 0101 1000 10
 */
+#define EXPECTED_NUM_BITS 64
+
 static int oil_smart_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
-    bitbuffer_t databits = {0};
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &databits, 64);
+    uint8_t databits[NUM_BYTES(EXPECTED_NUM_BITS)] = { 0 };
+    uint16_t databits_num_bits = 0;
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, databits, &databits_num_bits, EXPECTED_NUM_BITS);
 
-    if (databits.bits_per_row[0] < 64) {
+    if (databits_num_bits < 64) {
         return 0; // DECODE_ABORT_LENGTH; // TODO: fix calling code to handle negative return values
     }
 
-    uint8_t *b = databits.bb[0];
+    uint8_t *b = databits;
 
     if (b[0] != 0x55 || b[1] != 0x58) {
         decoder_log(decoder, 2, __func__, "Couldn't find preamble");

--- a/src/devices/oil_standard.c
+++ b/src/devices/oil_standard.c
@@ -40,12 +40,15 @@ Start of frame full preamble is depending on first data bit either
     01 0101 0101 0101 0101 0111 01
     01 0101 0101 0101 0101 1000 10
 */
+
+#define EXPECTED_NUM_BITS 41
+
 static int oil_standard_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
-    bitrow_t databits = {0};
+    uint8_t databits[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t databits_num_bits = 0;
 
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, databits, &databits_num_bits, 41);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, databits, &databits_num_bits, EXPECTED_NUM_BITS);
 
     if (databits_num_bits < 32 || databits_num_bits > 40 || (databits[4] & 0xfe) != 0)
         return 0; // TODO: fix calling code to handle negative return values

--- a/src/devices/oil_standard.c
+++ b/src/devices/oil_standard.c
@@ -42,13 +42,15 @@ Start of frame full preamble is depending on first data bit either
 */
 static int oil_standard_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
-    bitbuffer_t databits = {0};
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &databits, 41);
+    bitrow_t databits = {0};
+    uint16_t databits_num_bits = 0;
 
-    if (databits.bits_per_row[0] < 32 || databits.bits_per_row[0] > 40 || (databits.bb[0][4] & 0xfe) != 0)
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, databits, &databits_num_bits, 41);
+
+    if (databits_num_bits < 32 || databits_num_bits > 40 || (databits[4] & 0xfe) != 0)
         return 0; // TODO: fix calling code to handle negative return values
 
-    uint8_t *b = databits.bb[0];
+    uint8_t *b = databits;
 
     // The unit ID changes when you rebind by holding a magnet to the
     // sensor for long enough.

--- a/src/devices/oil_watchman.c
+++ b/src/devices/oil_watchman.c
@@ -36,12 +36,13 @@ static int oil_watchman_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         // Skip the matched preamble bits to point to the data
         bitpos += 6;
 
-        bitbuffer_t databits = {0};
-        bitpos = bitbuffer_manchester_decode(bitbuffer, 0, bitpos, &databits, 64);
-        if (databits.bits_per_row[0] != 64)
+        bitrow_t databits = {0};
+        uint16_t databits_num_bits = 0;
+        bitpos = bitbuffer_manchester_decode(bitbuffer, 0, bitpos, databits, &databits_num_bits, 64);
+        if (databits_num_bits != 64)
             continue; // DECODE_ABORT_LENGTH
 
-        uint8_t *b = databits.bb[0];
+        uint8_t *b = databits;
 
         // Check for postamble, depending on last data bit
         if (bitbuffer_search(bitbuffer, 0, bitpos, &postamble_pattern[b[7] & 1], 2) != bitpos)

--- a/src/devices/oil_watchman.c
+++ b/src/devices/oil_watchman.c
@@ -18,6 +18,8 @@ Tested devices:
 - Sensor Systems Watchman Sonic
 - Kingspan Watchman Sonic Plus
 */
+#define EXPECTED_NUM_BITS 64
+
 static int oil_watchman_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     // Start of frame preamble is 111000xx
@@ -36,10 +38,10 @@ static int oil_watchman_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         // Skip the matched preamble bits to point to the data
         bitpos += 6;
 
-        bitrow_t databits = {0};
+        uint8_t databits[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
         uint16_t databits_num_bits = 0;
-        bitpos = bitbuffer_manchester_decode(bitbuffer, 0, bitpos, databits, &databits_num_bits, 64);
-        if (databits_num_bits != 64)
+        bitpos = bitbuffer_manchester_decode(bitbuffer, 0, bitpos, databits, &databits_num_bits, EXPECTED_NUM_BITS);
+        if (databits_num_bits != EXPECTED_NUM_BITS)
             continue; // DECODE_ABORT_LENGTH
 
         uint8_t *b = databits;

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -192,6 +192,8 @@ Various Oregon Scientific protocols.
 
 @todo Documentation needed.
 */
+#define EXPECTED_NUM_BITS 173
+
 static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     uint8_t *b = bitbuffer->bb[0];
@@ -206,7 +208,7 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         return DECODE_ABORT_EARLY;
     }
 
-    bitrow_t databits = {0};
+    uint8_t databits[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t databits_num_bits = 0;
     uint8_t *msg = databits;
 
@@ -229,7 +231,7 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         decoder_logf(decoder, 1, __func__, "OS v2.1 Sync test val %08x found, starting decode at bit %d", sync_test_val, pattern_index);
 
         //decoder_log_bitrow(decoder, 0, __func__, b, bitbuffer->bits_per_row[0], "Raw OSv2 bits");
-        bitbuffer_manchester_decode(bitbuffer, 0, pattern_index + 40, databits, &databits_num_bits, 173);
+        bitbuffer_manchester_decode(bitbuffer, 0, pattern_index + 40, databits, &databits_num_bits, EXPECTED_NUM_BITS);
         reflect_nibbles(databits, (databits_num_bits+7)/8);
         //decoder_logf_bitbuffer(decoder, 0, __func__, &databits, "MC OSv2 bits (from %d+40)", pattern_index);
 

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -206,8 +206,9 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         return DECODE_ABORT_EARLY;
     }
 
-    bitbuffer_t databits = {0};
-    uint8_t *msg = databits.bb[0];
+    bitrow_t databits = {0};
+    uint16_t databits_num_bits = 0;
+    uint8_t *msg = databits;
 
     // Possible    v2.1 Protocol message
     unsigned int sync_test_val = ((unsigned)b[3] << 24) | (b[4] << 16) | (b[5] << 8) | (b[6]);
@@ -228,13 +229,13 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         decoder_logf(decoder, 1, __func__, "OS v2.1 Sync test val %08x found, starting decode at bit %d", sync_test_val, pattern_index);
 
         //decoder_log_bitrow(decoder, 0, __func__, b, bitbuffer->bits_per_row[0], "Raw OSv2 bits");
-        bitbuffer_manchester_decode(bitbuffer, 0, pattern_index + 40, &databits, 173);
-        reflect_nibbles(databits.bb[0], (databits.bits_per_row[0]+7)/8);
+        bitbuffer_manchester_decode(bitbuffer, 0, pattern_index + 40, databits, &databits_num_bits, 173);
+        reflect_nibbles(databits, (databits_num_bits+7)/8);
         //decoder_logf_bitbuffer(decoder, 0, __func__, &databits, "MC OSv2 bits (from %d+40)", pattern_index);
 
         break;
     }
-    int msg_bits = databits.bits_per_row[0];
+    int msg_bits = databits_num_bits;
 
     int sensor_id   = (msg[0] << 8) | msg[1];
     int channel     = (msg[2] >> 4) & 0x0f;

--- a/src/devices/proflame2.c
+++ b/src/devices/proflame2.c
@@ -42,6 +42,8 @@ The payload data is 7 bytes:
 */
 #include "decoder.h"
 
+#define EXPECTED_BITS 11
+
 /// out needs to be at least (bits / 26, usually 7) bytes long
 static int proflame2_mc(bitbuffer_t *bitbuffer, unsigned row, unsigned start, uint8_t *out)
 {
@@ -59,14 +61,15 @@ static int proflame2_mc(bitbuffer_t *bitbuffer, unsigned row, unsigned start, ui
         if (sync != 0xe)
             return f;
 
-        bitbuffer_t decoded = {0};
-        pos = bitbuffer_manchester_decode(bitbuffer, row, pos, &decoded, 11);
-        if (decoded.bits_per_row[0] != 11)
+        uint8_t decoded[NUM_BYTES(EXPECTED_BITS)] = {0};
+        uint16_t decoded_num_bits = 0;
+        pos = bitbuffer_manchester_decode(bitbuffer, row, pos, decoded, &decoded_num_bits, EXPECTED_BITS);
+        if (decoded_num_bits != EXPECTED_BITS)
             return f;
 
         // invert IEEE MC to G.E.T. MC
-        uint8_t data = decoded.bb[0][0] ^ 0xff;
-        uint8_t flag = decoded.bb[0][1] ^ 0xe0;
+        uint8_t data = decoded[0] ^ 0xff;
+        uint8_t flag = decoded[1] ^ 0xe0;
 
         int pad = (flag >> 7) & 1;
         int par = (flag >> 6) & 1;

--- a/src/devices/proove.c
+++ b/src/devices/proove.c
@@ -60,18 +60,19 @@ static int proove_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (bitbuffer->bits_per_row[0] != 64)
         return DECODE_ABORT_LENGTH;
 
-    bitbuffer_t databits = {0};
+    bitrow_t databits = {0};
+    uint16_t databits_num_bits = 0;
     // note: not manchester encoded but actually ternary
-    bitbuffer_manchester_decode(bitbuffer, 0, 0, &databits, 80);
+    bitbuffer_manchester_decode(bitbuffer, 0, 0, databits, &databits_num_bits, 80);
 
     /* Reject codes when Manchester decoding fails */
     /* 32 bits or 36 bits with dimmer value */
-    if (databits.bits_per_row[0] < 32)
+    if (databits_num_bits < 32)
         return DECODE_ABORT_LENGTH;
 
-    bitbuffer_invert(&databits);
+    bitrow_invert(databits, databits_num_bits);
 
-    uint8_t *b = databits.bb[0];
+    uint8_t *b = databits;
 
     uint32_t id        = (b[0] << 18) | (b[1] << 10) | (b[2] << 2) | (b[3] >> 6); // ID 26 bits
     uint32_t group_cmd = (b[3] >> 5) & 1;

--- a/src/devices/proove.c
+++ b/src/devices/proove.c
@@ -48,6 +48,8 @@ Packet gap is 10 ms.
 
 #include "decoder.h"
 
+#define EXPECTED_NUM_BITS 80
+
 static int proove_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     data_t *data;
@@ -60,10 +62,10 @@ static int proove_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (bitbuffer->bits_per_row[0] != 64)
         return DECODE_ABORT_LENGTH;
 
-    bitrow_t databits = {0};
+    uint8_t databits[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t databits_num_bits = 0;
     // note: not manchester encoded but actually ternary
-    bitbuffer_manchester_decode(bitbuffer, 0, 0, databits, &databits_num_bits, 80);
+    bitbuffer_manchester_decode(bitbuffer, 0, 0, databits, &databits_num_bits, EXPECTED_NUM_BITS);
 
     /* Reject codes when Manchester decoding fails */
     /* 32 bits or 36 bits with dimmer value */

--- a/src/devices/rainpoint.c
+++ b/src/devices/rainpoint.c
@@ -63,15 +63,16 @@ static int rainpoint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
     start_pos += sizeof (preamble_pattern) * 8 - 2; // keep initial data bit
 
-    bitbuffer_t msg = {0};
-    unsigned len = bitbuffer_manchester_decode(bitbuffer, 0, start_pos, &msg, 12 * 8);
+    bitrow_t msg = {0};
+    uint16_t msg_num_bits = 0;
+    unsigned len = bitbuffer_manchester_decode(bitbuffer, 0, start_pos, msg, &msg_num_bits, 12 * 8);
     if (len - start_pos != 12 * 2 * 8) {
         decoder_logf(decoder, 2, __func__, "Manchester decode failed, got %u bits", len - start_pos);
         return DECODE_ABORT_LENGTH;
     }
-    bitbuffer_invert(&msg);
+    bitrow_invert(msg, msg_num_bits);
 
-    uint8_t *b = msg.bb[0];
+    uint8_t *b = msg;
     reflect_bytes(b, 12);
     decoder_log_bitrow(decoder, 2, __func__, b, 12 * 8, "");
 

--- a/src/devices/rainpoint.c
+++ b/src/devices/rainpoint.c
@@ -43,6 +43,7 @@ Raw data:
     rtl_433 -R 0 -X 'n=RainPoint,m=OOK_PCM,s=500,l=500,r=1500'
 
 */
+#define EXPECTED_NUM_BYTES 12
 
 static int rainpoint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
@@ -63,18 +64,18 @@ static int rainpoint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
     start_pos += sizeof (preamble_pattern) * 8 - 2; // keep initial data bit
 
-    bitrow_t msg = {0};
+    uint8_t msg[EXPECTED_NUM_BYTES] = {0};
     uint16_t msg_num_bits = 0;
-    unsigned len = bitbuffer_manchester_decode(bitbuffer, 0, start_pos, msg, &msg_num_bits, 12 * 8);
-    if (len - start_pos != 12 * 2 * 8) {
+    unsigned len = bitbuffer_manchester_decode(bitbuffer, 0, start_pos, msg, &msg_num_bits, EXPECTED_NUM_BYTES * 8);
+    if (len - start_pos != EXPECTED_NUM_BYTES * 2 * 8) {
         decoder_logf(decoder, 2, __func__, "Manchester decode failed, got %u bits", len - start_pos);
         return DECODE_ABORT_LENGTH;
     }
     bitrow_invert(msg, msg_num_bits);
 
     uint8_t *b = msg;
-    reflect_bytes(b, 12);
-    decoder_log_bitrow(decoder, 2, __func__, b, 12 * 8, "");
+    reflect_bytes(b, EXPECTED_NUM_BYTES);
+    decoder_log_bitrow(decoder, 2, __func__, b, EXPECTED_NUM_BYTES * 8, "");
 
     // Checksum, add nibbles with carry
     int sum = add_nibbles(b, 10);

--- a/src/devices/schraeder.c
+++ b/src/devices/schraeder.c
@@ -236,7 +236,7 @@ static int schrader_SMD3MA4_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     // Check and decode the Manchester bits
-    bitrow_t decoded = { 0 };
+    uint8_t decoded[NUM_BYTES(NUM_BITS_DATA)] = { 0 };
     uint16_t decoded_num_bits = 0;
     int ret = bitbuffer_manchester_decode(bitbuffer, 0, NUM_BITS_PREAMBLE,
             decoded, &decoded_num_bits, NUM_BITS_DATA);
@@ -259,7 +259,7 @@ static int schrader_SMD3MA4_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int pressure  = ((b[3] & 0x1f) <<  3) | (b[4] >> 5);
     int check     = ((b[4] & 0x18) >> 3);
 
-    decoder_logf_bitbuffer(decoder, 3, __func__, &decoded, "Parity: %d%d Check: %d%d", parity >> 1, parity & 1, check >> 1, check & 1);
+    decoder_logf_bitrow(decoder, 3, __func__, decoded, decoded_num_bits, "Parity: %d%d Check: %d%d", parity >> 1, parity & 1, check >> 1, check & 1);
 
     // reject all-zero data
     if (!flags && !serial_id && !pressure) {

--- a/src/devices/schraeder.c
+++ b/src/devices/schraeder.c
@@ -236,15 +236,16 @@ static int schrader_SMD3MA4_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     // Check and decode the Manchester bits
-    bitbuffer_t decoded = {0};
+    bitrow_t decoded = { 0 };
+    uint16_t decoded_num_bits = 0;
     int ret = bitbuffer_manchester_decode(bitbuffer, 0, NUM_BITS_PREAMBLE,
-            &decoded, NUM_BITS_DATA);
+            decoded, &decoded_num_bits, NUM_BITS_DATA);
     if (ret != NUM_BITS_TOTAL) {
         decoder_log(decoder, 2, __func__, "invalid Manchester data");
         return DECODE_FAIL_MIC;
     }
-    bitbuffer_invert(&decoded);
-    b = decoded.bb[0];
+    bitrow_invert(decoded, decoded_num_bits);
+    b = decoded;
 
     // Compute parity
     int parity = xor_bytes(b, 4) ^ (b[4] & 0xe0);

--- a/src/devices/secplus_v2.c
+++ b/src/devices/secplus_v2.c
@@ -236,6 +236,7 @@ static int secplus_v2_decode_v2_half(r_device *decoder, bitrow_t bits, uint16_t 
 
 static const uint8_t _preamble[] = {0xaa, 0xaa, 0x95, 0x60};
 unsigned _preamble_len           = 28;
+#define EXPECTED_NUM_BITS 80
 
 /**
 Security+ 2.0 rolling code.
@@ -244,16 +245,16 @@ Security+ 2.0 rolling code.
 static int secplus_v2_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     unsigned search_index = 0;
-    bitrow_t bits = {0};
+    uint8_t bits[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t bits_num_bits = 0;
 
     uint16_t fixed_1_num_bits = 0;
-    bitrow_t fixed_1 = {0};
+    uint8_t fixed_1[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
 
     uint8_t rolling_1[16] = {0};
 
     uint16_t fixed_2_num_bits = 0;
-    bitrow_t fixed_2 = {0};
+    uint8_t fixed_2[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint8_t rolling_2[16] = {0};
 
     for (uint16_t row = 0; row < bitbuffer->num_rows; ++row) {
@@ -269,7 +270,8 @@ static int secplus_v2_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         bitrow_clear(bits, &bits_num_bits);
         bits_num_bits = 0;
-        bitbuffer_manchester_decode(bitbuffer, row, search_index + 26, bits, &bits_num_bits, 80);
+        bitbuffer_manchester_decode(bitbuffer, row, search_index + 26, bits, &bits_num_bits, EXPECTED_NUM_BITS);
+
         search_index += 20;
         if (bits_num_bits < 42) {
             continue; // DECODE_ABORT_LENGTH;

--- a/src/devices/secplus_v2.c
+++ b/src/devices/secplus_v2.c
@@ -68,7 +68,7 @@ Once the above has been run twice the two are merged
 
 */
 
-static int secplus_v2_decode_v2_half(r_device *decoder, bitrow_t bits, uint16_t bits_num_bits, uint8_t roll_array[], bitrow_t fixed_p, uint16_t* fixed_p_count)
+static int secplus_v2_decode_v2_half(r_device *decoder, uint8_t const *bits, uint16_t bits_num_bits, uint8_t roll_array[], uint8_t *fixed_p, uint16_t* fixed_p_count)
 {
     uint8_t invert = 0;
     uint8_t order  = 0;

--- a/src/devices/secplus_v2.c
+++ b/src/devices/secplus_v2.c
@@ -268,7 +268,7 @@ static int secplus_v2_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             break;
         }
 
-        bitrow_clear(bits, &bits_num_bits);
+        bitrow_clear(bits, &bits_num_bits, sizeof(bits));
         bits_num_bits = 0;
         bitbuffer_manchester_decode(bitbuffer, row, search_index + 26, bits, &bits_num_bits, EXPECTED_NUM_BITS);
 

--- a/src/devices/somfy_rts.c
+++ b/src/devices/somfy_rts.c
@@ -59,6 +59,9 @@ The command is fixed to 0xf, which we use as idication that an actual command is
 
 #include "decoder.h"
 
+#define EXPECTED_NUM_BITS 56
+#define MAX_NUM_BITS 80
+
 static int somfy_rts_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     char const *const control_strs[] = {
@@ -145,9 +148,9 @@ static int somfy_rts_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     if (bitpos + 56 * 2 > bitbuffer->bits_per_row[decode_row])
         return DECODE_ABORT_LENGTH;
 
-    bitrow_t decoded = { 0 };
+    uint8_t decoded[NUM_BYTES(MAX_NUM_BITS)] = {0};
     uint16_t decoded_num_bits = 0;
-    if (bitbuffer_manchester_decode(bitbuffer, decode_row, bitpos, decoded, &decoded_num_bits, 80) < 56)
+    if (bitbuffer_manchester_decode(bitbuffer, decode_row, bitpos, decoded, &decoded_num_bits, MAX_NUM_BITS) < EXPECTED_NUM_BITS)
         return DECODE_ABORT_LENGTH;
 
     uint8_t *b = decoded;

--- a/src/devices/somfy_rts.c
+++ b/src/devices/somfy_rts.c
@@ -145,12 +145,12 @@ static int somfy_rts_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     if (bitpos + 56 * 2 > bitbuffer->bits_per_row[decode_row])
         return DECODE_ABORT_LENGTH;
 
-    bitbuffer_t decoded = {0};
-    bitbuffer_manchester_decode(bitbuffer, decode_row, bitpos, &decoded, 80);
-    if (decoded.num_rows == 0 || decoded.bits_per_row[0] < 56)
+    bitrow_t decoded = { 0 };
+    uint16_t decoded_num_bits = 0;
+    if (bitbuffer_manchester_decode(bitbuffer, decode_row, bitpos, decoded, &decoded_num_bits, 80) < 56)
         return DECODE_ABORT_LENGTH;
 
-    uint8_t *b = decoded.bb[0];
+    uint8_t *b = decoded;
 
     // descramble
     for (int i = 6; i > 0; i--)

--- a/src/devices/tfa_30_3196.c
+++ b/src/devices/tfa_30_3196.c
@@ -54,7 +54,8 @@ static int tfa_303196_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     int row;
     data_t *data;
     uint8_t *b;
-    bitbuffer_t databits = {0};
+    bitrow_t databits = {0};
+    uint16_t databits_num_bits = 0;
 
     row = bitbuffer_find_repeated_row(bitbuffer, 2, 48 * 2 + 12); // expected are 4 rows, require 2
     if (row < 0)
@@ -66,12 +67,12 @@ static int tfa_303196_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (bitbuffer->bits_per_row[row] - start_pos < 48 * 2)
         return DECODE_ABORT_LENGTH; // short buffer or preamble not found
 
-    bitbuffer_manchester_decode(bitbuffer, row, start_pos, &databits, 48);
+    bitbuffer_manchester_decode(bitbuffer, row, start_pos, databits, &databits_num_bits, 48);
 
-    if (databits.bits_per_row[0] < 48)
+    if (databits_num_bits < 48)
         return DECODE_ABORT_LENGTH; // payload malformed MC
 
-    b = databits.bb[0];
+    b = databits;
 
     if (b[0] != 0xa8)
         return DECODE_FAIL_SANITY;

--- a/src/devices/tfa_30_3196.c
+++ b/src/devices/tfa_30_3196.c
@@ -47,6 +47,7 @@ Example data:
 */
 
 #include "decoder.h"
+#define EXPECTED_NUM_BITS 48
 
 static int tfa_303196_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
@@ -54,7 +55,7 @@ static int tfa_303196_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     int row;
     data_t *data;
     uint8_t *b;
-    bitrow_t databits = {0};
+    uint8_t databits[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t databits_num_bits = 0;
 
     row = bitbuffer_find_repeated_row(bitbuffer, 2, 48 * 2 + 12); // expected are 4 rows, require 2
@@ -67,9 +68,9 @@ static int tfa_303196_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     if (bitbuffer->bits_per_row[row] - start_pos < 48 * 2)
         return DECODE_ABORT_LENGTH; // short buffer or preamble not found
 
-    bitbuffer_manchester_decode(bitbuffer, row, start_pos, databits, &databits_num_bits, 48);
+    bitbuffer_manchester_decode(bitbuffer, row, start_pos, databits, &databits_num_bits, EXPECTED_NUM_BITS);
 
-    if (databits_num_bits < 48)
+    if (databits_num_bits < EXPECTED_NUM_BITS)
         return DECODE_ABORT_LENGTH; // payload malformed MC
 
     b = databits;

--- a/src/devices/tpms_abarth124.c
+++ b/src/devices/tpms_abarth124.c
@@ -39,7 +39,8 @@ Data layout (nibbles):
 static int tpms_abarth124_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    bitbuffer_t packet_bits = {0};
+    bitrow_t packet_bits = {0};
+    uint16_t packet_bits_num_bits = 0;
     uint8_t *b;
     char id_str[4 * 2 + 1];
     char flags[1 * 2 + 1];
@@ -48,15 +49,15 @@ static int tpms_abarth124_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsi
     int status;
     int checksum;
 
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 72);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 72);
 
     // make sure we decoded the expected number of bits
-    if (packet_bits.bits_per_row[0] < 72) {
+    if (packet_bits_num_bits < 72) {
         // decoder_logf(decoder, 0, __func__, "bitpos=%u start_pos=%u = %u", bitpos, start_pos, (start_pos - bitpos));
         return 0; // DECODE_FAIL_SANITY;
     }
 
-    b = packet_bits.bb[0];
+    b = packet_bits;
 
     // check checksum (checksum8 xor)
     checksum = xor_bytes(b, 9);

--- a/src/devices/tpms_abarth124.c
+++ b/src/devices/tpms_abarth124.c
@@ -35,11 +35,12 @@ Data layout (nibbles):
 */
 
 #include "decoder.h"
+#define EXPECTED_NUM_BITS 72
 
 static int tpms_abarth124_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    bitrow_t packet_bits = {0};
+    uint8_t packet_bits[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t packet_bits_num_bits = 0;
     uint8_t *b;
     char id_str[4 * 2 + 1];
@@ -49,10 +50,10 @@ static int tpms_abarth124_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsi
     int status;
     int checksum;
 
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 72);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, EXPECTED_NUM_BITS);
 
     // make sure we decoded the expected number of bits
-    if (packet_bits_num_bits < 72) {
+    if (packet_bits_num_bits < EXPECTED_NUM_BITS) {
         // decoder_logf(decoder, 0, __func__, "bitpos=%u start_pos=%u = %u", bitpos, start_pos, (start_pos - bitpos));
         return 0; // DECODE_FAIL_SANITY;
     }

--- a/src/devices/tpms_ave.c
+++ b/src/devices/tpms_ave.c
@@ -30,10 +30,13 @@ Packet nibbles:
 
 #include "decoder.h"
 
+#define EXPECTED_BITS 160
+
 static int tpms_ave_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    bitbuffer_t packet_bits = {0};
+    uint8_t packet_bits[NUM_BYTES(EXPECTED_BITS)] = {0};
+    uint16_t packet_bits_num_bits = 0;
     uint8_t *b;
     unsigned id;
     char id_str[9 + 1];
@@ -47,14 +50,14 @@ static int tpms_ave_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned r
     double ratio;
     double offset;
 
-    bitbuffer_differential_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 160);
+    bitbuffer_differential_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, EXPECTED_BITS);
 
-    if (packet_bits.bits_per_row[row] < 64) {
+    if (packet_bits_num_bits < 64) {
         return DECODE_ABORT_LENGTH; // too short to be a whole packet
     }
-    decoder_log_bitbuffer(decoder, 1, __func__, &packet_bits, "");
+    decoder_log_bitrow(decoder, 1, __func__, packet_bits, packet_bits_num_bits, "");
 
-    b = packet_bits.bb[row];
+    b = &packet_bits[0];
 
     id            = (unsigned)b[0] << 24 | b[1] << 16 | b[2] << 8 | b[3];
     pressure_raw  = b[4];

--- a/src/devices/tpms_citroen.c
+++ b/src/devices/tpms_citroen.c
@@ -32,7 +32,8 @@ Packet nibbles:
 static int tpms_citroen_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    bitbuffer_t packet_bits = {0};
+    bitrow_t packet_bits = {0};
+    uint16_t packet_bits_num_bits = 0;
     uint8_t *b;
     int state;
     char state_str[3];
@@ -45,14 +46,14 @@ static int tpms_citroen_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     int maybe_battery;
     int crc;
 
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 88);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 88);
 
     // decoder_logf(decoder, 3, __func__, "bits %d", packet_bits.bits_per_row[0]);
-    if (packet_bits.bits_per_row[0] < 80) {
+    if (packet_bits_num_bits < 80) {
         return DECODE_FAIL_SANITY; // sanity check failed
     }
 
-    b = packet_bits.bb[0];
+    b = packet_bits;
 
     if (b[6] == 0 || b[7] == 0) {
         return DECODE_ABORT_EARLY; // sanity check failed

--- a/src/devices/tpms_citroen.c
+++ b/src/devices/tpms_citroen.c
@@ -29,10 +29,12 @@ Packet nibbles:
 
 #include "decoder.h"
 
+#define EXPECTED_NUM_BITS 88
+
 static int tpms_citroen_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    bitrow_t packet_bits = {0};
+    uint8_t packet_bits[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t packet_bits_num_bits = 0;
     uint8_t *b;
     int state;
@@ -46,10 +48,10 @@ static int tpms_citroen_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     int maybe_battery;
     int crc;
 
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 88);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, EXPECTED_NUM_BITS);
 
     // decoder_logf(decoder, 3, __func__, "bits %d", packet_bits.bits_per_row[0]);
-    if (packet_bits_num_bits < 80) {
+    if (packet_bits_num_bits < EXPECTED_NUM_BITS - 8) {
         return DECODE_FAIL_SANITY; // sanity check failed
     }
 

--- a/src/devices/tpms_elantra2012.c
+++ b/src/devices/tpms_elantra2012.c
@@ -52,7 +52,8 @@ Preamble is 111 0001 0101 0101 (0x7155).
 static int tpms_elantra2012_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    bitbuffer_t packet_bits = {0};
+    bitrow_t packet_bits = {0};
+    uint16_t packet_bits_num_bits = 0;
     uint8_t *b;
     uint32_t id;
     char id_str[9];
@@ -62,12 +63,12 @@ static int tpms_elantra2012_decode(r_device *decoder, bitbuffer_t *bitbuffer, un
     int temperature_c;
     int triggered, battery_low, storage;
 
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 64);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 64);
     // require 64 data bits
-    if (packet_bits.bits_per_row[0] < 64) {
+    if (packet_bits_num_bits < 64) {
         return DECODE_ABORT_LENGTH;
     }
-    b = packet_bits.bb[0];
+    b = packet_bits;
 
     if (crc8(b, 8, 0x07, 0x00)) {
         return DECODE_FAIL_MIC;

--- a/src/devices/tpms_elantra2012.c
+++ b/src/devices/tpms_elantra2012.c
@@ -49,10 +49,12 @@ Preamble is 111 0001 0101 0101 (0x7155).
 
 #include "decoder.h"
 
+#define EXPECTED_NUM_BITS 64
+
 static int tpms_elantra2012_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    bitrow_t packet_bits = {0};
+    uint8_t packet_bits[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t packet_bits_num_bits = 0;
     uint8_t *b;
     uint32_t id;
@@ -63,9 +65,9 @@ static int tpms_elantra2012_decode(r_device *decoder, bitbuffer_t *bitbuffer, un
     int temperature_c;
     int triggered, battery_low, storage;
 
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 64);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, EXPECTED_NUM_BITS);
     // require 64 data bits
-    if (packet_bits_num_bits < 64) {
+    if (packet_bits_num_bits < EXPECTED_NUM_BITS) {
         return DECODE_ABORT_LENGTH;
     }
     b = packet_bits;

--- a/src/devices/tpms_ford.c
+++ b/src/devices/tpms_ford.c
@@ -53,10 +53,12 @@ Packet nibbles:
 
 #include "decoder.h"
 
+#define EXPECTED_NUM_BITS 160
+
 static int tpms_ford_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    bitrow_t packet_bits = {0};
+    uint8_t packet_bits[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t packet_bits_num_bits = 0;
     uint8_t *b;
     unsigned id;
@@ -71,7 +73,7 @@ static int tpms_ford_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned 
     int unknown;
     int unknown_3;
 
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 160);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, EXPECTED_NUM_BITS);
 
     // require 64 data bits
     if (packet_bits_num_bits < 64) {

--- a/src/devices/tpms_ford.c
+++ b/src/devices/tpms_ford.c
@@ -56,7 +56,8 @@ Packet nibbles:
 static int tpms_ford_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    bitbuffer_t packet_bits = {0};
+    bitrow_t packet_bits = {0};
+    uint16_t packet_bits_num_bits = 0;
     uint8_t *b;
     unsigned id;
     char id_str[9];
@@ -70,13 +71,13 @@ static int tpms_ford_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned 
     int unknown;
     int unknown_3;
 
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 160);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 160);
 
     // require 64 data bits
-    if (packet_bits.bits_per_row[0] < 64) {
+    if (packet_bits_num_bits < 64) {
         return 0;
     }
-    b = packet_bits.bb[0];
+    b = packet_bits;
 
     if (((b[0] + b[1] + b[2] + b[3] + b[4] + b[5] + b[6]) & 0xff) != b[7]) {
         return 0;

--- a/src/devices/tpms_hyundai_vdo.c
+++ b/src/devices/tpms_hyundai_vdo.c
@@ -43,7 +43,8 @@ Packet nibbles:
 static int tpms_hyundai_vdo_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    bitbuffer_t packet_bits = {0};
+    bitrow_t packet_bits = {0};
+    uint16_t packet_bits_num_bits = 0;
     uint8_t *b;
     int state;
     unsigned id;
@@ -55,13 +56,13 @@ static int tpms_hyundai_vdo_decode(r_device *decoder, bitbuffer_t *bitbuffer, un
     int maybe_battery;
     int crc;
 
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 80);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 80);
 
-    if (packet_bits.bits_per_row[0] < 80) {
+    if (packet_bits_num_bits < 80) {
         return DECODE_FAIL_SANITY; // too short to be a whole packet
     }
 
-    b = packet_bits.bb[0];
+    b = packet_bits;
 
 //  if (b[6] == 0 || b[7] == 0) {
 //      return DECODE_ABORT_EARLY; // pressure cannot really be 0, temperature is also probably not -50C

--- a/src/devices/tpms_hyundai_vdo.c
+++ b/src/devices/tpms_hyundai_vdo.c
@@ -40,10 +40,12 @@ Packet nibbles:
 
 #include "decoder.h"
 
+#define EXPECTED_NUM_BITS 80
+
 static int tpms_hyundai_vdo_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    bitrow_t packet_bits = {0};
+    uint8_t packet_bits[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t packet_bits_num_bits = 0;
     uint8_t *b;
     int state;
@@ -56,9 +58,9 @@ static int tpms_hyundai_vdo_decode(r_device *decoder, bitbuffer_t *bitbuffer, un
     int maybe_battery;
     int crc;
 
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 80);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, EXPECTED_NUM_BITS);
 
-    if (packet_bits_num_bits < 80) {
+    if (packet_bits_num_bits < EXPECTED_NUM_BITS) {
         return DECODE_FAIL_SANITY; // too short to be a whole packet
     }
 

--- a/src/devices/tpms_jansite.c
+++ b/src/devices/tpms_jansite.c
@@ -32,7 +32,8 @@ Data layout (nibbles):
 static int tpms_jansite_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    bitbuffer_t packet_bits = {0};
+    bitrow_t packet_bits = {0};
+    uint16_t packet_bits_num_bits = 0;
     uint8_t *b;
     unsigned id;
     char id_str[7 + 1];
@@ -41,13 +42,13 @@ static int tpms_jansite_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     int temperature;
     char code_str[7 * 2 + 1];
 
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 56);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 56);
 
-    if (packet_bits.bits_per_row[0] < 56) {
+    if (packet_bits_num_bits < 56) {
         return DECODE_FAIL_SANITY;
         // decoder_logf(decoder, 3, __func__, "packet_bits.bits_per_row = %d", packet_bits.bits_per_row[0]);
     }
-    b = packet_bits.bb[0];
+    b = packet_bits;
 
     // TODO: validate checksum
 

--- a/src/devices/tpms_jansite.c
+++ b/src/devices/tpms_jansite.c
@@ -29,10 +29,12 @@ Data layout (nibbles):
 
 #include "decoder.h"
 
+#define EXPECTED_NUM_BITS 56
+
 static int tpms_jansite_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    bitrow_t packet_bits = {0};
+    uint8_t packet_bits[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t packet_bits_num_bits = 0;
     uint8_t *b;
     unsigned id;
@@ -42,9 +44,9 @@ static int tpms_jansite_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     int temperature;
     char code_str[7 * 2 + 1];
 
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 56);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, EXPECTED_NUM_BITS);
 
-    if (packet_bits_num_bits < 56) {
+    if (packet_bits_num_bits < EXPECTED_NUM_BITS) {
         return DECODE_FAIL_SANITY;
         // decoder_logf(decoder, 3, __func__, "packet_bits.bits_per_row = %d", packet_bits.bits_per_row[0]);
     }

--- a/src/devices/tpms_jansite_solar.c
+++ b/src/devices/tpms_jansite_solar.c
@@ -41,10 +41,12 @@ TODO: identify battery bits
 
 #include "decoder.h"
 
+#define EXPECTED_NUM_BITS 88
+
 static int tpms_jansite_solar_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    bitrow_t packet_bits = {0};
+    uint8_t packet_bits[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t packet_bits_num_bits = 0;
     uint8_t *b;
     unsigned id;
@@ -54,10 +56,10 @@ static int tpms_jansite_solar_decode(r_device *decoder, bitbuffer_t *bitbuffer, 
     int temperature;
     char code_str[9 * 2 + 1];
 
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 88);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, EXPECTED_NUM_BITS);
     bitrow_invert(packet_bits, packet_bits_num_bits);
 
-    if (packet_bits_num_bits < 88) {
+    if (packet_bits_num_bits < EXPECTED_NUM_BITS) {
         return DECODE_FAIL_SANITY;
     }
     b = packet_bits;

--- a/src/devices/tpms_jansite_solar.c
+++ b/src/devices/tpms_jansite_solar.c
@@ -44,7 +44,8 @@ TODO: identify battery bits
 static int tpms_jansite_solar_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    bitbuffer_t packet_bits = {0};
+    bitrow_t packet_bits = {0};
+    uint16_t packet_bits_num_bits = 0;
     uint8_t *b;
     unsigned id;
     char id_str[7 + 1];
@@ -53,13 +54,13 @@ static int tpms_jansite_solar_decode(r_device *decoder, bitbuffer_t *bitbuffer, 
     int temperature;
     char code_str[9 * 2 + 1];
 
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 88);
-    bitbuffer_invert(&packet_bits);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 88);
+    bitrow_invert(packet_bits, packet_bits_num_bits);
 
-    if (packet_bits.bits_per_row[0] < 88) {
+    if (packet_bits_num_bits < 88) {
         return DECODE_FAIL_SANITY;
     }
-    b = packet_bits.bb[0];
+    b = packet_bits;
 
     /* Check for sync */
     if ((b[0] << 8 | b[1]) != 0xdd33) {

--- a/src/devices/tpms_kia.c
+++ b/src/devices/tpms_kia.c
@@ -41,10 +41,13 @@ NOTE: You may need to use the "-s 1000000" option of rtl_433 in order to get a c
 
 #include "decoder.h"
 
+#define EXPECTED_NUM_BITS 154
+
 static int tpms_kia_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    bitbuffer_t packet_bits = {0};
+    uint8_t packet_bits[NUM_BYTES(EXPECTED_NUM_BITS)] = { 0 };
+    uint16_t packet_bits_num_bits = 0;
     uint8_t *b;
     unsigned id;
     char id_str[9 + 1];
@@ -60,12 +63,12 @@ static int tpms_kia_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned r
     unsigned int start_pos;
     const unsigned int preamble_length = 16;
 
-    start_pos = bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 154 - preamble_length);
+    start_pos = bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 154 - preamble_length);
     if (start_pos - bitpos < 154 - preamble_length) {
         return DECODE_ABORT_LENGTH;
     }
 
-    b = packet_bits.bb[0];
+    b = packet_bits;
 
     unknown1    = b[0] >> 4;
     pressure    = b[0] << 4 | b[1] >> 4;

--- a/src/devices/tpms_pmv107j.c
+++ b/src/devices/tpms_pmv107j.c
@@ -27,13 +27,15 @@ based on work by Werner Johansson.
 
 #include "decoder.h"
 
+#define EXPECTED_NUM_BITS 70
+
 static int tpms_pmv107j_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
-    bitrow_t packet_bits = {0};
+    uint8_t packet_bits[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t packet_bits_num_bits = 0;
     uint8_t b[9];
 
-    unsigned start_pos = bitbuffer_differential_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 70); // 67 bits expected
+    unsigned start_pos = bitbuffer_differential_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, EXPECTED_NUM_BITS); // 67 bits expected
     if (start_pos - bitpos < 67 * 2) {
         return 0;
     }

--- a/src/devices/tpms_pmv107j.c
+++ b/src/devices/tpms_pmv107j.c
@@ -29,18 +29,19 @@ based on work by Werner Johansson.
 
 static int tpms_pmv107j_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
-    bitbuffer_t packet_bits = {0};
+    bitrow_t packet_bits = {0};
+    uint16_t packet_bits_num_bits = 0;
     uint8_t b[9];
 
-    unsigned start_pos = bitbuffer_differential_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 70); // 67 bits expected
+    unsigned start_pos = bitbuffer_differential_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 70); // 67 bits expected
     if (start_pos - bitpos < 67 * 2) {
         return 0;
     }
-    decoder_log_bitbuffer(decoder, 2, __func__, &packet_bits, "");
+    decoder_log_bitrow(decoder, 2, __func__, packet_bits, packet_bits_num_bits, "");
 
     // realign the buffer, prepending 6 bits of 0.
-    b[0] = packet_bits.bb[0][0] >> 6;
-    bitbuffer_extract_bytes(&packet_bits, 0, 2, b + 1, 64);
+    b[0] = packet_bits[0] >> 6;
+    bitrow_extract_bytes(packet_bits, 2, b + 1, 64);
     decoder_log_bitrow(decoder, 2, __func__, b, 72, "Realigned");
 
     int crc = b[8];

--- a/src/devices/tpms_porsche.c
+++ b/src/devices/tpms_porsche.c
@@ -37,18 +37,21 @@ Data layout (nibbles):
 
 #include "decoder.h"
 
+#define EXPECTED_BITS 80
+
 static int tpms_porsche_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
-    bitbuffer_t packet_bits = {0};
-    bitbuffer_differential_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 80);
+    uint8_t packet_bits[NUM_BYTES(EXPECTED_BITS)] = {0};
+    uint16_t packet_bits_num_bits = 0;
+    bitbuffer_differential_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, EXPECTED_BITS);
 
     // make sure we decoded the expected number of bits
-    if (packet_bits.bits_per_row[0] < 80) {
+    if (packet_bits_num_bits < EXPECTED_BITS) {
         // decoder_logf(decoder, 0, __func__, "bitpos=%u start_pos=%u = %u", bitpos, start_pos, (start_pos - bitpos));
         return 0; // DECODE_FAIL_SANITY;
     }
 
-    uint8_t *b = packet_bits.bb[0];
+    uint8_t *b = &packet_bits[0];
 
     // Checksum is CRC-16 poly 0x1021 init 0xffff over 8 bytes
     int checksum = crc16(b, 10, 0x1021, 0xffff);

--- a/src/devices/tpms_renault.c
+++ b/src/devices/tpms_renault.c
@@ -26,10 +26,12 @@ Packet nibbles:
 
 #include "decoder.h"
 
+#define EXPECTED_NUM_BITS 160
+
 static int tpms_renault_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    bitrow_t packet_bits = {0};
+    uint8_t packet_bits[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t packet_bits_num_bits = 0;
     uint8_t *b;
     int flags;
@@ -40,7 +42,7 @@ static int tpms_renault_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     double pressure_kpa;
     char code_str[5];
 
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 160);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, EXPECTED_NUM_BITS);
     // require 72 data bits
     if (packet_bits_num_bits < 72) {
         return 0;

--- a/src/devices/tpms_renault.c
+++ b/src/devices/tpms_renault.c
@@ -29,7 +29,8 @@ Packet nibbles:
 static int tpms_renault_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
-    bitbuffer_t packet_bits = {0};
+    bitrow_t packet_bits = {0};
+    uint16_t packet_bits_num_bits = 0;
     uint8_t *b;
     int flags;
     char flags_str[3];
@@ -39,12 +40,12 @@ static int tpms_renault_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     double pressure_kpa;
     char code_str[5];
 
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 160);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 160);
     // require 72 data bits
-    if (packet_bits.bits_per_row[0] < 72) {
+    if (packet_bits_num_bits < 72) {
         return 0;
     }
-    b = packet_bits.bb[0];
+    b = packet_bits;
 
     // 0x83; 0x107 FOP-8; ATM-8; CRC-8P
     if (crc8(b, 8, 0x07, 0x00) != b[8]) {

--- a/src/devices/tpms_renault_0435r.c
+++ b/src/devices/tpms_renault_0435r.c
@@ -70,16 +70,19 @@ not fit into 8 bits (that is for speeds above 93 kph on my tires).
 
 #include "decoder.h"
 
+#define EXPECTED_BITS 160
+
 static int tpms_renault_0435r_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
-    bitbuffer_t packet_bits = {0};
+    uint8_t packet_bits[NUM_BYTES(EXPECTED_BITS)] = {0};
+    uint16_t packet_bits_num_bits = 0;
 
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 160);
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, EXPECTED_BITS);
     // require 72 data bits
-    if (packet_bits.bits_per_row[0] < 72) {
+    if (packet_bits_num_bits < 72) {
         return DECODE_ABORT_EARLY;
     }
-    uint8_t *b = packet_bits.bb[0];
+    uint8_t *b = &packet_bits[0];
 
     // check checksum (checksum8 xor)
     int chk = xor_bytes(b, 9);

--- a/src/devices/tpms_toyota.c
+++ b/src/devices/tpms_toyota.c
@@ -32,7 +32,8 @@ static int tpms_toyota_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigne
 {
     data_t *data;
     unsigned int start_pos;
-    bitbuffer_t packet_bits = {0};
+    bitrow_t packet_bits = {0};
+    uint16_t packet_bits_num_bits = 0;
     uint8_t *b;
     unsigned id;
     char id_str[9];
@@ -40,11 +41,11 @@ static int tpms_toyota_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigne
     int crc;
 
     // skip the first 1 bit, i.e. raw "01" to get 72 bits
-    start_pos = bitbuffer_differential_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 80);
+    start_pos = bitbuffer_differential_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 80);
     if (start_pos - bitpos < 144) {
         return 0;
     }
-    b = packet_bits.bb[0];
+    b = packet_bits;
 
     crc = b[8];
     if (crc8(b, 8, 0x07, 0x80) != crc) {

--- a/src/devices/tpms_toyota.c
+++ b/src/devices/tpms_toyota.c
@@ -28,11 +28,13 @@ The pressure seems to be 1/4 PSI offset by -7 PSI (i.e. 28 raw = 0 PSI).
 
 #include "decoder.h"
 
+#define EXPECTED_NUM_BITS 80
+
 static int tpms_toyota_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
 {
     data_t *data;
     unsigned int start_pos;
-    bitrow_t packet_bits = {0};
+    uint8_t packet_bits[NUM_BYTES(EXPECTED_NUM_BITS)] = {0};
     uint16_t packet_bits_num_bits = 0;
     uint8_t *b;
     unsigned id;
@@ -41,7 +43,7 @@ static int tpms_toyota_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigne
     int crc;
 
     // skip the first 1 bit, i.e. raw "01" to get 72 bits
-    start_pos = bitbuffer_differential_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, 80);
+    start_pos = bitbuffer_differential_manchester_decode(bitbuffer, row, bitpos, packet_bits, &packet_bits_num_bits, EXPECTED_NUM_BITS);
     if (start_pos - bitpos < 144) {
         return 0;
     }

--- a/src/devices/vaillant_vrt340f.c
+++ b/src/devices/vaillant_vrt340f.c
@@ -47,6 +47,9 @@ static int validate_checksum(r_device *decoder, uint8_t *b, int from, int to, in
     return !chk;
 }
 
+#define MIN_NUM_BITS 128
+#define MAX_NUM_BITS MIN_NUM_BITS * 2
+
 static int vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     uint8_t *b = bitbuffer->bb[0];
@@ -54,12 +57,12 @@ static int vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     // TODO: Use repeat signal for error checking / correction!
 
     // each row needs to have at least 128 bits (plus a few more due to bit stuffing)
-    if (bitbuffer->bits_per_row[0] < 128)
+    if (bitbuffer->bits_per_row[0] < MIN_NUM_BITS)
         return DECODE_ABORT_LENGTH;
 
     // The protocol uses bit-stuffing => remove 0 bit after five consecutive 1 bits
     // Also, each byte is represented with least significant bit first -> swap them!
-    bitrow_t bits = {0};
+    uint8_t bits[NUM_BYTES(MAX_NUM_BITS)] = {0};
     uint16_t bits_num_bits = 0;
     int ones = 0;
     for (uint16_t k = 0; k < bitbuffer->bits_per_row[0]; k++) {

--- a/src/devices/vaillant_vrt340f.c
+++ b/src/devices/vaillant_vrt340f.c
@@ -75,7 +75,7 @@ static int vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         }
     }
 
-    b = &bits[0];
+    b = bits;
     uint16_t bitcount = bits_num_bits;
 
     // Change to least-significant-bit last (protocol uses least-significant-bit first)

--- a/src/devices/vaillant_vrt340f.c
+++ b/src/devices/vaillant_vrt340f.c
@@ -59,23 +59,24 @@ static int vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // The protocol uses bit-stuffing => remove 0 bit after five consecutive 1 bits
     // Also, each byte is represented with least significant bit first -> swap them!
-    bitbuffer_t bits = {0};
+    bitrow_t bits = {0};
+    uint16_t bits_num_bits = 0;
     int ones = 0;
     for (uint16_t k = 0; k < bitbuffer->bits_per_row[0]; k++) {
         int bit = bitrow_get_bit(b, k);
         if (bit == 1) {
-            bitbuffer_add_bit(&bits, 1);
+            bitrow_add_bit(bits, &bits_num_bits, 1);
             ones++;
         } else {
             if (ones != 5) { // Ignore a 0 bit after five consecutive 1 bits:
-                bitbuffer_add_bit(&bits, 0);
+                bitrow_add_bit(bits, &bits_num_bits, 0);
             }
             ones = 0;
         }
     }
 
-    b = bits.bb[0];
-    uint16_t bitcount = bits.bits_per_row[0];
+    b = &bits[0];
+    uint16_t bitcount = bits_num_bits;
 
     // Change to least-significant-bit last (protocol uses least-significant-bit first)
     reflect_bytes(b, (bitcount - 1) / 8);

--- a/tests/symbolizer.py
+++ b/tests/symbolizer.py
@@ -222,10 +222,12 @@ def process_source(path, name):
 
             # static int foo_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             # static int foo_callback(r_device *decoder, bitbuffer_t *bitbuffer, ...
+            # static int foo_callback(r_device *decoder, uint8_t const *bits, uint16_t bits_num_bits)
+            # static int foo_callback(r_device *decoder, uint8_t const *bits, uint16_t bits_num_bits, ...)
             # static int
             # foo_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             m = re.match(
-                r'(?:\s*static\s*int\s*)?([a-zA-Z0-9_]+)\(\s*r_device\s+\*\s*[a-z]+\s*,\s*bitbuffer_t\s+\*\s*[a-z]+', line)
+                r'(?:\s*static\s*int\s*)?([a-zA-Z0-9_]+)\(\s*r_device\s+\*\s*[a-z]+\s*,\s*(?:bitbuffer_t\s+\*|uint8_t\s+const\s+\*[a-z]+,\s*uint16_t)\s*[a-z]+', line)
             if m:
                 # print(m.group(1))
                 fName = m.group(1)


### PR DESCRIPTION
As discussed in #1726, manchester decoding functions require a `bitbuffer_t` to place the result of their decoding, but only ever use the first row in that buffer.

This pull request addresses this by having those method require a `uint8_t` array instead, which allows for far lower stack usage throughout the program.

Note that it introduces the `NUM_BYTES` macro already suggested in #2378 as it is used in all decoders that now require a `uint8_t` array whose size should be able contain the expected number of bits to be decoded. Once on of the two PR is merged, I'll gladly rebase the other one to avoid any conflicts and give a cleaner history path.