### PR TITLE
QUAL Fix spelling (identified with codespell)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,7 +155,7 @@
 ### Highlights
 
 - Last release to support Autotools (autoconf, automake) builds (#1644)
-- Last release to offer "oldmodel" keys (deprected since 2020)
+- Last release to offer "oldmodel" keys (deprecated since 2020)
 - Added Github Release builds for Windows
 - Added GPSd tags option (#1636)
 - Added optional TLS support to MQTT (#1633)

--- a/src/devices/blyss.c
+++ b/src/devices/blyss.c
@@ -13,7 +13,7 @@ Generic remote Blyss DC5-UK-WH as sold by B&Q.
 
 DC5-UK-WH pair with receivers, the codes used may be specific to a receiver - use with caution
 
-warmup pulse 5552 us, 2072 gap
+warm-up pulse 5552 us, 2072 gap
 short is 512 us pulse, 1484 us gap
 long is 1508 us pulse, 488 us gap
 packet gap is 6964 us

--- a/src/devices/ecodhome.c
+++ b/src/devices/ecodhome.c
@@ -67,7 +67,7 @@ Data Seen:
     52315c6a 7700 565a 007b00
     52315c6a 7700 565a 007a00
 
-Removing the first 1 or 2 bits gives a prefix of 55a8aaaaaa2dd4, the leading bits are likely warmup or garbage.
+Removing the first 1 or 2 bits gives a prefix of 55a8aaaaaa2dd4, the leading bits are likely warm-up or garbage.
 
 The next bytes of 5231 5c6a 7700 are likely a serial number (id).
 

--- a/src/devices/hcs200.c
+++ b/src/devices/hcs200.c
@@ -25,7 +25,7 @@ Hardware buttons might map to combinations of these bits.
 - Datasheet HCS200: http://ww1.microchip.com/downloads/en/devicedoc/40138c.pdf
 - Datasheet HCS300: http://ww1.microchip.com/downloads/en/devicedoc/21137g.pdf
 
-The warmup of 12 short pulses is followed by a long 4400 us gap.
+The warm-up of 12 short pulses is followed by a long 4400 us gap.
 There are two packets with a 17500 us gap.
 
 rtl_433 -R 0 -X 'n=hcs200,m=OOK_PWM,s=370,l=772,r=9000,g=1500,t=152'

--- a/src/devices/honeywell_cm921.c
+++ b/src/devices/honeywell_cm921.c
@@ -75,7 +75,7 @@ static const dev_map_entry_t device_map[] = {
         {.t = 10, .s = "OTB"}, // OpenTherm bridge (R8810)
         {.t = 12, .s = "THm"}, // Thermostat with setpoint schedule control (DTS92E, CME921)
         {.t = 13, .s = "BDR"}, // Wireless relay box (BDR91) (HC60NG too?)
-        {.t = 17, .s = " 17"}, // Dunno - Outside weather sensor?
+        {.t = 17, .s = " 17"}, // Unknown - Outside weather sensor?
         {.t = 18, .s = "HGI"}, // Honeywell Gateway Interface (HGI80, HGS80)
         {.t = 22, .s = "THM"}, // Thermostat with setpoint schedule control (DTS92E)
         {.t = 30, .s = "GWY"}, // Gateway (e.g. RFG100?)


### PR DESCRIPTION
Fixed spelling typos - mostly identified using codespell.