### PR TITLE
Add support for Oregon Scientific AWR129 BBQ thermometer

### DIFF
--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -176,6 +176,10 @@ static int acurite_rain_896_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     if (bitbuffer->bits_per_row[0] < 24)
         return DECODE_ABORT_LENGTH;
 
+    if (bitbuffer->num_rows < 12) 
+        return DECODE_ABORT_EARLY; // likely Oregon V1, not AcuRite
+
+
     if ((b[0] == 0) || (b[1] == 0) || (b[2] == 0) || (b[3] != 0) || (b[4] != 0))
         return DECODE_ABORT_EARLY;
 
@@ -1876,7 +1880,7 @@ r_device const acurite_rain_896 = {
         .gap_limit   = 3500,
         .reset_limit = 5000,
         .decode_fn   = &acurite_rain_896_decode,
-        .disabled    = 1, // Disabled by default due to false positives on oregon scientific v1 protocol see issue #353
+        .priority    = 10, // Eliminate false positives by letting oregon scientific v1 protocol go earlier
         .fields      = acurite_rain_gauge_output_fields,
 };
 

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -176,7 +176,7 @@ static int acurite_rain_896_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     if (bitbuffer->bits_per_row[0] < 24)
         return DECODE_ABORT_LENGTH;
 
-    if (bitbuffer->num_rows < 12) 
+    if (bitbuffer->num_rows < 12)
         return DECODE_ABORT_EARLY; // likely Oregon V1, not AcuRite
 
 

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -176,9 +176,9 @@ static int acurite_rain_896_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     if (bitbuffer->bits_per_row[0] < 24)
         return DECODE_ABORT_LENGTH;
 
+    // The nominal repeat count is 16, require a minimum of 12 rows
     if (bitbuffer->num_rows < 12)
         return DECODE_ABORT_EARLY; // likely Oregon V1, not AcuRite
-
 
     if ((b[0] == 0) || (b[1] == 0) || (b[2] == 0) || (b[3] != 0) || (b[4] != 0))
         return DECODE_ABORT_EARLY;

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -22,6 +22,7 @@
 #define ID_RGR968   0x2d10
 #define ID_THR228N  0xec40
 #define ID_THN132N  0xec40 // same as THR228N but different packet size
+#define ID_AWR129   0xec41
 #define ID_RTGN318  0x0cc3 // warning: id is from 0x0cc3 and 0xfcc3
 #define ID_RTGN129  0x0cc3 // same as RTGN318 but different packet size
 #define ID_THGR810  0xf824 // This might be ID_THGR81, but what's true is lost in (git) history
@@ -368,13 +369,13 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         decoder_output_data(decoder, data);
         return 1;
     }
-    else if (sensor_id == ID_THR228N && msg_bits == 76) {
+    else if ((sensor_id == ID_THR228N || sensor_id == ID_AWR129) && msg_bits == 76) {
         if (validate_os_v2_message(decoder, msg, 76, msg_bits, 12) != 0)
             return 0;
         float temp_c = get_os_temperature(msg);
         /* clang-format off */
         data = data_make(
-                "model",                 "",                        DATA_STRING, "Oregon-THR228N",
+                "model",                 "",                        DATA_STRING, (sensor_id == ID_AWR129) ? "Oregon-AWR129" : "Oregon-THR228N",
                 "id",                        "House Code",    DATA_INT,        get_os_rollingcode(msg),
                 "channel",             "Channel",         DATA_INT,        get_os_channel(msg, sensor_id),
                 "battery_ok",          "Battery",         DATA_INT,    !get_os_battery(msg),

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -22,7 +22,7 @@
 #define ID_RGR968   0x2d10
 #define ID_THR228N  0xec40
 #define ID_THN132N  0xec40 // same as THR228N but different packet size
-#define ID_AWR129   0xec41
+#define ID_AWR129   0xec41 // same as THR228N
 #define ID_RTGN318  0x0cc3 // warning: id is from 0x0cc3 and 0xfcc3
 #define ID_RTGN129  0x0cc3 // same as RTGN318 but different packet size
 #define ID_THGR810  0xf824 // This might be ID_THGR81, but what's true is lost in (git) history
@@ -375,7 +375,8 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         float temp_c = get_os_temperature(msg);
         /* clang-format off */
         data = data_make(
-                "model",                 "",                        DATA_STRING, (sensor_id == ID_AWR129) ? "Oregon-AWR129" : "Oregon-THR228N",
+                "model", "", DATA_COND, sensor_id == ID_THR228N, DATA_STRING, "Oregon-THR228N",
+                "model", "", DATA_COND, sensor_id == ID_AWR129, DATA_STRING, "Oregon-AWR129",
                 "id",                        "House Code",    DATA_INT,        get_os_rollingcode(msg),
                 "channel",             "Channel",         DATA_INT,        get_os_channel(msg, sensor_id),
                 "battery_ok",          "Battery",         DATA_INT,    !get_os_battery(msg),


### PR DESCRIPTION
Straightforward addition of a device equivalent to the existing Oregon-THR228N protocol.