### PR TITLE
add Driveway alarm motion sensor I8-W1901

### DIFF
--- a/conf/DrivewayAlarm_I8-W1901.conf
+++ b/conf/DrivewayAlarm_I8-W1901.conf
@@ -1,0 +1,58 @@
+#  
+#  Driveway alarm sensor  SKU I8-W1901
+#  This sensor Detects motion and comes with a receiver that plays 32 different
+#  melodies at selectable volumes. The receiver with the speaker plugs into a
+#  120Vac outlet and the motion sensor is powered by 3 AAA batteries. The plastic
+#  material is high quality and has brass inserts for the battery cover screws.
+#  The receiver (that comes with the sensor) has the ability to pair with 4
+#  different sensors.
+#    Amazon: https://www.amazon.com/Driveway-Alarms-Wireless-Outside-Weatherproof/dp/B0BFDMKD98
+#    SKU: I8-W1901
+#    On Amazon it is sold by FREETIM, but the packaging does not mention this name
+#    anywhere; it  is unbranded.
+#  It is a 433.92 Mhz device and it repeatedly  sends two rows of data when motion
+#  is detected:
+#                      ----------------------------------
+#                            Data             Length
+#  - first row                8               01 bit (artifact of sync bit)
+#  - second row          <device id>          25 bits
+#                      ----------------------------------
+#  There is no additional data provided by the sensor, it simply detects motion.
+#
+#  The following flex decoder was used for the above analisys.
+#     $ rtl_433 -R 0 -X 'n=driveway,m=OOK_PWM,s=200,l=596,r=6196,g=608,t=158,y=0,repeats>=10,bits>=20'
+#       repeats>=10 and bits>=20 was used to filter out any possible noise.
+# 
+#  Decoder
+#  -------
+#  After discussion with zuckschwerdt (https://github.com/merbanan/rtl_433/pull/2493)
+#  we decided to include the sync bit into the packet (for robustness) by increasing
+#  the gap limit to 900 us and then matching on 26 bits as the ID. This gives us a 
+#  flex decoder like this:
+#   $ rtl_433 -R 0 -X 'n=motion,m=OOK_PWM,s=188,l=588,r=7000,g=900,t=160,y=0,match={26}c4ea674,repeats>=3'
+#
+#  How to use
+#  ----------
+#  1. Run rtl_433 -R 0 -X 'n=motion,m=OOK_PWM,s=188,l=588,r=7000,g=900,t=160,y=0,repeats>=3,bits>=26'
+#  2. Activate the motion sensor, and write down the hex value of the 26 bits you get
+#  3. Replace the value in the match= line below with the one you just got
+#
+#  Voila! Enjoy!
+#  
+#  This sensor was tested at about 45 meters of distance and through layers of wood
+#  and walls and it worked well.
+#
+
+decoder {
+        n=Driveway alarm I8-W1901,
+        m=OOK_PWM,
+        s=188,
+        l=588,
+        r=7000,
+        g=900
+        t=160,
+        bits>=26,
+        repeats>=3,
+        countonly,
+        match={26}c4ea674
+}


### PR DESCRIPTION
This is a very nice (with high quality brass screw threads) motion sensor for driveways (SKU I8-W1901). The code was made based on `generic_motion.c`, and it works well. I have tested it at different distances and it worked up to about 45 meters.

It is a very simple sensor, since it only reports motion (without any signal indicating 'clear').

