### PR TITLE
Example hass typo fixes

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -359,7 +359,7 @@ mappings = {
         }
     },
 
-    "rain_mm_h": {
+    "rain_rate_mm_h": {
         "device_type": "sensor",
         "object_suffix": "RR",
         "config": {


### PR DESCRIPTION
I think this is a typo/legacy definition in the hass example, as only ever **rain_rate_mm_h** is used in the actual decoders.
