### PR TITLE
minor: Fix shell script as shellcheck suggests

### DIFF
--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -4,7 +4,7 @@
 set -e
 
 # navigate to the docs directory
-cd ${0%/*}
+cd "${0%/*}"
 
 # copy other docs
 sed 's/docs\///' ../README.md >README.md

--- a/tests/exitcode-for-output.sh
+++ b/tests/exitcode-for-output.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 # execute command and set exit code 1 if there is output on stdout or stderr
-out=$($@ 2>&1)
+out=$("$@" 2>&1)
 echo "$out"
 [ -z "$out" ]


### PR DESCRIPTION
Some shello variables are double quoted now to keep arguments with space as arguments with spaces.