### PR TITLE
Added variant to fineoffset_wh1050.c, which contains time data every 2h

### DIFF
--- a/src/devices/fineoffset_wh1050.c
+++ b/src/devices/fineoffset_wh1050.c
@@ -34,15 +34,26 @@ I.e., data packet, wait 48 seconds, two data packets, wait 48 seconds, data pack
 
 The 'Total rainfall' field is a cumulative counter, increased by 0.3 millimeters of rain each step.
 
-Message layout and example:
+The station is also known as TFA STRATOS 35.1077
+See the product page here: https://www.tfa-dostmann.de/en/product/wireless-weather-station-with-wind-and-rain-gauge-stratos-35-1077/
+This model seems also capable to decode the DCF77 time signal sent by the time signal decoder (which is enclosed on the sensor tx):
+around the minute 59 of the even hours the sensor's TX stops sending weather data, probably to receive (and sync with) DCF77 signals.
+After around 3-4 minutes of silence it starts to send just time data for some minute, then it starts again with
+weather data as usual.
+
+To recognize which message is received (weather or time) you can use the 'msg_type' field on json output:
+- msg_type 0 = weather data
+- msg_type 1 = time data
+
+Weather data - Message layout and example:
 
          AA BC CD DD EE FF GG HH HH II
     {80} ff 5f 51 93 48 00 00 12 46 aa
 
 - A :  8 bits : Preamble 0xFF
-- B :  4 bits : ?? - always seems to be 0x5
+- B :  4 bits : ?? - seems to be 0x5 for whether data, 0x6 for time data
 - C :  8 bits : Id, changes when reset (e.g., 0xF5)
-- D :  1 bit  : ?? - unknown, always seems to be 0
+- D :  1 bit  : msg_type - 0, for whether data
 - D :  1 bit  : Battery, 0 = ok, 1 = low (e.g, OK)
 - D : 10 bits : Temperature in Celsius, offset 400, scaled by 10 (e.g., 0.3 degrees C)
 - E :  8 bits : Relative humidity, percent (e.g., 72%)
@@ -50,6 +61,32 @@ Message layout and example:
 - G :  8 bits : Wind speed gust in m/s, scaled by 1/0.34 (e.g., 0 m/s)
 - H : 16 bits : Total rainfall in units of 0.3mm, since reset (e.g., 1403.4 mm)
 - I :  8 bits : CRC, poly 0x31, init 0x00 (excluding preamble)
+
+Time data - Message layout and example:
+
+        AA BC CD DE FG HI JK LM NO PP
+   {80} ff 69 0a 96 02 41 23 43 27 df
+
+- A :  8 bits : Preamble 0xFF
+- B :  4 bits : ?? - seems to be 0x5 for whether data, seems 0x6 for time data
+- C :  8 bits : Id, changes when reset (e.g., 0xF5)
+- D :  1 bit  : msg_type - 1, for time data
+- D :  1 bit  : Battery, 0 = ok, 1 = low (e.g, OK)
+- D :  4 bits : ??
+- D :  2 bits : hour BCD coded (*10)
+- E :  4 bits : hour BCD coded (*1)
+- F :  4 bits : minute BCD coded (*10)
+- G :  4 bits : minute BCD coded (*1)
+- H :  4 bits : second BCD coded (*10)
+- I :  4 bits : second BCD coded (*1)
+- J :  4 bits : year BCD coded (*10), counted from 2000
+- K :  4 bits : year BCD coded (*1), counted from 2000
+- L :  3 bits : ??
+- L :  1 bits : month BCD coded (*10)
+- M :  4 bits : month BCD coded (*1)
+- N :  4 bits : day BCD coded (*10)
+- O :  4 bits : day BCD coded (*1)
+- P :  8 bits : CRC, poly 0x31, init 0x00 (excluding preamble)
 
 */
 
@@ -91,30 +128,62 @@ static int fineoffset_wh1050_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_FAIL_MIC; // crc mismatch
     }
 
-    // GETTING WEATHER SENSORS DATA
-    int temp_raw      = ((br[1] & 0x03) << 8) | br[2];
-    float temperature = (temp_raw - 400) * 0.1f;
-    int humidity      = br[3];
-    float speed       = (br[4] * 0.34f) * 3.6f; // m/s -> km/h
-    float gust        = (br[5] * 0.34f) * 3.6f; // m/s -> km/h
-    int rain_raw      = (br[6] << 8) | br[7];
-    float rain        = rain_raw * 0.3f;
-    int device_id     = (br[0] << 4 & 0xf0) | (br[1] >> 4);
-    int battery_low   = br[1] & 0x04;
+    // GETTING MESSAGE TYPE
+    int msg_type = (br[1] & 0x08) >> 3;
 
