### PR TITLE
Add support for Shenzhen EGQ Q85 and improve Abarth 124 Spider

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [153]  Cotech 36-7959, SwitchDocLabs FT020T wireless weather station with USB
     [154]  Standard Consumption Message Plus (SCMplus)
     [155]  Fine Offset Electronics WH1080/WH3080 Weather Station (FSK)
-    [156]  Abarth 124 Spider TPMS
+    [156]  Abarth 124 Spider and Shenzhen EGQ Q85 TPMS
     [157]  Missil ML0757 weather station
     [158]  Sharp SPC775 weather station
     [159]  Insteon

--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [243]  Celsia CZC1 Thermostat
     [244]  Fine Offset Electronics WS90 weather station
     [245]* ThermoPro TX-2C Thermometer
+    [246]  TFA 30.3151 Weather Station
 
 * Disabled by default, use -R n or a conf file to enable
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -253,6 +253,7 @@
     DECL(celsia_czc1) \
     DECL(fineoffset_ws90) \
     DECL(thermopro_tx2c) \
+    DECL(tfa_303151) \
 
     /* Add new decoders here. */
 

--- a/src/devices/fineoffset_wh1050.c
+++ b/src/devices/fineoffset_wh1050.c
@@ -1,8 +1,9 @@
 /** @file
-    Fine Offset WH1050 Weather Station.
+    Fine Offset WH1050 and TFA 30.3151 Weather Station.
 
     2016 Nicola Quiriti ('ovrheat')
     Modifications 2016 by Don More
+    2023 Bruno OCTAU (ProfBoc75) for TFA 30.3151 FSK
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -16,7 +17,7 @@
 #define TYPE_FSK 2
 
 /** @fn in fineoffset_wh1050_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned bitpos, int type)
-Fine Offset WH1050 Weather Station.
+Fine Offset WH1050 and TFA 30.3151 Weather Station.
 
 This module is a cut-down version of the WH1080 decoder.
 The WH1050 sensor unit is like the WH1080 unit except it has no
@@ -45,6 +46,9 @@ This model seems also capable to decode the DCF77 time signal sent by the time s
 around the minute 59 of the even hours the sensor's TX stops sending weather data, probably to receive (and sync with) DCF77 signals.
 After around 3-4 minutes of silence it starts to send just time data for some minute, then it starts again with
 weather data as usual.
+
+TFA 30.3151 Sensor is FSK version and decodes here. See issue #2538
+Preamble is aaaa2dd4 and Temperature is not offset.
 
 To recognize which message is received (weather or time) you can use the 'msg_type' field on json output:
 - msg_type 0 = weather data
@@ -159,7 +163,8 @@ static int fineoffset_wh1050_decode(r_device *decoder, bitbuffer_t *bitbuffer, u
 
         /* clang-format off */
         data = data_make(
-                "model",            "",                 DATA_STRING,    "Fineoffset-WH1050",
+                "model",            "",                 DATA_COND, type == TYPE_OOK, DATA_STRING, "Fineoffset-WH1050",
+                "model",            "",                 DATA_COND, type == TYPE_FSK, DATA_STRING, "TFA-303151",
                 "id",               "Station ID",       DATA_INT,       device_id,
                 "msg_type",         "Msg type",         DATA_INT,       msg_type,
                 "battery_ok",       "Battery",          DATA_INT,       !battery_low,

--- a/src/devices/fineoffset_wh1050.c
+++ b/src/devices/fineoffset_wh1050.c
@@ -207,7 +207,7 @@ static int fineoffset_wh1050_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     unsigned bits = bitbuffer->bits_per_row[0];
     uint8_t preamble_byte = bitbuffer->bb[0][0]; // for OOK
-    uint8_t const preamble_fsk[] = {0xAA, 0x2D, 0xD4}; // part of preamble and sync word for FSK 
+    uint8_t const preamble_fsk[] = {0xAA, 0x2D, 0xD4}; // part of preamble and sync word for FSK
     if (bits == 79 && preamble_byte == 0xfe) {
         fineoffset_wh1050_decode(decoder, bitbuffer, 7, TYPE_OOK);
     } else if (bits == 80 && preamble_byte == 0xff) {

--- a/src/devices/fineoffset_wh1050.c
+++ b/src/devices/fineoffset_wh1050.c
@@ -134,7 +134,7 @@ static int fineoffset_wh1050_decode(r_device *decoder, bitbuffer_t *bitbuffer, u
         data = data_make(
                 "model",            "",                 DATA_COND, type == TYPE_OOK, DATA_STRING, "Fineoffset-WH1050",
                 "model",            "",                 DATA_COND, type == TYPE_FSK, DATA_STRING, "TFA-303151",
-                "id",               "Station ID",       DATA_FORMAT, "%04X",    DATA_INT,    device_id,
+                "id",               "Station ID",       DATA_FORMAT, "%02X",    DATA_INT,    device_id,
                 "msg_type",         "Msg type",         DATA_INT,    msg_type,
                 "battery_ok",       "Battery",          DATA_INT,    !battery_low,
                 "temperature_C",    "Temperature",      DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
@@ -165,7 +165,7 @@ static int fineoffset_wh1050_decode(r_device *decoder, bitbuffer_t *bitbuffer, u
         data = data_make(
                 "model",            "",                 DATA_COND, type == TYPE_OOK, DATA_STRING, "Fineoffset-WH1050",
                 "model",            "",                 DATA_COND, type == TYPE_FSK, DATA_STRING, "TFA-303151",
-                "id",               "Station ID",       DATA_FORMAT, "%04X",    DATA_INT,    device_id,
+                "id",               "Station ID",       DATA_FORMAT, "%02X",    DATA_INT,    device_id,
                 "msg_type",         "Msg type",         DATA_INT,       msg_type,
                 "battery_ok",       "Battery",          DATA_INT,       !battery_low,
                 "radio_clock",      "Radio Clock",      DATA_STRING,    clock_str,

--- a/src/devices/fineoffset_wh1050.c
+++ b/src/devices/fineoffset_wh1050.c
@@ -165,7 +165,7 @@ static int fineoffset_wh1050_decode(r_device *decoder, bitbuffer_t *bitbuffer, u
         data = data_make(
                 "model",            "",                 DATA_COND, type == TYPE_OOK, DATA_STRING, "Fineoffset-WH1050",
                 "model",            "",                 DATA_COND, type == TYPE_FSK, DATA_STRING, "TFA-303151",
-                "id",               "Station ID",       DATA_INT,       device_id,
+                "id",               "Station ID",       DATA_FORMAT, "%04X",    DATA_INT,    device_id,
                 "msg_type",         "Msg type",         DATA_INT,       msg_type,
                 "battery_ok",       "Battery",          DATA_INT,       !battery_low,
                 "radio_clock",      "Radio Clock",      DATA_STRING,    clock_str,

--- a/src/devices/fineoffset_wh1050.c
+++ b/src/devices/fineoffset_wh1050.c
@@ -139,9 +139,9 @@ static int fineoffset_wh1050_decode(r_device *decoder, bitbuffer_t *bitbuffer, u
                 "battery_ok",       "Battery",          DATA_INT,    !battery_low,
                 "temperature_C",    "Temperature",      DATA_FORMAT, "%.01f C", DATA_DOUBLE, temperature,
                 "humidity",         "Humidity",         DATA_FORMAT, "%u %%",   DATA_INT,    humidity,
-                "wind_avg_km_h",    "Wind avg speed",   DATA_FORMAT, "%.02f",   DATA_DOUBLE, speed,
-                "wind_max_km_h",    "Wind gust",        DATA_FORMAT, "%.02f",   DATA_DOUBLE, gust,
-                "rain_mm",          "Total rainfall",   DATA_FORMAT, "%.01f",   DATA_DOUBLE, rain,
+                "wind_avg_km_h",    "Wind avg speed",   DATA_FORMAT, "%.02f km/h",   DATA_DOUBLE, speed,
+                "wind_max_km_h",    "Wind gust",        DATA_FORMAT, "%.02f km/h ",   DATA_DOUBLE, gust,
+                "rain_mm",          "Total rainfall",   DATA_FORMAT, "%.01f mm",   DATA_DOUBLE, rain,
                 "mic",              "Integrity",        DATA_STRING, "CRC",
                 NULL);
         /* clang-format on */

--- a/src/devices/tpms_abarth124.c
+++ b/src/devices/tpms_abarth124.c
@@ -1,5 +1,8 @@
-/**  @file
-    VDO Type TG1C FSK 9 byte Manchester encoded checksummed TPMS data.
+/** @file
+    VDO TPMS Type TG1C and Q85.
+    Copyright (C) TTigges for (VDO Type TG1C via) Abarth 124 Spider TPMS decoded
+    Protocol similar (and based on) Jansite Solar TPMS by Andreas Spiess and Christian W. Zuckschwerdt
+    Copyright (C) 2023 Bruno OCTAU (ProfBoc75) Add Shenzhen EGQ Q85 support
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -8,9 +11,11 @@
 */
 
 /**
-(VDO Type TG1C via) Abarth 124 Spider TPMS decoded by TTigges
-Protocol similar (and based on) Jansite Solar TPMS by Andreas Spiess and Christian W. Zuckschwerdt
+VDO TPMS Type TG1C and Q85.
+VDO Type TG1C                                  FSK  9 byte Manchester encoded, checksummed for 8 bytes TPMS data.
+Q85 from Shenzhen EGQ Cloud technology CO,LTD, FSK 12 byte Manchester encoded, checksummed for 8 bytes TPMS data + CRC/16 CCITT-FASLE for 10 bytes DATA.
 
+TG1C (Abarth-124Spider):
 OEM Sensor is said to be a VDO Type TG1C, available in different cars,
 e.g.: Abarth 124 Spider, some Fiat 124 Spider, some Mazda MX-5 ND (and NC?) and probably some other Mazdas.
 Mazda reference/part no.: BHB637140A
@@ -22,46 +27,87 @@ Compatible with aftermarket sensors, e.g. Aligator sens.it RS3
 // Working Frequency: 433.92MHz+-38KHz
 // Tire monitoring range value: 0kPa-350kPa+-7kPa (to be checked, VDO says 450/900kPa)
 
+Q85 (Shenzhen-EGQ-Q85):
+Analysis asked by @js-3972 in issue #2556
+TPMS from Amazon here: https://www.amazon.com/dp/B0BK8SHDRZ?psc=1&ref=ppx_yo2ov_dt_b_product_details
+Air pressure setting range: 0.1~6.0BA / 1.45~87psi
+Temperature setting range: 60°C~110°C / 140ºF~230ºF
+Working temperature: -20°C~80°C / -68ºF~176ºF
+Storage temperature: -30°C~85°C / 86ºF~185ºF
+Power-on voltage: DC 5V
+Frequency: 433.92MHz±20.00MHZ (remark: more probably ±20.00KHZ than MHZ)
+
+Very similar to Abarth 124Spider, message lengh is bigger including a 0x40 then a CRC/16 CCITT-FALSE, (LSB first, then MSB)
+Temperature (°C) offset is 55 C
+Pressure (KPa) is divided by 3.
+
+Both payload:
+
+- The preamble is 0xaa..aa9 (or 0x55..556 depending on polarity)
+
 Data layout (nibbles):
-    II II II II ?? PP TT SS CC
+
+Byte    00 01 02 03 04 05 06 07 08 09 10 11
+TG1C    II II II II ?? PP TT SS CC
+Q85     II II II II ?? PP TT SS CC FF CR CR
+
 - I: 32 bit ID
 - ?: 4 bit unknown (seems to change with status)
 - ?: 4 bit unknown (seems static)
-- P: 8 bit Pressure (multiplyed by 1.38 = kPa)
-- T: 8 bit Temperature (deg. C offset by 50)
+- P: 8 bit Pressure (multiplyed by 1.38 = kPa for TG1C, by 3 for Q85)
+- T: 8 bit Temperature (deg. C offset by 50 for TG1C, by 55 for Q85)
 - S: Status? (first nibble seems static, second nibble seems to change with status)
-- C: 8 bit Checksum (Checksum8 XOR on bytes 0 to 8)
-- The preamble is 0xaa..aa9 (or 0x55..556 depending on polarity)
+- CC: 8 bit Checksum (Checksum8 XOR on bytes 0 to 8)
+- F: 8 bit unknown (Q85 only, seems fixed = 0x40)
+- CR: 16 bit CRC/16 CCITT-FASLE. little-Endian format (Q85 only, on bytes 0 to 9).
 */
 
 #include "decoder.h"
+#define MODEL_TG1C 1
+#define MODEL_Q85  2
 
-static int tpms_abarth124_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
+static int tpms_abarth124_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos, int type)
 {
     data_t *data;
     bitbuffer_t packet_bits = {0};
     uint8_t *b;
     char id_str[4 * 2 + 1];
     char flags[1 * 2 + 1];
-    int pressure;
-    int temperature;
-    int status;
-    int checksum;
+    int pressure, temperature, status, checksum, data_len;
+    uint16_t crc_little_endian, crc_result;
 
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 72);
+    // 9 byte or 12 byte
+    if (type == MODEL_TG1C) {
+        data_len = 72;
+    } else if (type == MODEL_Q85) {
+        data_len = 96;
+    } else {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, data_len);
 
     // make sure we decoded the expected number of bits
-    if (packet_bits.bits_per_row[0] < 72) {
+    if (packet_bits.bits_per_row[0] < data_len) {
         // decoder_logf(decoder, 0, __func__, "bitpos=%u start_pos=%u = %u", bitpos, start_pos, (start_pos - bitpos));
-        return 0; // DECODE_FAIL_SANITY;
+        return DECODE_FAIL_SANITY;
     }
 
     b = packet_bits.bb[0];
 
-    // check checksum (checksum8 xor)
+    // check checksum (checksum8 xor) same for both type model
     checksum = xor_bytes(b, 9);
     if (checksum != 0) {
-        return 0; // DECODE_FAIL_MIC;
+        return DECODE_FAIL_MIC;
+    }
+
+    if (type == MODEL_Q85) {
+        // check CRC for 0 to 9 byte only if type Q85, CRC 16 CCITT-FALSE little-endian
+        crc_little_endian = (b[11] << 8 ) | b[10];
+        crc_result = crc16(b, 10, 0x1021,0xffff); // CRC-16 CCITT-FALSE
+        if (crc_result != crc_little_endian) {
+            return DECODE_FAIL_MIC;
+        }
     }
 
     sprintf(flags, "%02x", b[4]);
@@ -73,14 +119,18 @@ static int tpms_abarth124_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsi
 
     /* clang-format off */
     data = data_make(
-            "model",            "",             DATA_STRING, "Abarth-124Spider",
+            "model",            "",             DATA_COND, type == MODEL_TG1C, DATA_STRING, "Abarth-124Spider",
+            "model",            "",             DATA_COND, type == MODEL_Q85,  DATA_STRING, "Shenzhen-EGQ-Q85",
             "type",             "",             DATA_STRING, "TPMS",
             "id",               "",             DATA_STRING, id_str,
             "flags",            "",             DATA_STRING, flags,
-            "pressure_kPa",     "Pressure",     DATA_FORMAT, "%.0f kPa", DATA_DOUBLE, (float)pressure * 1.38,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.0f C", DATA_DOUBLE, (float)temperature - 50.0,
+            "pressure_kPa",     "Pressure",     DATA_COND, type == MODEL_TG1C, DATA_FORMAT, "%.0f kPa", DATA_DOUBLE, (float)pressure * 1.38,
+            "pressure_kPa",     "Pressure",     DATA_COND, type == MODEL_Q85,  DATA_FORMAT, "%.0f kPa", DATA_DOUBLE, (float)pressure * 3,
+            "temperature_C",    "Temperature",  DATA_COND, type == MODEL_TG1C, DATA_FORMAT, "%.0f C", DATA_DOUBLE, (float)temperature - 50.0,
+            "temperature_C",    "Temperature",  DATA_COND, type == MODEL_Q85,  DATA_FORMAT, "%.0f C", DATA_DOUBLE, (float)temperature - 55.0,
             "status",           "",             DATA_INT, status,
-            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
+            "mic",              "Integrity",    DATA_COND, type == MODEL_TG1C, DATA_STRING, "CHECKSUM",
+            "mic",              "Integrity",    DATA_COND, type == MODEL_Q85,  DATA_STRING, "CRC",
             NULL);
     /* clang-format on */
 
@@ -96,12 +146,24 @@ static int tpms_abarth124_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     unsigned bitpos = 0;
     int events      = 0;
+    int type        = 0;
 
     bitbuffer_invert(bitbuffer);
+    unsigned bits = bitbuffer->bits_per_row[0];
+
+    // Define the type model , around 195 bits for TG1C MC encoded (result is 72 bits), around 353 bits for Q85 MC encoded (result is 96 bits)
+    if (bits > 150 && bits < 210) {
+        type = MODEL_TG1C;
+    } else if ( bits > 210 && bits < 400) {
+        type = MODEL_Q85;
+    } else {
+        return DECODE_ABORT_LENGTH;
+    }
+
     // Find a preamble with enough bits after it that it could be a complete packet
     while ((bitpos = bitbuffer_search(bitbuffer, 0, bitpos, preamble_pattern, 24)) + 80 <=
             bitbuffer->bits_per_row[0]) {
-        events += tpms_abarth124_decode(decoder, bitbuffer, 0, bitpos + 24);
+        events += tpms_abarth124_decode(decoder, bitbuffer, 0, bitpos + 24,type);
         bitpos += 2;
     }
 
@@ -122,7 +184,7 @@ static char const *const output_fields[] = {
 };
 
 r_device const tpms_abarth124 = {
-        .name        = "Abarth 124 Spider TPMS",
+        .name        = "Abarth 124 Spider and Shenzhen EGQ Q85 TPMS",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 52,  // 12-13 samples @250k
         .long_width  = 52,  // FSK


### PR DESCRIPTION
Hi,

This is a PR related to #2556 Analyzing Shenzhen EGQ TPMS , similar to Abarth 124 Spider but not properly decoded.
Issue reported by @js-3972.

3 majors gaps have been identified and added into this PR:
- EGQ Q85 data layout is common to Abarth 124 Spider (72 bits) plus a CRC 16 CCITT-FALSE data (96 bits).
- Temperature (°C) offset is 55 C instead 50
- Pressure (KPa) is by 3 instead of 1.38 

