### PR TITLE
Update rtl_433_mqtt_hass.py to add supercap_V

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -190,6 +190,19 @@ mappings = {
         }
     },
 
+    "supercap_V": {
+        "device_type": "sensor",
+        "object_suffix": "V",
+        "config": {
+            "device_class": "voltage",
+            "name": "Supercap V",
+            "unit_of_measurement": "V",
+            "value_template": "{{ float(value) }}",
+            "state_class": "measurement",
+            "entity_category": "diagnostic"
+        }
+    },
+
     "humidity": {
         "device_type": "sensor",
         "object_suffix": "H",


### PR DESCRIPTION
The fineoffset_ws90.c has a supercap in addition to the battery.  This will likely start appearing in other devices as well.