### PR TITLE
Update fineoffset_ws90.c battery_ok can >100

### DIFF
--- a/src/devices/fineoffset_ws90.c
+++ b/src/devices/fineoffset_ws90.c
@@ -109,9 +109,6 @@ static int fineoffset_ws90_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int supercap_V  = (b[21] & 0x3f);
     int firmware    = b[29];
 
-    if (battery_lvl > 100) // More then 100%?
-        battery_lvl = 100;
-
     char extra[31];
     snprintf(extra, sizeof(extra), "%02x%02x%02x%02x%02x------%02x%02x%02x%02x%02x%02x%02x", b[14], b[15], b[16], b[17], b[18], /* b[19,20] is the rain sensor, b[21] is supercap_V */ b[22], b[23], b[24], b[25], b[26], b[27], b[28]);
 


### PR DESCRIPTION
The ws90 driver capped battery_ok at 100, at 1.4V.
Lithium batteries go to 1.5V instead of 1.4V, so battery_ok >100 is fine.