### PR TITLE
Merge Carchet TPMS with EezTire TPMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
 ```
 
   A "rtl_433.conf" file is searched in "./", XDG_CONFIG_HOME e.g. "$HOME/.config/rtl_433/",
-  "/usr/local/etc/rtl_433/", "/etc/rtl_433/", then command line args will be parsed in order.
+  SYSCONFDIR e.g. "/usr/local/etc/rtl_433/", then command line args will be parsed in order.
 		= General options =
   [-V] Output the version string and exit
   [-v] Increase verbosity (can be used multiple times).
@@ -314,7 +314,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [226]  Kia TPMS (-s 1000k)
     [227]  SRSmith Pool Light Remote Control SRS-2C-TX (-f 915M)
     [228]  Neptune R900 flow meters
-    [229]* WEC-2103 temperature/humidity sensor
+    [229]  WEC-2103 temperature/humidity sensor
     [230]  Vauno EN8822C
     [231]  Govee Water Leak Detector H5054
     [232]  TFA Dostmann 14.1504.V2 Radio-controlled grill and meat thermometer
@@ -326,7 +326,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [238]  Wireless M-Bus, Mode T, 32.768kbps (-f 868.3M -s 1000k)
     [239]  Revolt NC-5642 Energy Meter
     [240]  LaCrosse TX31U-IT, The Weather Channel WS-1910TWC-IT
-    [241]  EezTire E618 (TPMS10ATC)
+    [241]  EezTire E618
     [242]* Baldr / RainPoint rain gauge.
     [243]  Celsia CZC1 Thermostat
     [244]  Fine Offset Electronics WS90 weather station
@@ -342,7 +342,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
   [-d <RTL-SDR USB device index>] (default: 0)
   [-d :<RTL-SDR USB device serial (can be set with rtl_eeprom -s)>]
 	To set gain for RTL-SDR use -g <gain> to set an overall gain in dB.
-	SoapySDR device driver is available.
+	SoapySDR device driver is not available.
   [-d ""] Open default SoapySDR device
   [-d driver=rtlsdr] Open e.g. specific SoapySDR device
 	To set gain for SoapySDR use -g ELEM=val,ELEM=val,... e.g. -g LNA=20,TIA=8,PGA=2 (for LimeSDR).

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [238]  Wireless M-Bus, Mode T, 32.768kbps (-f 868.3M -s 1000k)
     [239]  Revolt NC-5642 Energy Meter
     [240]  LaCrosse TX31U-IT, The Weather Channel WS-1910TWC-IT
-    [241]  EezTire E618
+    [241]  EezTire E618 | Carchet
     [242]* Baldr / RainPoint rain gauge.
     [243]  Celsia CZC1 Thermostat
     [244]  Fine Offset Electronics WS90 weather station

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -467,7 +467,7 @@ convert si
   protocol 238 # Wireless M-Bus, Mode T, 32.768kbps (-f 868.3M -s 1000k)
   protocol 239 # Revolt NC-5642 Energy Meter
   protocol 240 # LaCrosse TX31U-IT, The Weather Channel WS-1910TWC-IT
-  protocol 241 # EezTire E618
+  protocol 241 # EezTire E618 | Carchet
 # protocol 242 # Baldr / RainPoint rain gauge.
   protocol 243 # Celsia CZC1 Thermostat
   protocol 244 # Fine Offset Electronics WS90 weather station

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -455,7 +455,7 @@ convert si
   protocol 226 # Kia TPMS (-s 1000k)
   protocol 227 # SRSmith Pool Light Remote Control SRS-2C-TX (-f 915M)
   protocol 228 # Neptune R900 flow meters
-# protocol 229 # WEC-2103 temperature/humidity sensor
+  protocol 229 # WEC-2103 temperature/humidity sensor
   protocol 230 # Vauno EN8822C
   protocol 231 # Govee Water Leak Detector H5054
   protocol 232 # TFA Dostmann 14.1504.V2 Radio-controlled grill and meat thermometer
@@ -467,7 +467,7 @@ convert si
   protocol 238 # Wireless M-Bus, Mode T, 32.768kbps (-f 868.3M -s 1000k)
   protocol 239 # Revolt NC-5642 Energy Meter
   protocol 240 # LaCrosse TX31U-IT, The Weather Channel WS-1910TWC-IT
-  protocol 241 # EezTire E618 (TPMS10ATC)
+  protocol 241 # EezTire E618
 # protocol 242 # Baldr / RainPoint rain gauge.
   protocol 243 # Celsia CZC1 Thermostat
   protocol 244 # Fine Offset Electronics WS90 weather station

--- a/man/man1/rtl_433.1
+++ b/man/man1/rtl_433.1
@@ -40,7 +40,7 @@ Detailed information on some options follows.
 
 
   A "rtl_433.conf" file is searched in "./", XDG_CONFIG_HOME e.g. "$HOME/.config/rtl_433/",
-  "/usr/local/etc/rtl_433/", "/etc/rtl_433/", then command line args will be parsed in order.
+  SYSCONFDIR e.g. "/usr/local/etc/rtl_433/", then command line args will be parsed in order.
 .SS "General options"
 .TP
 [ \fB\-V\fI\fP ]
@@ -168,7 +168,7 @@ RTL\-SDR device driver is available.
 To set gain for RTL\-SDR use \-g <gain> to set an overall gain in dB.
 .RE
 .RS
-SoapySDR device driver is available.
+SoapySDR device driver is not available.
 .RE
 .TP
 [ \fB\-d\fI ""\fP ]

--- a/src/devices/tpms_eezrv.c
+++ b/src/devices/tpms_eezrv.c
@@ -1,7 +1,8 @@
 /** @file
-    EezTire E618 TPMS.
+    EezTire E618 TPMS and Carchet TPMS (same protocol)
+    Tested with RTL-SDR USB, Universal Radio Hacker (URH), and RTL_433
 
-    Copyright (C) 2023 Bruno OCTAU (ProfBoc75) and Gliebig
+    Copyright (C) 2023 Bruno OCTAU (ProfBoc75), Gliebig, and Karen Suhm
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -12,22 +13,48 @@
 #include "decoder.h"
 
 /**
-EezTire E618 TPMS.
+EezTire E618 TPMS and Carchet TPMS (same protocol).
 
 Eez RV supported TPMS sensor model E618 : https://eezrvproducts.com/shop/ols/products/tpms-system-e518-anti-theft-replacement-sensor-1-ea
+Carchet TPMS: http://carchet.easyofficial.com/carchet-rv-trailer-car-solar-tpms-tire-pressure-monitoring-system-6-sensor-lcd-display-p6.html,
 
-S.a issue #2384, #2657
+The device uses OOK (ASK) encoding,
+The device sends a transmission every 1 second when quick deflation is detected, every 13 - 23 sec when quick inflation is detected, and every 4 min 40 s under steady state pressure.
+A transmission starts with a preamble of 0x0000 and the packet is sent twice.
 
-Data layout:
+S.a issue #2384, #2657, #2063, #2677
+
+Data collection parameters on URH software were as follows:
+    Sensor frequency: 433.92 MHz
+    Sample rate: 2.0 MSps
+    Bandwidth: 2.0 Hz
+    Gain: 125
+
+    Modulation is ASK (OOK). Packets in URH arrive in the following format:
+
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa [Pause: 897679 samples]
+    aaaaaaaa5956a5a5a6555aaa65959999a5aaaaaa [Pause: 6030 samples]
+    aaaaaaaa5956a5a5a6555aaa65959999a5aaaaaa [Pause: 11176528 samples]
+
+    Decoding is Manchester I.  After decoding, the packets look like this:
+
+    00000000000000000000000000000000000000
+    0000de332fc0b7553000
+    0000de332fc0b7553000
+
+ Using rtl_433 software, packets were detected using the following command line entry:
+ rtl_433 -X "n=Carchet,m=OOK_MC_ZEROBIT,s=50,l=50,r=1000,invert" -s 1M
+
+ Data layout:
 
     PRE CC IIIIII PP TT FF FF
 
 - PRE : FFFF
-- C : 8 bit CheckSum
-- I: 24 bit ID
-- P: 8 bit pressure  P * 2.5 = Pressure kPa
-- T: 8 bit temperature   T - 50 = Temperature C
-- F: 16  bit battery (not verified), deflation pressure (for sure), pressure MSB
+- C : 8 bit CheckSum, modulo 256 with overflow flag
+- I: 24 bit little-endian ID
+- P: 8 bit little-endian pressure  P * 2.5 = Pressure kPa
+- T: 8 bit little-endian temperature   T - 50 = Temperature C
+- F: 16 bit status flags: 0x8000 = low battery, 0x1000 = quick deflation, 0x3000 = quick inflation, 0x0000 = static/steady state
 
 Raw Data example :
 
@@ -80,14 +107,21 @@ static int tpms_eezrv_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_FAIL_MIC;
     }
 
-    int temperature_C      = b[4] - 50;
+    int temperature_C      = b[4] - 50;//int temperature_F    = b[4];
     int flags1             = b[5];
     int flags2             = b[6];
-    int fast_leak_detected = (flags1 & 0x10);
-    int fast_leak_resolved = (flags1 & 0x20);
+    int fast_leak_detected = (flags1 & 0x10); // fast leak - reports every second
+    int infl_detected = (flags1 & 0x20) >> 5; // inflating - reports every 15 - 20 sec
 
-    int fast_leak = fast_leak_detected && !fast_leak_resolved;
+    int fast_leak = fast_leak_detected && !infl_detected;
     float pressure_kPa = (((flags2 & 0x01) << 8) + b[3]) * 2.5;
+    
+    //float pressure_PSI = b[6] *  0.363 - 0.06946;
+    //if(pressure_PSI < 0){pressure_PSI = 0;}; // 0 PSI is non-negative
+
+    // Low batt = 0x8000;
+    int low_batt = flags1 >> 7;// Low batt flag is MSB (activated at V < 3.15 V)(Device fails at V < 3.10 V)
+    // Mystery flag at (flags2 & 0x20) showed up during low batt testing
 
     char id_str[7];
     snprintf(id_str, sizeof(id_str), "%02x%02x%02x", b[0], b[1], b[2]);
@@ -102,8 +136,11 @@ static int tpms_eezrv_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "id",               "",             DATA_STRING, id_str,
             "pressure_kPa",     "Pressure",     DATA_FORMAT, "%.0f kPa", DATA_DOUBLE, (double)pressure_kPa,
             "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, (double)temperature_C,
-            "fast_leak",        "Fast Leak",    DATA_INT,    fast_leak,
             "flags",            "Flags",        DATA_STRING, flags_str,
+            "fast_leak",        "Fast Leak",    DATA_INT,    fast_leak,
+            "inflate",          "Inflate",      DATA_INT,    infl_detected,
+            "low batt",         "Low batt",     DATA_INT,    low_batt,
+
             "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
             NULL);
     /* clang-format on */
@@ -118,14 +155,16 @@ static char const *const output_fields[] = {
         "id",
         "temperature_C",
         "pressure_kPa",
-        "fast_leak",
         "flags",
+        "fast_leak",
+        "inflate",
+        "low batt",
         "mic",
         NULL,
 };
 
 r_device const tpms_eezrv = {
-        .name        = "EezTire E618",
+        .name        = "EezTire E618 | Carchet",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 50,
         .long_width  = 50,


### PR DESCRIPTION
I merged the code for these two sensors because they appear to use the same protocol. I added low battery and inflate flags to the readout.  The low battery flag has been verified with the Carchet dashboard monitor, but not the EezTire monitor. During low battery flag testing, I was able to trigger the second flags byte (flags2) to a value of 0x20, but was unable to controllably reproduce this.

I also commented in operations which can be used to display pressure in PSI and temperature in deg F.
