### PR TITLE
examples: rtl_433_mqtt_hass: publish humidity_1, humidity_2

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -201,6 +201,28 @@ mappings = {
             "state_class": "measurement"
         }
     },
+    "humidity_1": {
+        "device_type": "sensor",
+        "object_suffix": "H1",
+        "config": {
+            "device_class": "humidity",
+            "name": "Humidity 1",
+            "unit_of_measurement": "%",
+            "value_template": "{{ value|float }}",
+            "state_class": "measurement"
+        }
+    },
+    "humidity_2": {
+        "device_type": "sensor",
+        "object_suffix": "H2",
+        "config": {
+            "device_class": "humidity",
+            "name": "Humidity 2",
+            "unit_of_measurement": "%",
+            "value_template": "{{ value|float }}",
+            "state_class": "measurement"
+        }
+    },
 
     "moisture": {
         "device_type": "sensor",


### PR DESCRIPTION
This adds support for publishing `humidity_1` and `humidity_2`, similar to how `temperature{,_1,_2}` are handled.  I've only observed this for a Telldus sensor:

```
INFO:root:Skipped Telldus-FT0385R: humidity_2
INFO:root:Published Telldus-FT0385R: time, temperature_C, humidity, temperature_2_C, pressure_hPa, [...]
```

Rationale:

The Acurite 00275RM room monitor sensor outputs `humidity_1` in addition to `humidity`.

- https://github.com/merbanan/rtl_433/blob/master/src/devices/acurite.c#L1782-L1868

Similarly, the Telldus FT0385R sensor outputs `humidity_2` (Humidity in) in addition to `humidity`.

- https://github.com/merbanan/rtl_433/blob/master/src/devices/telldus_ft0385r.c#L158-L186