### PR TITLE
Fix id_rev portion of hcs200

### DIFF
--- a/src/devices/hcs200.c
+++ b/src/devices/hcs200.c
@@ -58,7 +58,7 @@ static int hcs200_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // The transmission is LSB first, big endian.
     uint32_t encrypted = ((unsigned)reverse8(b[3]) << 24) | (reverse8(b[2]) << 16) | (reverse8(b[1]) << 8) | (reverse8(b[0]));
-    int serial         = (reverse8(b[7] & 0xf0) << 24) | (reverse8(b[6]) << 16) | (reverse8(b[5]) << 8) | (reverse8(b[4]));
+    int serial         = (reverse8(b[7] & 0xff) << 24) | (reverse8(b[6]) << 16) | (reverse8(b[5]) << 8) | (reverse8(b[4]));
     int btn            = (b[7] & 0x0f);
     int btn_num        = (btn & 0x08) | ((btn & 0x01) << 2) | (btn & 0x02) | ((btn & 0x04) >> 2); // S3, S0, S1, S2
     int learn          = (b[7] & 0x0f) == 0x0f;


### PR DESCRIPTION
Correctly display ID_rev portion. 

Current decoder uses & 0xf0, when tested with a Doorhan remote with id_rev of A29D6890, rtl_433 shows id_rev A9D68900 (attached).

Using & 0xff gives the expected A29D6890.

![rtl](https://github.com/merbanan/rtl_433/assets/85343771/94fc9d20-4e61-4afc-9009-c81f949a9743)
