### PR TITLE
Refactor to type-safe data-api

### DIFF
--- a/include/data.h
+++ b/include/data.h
@@ -40,6 +40,7 @@
 #endif
 
 #include <stddef.h>
+#include <stdint.h>
 
 typedef enum {
     DATA_DATA,   /**< pointer to data is stored */
@@ -109,17 +110,49 @@ typedef struct data {
 */
 R_API data_t *data_make(const char *key, const char *pretty_key, ...);
 
-/** Adds to a structured data object, by appending data.
-
-    @see data_make()
-*/
-R_API data_t *data_append(data_t *first, const char *key, const char *pretty_key, ...);
-
 /** Adds to a structured data object, by prepending data.
 
     @see data_make()
 */
 R_API data_t *data_prepend(data_t *first, const char *key, const char *pretty_key, ...);
+
+/** Adds to a structured data object, by appending `int` data.
+
+    Type-safe alternative to `data_make()` and `data_append()`.
+*/
+R_API data_t *data_int(data_t *first, char const *key, char const *pretty_key, char const *format, int val);
+
+/** Adds to a structured data object, by appending `double` data.
+
+    Type-safe alternative to `data_make()` and `data_append()`.
+*/
+R_API data_t *data_dbl(data_t *first, char const *key, char const *pretty_key, char const *format, double val);
+
+/** Adds to a structured data object, by appending string data.
+
+    Type-safe alternative to `data_make()` and `data_append()`.
+*/
+R_API data_t *data_str(data_t *first, char const *key, char const *pretty_key, char const *format, char const *val);
+
+/** Adds to a structured data object, by appending `data_array_t` data.
+
+    Type-safe alternative to `data_make()` and `data_append()`.
+*/
+R_API data_t *data_ary(data_t *first, char const *key, char const *pretty_key, char const *format, data_array_t *val);
+
+/** Adds to a structured data object, by appending `data_t` data.
+
+    Type-safe alternative to `data_make()` and `data_append()`.
+*/
+R_API data_t *data_dat(data_t *first, char const *key, char const *pretty_key, char const *format, data_t *val);
+
+/** Adds to a structured data object, by appending hex string data.
+
+    Type-safe alternative to `data_make()` and `data_append()`.
+
+    Caller needs to provide a sufficiently sized buffer.
+*/
+R_API data_t *data_hex(data_t *first, char const *key, char const *pretty_key, char const *format, uint8_t const *val, unsigned len, char *buf);
 
 /** Constructs an array from given data of the given uniform type.
 

--- a/src/data.c
+++ b/src/data.c
@@ -181,10 +181,13 @@ static data_t *vdata_make(data_t *first, const char *key, const char *pretty_key
                 fprintf(stderr, "vdata_make() format type used twice\n");
                 goto alloc_error;
             }
-            format = strdup(va_arg(ap, char *));
-            if (!format) {
-                WARN_STRDUP("vdata_make()");
-                goto alloc_error;
+            format = va_arg(ap, char *);
+            if (format) {
+                format = strdup(format);
+                if (!format) {
+                    WARN_STRDUP("vdata_make()");
+                    goto alloc_error;
+                }
             }
             type = va_arg(ap, data_type_t);
             continue;
@@ -203,7 +206,7 @@ static data_t *vdata_make(data_t *first, const char *key, const char *pretty_key
             break;
         case DATA_STRING:
             value_release = (value_release_fn)free; // appease CSA checker
-            value.v_ptr = strdup(va_arg(ap, char *));
+            value.v_ptr = strdup(va_arg(ap, char const *));
             if (!value.v_ptr)
                 WARN_STRDUP("vdata_make()");
             break;
@@ -284,7 +287,7 @@ R_API data_t *data_make(const char *key, const char *pretty_key, ...)
     return result;
 }
 
-R_API data_t *data_append(data_t *first, const char *key, const char *pretty_key, ...)
+static data_t *data_append(data_t *first, const char *key, const char *pretty_key, ...)
 {
     va_list ap;
     va_start(ap, pretty_key);
@@ -309,6 +312,42 @@ R_API data_t *data_prepend(data_t *first, const char *key, const char *pretty_ke
     prev->next = first;
 
     return result;
+}
+
+// Wrappers for now, should be refactored.
+R_API data_t *data_int(data_t *first, char const *key, char const *pretty_key, char const *format, int val)
+{
+    return data_append(first, key, pretty_key, DATA_FORMAT, format, DATA_INT, val, NULL);
+}
+R_API data_t *data_dbl(data_t *first, char const *key, char const *pretty_key, char const *format, double val)
+{
+    return data_append(first, key, pretty_key, DATA_FORMAT, format, DATA_DOUBLE, val, NULL);
+}
+R_API data_t *data_str(data_t *first, char const *key, char const *pretty_key, char const *format, char const *val)
+{
+    return data_append(first, key, pretty_key, DATA_FORMAT, format, DATA_STRING, val, NULL);
+}
+R_API data_t *data_ary(data_t *first, char const *key, char const *pretty_key, char const *format, data_array_t *val)
+{
+    return data_append(first, key, pretty_key, DATA_FORMAT, format, DATA_ARRAY, val, NULL);
+}
+R_API data_t *data_dat(data_t *first, char const *key, char const *pretty_key, char const *format, data_t *val)
+{
+    return data_append(first, key, pretty_key, DATA_FORMAT, format, DATA_DATA, val, NULL);
+}
+R_API data_t *data_hex(data_t *first, char const *key, char const *pretty_key, char const *format, uint8_t const *val, unsigned len, char *buf)
+{
+    if (!format || !*format) {
+        format = "%02x";
+    }
+
+    char *p = buf;
+    for (unsigned i = 0; i < len; i += 1) {
+        p += sprintf(p, format, val[i]);
+    }
+    *p = '\0';
+
+    return data_append(first, key, pretty_key, DATA_FORMAT, format, DATA_STRING, val, NULL);
 }
 
 R_API void data_array_free(data_array_t *array)

--- a/src/data_tag.c
+++ b/src/data_tag.c
@@ -280,9 +280,7 @@ static data_t *append_filtered_json(data_t *data, char const *json, char const *
             int len = MIN(v->end - v->start, (int)sizeof(buf) - 1);
             memcpy(buf, json + v->start, len);
             buf[len] = '\0';
-            data = data_append(data,
-                    key, "", DATA_STRING, buf,
-                    NULL);
+            data = data_str(data, key, "", NULL, buf);
         }
     }
 
@@ -299,9 +297,7 @@ data_t *data_tag_apply(data_tag_t *tag, data_t *data, char const *filename)
                 // wrap tag includes
                 data_t *obj = append_filtered_json(NULL, val, tag->includes);
                 // append tag wrapper
-                data = data_append(data,
-                        tag->key, "", DATA_DATA, obj,
-                        NULL);
+                data = data_dat(data, tag->key, "", NULL, obj);
             }
             else {
                 // append tag includes
@@ -310,9 +306,7 @@ data_t *data_tag_apply(data_tag_t *tag, data_t *data, char const *filename)
         }
         else {
             // append tag string
-            data = data_append(data,
-                    tag->key, "", DATA_STRING, val,
-                    NULL);
+            data = data_str(data, tag->key, "", NULL, val);
         }
         return data;
     }

--- a/src/decoder_util.c
+++ b/src/decoder_util.c
@@ -179,9 +179,7 @@ void decoder_log_bitbuffer(r_device *decoder, int level, char const *func, const
         /* clang-format on */
 
         if (decoder->verbose_bits) {
-            data_append(data,
-                    "bits", "", DATA_ARRAY, data_array(num_rows, DATA_STRING, row_bits),
-                    NULL);
+            data = data_ary(data, "bits", "", NULL, data_array(num_rows, DATA_STRING, row_bits));
         }
 
         decoder_output_log(decoder, level, data);
@@ -229,9 +227,7 @@ void decoder_log_bitrow(r_device *decoder, int level, char const *func, uint8_t 
 
         if (decoder->verbose_bits) {
             row_bits = bitrow_asprint_bits(bitrow, bit_len);
-            data_append(data,
-                    "bits", "", DATA_STRING, row_bits,
-                    NULL);
+            data = data_str(data, "bits", "", NULL, row_bits);
         }
 
         decoder_output_log(decoder, level, data);

--- a/src/devices/digitech_xc0324.c
+++ b/src/devices/digitech_xc0324.c
@@ -181,8 +181,7 @@ static int digitech_xc0324_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             // Keep production output (decoder_verbose == 0) separate from
             // (simulated) development stage output (decoder_verbose > 0)
             if (events > 0 && !decoder_verbose(decoder)) { // Production output
-                data_append(data,
-                        "message_num", "Message repeat count", DATA_INT, events, NULL);
+                data = data_int(data, "message_num", "Message repeat count", NULL, events);
                 decoder_output_data(decoder, data);
                 return events; // in production, first successful decode is enough
             }

--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -125,22 +125,12 @@ static void render_getters(data_t *data, uint8_t *bits, struct flex_params *para
         int m;
         for (m = 0; getter->map[m].val; m++) {
             if (getter->map[m].key == val) {
-                data_append(data,
-                        getter->name, "", DATA_STRING, getter->map[m].val,
-                        NULL);
+                data_str(data, getter->name, "", NULL, getter->map[m].val);
                 break;
             }
         }
         if (!getter->map[m].val) {
-            if (getter->format) {
-                data_append(data,
-                    getter->name, "", DATA_FORMAT, getter->format, DATA_INT, val,
-                    NULL);
-            } else {
-                data_append(data,
-                        getter->name, "", DATA_INT, val,
-                        NULL);
-            }
+            data_int(data, getter->name, "", getter->format, val);
         }
     }
 }

--- a/src/devices/lacrosse_tx31u.c
+++ b/src/devices/lacrosse_tx31u.c
@@ -149,41 +149,31 @@ static int lacrosse_tx31u_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         switch (type) {
             case TEMP: {
                 float temp_c = 10*nib1 + nib2 + 0.1f*nib3 - 40.0f; // BCD offset 40 deg C
-                data = data_append( data,
-                    "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-                    NULL);
+                data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C", temp_c);
             } break;
             case HUMIDITY: {
                 int humidity = 100*nib1 + 10*nib2 + nib3; // BCD %
-                data = data_append( data,
-                    "humidity",         "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, humidity,
-                    NULL);
+                data = data_int(data, "humidity",         "Humidity",     "%u %%",  humidity);
             } break;
             case RAIN: {
                 int raw_rain = (nib1<<8) + (nib2<<4) + nib3; // count of contact closures
                 if ( !no_ext_sensor && raw_rain > 0) { // most of these do not have rain gauges.  Suppress output if zero.
-                    data = data_append( data,
-                        "rain",         "raw_rain",     DATA_FORMAT, "%03x", DATA_INT, raw_rain,
-                        NULL);
+                    data = data_int(data, "rain",         "raw_rain",     "%03x",   raw_rain);
                 }
             } break;
             case WIND_AVG: {
                 if ( !no_ext_sensor ) {
                     float wind_dir = nib1 * 22.5 ; // compass direction in degrees
                     float wind_avg = ((nib2<<4) + nib3) * 0.1f * 3.6; // wind values are decimal m/sec, convert to km/hr
-                    data = data_append( data,
-                        "wind_dir_deg",   "Wind direction",  DATA_FORMAT, "%.1f",       DATA_DOUBLE, wind_dir,
-                        "wind_avg_km_h",  "Wind speed",      DATA_FORMAT, "%.1f km/h",  DATA_DOUBLE, wind_avg,
-                        NULL);
+                    data = data_dbl(data, "wind_dir_deg",   "Wind direction",   "%.1f",       wind_dir);
+                    data = data_dbl(data, "wind_avg_km_h",  "Wind speed",       "%.1f km/h",  wind_avg);
                 }
             } break;
             case WIND_MAX: {
                 int wind_input_lost = CHECK_BIT(nib1, 0); // a sensor was attached, but now not detected
                 if ( !no_ext_sensor && !wind_input_lost ) {
                     float wind_max = ((nib2<<4) + nib3) * 0.1f * 3.6; // wind values are decimal m/sec, convert to km/hr
-                    data = data_append( data,
-                        "wind_max_km_h",  "Wind gust",    DATA_FORMAT, "%.1f km/h",  DATA_DOUBLE, wind_max,
-                        NULL);
+                    data = data_dbl(data, "wind_max_km_h",  "Wind gust",     "%.1f km/h",  wind_max);
                 }
             } break;
             default:
@@ -192,9 +182,7 @@ static int lacrosse_tx31u_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         }
     }
 
-    data = data_append( data,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = data_str(data, "mic",              "Integrity",  NULL,   "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -852,23 +852,19 @@ void data_acquired_handler(r_device *r_dev, data_t *data)
     }
 
     if (cfg->report_meta && cfg->demod->fsk_pulse_data.fsk_f2_est) {
-        data_append(data,
-                "mod",   "Modulation",  DATA_STRING, "FSK",
-                "freq1", "Freq1",       DATA_FORMAT, "%.1f MHz", DATA_DOUBLE, cfg->demod->fsk_pulse_data.freq1_hz / 1000000.0,
-                "freq2", "Freq2",       DATA_FORMAT, "%.1f MHz", DATA_DOUBLE, cfg->demod->fsk_pulse_data.freq2_hz / 1000000.0,
-                "rssi",  "RSSI",        DATA_FORMAT, "%.1f dB", DATA_DOUBLE, cfg->demod->fsk_pulse_data.rssi_db,
-                "snr",   "SNR",         DATA_FORMAT, "%.1f dB", DATA_DOUBLE, cfg->demod->fsk_pulse_data.snr_db,
-                "noise", "Noise",       DATA_FORMAT, "%.1f dB", DATA_DOUBLE, cfg->demod->fsk_pulse_data.noise_db,
-                NULL);
+        data = data_str(data, "mod",   "Modulation",  NULL,         "FSK");
+        data = data_dbl(data, "freq1", "Freq1",       "%.1f MHz",   cfg->demod->fsk_pulse_data.freq1_hz / 1000000.0);
+        data = data_dbl(data, "freq2", "Freq2",       "%.1f MHz",   cfg->demod->fsk_pulse_data.freq2_hz / 1000000.0);
+        data = data_dbl(data, "rssi",  "RSSI",        "%.1f dB",    cfg->demod->fsk_pulse_data.rssi_db);
+        data = data_dbl(data, "snr",   "SNR",         "%.1f dB",    cfg->demod->fsk_pulse_data.snr_db);
+        data = data_dbl(data, "noise", "Noise",       "%.1f dB",    cfg->demod->fsk_pulse_data.noise_db);
     }
     else if (cfg->report_meta) {
-        data_append(data,
-                "mod",   "Modulation",  DATA_STRING, "ASK",
-                "freq",  "Freq",        DATA_FORMAT, "%.1f MHz", DATA_DOUBLE, cfg->demod->pulse_data.freq1_hz / 1000000.0,
-                "rssi",  "RSSI",        DATA_FORMAT, "%.1f dB", DATA_DOUBLE, cfg->demod->pulse_data.rssi_db,
-                "snr",   "SNR",         DATA_FORMAT, "%.1f dB", DATA_DOUBLE, cfg->demod->pulse_data.snr_db,
-                "noise", "Noise",       DATA_FORMAT, "%.1f dB", DATA_DOUBLE, cfg->demod->pulse_data.noise_db,
-                NULL);
+        data = data_str(data, "mod",   "Modulation",  NULL,         "ASK");
+        data = data_dbl(data, "freq",  "Freq",        "%.1f MHz",   cfg->demod->pulse_data.freq1_hz / 1000000.0);
+        data = data_dbl(data, "rssi",  "RSSI",        "%.1f dB",    cfg->demod->pulse_data.rssi_db);
+        data = data_dbl(data, "snr",   "SNR",         "%.1f dB",    cfg->demod->pulse_data.snr_db);
+        data = data_dbl(data, "noise", "Noise",       "%.1f dB",    cfg->demod->pulse_data.noise_db);
     }
 
     // prepend "time" if requested
@@ -919,25 +915,15 @@ data_t *create_report_data(r_cfg_t *cfg, int level)
                 NULL);
 
         if (r_dev->decode_fails[-DECODE_FAIL_OTHER])
-            data_append(data,
-                    "fail_other",   "", DATA_INT, r_dev->decode_fails[-DECODE_FAIL_OTHER],
-                    NULL);
+            data = data_int(data, "fail_other",   "", NULL, r_dev->decode_fails[-DECODE_FAIL_OTHER]);
         if (r_dev->decode_fails[-DECODE_ABORT_LENGTH])
-            data_append(data,
-                    "abort_length", "", DATA_INT, r_dev->decode_fails[-DECODE_ABORT_LENGTH],
-                    NULL);
+            data = data_int(data, "abort_length", "", NULL, r_dev->decode_fails[-DECODE_ABORT_LENGTH]);
         if (r_dev->decode_fails[-DECODE_ABORT_EARLY])
-            data_append(data,
-                    "abort_early",  "", DATA_INT, r_dev->decode_fails[-DECODE_ABORT_EARLY],
-                    NULL);
+            data = data_int(data, "abort_early",  "", NULL, r_dev->decode_fails[-DECODE_ABORT_EARLY]);
         if (r_dev->decode_fails[-DECODE_FAIL_MIC])
-            data_append(data,
-                    "fail_mic",     "", DATA_INT, r_dev->decode_fails[-DECODE_FAIL_MIC],
-                    NULL);
+            data = data_int(data, "fail_mic",     "", NULL, r_dev->decode_fails[-DECODE_FAIL_MIC]);
         if (r_dev->decode_fails[-DECODE_FAIL_SANITY])
-            data_append(data,
-                    "fail_sanity",  "", DATA_INT, r_dev->decode_fails[-DECODE_FAIL_SANITY],
-                    NULL);
+            data = data_int(data, "fail_sanity",  "", NULL, r_dev->decode_fails[-DECODE_FAIL_SANITY]);
 
         list_push(&dev_data_list, data);
     }

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1398,28 +1398,22 @@ static void sdr_handler(struct mg_connection *nc, int ev_type, void *ev_data)
     data_t *data = NULL;
     if (ev->ev & SDR_EV_RATE) {
         // cfg->samp_rate = ev->sample_rate;
-        data = data_append(data,
-                "sample_rate", "", DATA_INT, ev->sample_rate,
-                NULL);
+        data = data_int(data, "sample_rate", "", NULL, ev->sample_rate);
     }
     if (ev->ev & SDR_EV_CORR) {
         // cfg->ppm_error = ev->freq_correction;
-        data = data_append(data,
-                "freq_correction", "", DATA_INT, ev->freq_correction,
-                NULL);
+        data = data_int(data, "freq_correction", "", NULL, ev->freq_correction);
     }
     if (ev->ev & SDR_EV_FREQ) {
         // cfg->center_frequency = ev->center_frequency;
-        data = data_append(data,
-                "center_frequency", "", DATA_INT, ev->center_frequency,
-                "frequencies", "", DATA_COND, cfg->frequencies > 1, DATA_ARRAY, data_array(cfg->frequencies, DATA_INT, cfg->frequency),
-                "hop_times", "", DATA_COND, cfg->frequencies > 1, DATA_ARRAY, data_array(cfg->hop_times, DATA_INT, cfg->hop_time),
-                NULL);
+        data = data_int(data, "center_frequency", "", NULL, ev->center_frequency);
+        if (cfg->frequencies > 1) {
+            data = data_ary(data, "frequencies", "", NULL, data_array(cfg->frequencies, DATA_INT, cfg->frequency));
+            data = data_ary(data, "hop_times", "", NULL, data_array(cfg->hop_times, DATA_INT, cfg->hop_time));
+        }
     }
     if (ev->ev & SDR_EV_GAIN) {
-        data = data_append(data,
-                "gain", "", DATA_STRING, ev->gain_str,
-                NULL);
+        data = data_str(data, "gain", "", NULL, ev->gain_str);
     }
     if (data) {
         event_occurred_handler(cfg, data);

--- a/tests/symbolizer.py
+++ b/tests/symbolizer.py
@@ -240,8 +240,12 @@ def process_source(path, name):
                     links[fName].update({"doc_line": dLine, "doc": doc})
                     doc = None
                 continue
+            # Match the prefix string up to "TheModelName"
             # "model", "", DATA_STRING, "Schrader",
             m = re.match(r'\s*"model"\s*,.*DATA_STRING', line)
+            if not m:
+                # data_t *data = data_str(NULL, "model", "", NULL, "Honeywell-CM921");
+                m = re.match(r'.*data_str\([^,]*\s*,\s*"model"\s*,[^,]*,[^,]*,', line)
             if m:
                 prefix = m.group(0)
                 s = line[len(prefix):]


### PR DESCRIPTION
There are a few example use-cases now that use the protocol decoders.
This entails using the whole data_t plumbing and some of the outputs.
We should make it easier to decouple data output in decoders from the current implementation details.

This can be achieved by moving from one big varargs list in `data_make()` to individual `data_append_x()` calls.
(Users of the decoders can then easily provide their own stubs for these simple functions.)

The changes to `bresser_3ch.c` are a simple sketch how this could look (other changes just to have it compiling).
(Likely the final type used/passed would not be `*data_t / *data` but a wrapper type)

Pros:
- Syntax checking for each output
- Semantic help from IDEs
- Flexible prototypes for the calls (e.g. we could pass something like two ints to represent a complex number ;)
- Easier to extend (the calls do not need to look that much like the resulting data structure)
- (no vararg magic)

Cons:
- maybe a slight overhead from issuing ~10 calls instead of one big vararg call (this is offset by not dealing with varargs setup/teardown though)
- Need to bulk replace existing `data_make()`s