### PR TITLE
Removed depreciated option -M newmodel from rtl_433_mqtt_hass.py documentation

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -18,7 +18,7 @@ as device topics by MQTT.
 """
 
 AP_EPILOG="""
-It is strongly recommended to run rtl_433 with "-C si" and "-M newmodel".
+It is strongly recommended to run rtl_433 with "-C si".
 This script requires rtl_433 to publish both event messages and device
 messages. If you've changed the device topic in rtl_433, use the same device
 topic with the "-T" parameter.


### PR DESCRIPTION
`-M newmodel` option is removed from some time.
When used, warning message "depreciated" is shown.

The commit modifies only documentation for `rtl_433_mqtt_hass.py` Python script..
