### PR TITLE
Fix spelling

### DIFF
--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -210,7 +210,7 @@ output json
 #   -K loc=gpsd,lat,lon" (report lat and lon in loc object)
 #   -K gpsd" (full json TPV report, in default "gps" object)
 #   -K foo=gpsd://127.0.0.1:2947" (with key and address)
-#   -K bar=gpsd,nmea" (NMEA deault GPGGA report)
+#   -K bar=gpsd,nmea" (NMEA default GPGGA report)
 #   -K rmc=gpsd,nmea,filter='$GPRMC'" (NMEA GPRMC report)
 # Also <tag> can be a generic tcp address, e.g.
 #   -K foo=tcp:localhost:4000" (read lines as TCP client)

--- a/conf/tyreguard400.conf
+++ b/conf/tyreguard400.conf
@@ -30,7 +30,7 @@
 #
 # To peer a new sensor to the unit, bit 79 and 80 has to be both to 1.
 #
-# NOTE: In the datasheet, it is said that the sensor can report low batterie. During my tests/reseach i'm not able to see this behavior. I have fuzzed all bits nothing was reported to the reader.
+# NOTE: In the datasheet, it is said that the sensor can report low batterie. During my tests/research i'm not able to see this behavior. I have fuzzed all bits nothing was reported to the reader.
 #
 
 decoder {

--- a/docs/ANALYZE.md
+++ b/docs/ANALYZE.md
@@ -85,7 +85,7 @@ Preferably put the codes and annotations in a [BitBench](https://triq.net/bitben
   `rtl_433 -S unknown`
 - capture samples of every received frame
   `rtl_433 -S all`
-- anaylze a capture to get an overview of the timings
+- analyze a capture to get an overview of the timings
   `rtl_433 -A SAMPLE.cu8`
 - show the raw data pulse data from a captured sample
   `rtl_433 -w OOK:- SAMPLE.cu8`

--- a/docs/STARTING.md
+++ b/docs/STARTING.md
@@ -83,7 +83,7 @@ Suffixes of `M`, and `k`, `G` are accepted.
 Multiple center frequencies can be given to set up frequency hopping.
 The hopping time can be given with `-H <seconds>`, the default is 10 minutes (600 s).
 Multiple hopping times can be given and apply to each frequency given in that order.
-You can give `-E hop` to hop immediatly after each received event.
+You can give `-E hop` to hop immediately after each received event.
 
 The default sample rate for `433.92M` is `250k` Hz and `1000k` for higher frequencies like `868M`.
 Select a sample rate using `-s <sample rate>` -- rates higher than `1024k` or maybe `2048k` are not recommended.
@@ -271,7 +271,7 @@ Use
 When reading live inputs `rtl_433` will usually run forever, but you can limit the runtime
 - to a specific time using `-T <seconds>`, also formats like `12:34` or `1h23m45s` are accepted,
 - to a number of samples using `-n <value>` as a number of samples to take (each sample is an I/Q pair),
-- to recieving an event using `-E quit`, to quit after outputting the first event.
+- to receiving an event using `-E quit`, to quit after outputting the first event.
 
 When reading input from files `rtl_433` will process the data as fast as possible.
 You can limit the processing to original (or N-times) real-time using `-M replay[:N]`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,7 +40,7 @@ This is in many ways simple, but the programs must be started and
 stopped together, and only one rtl_433 can write to the processing
 script.
 
-There are only two pipe progams, collectd and statsd.
+There are only two pipe programs, collectd and statsd.
 
 ## UDP syslog
 
@@ -66,9 +66,9 @@ This section is speculative.
 Many devices will send a frame multiple times, perhaps 3 or 4, as a
 form of redundancy.  Many devices have non-robust checksums.  If
 displaying a temperature, that is often not a big deal.  If storing it
-in a datbase, bad data is troublesome.  One could process multiple
+in a database, bad data is troublesome.  One could process multiple
 frames that arrive close in time and try to infer which are bad
-decodes and what the consensus data is, and from tha output one good
+decodes and what the consensus data is, and from that output one good
 frame.  One could further reject physically implausible data (temp of
 fridge has been 2C and we just got a 30C reading), but this needs to
 recover from arbitrary situations so that would be tricky code to

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -139,7 +139,7 @@ static char const *acurite_getChannel(uint8_t byte)
 }
 
 // Add exception and raw message bytes to message to enable
-// later analysis of unexpected/possbily undecoded data
+// later analysis of unexpected/possibly undecoded data
 static void data_append_exception(data_t* data, int exception, uint8_t* bb, int browlen)
 {
     char raw_str[31], *rawp;
@@ -497,7 +497,7 @@ Acurite 899 Rain Gauge decoder
 static int acurite_899_decode(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t *bb)
 {
     (void)bitbuffer;
-    // MIC (checkum, parity) validated in calling function
+    // MIC (checksum, parity) validated in calling function
 
     uint16_t sensor_id = ((bb[0] & 0x3f) << 8) | bb[1]; //
     int battery_low = (bb[2] & 0x40) == 0;
@@ -505,7 +505,7 @@ static int acurite_899_decode(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t
     /*
       @todo bug? channel output isn't consistent with the rest of he Acurite
       devices in this family, should output ('A', 'B', or 'C')
-      Currently outputing 00 = A, 01 = B, 10 = C
+      Currently outputting 00 = A, 01 = B, 10 = C
       Leaving as is to maintain compatibility for now
     */
 
@@ -547,7 +547,7 @@ Acurite 3n1 Weather Station decoder
 */
 static int acurite_3n1_decode(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t *bb)
 {
-    // MIC (checkum, parity) validated in calling function
+    // MIC (checksum, parity) validated in calling function
     (void)bitbuffer;
 
     char const* channel_str = acurite_getChannel(bb[0]);
@@ -568,7 +568,7 @@ static int acurite_3n1_decode(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t
       which was copied from 5n1, but existing code 3n1 uses
       14 bits for ID. so these bits are used twice.
 
-      Leaving for compatibility, but probaby sequence_num
+      Leaving for compatibility, but probably sequence_num
       doesn't exist and should be deleted. If the 3n1 did use
       a sequence number, the ID would change on each output.
     */
@@ -631,7 +631,7 @@ XXX todo docs
 */
 static int acurite_5n1_decode(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t* bb)
 {
-    // MIC (checkum, parity) validated in calling function
+    // MIC (checksum, parity) validated in calling function
     (void)bitbuffer;
 
     char const* channel_str = acurite_getChannel(bb[0]);
@@ -832,7 +832,7 @@ static int acurite_atlas_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsig
     wind_speed_mph = ((bb[3] & 0x7F) << 1) | ((bb[4] & 0x40) >> 6);
 
     if (wind_speed_mph > 200) {
-        decoder_logf(decoder, 1, __func__, "Atlas 0x%04X Ch %s, invalid wind spped: %.1f MPH",
+        decoder_logf(decoder, 1, __func__, "Atlas 0x%04X Ch %s, invalid wind speed: %.1f MPH",
                      sensor_id, channel_str, wind_speed_mph);
         return DECODE_FAIL_SANITY;
     }
@@ -1007,7 +1007,7 @@ Notes:
 */
 static int acurite_tower_decode(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t *bb)
 {
-    // MIC (checkum, parity) validated in calling function
+    // MIC (checksum, parity) validated in calling function
 
     (void)bitbuffer;
     int exception = 0;
@@ -1123,7 +1123,7 @@ CCII IIII | IIII IIII | pBMM MMMM | bTTT TTTT | bTTT TTTT | KKKK KKKK
 */
 static int acurite_515_decode(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t *bb)
 {
-    // length, MIC (checkum, parity) validated in calling function
+    // length, MIC (checksum, parity) validated in calling function
 
     (void)bitbuffer;
     int exception = 0;

--- a/src/devices/ant_antplus.c
+++ b/src/devices/ant_antplus.c
@@ -96,7 +96,7 @@ static int ant_antplus_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_ABORT_LENGTH;
     }
 
-    // ANT and ANT+ packes have either aa or 55 preamble, depending on the first bit of
+    // ANT and ANT+ packets have either aa or 55 preamble, depending on the first bit of
     // the following byte. i.e. 10101010 1xxxxxxx or 01010101 0xxxxxxx
     // the best way to know which is being used, is to verify which one has a valid CRC
     // the following code relies on the fact that 55 is aa shifted right

--- a/src/devices/archos_tbh.c
+++ b/src/devices/archos_tbh.c
@@ -51,7 +51,7 @@ Raw data frame (power index):
 - Index     {24}
 - Timestamp {34}
 - MaxPower  {16}
-- some additinal data ???
+- some additional data ???
 - CRC8 poly=0x7 the crc includes a length byte at the beginning
 */
 

--- a/src/devices/dsc.c
+++ b/src/devices/dsc.c
@@ -194,7 +194,7 @@ static int dsc_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         // Tamper: 0x10 set or 0x01 unset indicate tamper
         // 0x10 Set to tamper message type (more testing needed)
-        // 0x01 Cleared tamper status (seend during hearbeats)
+        // 0x01 Cleared tamper status (seen during heartbeats)
         s_tamper = ((status & 0x01) != 0x01) || ((status & 0x10) == 0x10);
 
         // "experimental" (naming might change)

--- a/src/devices/fineoffset_ws90.c
+++ b/src/devices/fineoffset_ws90.c
@@ -21,7 +21,7 @@ Fine Offset Electronics WS90 weather station.
 The WS90 is a WS80 with the addition of a piezoelectric rain gauge.
 Data bytes 1-13 are the same between the two models.  The new rain data
 is in bytes 16-20, with bytes 19 and 20 reporting total rain.  Bytes
-17 and 18 are affected by rain, but it is unknow what they report.  Byte
+17 and 18 are affected by rain, but it is unknown what they report.  Byte
 21 reports the voltage of the super cap. And the checksum and CRC
 have been moved to bytes 30 and 31.  What is reported in the other
 bytes is unknown at this time.
@@ -64,7 +64,7 @@ static int fineoffset_ws90_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // Validate package, WS90 nominal size is 330 bit periods
     if (bitbuffer->bits_per_row[0] < 168 || bitbuffer->bits_per_row[0] > 330) {
-        decoder_logf_bitbuffer(decoder, 2, __func__, bitbuffer, "abort lenght" );
+        decoder_logf_bitbuffer(decoder, 2, __func__, bitbuffer, "abort length" );
         return DECODE_ABORT_LENGTH;
     }
 

--- a/src/devices/flowis.c
+++ b/src/devices/flowis.c
@@ -71,7 +71,7 @@ static int flowis_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     bitbuffer_extract_bytes(bitbuffer, row, start_pos + sizeof (preamble) * 8, &len, 8);
 
 
-    uint8_t frame[256+2+1] = {0}; // uint8_t max bytes + 2 bytes crc + 1 lenght byte
+    uint8_t frame[256+2+1] = {0}; // uint8_t max bytes + 2 bytes crc + 1 length byte
     frame[0] = len;
     // Get frame (len don't include the length byte and the crc16 bytes)
     bitbuffer_extract_bytes(bitbuffer, row,

--- a/src/devices/lacrosse_tx31u.c
+++ b/src/devices/lacrosse_tx31u.c
@@ -161,7 +161,7 @@ static int lacrosse_tx31u_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             } break;
             case RAIN: {
                 int raw_rain = (nib1<<8) + (nib2<<4) + nib3; // count of contact closures
-                if ( !no_ext_sensor && raw_rain > 0) { // most of these do not have rain gauges.  Surpress output if zero.
+                if ( !no_ext_sensor && raw_rain > 0) { // most of these do not have rain gauges.  Suppress output if zero.
                     data = data_append( data,
                         "rain",         "raw_rain",     DATA_FORMAT, "%03x", DATA_INT, raw_rain,
                         NULL);
@@ -178,7 +178,7 @@ static int lacrosse_tx31u_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 }
             } break;
             case WIND_MAX: {
-                int wind_input_lost = CHECK_BIT(nib1, 0); // a sensor was attched, but now not detected
+                int wind_input_lost = CHECK_BIT(nib1, 0); // a sensor was attached, but now not detected
                 if ( !no_ext_sensor && !wind_input_lost ) {
                     float wind_max = ((nib2<<4) + nib3) * 0.1f * 3.6; // wind values are decimal m/sec, convert to km/hr
                     data = data_append( data,

--- a/src/devices/maverick_et73x.c
+++ b/src/devices/maverick_et73x.c
@@ -59,7 +59,7 @@ static int maverick_et73x_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     // decode the inner manchester encoding
     bitbuffer_manchester_decode(bitbuffer, 0, 0, &mc, 104);
 
-    // we require 7 bytes 13 nibble rounded up (b[6] highest referance below)
+    // we require 7 bytes 13 nibble rounded up (b[6] highest reference below)
     if (mc.bits_per_row[0] < 52) {
         return DECODE_FAIL_SANITY; // manchester_decode fail
     }

--- a/src/devices/neptune_r900.c
+++ b/src/devices/neptune_r900.c
@@ -111,7 +111,7 @@ static int neptune_r900_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int count = 0;
 
     /*
-     * Each group of four of these chips must be interpretted as a digit in base 6
+     * Each group of four of these chips must be interpreted as a digit in base 6
      *             according to the following mapping:
      * 0011 -> 0
      * 0101 -> 1

--- a/src/devices/tpms_abarth124.c
+++ b/src/devices/tpms_abarth124.c
@@ -27,7 +27,7 @@ Data layout (nibbles):
 - I: 32 bit ID
 - ?: 4 bit unknown (seems to change with status)
 - ?: 4 bit unknown (seems static)
-- P: 8 bit Pressure (multiplyed by 1.38 = kPa)
+- P: 8 bit Pressure (multiplied by 1.38 = kPa)
 - T: 8 bit Temperature (deg. C offset by 50)
 - S: Status? (first nibble seems static, second nibble seems to change with status)
 - C: 8 bit Checksum (Checksum8 XOR on bytes 0 to 8)

--- a/src/devices/tpms_eezrv.c
+++ b/src/devices/tpms_eezrv.c
@@ -29,7 +29,7 @@ Data layout:
 - T: 8 bit temperature   T - 50 = Temperature C
 - F: 8 bit battery (not verified) and deflation pressure (for sure) flags
 
-Raw Data exemple :
+Raw Data example :
 
     ffff 8b 0d177e 8f 4a 10 00
 
@@ -37,7 +37,7 @@ Format string:
 
     CHECKSUM:8h ID:24h KPA:8d TEMP:8d FLAG:4b 4h8h
 
-Decode exemple:
+Decode example:
 
     CHECKSUM:8b ID:0d177e KPA:8f TEMP:4a FLAG:10 00
 

--- a/src/devices/tpms_kia.c
+++ b/src/devices/tpms_kia.c
@@ -26,7 +26,7 @@ Legend:
     z: 16-bit preamble = 0xed71. Must be omitted from Manchester-decoding
     a: Unknown, but 0xf in all my own readings
     p: 8-bit pressure given as PSI * 5
-    t: 8-bit temperature given as Celcius + 50
+    t: 8-bit temperature given as Celsius + 50
     i: 32-bit Sensor ID
     d: Unknown, with different value in each packet
     c: First 5 bits of CRC. We need to append 000 to reach 8 bits. poly=0x07, init=0x76.

--- a/src/devices/tpms_tyreguard400.c
+++ b/src/devices/tpms_tyreguard400.c
@@ -39,7 +39,7 @@ Packet layout:
 
 To peer a new sensor to the unit, bit 79 and 80 has to be both to 1.
 
-NOTE: In the datasheet, it is said that the sensor can report low batterie. During my tests/reseach i'm not able to see this behavior. I have fuzzed all bits nothing was reported to the reader.
+NOTE: In the datasheet, it is said that the sensor can report low batterie. During my tests/research i'm not able to see this behavior. I have fuzzed all bits nothing was reported to the reader.
 
 Flex decoder:
 
@@ -130,7 +130,7 @@ static int tpms_tyreguard400_decode(r_device *decoder, bitbuffer_t *bitbuffer, u
 static int tpms_tyreguard400_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     //uint8_t const tyreguard_frame_sync[] = {0xf, 0xd5, 0xfd, 0x5f}
-    uint8_t const tyreguard_frame_sync[] = {0xfd, 0x5f, 0xd5, 0xf0}; // needs to shift sync to align bytes 28x bits usefull
+    uint8_t const tyreguard_frame_sync[] = {0xfd, 0x5f, 0xd5, 0xf0}; // needs to shift sync to align bytes 28x bits useful
 
     int ret    = 0;
     int events = 0;


### PR DESCRIPTION
Fixed with:
```codespell --ignore-words-list=als,ans,ba,bu,fo,hass,hist,hsa,nd,produkt,proove,te,temperatur,toke,tthe,ue --skip=AUTHORS,CHANGELOG.md,mongoose.* --summary --interactive 2 --write-changes```
 and manual edits.