### PR TITLE
mongoose.c: Fix SO_NOSIGPIPE change

### DIFF
--- a/src/mongoose.c
+++ b/src/mongoose.c
@@ -3877,11 +3877,14 @@ static int mg_is_error(void) {
 void mg_socket_if_connect_tcp(struct mg_connection *nc,
                               const union socket_address *sa) {
   int rc, proto = 0;
+#ifdef SO_NOSIGPIPE
+  int nopipe = 1;
+#endif
   nc->sock = socket(sa->sa.sa_family, SOCK_STREAM, proto);
   if (nc->sock == INVALID_SOCKET
 #ifdef SO_NOSIGPIPE
       /* Prevent SIGPIPE per file descriptor, supported on MacOS and most BSDs */
-      || setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, (void *)&nopipe, sizeof(nopipe))
+      || setsockopt(nc->sock, SOL_SOCKET, SO_NOSIGPIPE, (void *)&nopipe, sizeof(nopipe))
 #endif
   ) {
     nc->err = mg_get_errno() ? mg_get_errno() : 1;
@@ -3899,11 +3902,14 @@ void mg_socket_if_connect_tcp(struct mg_connection *nc,
 }
 
 void mg_socket_if_connect_udp(struct mg_connection *nc) {
+#ifdef SO_NOSIGPIPE
+  int nopipe = 1;
+#endif
   nc->sock = socket(AF_INET, SOCK_DGRAM, 0);
   if (nc->sock == INVALID_SOCKET
 #ifdef SO_NOSIGPIPE
       /* Prevent SIGPIPE per file descriptor, supported on MacOS and most BSDs */
-      || setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, (void *)&nopipe, sizeof(nopipe))
+      || setsockopt(nc->sock, SOL_SOCKET, SO_NOSIGPIPE, (void *)&nopipe, sizeof(nopipe))
 #endif
   ) {
     nc->err = mg_get_errno() ? mg_get_errno() : 1;
@@ -4021,7 +4027,9 @@ static sock_t mg_open_listening_socket(union socket_address *sa, int type,
   socklen_t sa_len =
       (sa->sa.sa_family == AF_INET) ? sizeof(sa->sin) : sizeof(sa->sin6);
   sock_t sock = INVALID_SOCKET;
+#ifdef SO_NOSIGPIPE
   int nopipe = 1;
+#endif
 #if !MG_LWIP
   int on = 1;
 #endif


### PR DESCRIPTION
On NetBSD 10, this fails to build, with both sock and nopipe undefined, and code reading agrees with the compiler.
  - Define nopipe, used in the ioctl, guarded by the same ifdef, in 2 places.
    - Add ifdef guard in the 1 existing place
  - Use nc->sock instead of bare sock
