### PR TITLE
Update rtl_433_mqtt_hass.py to use moisture class

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -228,7 +228,7 @@ mappings = {
         "device_type": "sensor",
         "object_suffix": "H",
         "config": {
-            "device_class": "humidity",
+            "device_class": "moisture",
             "name": "Moisture",
             "unit_of_measurement": "%",
             "value_template": "{{ value|float }}",

--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -226,7 +226,7 @@ mappings = {
 
     "moisture": {
         "device_type": "sensor",
-        "object_suffix": "H",
+        "object_suffix": "M",
         "config": {
             "device_class": "moisture",
             "name": "Moisture",


### PR DESCRIPTION
Moisture should be "moisture" class, not "humidity" class.

This is a decomposed part of https://github.com/merbanan/rtl_433/pull/2581 , with added requested improvement.