-    /* clang-format off */
-    data = data_make(
-            "model",            "",                 DATA_STRING, "Fineoffset-WH1050",
-            "id",               "StationID",        DATA_FORMAT, "%04X",    DATA_INT,    device_id,
-            "battery_ok",       "Battery",          DATA_INT,    !battery_low,
-            "temperature_C",    "Temperature",      DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
-            "humidity",         "Humidity",         DATA_FORMAT, "%u %%",   DATA_INT,    humidity,
-            "wind_avg_km_h",    "Wind avg speed",   DATA_FORMAT, "%.02f",   DATA_DOUBLE, speed,
-            "wind_max_km_h",    "Wind gust",        DATA_FORMAT, "%.02f",   DATA_DOUBLE, gust,
-            "rain_mm",          "Total rainfall",   DATA_FORMAT, "%.01f",   DATA_DOUBLE, rain,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
-    /* clang-format on */
+    if (msg_type == 0) {
+        // GETTING WEATHER SENSORS DATA
+        int temp_raw      = ((br[1] & 0x03) << 8) | br[2];
+        float temperature = (temp_raw - 400) * 0.1f;
+        int humidity      = br[3];
+        float speed       = (br[4] * 0.34f) * 3.6f; // m/s -> km/h
+        float gust        = (br[5] * 0.34f) * 3.6f; // m/s -> km/h
+        int rain_raw      = (br[6] << 8) | br[7];
+        float rain        = rain_raw * 0.3f;
+        int device_id     = (br[0] << 4 & 0xf0) | (br[1] >> 4);
+        int battery_low   = br[1] & 0x04;
+
+        /* clang-format off */
+        data = data_make(
+                "model",            "",                 DATA_STRING, "Fineoffset-WH1050",
+                "subtype",          "Msg type",         DATA_INT,    msg_type,
+                "id",               "StationID",        DATA_FORMAT, "%04X",    DATA_INT,    device_id,
+                "battery_ok",       "Battery",          DATA_INT,    !battery_low,
+                "temperature_C",    "Temperature",      DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
+                "humidity",         "Humidity",         DATA_FORMAT, "%u %%",   DATA_INT,    humidity,
+                "wind_avg_km_h",    "Wind avg speed",   DATA_FORMAT, "%.02f",   DATA_DOUBLE, speed,
+                "wind_max_km_h",    "Wind gust",        DATA_FORMAT, "%.02f",   DATA_DOUBLE, gust,
+                "rain_mm",          "Total rainfall",   DATA_FORMAT, "%.01f",   DATA_DOUBLE, rain,
+                "mic",              "Integrity",        DATA_STRING, "CRC",
+                NULL);
+        /* clang-format on */
+    }
+    else {
+        // GETTING TIME DATA
+        int device_id   = (br[0] << 4 & 0xf0) | (br[1] >> 4);
+        int battery_low = br[1] & 0x04;
+        int hours       = ((br[2] & 0x30) >> 4) * 10 + (br[2] & 0x0F);
+        int minutes     = ((br[3] & 0xF0) >> 4) * 10 + (br[3] & 0x0F);
+        int seconds     = ((br[4] & 0xF0) >> 4) * 10 + (br[4] & 0x0F);
+        int year        = ((br[5] & 0xF0) >> 4) * 10 + (br[5] & 0x0F) + 2000;
+        int month       = ((br[6] & 0x10) >> 4) * 10 + (br[6] & 0x0F);
+        int day         = ((br[7] & 0xF0) >> 4) * 10 + (br[7] & 0x0F);
+
+        char clock_str[23];
+        sprintf(clock_str, "%04d-%02d-%02dT%02d:%02d:%02d",
+                year, month, day, hours, minutes, seconds);
+
+        /* clang-format off */
+        data = data_make(
+                "model",            "",                 DATA_STRING,    "Fineoffset-WH1050",
+                "subtype",          "Msg type",         DATA_INT,       msg_type,
+                "id",               "Station ID",       DATA_INT,       device_id,
+                "battery_ok",       "Battery",          DATA_INT,       !battery_low,
+                "radio_clock",      "Radio Clock",      DATA_STRING,    clock_str,
+                "mic",              "Integrity",        DATA_STRING,    "CRC",
+                NULL);
+        /* clang-format on */
+    }
 
     decoder_output_data(decoder, data);
     return 1;
@@ -123,12 +192,14 @@ static int fineoffset_wh1050_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 static char const *const output_fields[] = {
         "model",
         "id",
+        "subtype",
         "battery_ok",
         "temperature_C",
         "humidity",
         "wind_avg_km_h",
         "wind_max_km_h",
         "rain_mm",
+        "radio_clock",
         "mic",
         NULL,
 };

--- a/src/devices/fineoffset_wh1050.c
+++ b/src/devices/fineoffset_wh1050.c
@@ -146,7 +146,7 @@ static int fineoffset_wh1050_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         /* clang-format off */
         data = data_make(
                 "model",            "",                 DATA_STRING, "Fineoffset-WH1050",
-                "subtype",          "Msg type",         DATA_INT,    msg_type,
+                "msg_type",         "Msg type",         DATA_INT,    msg_type,
                 "id",               "StationID",        DATA_FORMAT, "%04X",    DATA_INT,    device_id,
                 "battery_ok",       "Battery",          DATA_INT,    !battery_low,
                 "temperature_C",    "Temperature",      DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
@@ -176,7 +176,7 @@ static int fineoffset_wh1050_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         /* clang-format off */
         data = data_make(
                 "model",            "",                 DATA_STRING,    "Fineoffset-WH1050",
-                "subtype",          "Msg type",         DATA_INT,       msg_type,
+                "msg_type",         "Msg type",         DATA_INT,       msg_type,
                 "id",               "Station ID",       DATA_INT,       device_id,
                 "battery_ok",       "Battery",          DATA_INT,       !battery_low,
                 "radio_clock",      "Radio Clock",      DATA_STRING,    clock_str,
@@ -192,7 +192,7 @@ static int fineoffset_wh1050_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 static char const *const output_fields[] = {
         "model",
         "id",
-        "subtype",
+        "msg_type",
         "battery_ok",
         "temperature_C",
         "humidity",


### PR DESCRIPTION
The "fine offset wh1050" decoder works in principle also with station TFA STRATOS 35.1077.

See the product page here: 
https://www.tfa-dostmann.de/en/product/wireless-weather-station-with-wind-and-rain-gauge-stratos-35-1077/

The only issue is, that every two hours some packages with wrong data is reported.

The test data which belongs to this pull request can be found here:
https://github.com/blackholefinder/rtl_433_tests/commit/976e27372b0dac5f3fa1858b2078f7c6c51cb6f7
