### PR TITLE
Improve handling of units within HA UI

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -264,6 +264,7 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "WS",
         "config": {
+            "device_class": "wind_speed",
             "name": "Wind Speed",
             "unit_of_measurement": "km/h",
             "value_template": "{{ value|float }}",
@@ -275,6 +276,7 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "WS",
         "config": {
+            "device_class": "wind_speed",
             "name": "Wind Speed",
             "unit_of_measurement": "km/h",
             "value_template": "{{ value|float }}",
@@ -286,6 +288,7 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "WS",
         "config": {
+            "device_class": "wind_speed",
             "name": "Wind Speed",
             "unit_of_measurement": "mi/h",
             "value_template": "{{ value|float }}",
@@ -297,6 +300,7 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "WS",
         "config": {
+            "device_class": "wind_speed",
             "name": "Wind Average",
             "unit_of_measurement": "km/h",
             "value_template": "{{ (float(value|float) * 3.6) | round(2) }}",
@@ -308,6 +312,7 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "WS",
         "config": {
+            "device_class": "wind_speed",
             "name": "Wind Speed",
             "unit_of_measurement": "km/h",
             "value_template": "{{ float(value|float) * 3.6 }}",
@@ -319,6 +324,7 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "GS",
         "config": {
+            "device_class": "wind_speed",
             "name": "Gust Speed",
             "unit_of_measurement": "km/h",
             "value_template": "{{ value|float }}",
@@ -330,6 +336,7 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "GS",
         "config": {
+            "device_class": "wind_speed",
             "name": "Wind max speed",
             "unit_of_measurement": "km/h",
             "value_template": "{{ value|float }}",
@@ -341,6 +348,7 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "GS",
         "config": {
+            "device_class": "wind_speed",
             "name": "Wind max",
             "unit_of_measurement": "km/h",
             "value_template": "{{ (float(value|float) * 3.6) | round(2) }}",
@@ -352,6 +360,7 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "GS",
         "config": {
+            "device_class": "wind_speed",
             "name": "Gust Speed",
             "unit_of_measurement": "km/h",
             "value_template": "{{ float(value|float) * 3.6 }}",
@@ -374,6 +383,7 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "RT",
         "config": {
+            "device_class": "precipitation",
             "name": "Rain Total",
             "unit_of_measurement": "mm",
             "value_template": "{{ value|float|round(2) }}",
@@ -385,6 +395,7 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "RR",
         "config": {
+            "device_class": "precipitation_intensity",
             "name": "Rain Rate",
             "unit_of_measurement": "mm/h",
             "value_template": "{{ value|float }}",
@@ -396,6 +407,7 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "RT",
         "config": {
+            "device_class": "precipitation",
             "name": "Rain Total",
             "unit_of_measurement": "mm",
             "value_template": "{{ (float(value|float) * 25.4) | round(2) }}",
@@ -407,6 +419,7 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "RR",
         "config": {
+            "device_class": "precipitation_intensity",
             "name": "Rain Rate",
             "unit_of_measurement": "mm/h",
             "value_template": "{{ (float(value|float) * 25.4) | round(2) }}",


### PR DESCRIPTION
By changing the device_class attribute to be "wind_speed" or "precipitation", this allows the lovelace UI in HomeAssistant to automatically do unit conversions through the UI. I tested these changes locally and they worked after removing the device from the MQTT integration and running this python script to re-preform the autodiscovery.

Valid device classes can be found here: https://www.home-assistant.io/integrations/sensor/#device-class