### PR TITLE
Update fineoffset_ws90.c packet size check

### DIFF
--- a/src/devices/fineoffset_ws90.c
+++ b/src/devices/fineoffset_ws90.c
@@ -62,8 +62,8 @@ static int fineoffset_ws90_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     uint8_t const preamble[] = {0xaa, 0xaa, 0x2d, 0xd4}; // 32 bit, part of preamble and sync word
     uint8_t b[32];
 
-    // Validate package, WS90 nominal size is 330 bit periods
-    if (bitbuffer->bits_per_row[0] < 168 || bitbuffer->bits_per_row[0] > 330) {
+    // Validate package, WS90 nominal size is 345 bit periods
+    if (bitbuffer->bits_per_row[0] < 168 || bitbuffer->bits_per_row[0] > 350) {
         decoder_logf_bitbuffer(decoder, 2, __func__, bitbuffer, "abort length" );
         return DECODE_ABORT_LENGTH;
     }


### PR DESCRIPTION
Update the allowable packet size to 350 bits.  The packet size was increase in firmware 1.3.8 to ~345 bits.