### PR TITLE
fix malformed json for empty row {0} to "{0}0"

### DIFF
--- a/src/decoder_util.c
+++ b/src/decoder_util.c
@@ -56,6 +56,11 @@ static char *bitrow_asprint_code(uint8_t const *bitrow, unsigned bit_len)
     // remove last nibble if needed
     row_bytes[2 * (bit_len + 3) / 8] = '\0';
 
+    // print at least one '0'
+    if (bit_len == 0) {
+        sprintf(row_bytes, "0");
+    }
+
     // a simple bitrow representation
     row_code = malloc(8 + bit_len / 4 + 1); // "{nnnn}..\0"
     if (!row_code) {

--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -317,6 +317,11 @@ static int flex_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         // add a data line for each getter
         render_getters(row_data[i], bitbuffer->bb[i], params);
 
+        // print at least one '0'
+        if (row_bytes[0] == '\0') {
+            sprintf(row_bytes, "0");
+        }
+
         // a simpler representation for csv output
         row_codes[i] = malloc(8 + bitbuffer->bits_per_row[i] / 4 + 1); // "{nnnn}..\0"
         if (!row_codes[i])


### PR DESCRIPTION
When using 
`rtl_433 -F json -X 'n=raw,m=FSK_MC_ZEROBIT'`
sometimes rtl_433 outputs json containing an invalid dictionary:
`"codes" : [{0}]`

Fix the source to output "{0}0" in case of an empty row.

Closes #2577