### PR TITLE
Fix detection of Bresser Professional Rain Gauge

### DIFF
--- a/src/devices/bresser_5in1.c
+++ b/src/devices/bresser_5in1.c
@@ -32,6 +32,9 @@ Packet payload without preamble (203 bits):
     -----------------------------------------------------------------------------
     ed ee 46 ff ff ff ef 9f ff 8b 7d eb ff 12 11 b9 00 00 00 10 60 00 74 82 14 00 00 00 (Rain Gauge)
     e9 ee 46 ff ff ff ef 99 ff 8b 8b eb ff 16 11 b9 00 00 00 10 66 00 74 74 14 00 00 00 (Rain Gauge)
+    ec 3d 45 ff ff ff ef 66 ff 8e bf fe ff 13 c2 ba 00 00 00 10 99 00 71 40 01 00 00 00 (Rain Gauge)
+    eb 28 c4 ff ff ff ef ea fe 8e ff ff ff 14 d7 3b 00 00 00 10 15 01 71 00 00 00 00 00 (Rain Gauge, immediately after reset)
+    e9 28 44 ff ff ff ef 6a ff 8e fe ff ff 16 d7 bb 00 00 00 10 95 00 71 01 00 00 00 00 (same Rain Gauge, 90 min after reset)
     ee 93 7f f7 bf fb ef 9e fe ae bf ff ff 11 6c 80 08 40 04 10 61 01 51 40 00 00
     ed 93 7f ff 0f ff ef b8 fe 7d bf ff ff 12 6c 80 00 f0 00 10 47 01 82 40 00 00
     eb 93 7f eb 9f ee ef fc fc d6 bf ff ff 14 6c 80 14 60 11 10 03 03 29 40 00 00
@@ -45,9 +48,11 @@ Packet payload without preamble (203 bits):
     CC CC CC CC CC CC CC CC CC CC CC CC CC uu II sS GG DG WW  W TT  T HH RR RR Bt
                                               G-MSB ^     ^ W-MSB  (strange but consistent order)
 
-- C = Check, inverted data of 13 byte further
+- C = check, inverted data of 13 byte further
 - uu = checksum (number/count of set bits within bytes 14-25)
 - I = station ID (maybe)
+- s = startup, MSb is 0b0 after power-on/reset and 0b1 after 1 hour
+- S = sensor type, 0x9/0xA/0xB for Bresser Professional Rain Gauge
 - G = wind gust in 1/10 m/s, normal binary coded, GGxG = 0x76D1 => 0x0176 = 256 + 118 = 374 => 37.4 m/s.  MSB is out of sequence.
 - D = wind direction 0..F = N..NNE..E..S..W..NNW
 - W = wind speed in 1/10 m/s, BCD coded, WWxW = 0x7512 => 0x0275 = 275 => 27.5 m/s. MSB is out of sequence.
@@ -55,9 +60,7 @@ Packet payload without preamble (203 bits):
 - t = temperature sign, minus if unequal 0
 - H = humidity in percent, BCD coded, HH = 23 => 23 %
 - R = rain in mm, BCD coded, RRRR = 1203 => 031.2 mm
-- B = Battery. 0=Ok, 8=Low.
-- s = startup, 0 after power-on/reset / 8 after 1 hour
-- S = sensor type, only low nibble used, 0x9 for Bresser Professional Rain Gauge
+- B = battery, 0=Ok, 8=Low
 */
 
 static int bresser_5in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
@@ -126,8 +129,10 @@ static int bresser_5in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     int battery_low = (msg[25] & 0x80);
 
+    int sensor_type = (msg[15] & 0x7f);
+
     /* check if the message is from a Bresser Professional Rain Gauge */
-    if ((msg[15] & 0xF) == 0x9) {
+    if ((sensor_type >= 0x39) && (sensor_type <= 0x3b)) {
         // rescale the rain sensor readings
         rain = rain * 2.5;
         /* clang-format off */


### PR DESCRIPTION
I have been using rtl_433 for roughly a year now to receive the data from my rain sensor, a Bresser Professional Rain Gauge. It worked out of the box, and I didn't experience any issues. Until two weeks ago. I had to change the batteries, and after that my setup stopped working. rtl_433 was still receiving the data from the sensor, but it was incorrectly labelled as a "Bresser-5in1" weather center, and the rain values were too low.

Looking at the code I realised that there is a magic nibble in each packet which is used to identify the type of device. Unfortunately I don't have any recordings from before the battery change. But it must have been 0x9 then (otherwise it wouldn't have worked). Now it is 0xA, though. So the assumption that the respective byte is static was incorrect.

I don't know if there is any way at all to identify the type of device from the packets themselves. And unfortunately I currently don't have physical access to the sensor to do another battery change and see what happens. For now I adapted the code to check for `((msg[15] & 0xF) >= 0x9)` instead of `((msg[15] & 0xF) == 0x9)`.

Attached is a sample I captured today with my modified version of rtl_433.

```
time      : 2023-03-18 19:37:20
model     : Bresser-ProRainGauge                   id        : 194
Battery   : 1            Temperature: 9.9 C        Rain      : 35.0 mm       Integrity : CHECKSUM
[pulse_slicer_pcm] Bresser Weather Center 5-in-1
codes     : {276}aaaaaaaaaa2dd4ec3d45ffffffef66ff8ebffeff13c2ba00000010990071400100000
```
[g001_868.3M_1000k.cu8.gz](https://github.com/merbanan/rtl_433/files/11009319/g001_868.3M_1000k.cu8.gz)