### PR TITLE
move the ith20r inkbird sensor to use battery_ok and the correct float range for the battery value

### DIFF
--- a/src/devices/inkbird_ith20r.c
+++ b/src/devices/inkbird_ith20r.c
@@ -102,7 +102,7 @@ static int inkbird_ith20r_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     uint32_t subtype = (msg[3] << 24 | msg[2] << 16 | msg[1] << 8 | msg[0]);
     int sensor_num = msg[4];
     uint16_t word56 = (msg[6] << 8 | msg[5]);
-    float battery = msg[7] * 0.01f;
+    float battery_ok = msg[7] * 0.01f;
     uint16_t sensor_id = (msg[9] << 8 | msg[8]);
     float temperature = ((int16_t)(msg[11] << 8 | msg[10])) * 0.1f;
     float temperature_ext = ((int16_t)(msg[13] << 8 | msg[12])) * 0.1f;
@@ -115,7 +115,7 @@ static int inkbird_ith20r_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     data = data_make(
             "model",            "",             DATA_STRING, "Inkbird-ITH20R",
             "id",               "",             DATA_INT,    sensor_id,
-            "battery_ok",       "Battery",      DATA_FORMAT, "%.1f %%", DATA_DOUBLE, battery,
+            "battery_ok",       "Battery",      DATA_DOUBLE, battery_ok,
             "sensor_num",       "",             DATA_INT,    sensor_num,
             "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
             "temperature_2_C",  "Temperature2", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature_ext,

--- a/src/devices/inkbird_ith20r.c
+++ b/src/devices/inkbird_ith20r.c
@@ -131,7 +131,7 @@ static int inkbird_ith20r_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 static char const *const output_fields[] = {
         "model",
         "id",
-        "battery",
+        "battery_ok",
         "sensor_num",
         "temperature_C",
         "temperature_2_C",

--- a/src/devices/inkbird_ith20r.c
+++ b/src/devices/inkbird_ith20r.c
@@ -102,7 +102,7 @@ static int inkbird_ith20r_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     uint32_t subtype = (msg[3] << 24 | msg[2] << 16 | msg[1] << 8 | msg[0]);
     int sensor_num = msg[4];
     uint16_t word56 = (msg[6] << 8 | msg[5]);
-    int battery = msg[7];
+    float battery = msg[7] * 0.01f;
     uint16_t sensor_id = (msg[9] << 8 | msg[8]);
     float temperature = ((int16_t)(msg[11] << 8 | msg[10])) * 0.1f;
     float temperature_ext = ((int16_t)(msg[13] << 8 | msg[12])) * 0.1f;
@@ -115,7 +115,7 @@ static int inkbird_ith20r_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     data = data_make(
             "model",            "",             DATA_STRING, "Inkbird-ITH20R",
             "id",               "",             DATA_INT,    sensor_id,
-            "battery",          "Battery",      DATA_INT,    battery,
+            "battery_ok",       "Battery",      DATA_FORMAT, "%.1f %%", DATA_DOUBLE, battery,
             "sensor_num",       "",             DATA_INT,    sensor_num,
             "mic",              "Integrity",    DATA_STRING, "CRC",
             "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,

--- a/src/devices/inkbird_ith20r.c
+++ b/src/devices/inkbird_ith20r.c
@@ -117,10 +117,10 @@ static int inkbird_ith20r_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             "id",               "",             DATA_INT,    sensor_id,
             "battery_ok",       "Battery",      DATA_FORMAT, "%.1f %%", DATA_DOUBLE, battery,
             "sensor_num",       "",             DATA_INT,    sensor_num,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
             "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
             "temperature_2_C",  "Temperature2", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature_ext,
             "humidity",         "Humidity",     DATA_FORMAT, "%.1f %%", DATA_DOUBLE, humidity,
+            "mic",              "Integrity",    DATA_STRING, "CRC",
             NULL);
     /* clang-format on */
 
@@ -133,10 +133,10 @@ static char const *const output_fields[] = {
         "id",
         "battery",
         "sensor_num",
-        "mic",
         "temperature_C",
         "temperature_2_C",
         "humidity",
+        "mic",
         NULL,
 };
 


### PR DESCRIPTION
The inkbird ith20r use the wrong name and format for the battery data.

Based on feedback from abandoned PR https://github.com/merbanan/rtl_433/pull/2595