### PR TITLE
Do not use xor which is equivalent to ^

### DIFF
--- a/src/devices/funkbus.c
+++ b/src/devices/funkbus.c
@@ -74,12 +74,12 @@ static uint8_t calc_checksum(uint8_t const *bitrow, unsigned len)
     const uint8_t full_bytes = len / 8;
     const uint8_t bits_left  = len % 8;
 
-    uint8_t xor = xor_bytes(bitrow, full_bytes);
+    uint8_t xor_byte = xor_bytes(bitrow, full_bytes);
     if (bits_left) {
-        xor ^= bitrow[full_bytes] & ~BIT_MASK(8 - bits_left);
+        xor_byte ^= bitrow[full_bytes] & ~BIT_MASK(8 - bits_left);
     }
 
-    const uint8_t xor_nibble = ((xor&0xF0) >> 4) ^ (xor&0x0F);
+    const uint8_t xor_nibble = ((xor_byte&0xF0) >> 4) ^ (xor_byte&0x0F);
 
     uint8_t result = 0;
     if (xor_nibble & 0x8) {
@@ -96,7 +96,7 @@ static uint8_t calc_checksum(uint8_t const *bitrow, unsigned len)
     }
 
     result = result & 0xF;
-    result |= (parity8(xor) << 4);
+    result |= (parity8(xor_byte) << 4);
 
     return result;
 }

--- a/src/devices/norgo.c
+++ b/src/devices/norgo.c
@@ -141,10 +141,10 @@ static int norgo_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_ABORT_EARLY;
     }
 
-    int xor = xor_bytes(b + 1, (bitbuffer->bits_per_row[0] - 15) / 8);
-    if (xor != 0xff) { // before invert 0 is ff
+    int xor_byte = xor_bytes(b + 1, (bitbuffer->bits_per_row[0] - 15) / 8);
+    if (xor_byte != 0xff) { // before invert 0 is ff
         decoder_logf_bitrow(decoder, 1, __func__, b, bitbuffer->bits_per_row[0], "XOR fail (%02x)",
-                    xor);
+                    xor_byte);
         return DECODE_FAIL_MIC;
     }
 


### PR DESCRIPTION
xor is an alternative for '^' and should be avoided.

The code was updated to use 'xor_byte' as the name for the variable.