### PR TITLE
Update rtl_433_mqtt_hass.py to add battery_mV

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -190,6 +190,19 @@ mappings = {
         }
     },
 
+    "battery_mV": {
+        "device_type": "sensor",
+        "object_suffix": "mV",
+        "config": {
+            "device_class": "voltage",
+            "name": "Battery mV",
+            "unit_of_measurement": "mV",
+            "value_template": "{{ float(value) }}",
+            "state_class": "measurement",
+            "entity_category": "diagnostic"
+        }
+    },
+
     "humidity": {
         "device_type": "sensor",
         "object_suffix": "H",


### PR DESCRIPTION
In addition to battery_ok, many devices also surface the measured battery voltage.

This is a decomposed part of https://github.com/merbanan/rtl_433/pull/2581