### PR TITLE
fix(#2591): Remove device name from Home Assistant entities

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -720,7 +720,7 @@ def sanitize(text):
             .replace(".", "_")
             .replace("&", ""))
 
-def rtl_433_device_info(data, topic_prefix):
+def rtl_433_device_info(data):
     """Return rtl_433 device topic to subscribe to for a data element, based on the
     rtl_433 device topic argument, as well as the device identifier"""
 
@@ -745,7 +745,7 @@ def rtl_433_device_info(data, topic_prefix):
 
     path = ''.join(list(filter(lambda item: item, path_elements)))
     id = '-'.join(id_elements)
-    return (f"{topic_prefix}/{path}", id)
+    return (path, id)
 
 
 def publish_config(mqttc, topic, model, object_id, mapping, key=None):
@@ -807,7 +807,7 @@ def bridge_event_to_hass(mqttc, topic_prefix, data):
     skipped_keys = []
     published_keys = []
 
-    base_topic, device_id = rtl_433_device_info(data, topic_prefix)
+    base_topic, device_id = rtl_433_device_info(data)
     if not device_id:
         # no unique device identifier
         logging.warning("No suitable identifier found for model: ", model)


### PR DESCRIPTION
Fixes #2591 . 
I also propose to give the entities a longer name than we do currently. Since HA will strip the device name, our suffix -T becomes a device called "-T". Instead I propose that we use the human readable sensor name.

This would then look like this with current HA:
![Screenshot from 2023-08-11 13-22-57](https://github.com/merbanan/rtl_433/assets/1876063/42ed841b-72d4-4723-8411-81c7f254e408)
![Screenshot from 2023-08-11 13-18-18](https://github.com/merbanan/rtl_433/assets/1876063/a5fa5d4d-a020-45e1-9932-2f9492910448)

