### PR TITLE
ci: Fix trailing whitespace as seen in #2738

### DIFF
--- a/examples/rtl_433_json_to_rtlwmbus.py
+++ b/examples/rtl_433_json_to_rtlwmbus.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-""" 
+"""
 $ rtl_433 -R 104 -F json | rtl_433_json_to_rtlwmbus.py
 
 A script to convert rtl_433 wmbus json output to rtlwmbus output

--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -534,7 +534,7 @@ mappings = {
             "state_class": "measurement"
         }
     },
-  
+
     "energy_kWh": {
         "device_type": "sensor",
         "object_suffix": "kwh",
@@ -546,7 +546,7 @@ mappings = {
             "state_class": "measurement"
         }
     },
-  
+
     "current_A": {
         "device_type": "sensor",
         "object_suffix": "A",
@@ -558,7 +558,7 @@ mappings = {
             "state_class": "measurement"
         }
     },
-  
+
     "voltage_V": {
         "device_type": "sensor",
         "object_suffix": "V",
@@ -656,7 +656,7 @@ mappings = {
             "state_class": "total_increasing",
         }
     },
-  
+
     "consumption": {
         "device_type": "sensor",
         "object_suffix": "consumption",

--- a/tests/symbolizer.py
+++ b/tests/symbolizer.py
@@ -154,9 +154,9 @@ def process_source(path, name):
             m = re.match(r'(?:static)?\s?char\s?\*\s?[^\*\s]+\s?=\s?(?:{|")', line)
             if m:
                 err(f"::error file={name},line={i}::char * variable should be char const * when being given a constant value")
-                
+
             # look for output fields declarations that must be static char const *const
-            m = re.match(r'static\s?char\s+const\s*\*\s*[^\*\s]+\[\]\s*=\s*\{', line) 
+            m = re.match(r'static\s?char\s+const\s*\*\s*[^\*\s]+\[\]\s*=\s*\{', line)
             if m:
                 err(f"::error file={name},line={i}::output fields static variable should be 'static char const *const'")
 


### PR DESCRIPTION
This fixes (removes) the trailing whitespaces as detected in the corresponding pre-commit hook.