### PR TITLE
Add support for Silvercrest Doorbell T (STKK 16 B1)

### DIFF
--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -251,7 +251,7 @@
     DECL(tpms_eezrv) \
     DECL(baldr_rain) \
     DECL(celsia_czc1) \
-
+    DECL(silvercrest_doorbell_t) \
     /* Add new decoders here. */
 
 #define DECL(name) extern r_device name;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -204,6 +204,7 @@ add_library(r_433 STATIC
     devices/secplus_v2.c
     devices/sharp_spc775.c
     devices/silvercrest.c
+    devices/silvercrest-doorbell-t.c
     devices/simplisafe.c
     devices/simplisafe_gen3.c
     devices/smoke_gs558.c

--- a/src/devices/silvercrest-doorbell-t.c
+++ b/src/devices/silvercrest-doorbell-t.c
@@ -1,0 +1,62 @@
+/** @file
+    Silvercrest Doorbell T decoder.
+
+    Copyright (C) 2018 Benjamin Larsson
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#include "decoder.h"
+
+/** @fn int silvercrest_doorbell_t_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+Silvercrest Doorbell T decoder.
+
+Model number: STKK 16 B1
+Manufactured: 2022-09
+IAN: 498825_2204
+
+Data layout:
+
+    - byte 0: probably some ID
+
+*/
+
+static int silvercrest_doorbell_t_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+
+    data_t *data;
+
+    if (bitbuffer->num_rows == 1 && bitbuffer->bits_per_row[0] == 8 && bitbuffer->bb[0][0] == 0xf9) {
+
+        /* clang-format off */
+        data = data_make(
+                "model", "", DATA_STRING, "Silvercrest Doorbell T(STKK 16 B1)",
+                "id", "", DATA_INT, bitbuffer->bb[0][0],
+                NULL);
+        /* clang-format on */
+
+        decoder_output_data(decoder, data);
+        return 1;
+    }
+    return DECODE_ABORT_EARLY;
+}
+
+static char const *const output_fields[] = {
+        "model",
+        "id",
+        NULL,
+};
+
+r_device const silvercrest_doorbell_t = {
+        .name        = "Silvercrest Doorbell T(STKK 16 B1)",
+        .modulation  = OOK_PULSE_PWM,
+        .short_width = 25,
+        .long_width  = 75,
+        .reset_limit = 12000,
+        .gap_limit   = 5000,
+        .decode_fn   = &silvercrest_doorbell_t_decode,
+        .fields      = output_fields,
+};


### PR DESCRIPTION
This PR adds support for the Silvercrest Doorbell T. 

The samples for it can be found here: https://github.com/merbanan/rtl_433_tests/pull/451

It seems that just one byte of data is sent from the emitter. I am not sure if this the value I got is the same for all devices, since I have only one unit, 

Is there a way to make this code configurable, in case it varies between devices?

I am not exactly sure about the `reset_limit` and the `gap_limit`.