### PR TITLE
fix invalid warning message

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -837,7 +837,7 @@ def bridge_event_to_hass(mqttc, topic_prefix, data):
     base_topic, device_id = rtl_433_device_info(data, topic_prefix)
     if not device_id:
         # no unique device identifier
-        logging.warning("No suitable identifier found for model: ", model)
+        logging.warning("No suitable identifier found for model: %s", model)
         return
 
     if args.ids and "id" in data and data.get("id") not in args.ids:


### PR DESCRIPTION
The examples/rtl_433_mqtt_hass.py script doesn't currently work for me - there is a warning message that tries to use invalid syntax that leads to a backtrace.  simple fix.