### PR TITLE
Add support for Govee water sensors to rtl_433_mqtt_hass

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -236,6 +236,18 @@ mappings = {
         }
     },
 
+    "detect_wet": {
+        "device_type": "binary_sensor",
+        "object_suffix": "moisture",
+        "config": {
+            "name": "Water Sensor",
+            "device_class": "moisture",
+            "force_update": "true",
+            "payload_on": "1",
+            "payload_off": "0"
+        }
+    },
+
     "pressure_hPa": {
         "device_type": "sensor",
         "object_suffix": "P",


### PR DESCRIPTION
This PR adds support for auto-discovering Govee water leak detectors and configuring them as binary moisture sensors. Moisture sensor configuration fields are modeled after the existing alarm and tamper binary sensors.  This code has been tested with Govee Water Leak Detectors model H5054.

As discussed in https://github.com/merbanan/rtl_433/issues/2404, some versions of the these Govee water sensors report a `leak_num` field while while others do not. This change attempts to address both versions of the sensor by relying on the `event` field instead. Since the `event` field is present in many different sensors' data, it is necessary to examine the contents of the field to verify that the mqtt data does indeed pertain to a water sensor. The logic to compare the contents of a field to a predetermined value has been added generically and could be used to aid in the discovery of other sensors in the future.

Note: The logic in `bridge_event_to_hass` was originally written as follows:
```
    # detect known attributes
    for key in data.keys():
        if key in mappings:
            if "value" in mappings[key] and mappings[key]["value"] != data[key]: continue
```
However, this prevents keys associated with a mapping  that has a value field whose value field does not match from being added to the `skipped_keys` list so it was necessary to combine the new conditional logic with the main if statement.