### PR TITLE
fix: make r_device.fields a constant pointer 

### DIFF
--- a/include/r_device.h
+++ b/include/r_device.h
@@ -71,7 +71,7 @@ typedef struct r_device {
     struct r_device *(*create_fn)(char *args);
     unsigned priority; ///< Run later and only if no previous events were produced
     unsigned disabled; ///< 0: default enabled, 1: default disabled, 2: disabled, 3: disabled and hidden
-    char const **fields; ///< List of fields this decoder produces; required for CSV output. NULL-terminated.
+    char const *const *fields; ///< List of fields this decoder produces; required for CSV output. NULL-terminated.
 
     /* public for each decoder */
     int verbose;

--- a/src/devices/abmt.c
+++ b/src/devices/abmt.c
@@ -81,7 +81,7 @@ static int abmt_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "temperature_C",

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -132,7 +132,7 @@ int const acurite_5n1_winddirections[] = {
 //  11 = A
 static char const *acurite_getChannel(uint8_t byte)
 {
-    static char const *channel_strs[] = {"C", "E", "B", "A"}; // 'E' stands for error
+    static char const *const channel_strs[] = {"C", "E", "B", "A"}; // 'E' stands for error
 
     int channel = (byte & 0xC0) >> 6;
     return channel_strs[channel];
@@ -1861,7 +1861,7 @@ static int acurite_00275rm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return result;
 }
 
-static char const *acurite_rain_gauge_output_fields[] = {
+static char const *const acurite_rain_gauge_output_fields[] = {
         "model",
         "id",
         "rain_mm",
@@ -1880,7 +1880,7 @@ r_device const acurite_rain_896 = {
         .fields      = acurite_rain_gauge_output_fields,
 };
 
-static char const *acurite_th_output_fields[] = {
+static char const *const acurite_th_output_fields[] = {
         "model",
         "id",
         "battery_ok",
@@ -1906,7 +1906,7 @@ r_device const acurite_th = {
  * For Acurite 592 TXR Temp/Humidity, but
  * Should match Acurite 592TX, 5-n-1, etc.
  */
-static char const *acurite_txr_output_fields[] = {
+static char const *const acurite_txr_output_fields[] = {
         "model",
         "message_type", // TODO: remove this
         "id",
@@ -1957,7 +1957,7 @@ r_device const acurite_txr = {
  * A transmission consists of two packets that run into each other.
  * There should be 40 bits of data though. But the last bit can't be detected.
  */
-static char const *acurite_986_output_fields[] = {
+static char const *const acurite_986_output_fields[] = {
         "model",
         "id",
         "channel",
@@ -1986,7 +1986,7 @@ r_device const acurite_986 = {
  *
  */
 
-static char const *acurite_606_output_fields[] = {
+static char const *const acurite_606_output_fields[] = {
         "model",
         "id",
         "battery_ok",
@@ -1995,7 +1995,7 @@ static char const *acurite_606_output_fields[] = {
         NULL,
 };
 
-static char const *acurite_590_output_fields[] = {
+static char const *const acurite_590_output_fields[] = {
         "model",
         "id",
         "battery_ok",
@@ -2023,7 +2023,7 @@ r_device const acurite_606 = {
         .fields      = acurite_606_output_fields,
 };
 
-static char const *acurite_00275rm_output_fields[] = {
+static char const *const acurite_00275rm_output_fields[] = {
         "model",
         "subtype",
         "id",

--- a/src/devices/acurite_01185m.c
+++ b/src/devices/acurite_01185m.c
@@ -114,7 +114,7 @@ static int acurite_01185m_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return result;
 }
 
-static char const *acurite_01185m_output_fields[] = {
+static char const *const acurite_01185m_output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/akhan_100F14.c
+++ b/src/devices/akhan_100F14.c
@@ -62,7 +62,7 @@ static int akhan_rke_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "data",

--- a/src/devices/alecto.c
+++ b/src/devices/alecto.c
@@ -208,7 +208,7 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return DECODE_FAIL_SANITY;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/ambient_weather.c
+++ b/src/devices/ambient_weather.c
@@ -157,7 +157,7 @@ static int ambient_weather_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/ambientweather_tx8300.c
+++ b/src/devices/ambientweather_tx8300.c
@@ -118,7 +118,7 @@ static int ambientweather_tx8300_callback(r_device *decoder, bitbuffer_t *bitbuf
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/ambientweather_wh31e.c
+++ b/src/devices/ambientweather_wh31e.c
@@ -356,7 +356,7 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return events;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/ant_antplus.c
+++ b/src/devices/ant_antplus.c
@@ -139,7 +139,7 @@ static int ant_antplus_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "network",
         "channel",

--- a/src/devices/archos_tbh.c
+++ b/src/devices/archos_tbh.c
@@ -212,7 +212,7 @@ static int archos_tbh_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/atech_ws308.c
+++ b/src/devices/atech_ws308.c
@@ -119,7 +119,7 @@ static int atech_ws308_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "temperature_C",

--- a/src/devices/auriol_4ld5661.c
+++ b/src/devices/auriol_4ld5661.c
@@ -77,7 +77,7 @@ static int auriol_4ld5661_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/auriol_aft77b2.c
+++ b/src/devices/auriol_aft77b2.c
@@ -137,7 +137,7 @@ static int auriol_aft77_b2_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "temperature_C",

--- a/src/devices/auriol_afw2a1.c
+++ b/src/devices/auriol_afw2a1.c
@@ -105,7 +105,7 @@ static int auriol_afw2a1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/auriol_ahfl.c
+++ b/src/devices/auriol_ahfl.c
@@ -96,7 +96,7 @@ static int auriol_ahfl_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/auriol_hg02832.c
+++ b/src/devices/auriol_hg02832.c
@@ -89,7 +89,7 @@ static int auriol_hg02832_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/badger_water.c
+++ b/src/devices/badger_water.c
@@ -138,7 +138,7 @@ static int badger_orion_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 // Note: At this time the exact meaning of the flags is not known.
-static char const *badger_output_fields[] = {
+static char const *const badger_output_fields[] = {
         "model",
         "id",
         "flags_1",

--- a/src/devices/baldr_rain.c
+++ b/src/devices/baldr_rain.c
@@ -85,7 +85,7 @@ static int baldr_rain_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "flags",

--- a/src/devices/blueline.c
+++ b/src/devices/blueline.c
@@ -384,7 +384,7 @@ static int blueline_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return ((payloads_decoded > 0) ? payloads_decoded : most_applicable_failure);
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "flags",

--- a/src/devices/blyss.c
+++ b/src/devices/blyss.c
@@ -56,7 +56,7 @@ static int blyss_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return DECODE_FAIL_SANITY;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         NULL,

--- a/src/devices/brennenstuhl_rcs_2044.c
+++ b/src/devices/brennenstuhl_rcs_2044.c
@@ -113,7 +113,7 @@ static int brennenstuhl_rcs_2044_callback(r_device *decoder, bitbuffer_t *bitbuf
     return counter;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "key",

--- a/src/devices/bresser_3ch.c
+++ b/src/devices/bresser_3ch.c
@@ -95,7 +95,7 @@ static int bresser_3ch_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/bresser_5in1.c
+++ b/src/devices/bresser_5in1.c
@@ -160,7 +160,7 @@ static int bresser_5in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/bresser_6in1.c
+++ b/src/devices/bresser_6in1.c
@@ -218,7 +218,7 @@ static int bresser_6in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/bresser_7in1.c
+++ b/src/devices/bresser_7in1.c
@@ -134,7 +134,7 @@ static int bresser_7in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "temperature_C",

--- a/src/devices/bt_rain.c
+++ b/src/devices/bt_rain.c
@@ -84,7 +84,7 @@ static int bt_rain_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/burnhardbbq.c
+++ b/src/devices/burnhardbbq.c
@@ -119,7 +119,7 @@ static int burnhardbbq_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/calibeur.c
+++ b/src/devices/calibeur.c
@@ -116,7 +116,7 @@ static int calibeur_rf104_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "temperature_C",

--- a/src/devices/cardin.c
+++ b/src/devices/cardin.c
@@ -109,7 +109,7 @@ static int cardin_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "dipswitch",
         "rbutton",

--- a/src/devices/cavius.c
+++ b/src/devices/cavius.c
@@ -118,7 +118,7 @@ static int cavius_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/ced7000.c
+++ b/src/devices/ced7000.c
@@ -93,7 +93,7 @@ static int ced7000_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "count",

--- a/src/devices/celsia_czc1.c
+++ b/src/devices/celsia_czc1.c
@@ -132,7 +132,7 @@ static int celsia_czc1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "heat",

--- a/src/devices/chuango.c
+++ b/src/devices/chuango.c
@@ -87,7 +87,7 @@ static int chuango_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "cmd",

--- a/src/devices/cmr113.c
+++ b/src/devices/cmr113.c
@@ -109,7 +109,7 @@ static int cmr113_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "current_1_A",
         "current_2_A",

--- a/src/devices/companion_wtr001.c
+++ b/src/devices/companion_wtr001.c
@@ -127,7 +127,7 @@ static int companion_wtr001_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "temperature_C",
         "mic",

--- a/src/devices/cotech_36_7959.c
+++ b/src/devices/cotech_36_7959.c
@@ -133,7 +133,7 @@ static int cotech_36_7959_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *cotech_36_7959_output_fields[] = {
+static char const *const cotech_36_7959_output_fields[] = {
         "model",
         //"subtype",
         "id",

--- a/src/devices/current_cost.c
+++ b/src/devices/current_cost.c
@@ -114,7 +114,7 @@ static int current_cost_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 0;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "subtype",

--- a/src/devices/danfoss.c
+++ b/src/devices/danfoss.c
@@ -147,7 +147,7 @@ static int danfoss_cfr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return DECODE_ABORT_LENGTH;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "temperature_C",

--- a/src/devices/digitech_xc0324.c
+++ b/src/devices/digitech_xc0324.c
@@ -208,7 +208,7 @@ static int digitech_xc0324_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return events > 0 ? events : ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "temperature_C",

--- a/src/devices/directv.c
+++ b/src/devices/directv.c
@@ -360,7 +360,7 @@ static int directv_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "button_id",

--- a/src/devices/dish_remote_6_3.c
+++ b/src/devices/dish_remote_6_3.c
@@ -133,7 +133,7 @@ static int dish_remote_6_3_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "button",
         NULL,

--- a/src/devices/dsc.c
+++ b/src/devices/dsc.c
@@ -244,7 +244,7 @@ static int dsc_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return result;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "closed",

--- a/src/devices/ecodhome.c
+++ b/src/devices/ecodhome.c
@@ -171,7 +171,7 @@ static int ecodhome_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "message_type",

--- a/src/devices/ecowitt.c
+++ b/src/devices/ecowitt.c
@@ -106,7 +106,7 @@ static int ecowitt_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/efergy_e2_classic.c
+++ b/src/devices/efergy_e2_classic.c
@@ -110,7 +110,7 @@ static int efergy_e2_classic_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/efergy_optical.c
+++ b/src/devices/efergy_optical.c
@@ -124,7 +124,7 @@ static int efergy_optical_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "pulses",

--- a/src/devices/efth800.c
+++ b/src/devices/efth800.c
@@ -121,7 +121,7 @@ static int eurochron_efth800_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/elro_db286a.c
+++ b/src/devices/elro_db286a.c
@@ -49,7 +49,7 @@ static int elro_db286a_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         NULL,

--- a/src/devices/elv.c
+++ b/src/devices/elv.c
@@ -95,7 +95,7 @@ static int em1000_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *elv_em1000_output_fields[] = {
+static char const *const elv_em1000_output_fields[] = {
         "model",
         "id",
         "seq",
@@ -263,7 +263,7 @@ static int ws2000_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *elv_ws2000_output_fields[] = {
+static char const *const elv_ws2000_output_fields[] = {
         "model",
         "id",
         "subtype",

--- a/src/devices/emax.c
+++ b/src/devices/emax.c
@@ -250,7 +250,7 @@ static int emax_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/emontx.c
+++ b/src/devices/emontx.c
@@ -138,7 +138,7 @@ static int emontx_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "node",
         "ct1",

--- a/src/devices/emos_e6016.c
+++ b/src/devices/emos_e6016.c
@@ -124,7 +124,7 @@ static int emos_e6016_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/emos_e6016_rain.c
+++ b/src/devices/emos_e6016_rain.c
@@ -99,7 +99,7 @@ static int emos_e6016_rain_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/enocean_erp1.c
+++ b/src/devices/enocean_erp1.c
@@ -90,7 +90,7 @@ static int enocean_erp1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "telegram",
         "mic",

--- a/src/devices/ert_idm.c
+++ b/src/devices/ert_idm.c
@@ -581,7 +581,7 @@ static int ert_netidm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
 
         // Common fields
         "model",

--- a/src/devices/ert_scm.c
+++ b/src/devices/ert_scm.c
@@ -95,7 +95,7 @@ static int ert_scm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "physical_tamper",

--- a/src/devices/esa.c
+++ b/src/devices/esa.c
@@ -87,7 +87,7 @@ static int esa_cost_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "impulses",

--- a/src/devices/esic_emt7110.c
+++ b/src/devices/esic_emt7110.c
@@ -91,7 +91,7 @@ static int esic_emt7110_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "power_W",

--- a/src/devices/esperanza_ews.c
+++ b/src/devices/esperanza_ews.c
@@ -112,7 +112,7 @@ static int esperanza_ews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/eurochron.c
+++ b/src/devices/eurochron.c
@@ -83,7 +83,7 @@ static int eurochron_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -953,7 +953,7 @@ static int fineoffset_WH0530_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "temperature_C",
@@ -962,7 +962,7 @@ static char const *output_fields[] = {
         NULL,
 };
 
-static char const *output_fields_WH25[] = {
+static char const *const output_fields_WH25[] = {
         "model",
         "id",
         "battery_ok",
@@ -984,7 +984,7 @@ static char const *output_fields_WH25[] = {
         NULL,
 };
 
-static char const *output_fields_WH51[] = {
+static char const *const output_fields_WH51[] = {
         "model",
         "id",
         "battery_ok",
@@ -996,7 +996,7 @@ static char const *output_fields_WH51[] = {
         NULL,
 };
 
-static char const *output_fields_WH0530[] = {
+static char const *const output_fields_WH0530[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/fineoffset_wh1050.c
+++ b/src/devices/fineoffset_wh1050.c
@@ -120,7 +120,7 @@ static int fineoffset_wh1050_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/fineoffset_wh1080.c
+++ b/src/devices/fineoffset_wh1080.c
@@ -326,7 +326,7 @@ static int fineoffset_wh1080_callback_fsk(r_device *decoder, bitbuffer_t *bitbuf
     return fineoffset_wh1080_callback(decoder, bitbuffer, TYPE_FSK);
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "subtype",
         "id",

--- a/src/devices/fineoffset_wh31l.c
+++ b/src/devices/fineoffset_wh31l.c
@@ -154,7 +154,7 @@ static int fineoffset_wh31l_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/fineoffset_wh45.c
+++ b/src/devices/fineoffset_wh45.c
@@ -128,7 +128,7 @@ static int fineoffset_wh45_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/fineoffset_wn34.c
+++ b/src/devices/fineoffset_wn34.c
@@ -110,7 +110,7 @@ static int fineoffset_wn34_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/fineoffset_ws80.c
+++ b/src/devices/fineoffset_ws80.c
@@ -113,7 +113,7 @@ static int fineoffset_ws80_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -342,7 +342,7 @@ static int flex_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "count",
         "num_rows",

--- a/src/devices/flowis.c
+++ b/src/devices/flowis.c
@@ -122,7 +122,7 @@ static int flowis_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "type",

--- a/src/devices/fordremote.c
+++ b/src/devices/fordremote.c
@@ -62,7 +62,7 @@ static int fordremote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return found;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "code",

--- a/src/devices/fs20.c
+++ b/src/devices/fs20.c
@@ -33,7 +33,7 @@ Command extensions are also not decoded. feel free to improve!
 
 static int fs20_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    static char const *cmd_tab[] = {
+    static char const *const cmd_tab[] = {
             "off",
             "on, 6.25%",
             "on, 12.5%",
@@ -122,7 +122,7 @@ static int fs20_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "housecode",
         "address",

--- a/src/devices/ft004b.c
+++ b/src/devices/ft004b.c
@@ -65,7 +65,7 @@ static int ft004b_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "temperature_C",
         NULL,

--- a/src/devices/funkbus.c
+++ b/src/devices/funkbus.c
@@ -160,7 +160,7 @@ static int funkbus_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return events;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/gasmate_ba1008.c
+++ b/src/devices/gasmate_ba1008.c
@@ -92,7 +92,7 @@ static int gasmate_ba1008_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "temperature_C",
         "unknown_1",

--- a/src/devices/ge_coloreffects.c
+++ b/src/devices/ge_coloreffects.c
@@ -157,7 +157,7 @@ static int ge_coloreffects_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events > 0 ? events : ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "command",

--- a/src/devices/generic_motion.c
+++ b/src/devices/generic_motion.c
@@ -62,7 +62,7 @@ static int generic_motion_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return DECODE_ABORT_EARLY;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "code",
         NULL,

--- a/src/devices/generic_remote.c
+++ b/src/devices/generic_remote.c
@@ -71,7 +71,7 @@ static int generic_remote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "cmd",

--- a/src/devices/generic_temperature_sensor.c
+++ b/src/devices/generic_temperature_sensor.c
@@ -60,7 +60,7 @@ static int generic_temperature_sensor_callback(r_device *decoder, bitbuffer_t *b
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/geo_minim.c
+++ b/src/devices/geo_minim.c
@@ -343,7 +343,7 @@ static int minim_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 // List of fields to appear in the `-F csv` output.
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "power_VA",

--- a/src/devices/govee.c
+++ b/src/devices/govee.c
@@ -238,7 +238,7 @@ static int govee_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/gt_tmbbq05.c
+++ b/src/devices/gt_tmbbq05.c
@@ -127,7 +127,7 @@ static int gt_tmbbq05_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "temperature_F",

--- a/src/devices/gt_wt_02.c
+++ b/src/devices/gt_wt_02.c
@@ -115,7 +115,7 @@ static int gt_wt_02_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return counter;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/gt_wt_03.c
+++ b/src/devices/gt_wt_03.c
@@ -146,7 +146,7 @@ static int gt_wt_03_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/hcs200.c
+++ b/src/devices/hcs200.c
@@ -86,7 +86,7 @@ static int hcs200_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/hideki.c
+++ b/src/devices/hideki.c
@@ -226,7 +226,7 @@ static int hideki_ts04_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/holman_ws5029.c
+++ b/src/devices/holman_ws5029.c
@@ -118,7 +118,7 @@ static int holman_ws5029pcm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "temperature_C",

--- a/src/devices/hondaremote.c
+++ b/src/devices/hondaremote.c
@@ -18,7 +18,7 @@ Note that this is actually Manchester coded and should be changed.
 */
 #include "decoder.h"
 
-static char const *command_code[] = {"boot", "unlock" , "lock",};
+static char const *const command_code[] = {"boot", "unlock" , "lock",};
 
 static char const *get_command_codes(const uint8_t *bytes)
 {
@@ -61,7 +61,7 @@ static int hondaremote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 0;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "code",

--- a/src/devices/honeywell.c
+++ b/src/devices/honeywell.c
@@ -123,7 +123,7 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/honeywell_cm921.c
+++ b/src/devices/honeywell_cm921.c
@@ -418,7 +418,7 @@ static int honeywell_cm921_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "ids",
 #ifdef _DEBUG

--- a/src/devices/honeywell_wdb.c
+++ b/src/devices/honeywell_wdb.c
@@ -113,7 +113,7 @@ static int honeywell_wdb_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "subtype",
         "id",

--- a/src/devices/ht680.c
+++ b/src/devices/ht680.c
@@ -79,7 +79,7 @@ static int ht680_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 0;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "button1",

--- a/src/devices/ibis_beacon.c
+++ b/src/devices/ibis_beacon.c
@@ -80,7 +80,7 @@ static int ibis_beacon_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "counter",

--- a/src/devices/ikea_sparsnas.c
+++ b/src/devices/ikea_sparsnas.c
@@ -274,7 +274,7 @@ static int ikea_sparsnas_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "sequence",

--- a/src/devices/infactory.c
+++ b/src/devices/infactory.c
@@ -98,7 +98,7 @@ static int infactory_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/inkbird_ith20r.c
+++ b/src/devices/inkbird_ith20r.c
@@ -128,7 +128,7 @@ static int inkbird_ith20r_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery",

--- a/src/devices/inovalley-kw9015b.c
+++ b/src/devices/inovalley-kw9015b.c
@@ -74,7 +74,7 @@ static int kw9015b_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *kw9015b_csv_output_fields[] = {
+static char const *const kw9015b_csv_output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/insteon.c
+++ b/src/devices/insteon.c
@@ -458,7 +458,7 @@ static int insteon_callback(r_device *decoder, bitbuffer_t *bitbuffer)
  *
  */
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         // "id",
         // "data",

--- a/src/devices/interlogix.c
+++ b/src/devices/interlogix.c
@@ -214,7 +214,7 @@ static int interlogix_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "subtype",
         "id",

--- a/src/devices/intertechno.c
+++ b/src/devices/intertechno.c
@@ -51,7 +51,7 @@ static int intertechno_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "type",
         "id",

--- a/src/devices/jasco.c
+++ b/src/devices/jasco.c
@@ -69,7 +69,7 @@ static int jasco_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "status",

--- a/src/devices/kedsum.c
+++ b/src/devices/kedsum.c
@@ -93,7 +93,7 @@ static int kedsum_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/kerui.c
+++ b/src/devices/kerui.c
@@ -90,7 +90,7 @@ static int kerui_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "cmd",

--- a/src/devices/klimalogg.c
+++ b/src/devices/klimalogg.c
@@ -90,7 +90,7 @@ static int klimalogg_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/lacrosse.c
+++ b/src/devices/lacrosse.c
@@ -174,7 +174,7 @@ static int lacrossetx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return result;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "temperature_C",

--- a/src/devices/lacrosse_breezepro.c
+++ b/src/devices/lacrosse_breezepro.c
@@ -152,7 +152,7 @@ static int lacrosse_breezepro_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "seq",

--- a/src/devices/lacrosse_r1.c
+++ b/src/devices/lacrosse_r1.c
@@ -191,7 +191,7 @@ static int lacrosse_r1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/lacrosse_th3.c
+++ b/src/devices/lacrosse_th3.c
@@ -137,7 +137,7 @@ static int lacrosse_th_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "seq",

--- a/src/devices/lacrosse_tx141x.c
+++ b/src/devices/lacrosse_tx141x.c
@@ -287,7 +287,7 @@ static int lacrosse_tx141x_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/lacrosse_tx31u.c
+++ b/src/devices/lacrosse_tx31u.c
@@ -202,7 +202,7 @@ static int lacrosse_tx31u_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/lacrosse_tx34.c
+++ b/src/devices/lacrosse_tx34.c
@@ -103,7 +103,7 @@ static int lacrosse_tx34_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/lacrosse_tx35.c
+++ b/src/devices/lacrosse_tx35.c
@@ -169,7 +169,7 @@ static int lacrossetx35_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return lacrosse_it(decoder, bitbuffer, LACROSSE_TX35_MODEL);
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/lacrosse_wr1.c
+++ b/src/devices/lacrosse_wr1.c
@@ -122,7 +122,7 @@ static int lacrosse_wr1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "seq",

--- a/src/devices/lacrosse_ws7000.c
+++ b/src/devices/lacrosse_ws7000.c
@@ -213,7 +213,7 @@ static int lacrosse_ws7000_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return DECODE_FAIL_SANITY; // should not be reached
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/lacrossews.c
+++ b/src/devices/lacrossews.c
@@ -201,7 +201,7 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "temperature_C",

--- a/src/devices/lightwave_rf.c
+++ b/src/devices/lightwave_rf.c
@@ -136,7 +136,7 @@ static int lightwave_rf_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "subunit",

--- a/src/devices/m_bus.c
+++ b/src/devices/m_bus.c
@@ -1165,7 +1165,7 @@ static int m_bus_mode_s_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 // NOTE: we'd need to add "value_types_tab X unit_names X n" fields
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "mode",
         "id",

--- a/src/devices/markisol.c
+++ b/src/devices/markisol.c
@@ -110,7 +110,7 @@ static int markisol_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "control",

--- a/src/devices/marlec_solar.c
+++ b/src/devices/marlec_solar.c
@@ -98,7 +98,7 @@ static int marlec_solar_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "raw",
         "mic",

--- a/src/devices/maverick_et73.c
+++ b/src/devices/maverick_et73.c
@@ -90,7 +90,7 @@ static int maverick_et73_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "temperature_1_C",

--- a/src/devices/maverick_et73x.c
+++ b/src/devices/maverick_et73x.c
@@ -103,7 +103,7 @@ static int maverick_et73x_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "status",

--- a/src/devices/maverick_xr30.c
+++ b/src/devices/maverick_xr30.c
@@ -93,7 +93,7 @@ static int maverick_xr30_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "status",

--- a/src/devices/mebus.c
+++ b/src/devices/mebus.c
@@ -67,7 +67,7 @@ static int mebus433_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return DECODE_ABORT_EARLY;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/megacode.c
+++ b/src/devices/megacode.c
@@ -81,7 +81,7 @@ static int megacode_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "raw",

--- a/src/devices/missil_ml0757.c
+++ b/src/devices/missil_ml0757.c
@@ -130,7 +130,7 @@ static int missil_ml0757_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/neptune_r900.c
+++ b/src/devices/neptune_r900.c
@@ -214,7 +214,7 @@ static int neptune_r900_decode(r_device *decoder, bitbuffer_t *bitbuffer)
  * order for this device when using -F csv.
  *
  */
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "unkn1",

--- a/src/devices/new_template.c
+++ b/src/devices/new_template.c
@@ -253,7 +253,7 @@ static int new_template_decode(r_device *decoder, bitbuffer_t *bitbuffer)
  * order for this device when using -F csv.
  *
  */
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "data",

--- a/src/devices/newkaku.c
+++ b/src/devices/newkaku.c
@@ -73,7 +73,7 @@ static int newkaku_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "unit",

--- a/src/devices/nexa.c
+++ b/src/devices/nexa.c
@@ -69,7 +69,7 @@ static int nexa_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -102,7 +102,7 @@ static int nexus_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/nice_flor_s.c
+++ b/src/devices/nice_flor_s.c
@@ -60,7 +60,7 @@ static int nice_flor_s_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "button",
         "serial",

--- a/src/devices/norgo.c
+++ b/src/devices/norgo.c
@@ -208,7 +208,7 @@ static int norgo_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/oil_smart.c
+++ b/src/devices/oil_smart.c
@@ -125,7 +125,7 @@ static int oil_smart_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "depth_cm",

--- a/src/devices/oil_standard.c
+++ b/src/devices/oil_standard.c
@@ -124,7 +124,7 @@ static int oil_standard_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "flags",

--- a/src/devices/oil_watchman.c
+++ b/src/devices/oil_watchman.c
@@ -98,7 +98,7 @@ static int oil_watchman_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return events;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "flags",

--- a/src/devices/oil_watchman_advanced.c
+++ b/src/devices/oil_watchman_advanced.c
@@ -93,7 +93,7 @@ static int oil_watchman_advanced_decode(r_device *decoder, bitbuffer_t *bitbuffe
     return events;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "temperature_C",

--- a/src/devices/opus_xt300.c
+++ b/src/devices/opus_xt300.c
@@ -95,7 +95,7 @@ static int opus_xt300_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return ret > 0 ? ret : fail_code;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "channel",
         "temperature_C",

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -935,7 +935,7 @@ static int oregon_scientific_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/oregon_scientific_sl109h.c
+++ b/src/devices/oregon_scientific_sl109h.c
@@ -104,7 +104,7 @@ static int oregon_scientific_sl109h_callback(r_device *decoder, bitbuffer_t *bit
     return 0;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/oregon_scientific_v1.c
+++ b/src/devices/oregon_scientific_v1.c
@@ -85,7 +85,7 @@ static int oregon_scientific_v1_callback(r_device *decoder, bitbuffer_t *bitbuff
     return ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/philips_aj3650.c
+++ b/src/devices/philips_aj3650.c
@@ -134,7 +134,7 @@ static int philips_aj3650_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "channel",
         "battery_ok",

--- a/src/devices/philips_aj7010.c
+++ b/src/devices/philips_aj7010.c
@@ -112,7 +112,7 @@ static int philips_aj7010_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "time",
         "model",
         "channel",

--- a/src/devices/proflame2.c
+++ b/src/devices/proflame2.c
@@ -137,7 +137,7 @@ static int proflame2_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 0;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "pilot",

--- a/src/devices/prologue.c
+++ b/src/devices/prologue.c
@@ -86,7 +86,7 @@ static int prologue_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "subtype",
         "id",

--- a/src/devices/proove.c
+++ b/src/devices/proove.c
@@ -94,7 +94,7 @@ static int proove_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/quhwa.c
+++ b/src/devices/quhwa.c
@@ -55,7 +55,7 @@ static int quhwa_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         NULL,

--- a/src/devices/radiohead_ask.c
+++ b/src/devices/radiohead_ask.c
@@ -223,7 +223,7 @@ static int sensible_living_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *radiohead_ask_output_fields[] = {
+static char const *const radiohead_ask_output_fields[] = {
         "model",
         "len",
         "to",
@@ -235,7 +235,7 @@ static char const *radiohead_ask_output_fields[] = {
         NULL,
 };
 
-static char const *sensible_living_output_fields[] = {
+static char const *const sensible_living_output_fields[] = {
         "model",
         "house_id",
         "module_id",

--- a/src/devices/rainpoint.c
+++ b/src/devices/rainpoint.c
@@ -117,7 +117,7 @@ static int rainpoint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/regency_fan.c
+++ b/src/devices/regency_fan.c
@@ -160,7 +160,7 @@ static int regency_fan_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return return_code;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "type",
         "channel",

--- a/src/devices/revolt_nc5462.c
+++ b/src/devices/revolt_nc5462.c
@@ -98,7 +98,7 @@ static int revolt_nc5462_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "voltage_V",

--- a/src/devices/rftech.c
+++ b/src/devices/rftech.c
@@ -69,7 +69,7 @@ static int rftech_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *csv_output_fields[] = {
+static char const *const csv_output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/rojaflex.c
+++ b/src/devices/rojaflex.c
@@ -284,7 +284,7 @@ static int rojaflex_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/rubicson.c
+++ b/src/devices/rubicson.c
@@ -95,7 +95,7 @@ static int rubicson_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/rubicson_48659.c
+++ b/src/devices/rubicson_48659.c
@@ -182,7 +182,7 @@ static int rubicson_48659_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "temperature_F",

--- a/src/devices/rubicson_pool_48942.c
+++ b/src/devices/rubicson_pool_48942.c
@@ -87,7 +87,7 @@ static int rubicson_pool_48942_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "channel",
         "id",

--- a/src/devices/s3318p.c
+++ b/src/devices/s3318p.c
@@ -112,7 +112,7 @@ static int s3318p_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/schraeder.c
+++ b/src/devices/schraeder.c
@@ -283,7 +283,7 @@ static int schrader_SMD3MA4_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "type",
         "id",
@@ -294,7 +294,7 @@ static char const *output_fields[] = {
         NULL,
 };
 
-static char const *output_fields_EG53MA4[] = {
+static char const *const output_fields_EG53MA4[] = {
         "model",
         "type",
         "id",
@@ -305,7 +305,7 @@ static char const *output_fields_EG53MA4[] = {
         NULL,
 };
 
-static char const *output_fields_SMD3MA4[] = {
+static char const *const output_fields_SMD3MA4[] = {
         "model",
         "type",
         "id",

--- a/src/devices/scmplus.c
+++ b/src/devices/scmplus.c
@@ -156,7 +156,7 @@ static int scmplus_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "ProtocolID",

--- a/src/devices/secplus_v1.c
+++ b/src/devices/secplus_v1.c
@@ -377,7 +377,7 @@ static int secplus_v1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "id0",

--- a/src/devices/secplus_v2.c
+++ b/src/devices/secplus_v2.c
@@ -380,7 +380,7 @@ static int secplus_v2_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         // Common fields
         "model",
         "id",

--- a/src/devices/sharp_spc775.c
+++ b/src/devices/sharp_spc775.c
@@ -89,7 +89,7 @@ static int sharp_spc775_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/silvercrest.c
+++ b/src/devices/silvercrest.c
@@ -49,7 +49,7 @@ static int silvercrest_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return DECODE_ABORT_EARLY;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "button",
         NULL,

--- a/src/devices/simplisafe.c
+++ b/src/devices/simplisafe.c
@@ -194,7 +194,7 @@ static int ss_sensor_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 }
 
-static char const *sensor_output_fields[] = {
+static char const *const sensor_output_fields[] = {
         "model",
         "id",
         "seq",

--- a/src/devices/simplisafe_gen3.c
+++ b/src/devices/simplisafe_gen3.c
@@ -86,7 +86,7 @@ static int simplisafe_gen3_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "msg_type",

--- a/src/devices/smoke_gs558.c
+++ b/src/devices/smoke_gs558.c
@@ -117,7 +117,7 @@ static int smoke_gs558_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "unit",

--- a/src/devices/solight_te44.c
+++ b/src/devices/solight_te44.c
@@ -83,7 +83,7 @@ static int solight_te44_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/somfy_iohc.c
+++ b/src/devices/somfy_iohc.c
@@ -195,7 +195,7 @@ static int somfy_iohc_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "dst_id",

--- a/src/devices/somfy_rts.c
+++ b/src/devices/somfy_rts.c
@@ -193,7 +193,7 @@ static int somfy_rts_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "control",

--- a/src/devices/springfield.c
+++ b/src/devices/springfield.c
@@ -89,7 +89,7 @@ static int springfield_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/srsmith_pool_srs_2c_tx.c
+++ b/src/devices/srsmith_pool_srs_2c_tx.c
@@ -148,7 +148,7 @@ static int srsmith_pool_srs_2c_tx_decode(r_device *decoder, bitbuffer_t *bitbuff
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "mic",
         "id",

--- a/src/devices/steelmate.c
+++ b/src/devices/steelmate.c
@@ -98,7 +98,7 @@ static int steelmate_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return DECODE_FAIL_SANITY;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "type",
         "model",
         "id",

--- a/src/devices/telldus_ft0385r.c
+++ b/src/devices/telldus_ft0385r.c
@@ -189,7 +189,7 @@ static int telldus_ft0385r_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *telldus_ft0385r_output_fields[] = {
+static char const *const telldus_ft0385r_output_fields[] = {
         "model",
         "battery_ok",
         "temperature_F",

--- a/src/devices/tfa_14_1504_v2.c
+++ b/src/devices/tfa_14_1504_v2.c
@@ -116,7 +116,7 @@ static int tfa_14_1504_v2_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "battery_ok",
         "probe_fail",

--- a/src/devices/tfa_30_3196.c
+++ b/src/devices/tfa_30_3196.c
@@ -103,7 +103,7 @@ static int tfa_303196_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/tfa_30_3221.c
+++ b/src/devices/tfa_30_3221.c
@@ -90,7 +90,7 @@ static int tfa_303221_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/tfa_drop_30.3233.c
+++ b/src/devices/tfa_drop_30.3233.c
@@ -176,7 +176,7 @@ static int tfa_drop_303233_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/tfa_marbella.c
+++ b/src/devices/tfa_marbella.c
@@ -87,7 +87,7 @@ static int tfa_marbella_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "counter",

--- a/src/devices/tfa_pool_thermometer.c
+++ b/src/devices/tfa_pool_thermometer.c
@@ -78,7 +78,7 @@ static int tfa_pool_thermometer_decode(r_device *decoder, bitbuffer_t *bitbuffer
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/tfa_twin_plus_30.3049.c
+++ b/src/devices/tfa_twin_plus_30.3049.c
@@ -107,7 +107,7 @@ static int tfa_twin_plus_303049_callback(r_device *decoder, bitbuffer_t *bitbuff
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/thermopro_tp11.c
+++ b/src/devices/thermopro_tp11.c
@@ -60,7 +60,7 @@ static int thermopro_tp11_sensor_callback(r_device *decoder, bitbuffer_t *bitbuf
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "temperature_C",

--- a/src/devices/thermopro_tp12.c
+++ b/src/devices/thermopro_tp12.c
@@ -102,7 +102,7 @@ static int thermopro_tp12_sensor_callback(r_device *decoder, bitbuffer_t *bitbuf
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "temperature_1_C",

--- a/src/devices/thermopro_tx2.c
+++ b/src/devices/thermopro_tx2.c
@@ -93,7 +93,7 @@ static int thermopro_tx2_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "subtype",
         "id",

--- a/src/devices/tpms_abarth124.c
+++ b/src/devices/tpms_abarth124.c
@@ -108,7 +108,7 @@ static int tpms_abarth124_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "type",
         "id",

--- a/src/devices/tpms_ave.c
+++ b/src/devices/tpms_ave.c
@@ -141,7 +141,7 @@ static int tpms_ave_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events > 0 ? events : ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "type",
         "id",

--- a/src/devices/tpms_citroen.c
+++ b/src/devices/tpms_citroen.c
@@ -117,7 +117,7 @@ static int tpms_citroen_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events > 0 ? events : ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "type",
         "id",

--- a/src/devices/tpms_eezrv.c
+++ b/src/devices/tpms_eezrv.c
@@ -94,7 +94,7 @@ static int tpms_eezrv_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "type",
         "id",

--- a/src/devices/tpms_elantra2012.c
+++ b/src/devices/tpms_elantra2012.c
@@ -134,7 +134,7 @@ static int tpms_elantra2012_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events > 0 ? events : ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "type",
         "id",

--- a/src/devices/tpms_ford.c
+++ b/src/devices/tpms_ford.c
@@ -208,7 +208,7 @@ static int tpms_ford_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events > 0 ? events : ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "type",
         "id",

--- a/src/devices/tpms_hyundai_vdo.c
+++ b/src/devices/tpms_hyundai_vdo.c
@@ -128,7 +128,7 @@ static int tpms_hyundai_vdo_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events > 0 ? events : ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "type",
         "id",

--- a/src/devices/tpms_jansite.c
+++ b/src/devices/tpms_jansite.c
@@ -101,7 +101,7 @@ static int tpms_jansite_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events > 0 ? events : ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "type",
         "id",

--- a/src/devices/tpms_jansite_solar.c
+++ b/src/devices/tpms_jansite_solar.c
@@ -118,7 +118,7 @@ static int tpms_jansite_solar_callback(r_device *decoder, bitbuffer_t *bitbuffer
     return events > 0 ? events : ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "type",
         "id",

--- a/src/devices/tpms_kia.c
+++ b/src/devices/tpms_kia.c
@@ -131,7 +131,7 @@ static int tpms_kia_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events > 0 ? events : ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "type",
         "id",

--- a/src/devices/tpms_pmv107j.c
+++ b/src/devices/tpms_pmv107j.c
@@ -108,7 +108,7 @@ static int tpms_pmv107j_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events > 0 ? events : ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "type",
         "id",

--- a/src/devices/tpms_porsche.c
+++ b/src/devices/tpms_porsche.c
@@ -102,7 +102,7 @@ static int tpms_porsche_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "type",
         "id",

--- a/src/devices/tpms_renault.c
+++ b/src/devices/tpms_renault.c
@@ -108,7 +108,7 @@ static int tpms_renault_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events > 0 ? events : ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "type",
         "id",

--- a/src/devices/tpms_renault_0435r.c
+++ b/src/devices/tpms_renault_0435r.c
@@ -160,7 +160,7 @@ static int tpms_renault_0435r_callback(r_device *decoder, bitbuffer_t *bitbuffer
     return events > 0 ? events : ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "type",
         "id",

--- a/src/devices/tpms_toyota.c
+++ b/src/devices/tpms_toyota.c
@@ -103,7 +103,7 @@ static int tpms_toyota_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events > 0 ? events : ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "type",
         "id",

--- a/src/devices/tpms_truck.c
+++ b/src/devices/tpms_truck.c
@@ -114,7 +114,7 @@ static int tpms_truck_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "type",
         "id",

--- a/src/devices/tpms_tyreguard400.c
+++ b/src/devices/tpms_tyreguard400.c
@@ -173,7 +173,7 @@ static int tpms_tyreguard400_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events > 0 ? events : ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "type",
         "id",

--- a/src/devices/ts_ft002.c
+++ b/src/devices/ts_ft002.c
@@ -103,7 +103,7 @@ static int ts_ft002_decoder(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "depth_cm",

--- a/src/devices/ttx201.c
+++ b/src/devices/ttx201.c
@@ -206,7 +206,7 @@ static int ttx201_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return events > 0 ? events : ret;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/vaillant_vrt340f.c
+++ b/src/devices/vaillant_vrt340f.c
@@ -137,7 +137,7 @@ static int vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return DECODE_FAIL_SANITY;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "heating",

--- a/src/devices/vauno_en8822c.c
+++ b/src/devices/vauno_en8822c.c
@@ -88,7 +88,7 @@ static int vauno_en8822c_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/visonic_powercode.c
+++ b/src/devices/visonic_powercode.c
@@ -105,7 +105,7 @@ static int visonic_powercode_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "tamper",

--- a/src/devices/waveman.c
+++ b/src/devices/waveman.c
@@ -79,7 +79,7 @@ static int waveman_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/wec2103.c
+++ b/src/devices/wec2103.c
@@ -73,7 +73,7 @@ static int wec2103_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/wg_pb12v1.c
+++ b/src/devices/wg_pb12v1.c
@@ -83,7 +83,7 @@ static int wg_pb12v1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "temperature_C",

--- a/src/devices/ws2032.c
+++ b/src/devices/ws2032.c
@@ -100,7 +100,7 @@ static int fineoffset_ws2032_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "battery_ok",

--- a/src/devices/wssensor.c
+++ b/src/devices/wssensor.c
@@ -82,7 +82,7 @@ static int wssensor_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/wt0124.c
+++ b/src/devices/wt0124.c
@@ -97,7 +97,7 @@ static int wt1024_callback(r_device *decoder, bitbuffer_t *bitbuffer)
  * order for this device when using -F csv.
  *
  */
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/wt450.c
+++ b/src/devices/wt450.c
@@ -115,7 +115,7 @@ static int wt450_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "channel",

--- a/src/devices/x10_rf.c
+++ b/src/devices/x10_rf.c
@@ -149,7 +149,7 @@ static int x10_rf_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "channel",
         "id",

--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -186,7 +186,7 @@ static int x10_sec_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "code",

--- a/src/devices/yale_hsa.c
+++ b/src/devices/yale_hsa.c
@@ -121,7 +121,7 @@ static int yale_hsa_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 0;
 }
 
-static char const *output_fields[] = {
+static char const *const output_fields[] = {
         "model",
         "id",
         "stype",

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -266,7 +266,7 @@ static data_t *protocols_data(r_cfg_t *cfg)
             }
         }
         int fields_len = 0;
-        for (char const **iter = dev->fields; iter && *iter; ++iter) {
+        for (char const *const *iter = dev->fields; iter && *iter; ++iter) {
             fields_len++;
         }
         data_t *data = data_make(
@@ -294,7 +294,7 @@ static data_t *protocols_data(r_cfg_t *cfg)
                 continue;
         }
         int fields_len = 0;
-        for (char const **iter2 = dev->fields; iter2 && *iter2; ++iter2) {
+        for (char const *const *iter2 = dev->fields; iter2 && *iter2; ++iter2) {
             fields_len++;
         }
         data_t *data = data_make(

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -681,7 +681,7 @@ void data_acquired_handler(r_device *r_dev, data_t *data)
     // check for undeclared csv fields
     for (data_t *d = data; d; d = d->next) {
         int found = 0;
-        for (char const **p = r_dev->fields; *p; ++p) {
+        for (char const *const *p = r_dev->fields; *p; ++p) {
             if (!strcmp(d->key, *p)) {
                 found = 1;
                 break;

--- a/tests/symbolizer.py
+++ b/tests/symbolizer.py
@@ -5,7 +5,7 @@
 # from ../include/rtl_433_devices.h
 #     DECL(silvercrest) \
 #
-# static char *output_fields_EG53MA4[] = {
+# static char const *const output_fields_EG53MA4[] = {
 #         "model",
 #         "type",
 #         "id",
@@ -16,7 +16,7 @@
 #         NULL,
 # };
 #
-# r_device schraeder = {
+# r_device const schraeder = {
 #         .name        = "Schrader TPMS",
 #         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
 #         .short_width = 120,
@@ -154,6 +154,11 @@ def process_source(path, name):
             m = re.match(r'(?:static)?\s?char\s?\*\s?[^\*\s]+\s?=\s?(?:{|")', line)
             if m:
                 err(f"::error file={name},line={i}::char * variable should be char const * when being given a constant value")
+                
+            # look for output fields declarations that must be static char const *const
+            m = re.match(r'static\s?char\s+const\s*\*\s*[^\*\s]+\[\]\s*=\s*\{', line) 
+            if m:
+                err(f"::error file={name},line={i}::output fields static variable should be 'static char const *const'")
 
             # look for r_device with decode_fn
             m = re.match(r'\s*r_device\s+const\s+([^\*]*?)\s*=', line)


### PR DESCRIPTION
This allows for static "output_fields" to be stored in readonly memory on embedded architectures saving the very limited RAM available.
This saves about 7kB, representing 2.3% of the total installed RAM, which may not sound much but makes quite a difference for other parts of the program.