### PR TITLE
examples: rtl_433_mqtt_hass: add timestamp to logs

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -855,6 +855,7 @@ def run():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(format='[%(asctime)s] %(levelname)s:%(name)s:%(message)s',datefmt='%Y-%m-%dT%H:%M:%S%z')
     logging.getLogger().setLevel(logging.INFO)
 
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,


### PR DESCRIPTION
Prefix log entries with a timestamp to make it easier to determine when an event happened.

Before:

    INFO:root:Skipped Telldus-FT0385R: humidity_2
    INFO:root:Published Telldus-FT0385R: time, temperature_C, humidity, ...

After:

    [2023-07-14T22:53:31+0200] INFO:root:Skipped Telldus-FT0385R: humidity_2
    [2023-07-14T22:53:31+0200] INFO:root:Published Telldus-FT0385R: time, temperature_C, humidity, ...