### PR TITLE
Rough build - not working - Vivint DW11 Contact Sensor

### DIFF
--- a/src/devices/honeywell.c
+++ b/src/devices/honeywell.c
@@ -34,12 +34,39 @@ Data layout:
 - E: 8bit Event, where 0x80 = Open/Close, 0x04 = Heartbeat / or id
 - S: 16bit CRC
 
+These are my rough notes for the Vivint DW11 device
+
+Vivint DW11 - 96 Bits
+
+// hh COUNT:16d CON:b TAM:b REED:b ALARM:b BAT:b HEART:b bb ID:32d CRC:hh CRC:hh
+
+    b    0  1 2  3  4 5  6 7  8 9
+    PPPP 7A TTTT EE IIII IIII SSSS
+    {80} 7a 0091 00 0105 7325 2480
+
+- P: 16bit Preamble and sync bit (always ff fe)
+- T: 16bit Count
+- E: 8bit Event, where 0x80 = Open/Close, 0x04 = Heartbeat / or id
+- I: 32bit Device serial number / or counter value
+- S: 16bit CRC
+
 */
 
 #include "decoder.h"
 
+#define BYTE_TO_BINARY(byte) \
+    ((byte)&0x80 ? '1' : '0'), \
+            ((byte)&0x40 ? '1' : '0'), \
+            ((byte)&0x20 ? '1' : '0'), \
+            ((byte)&0x10 ? '1' : '0'), \
+            ((byte)&0x08 ? '1' : '0'), \
+            ((byte)&0x04 ? '1' : '0'), \
+            ((byte)&0x02 ? '1' : '0'), \
+            ((byte)&0x01 ? '1' : '0')
+
 static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
+    decoder_logf(decoder, 0, __func__, "honeywell_decode - start");
     // full preamble is 0xFFFE
     uint8_t const preamble_pattern[2] = {0xff, 0xe0}; // 12 bits
 
@@ -51,6 +78,7 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int channel;
     int device_id;
     int event;
+    int count;
     uint16_t crc_calculated;
     uint16_t crc;
     int reed;
@@ -61,38 +89,64 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int battery_low;
 
     row = 0; // we expect a single row only. reduce collisions
-    if (bitbuffer->num_rows != 1 || bitbuffer->bits_per_row[row] < 60)
+    if (bitbuffer->num_rows != 1 || bitbuffer->bits_per_row[row] < 60) {
+        decoder_logf(decoder, 0, __func__, "DECODE_ABORT_LENGTH rows %d, bits per %d", bitbuffer->num_rows, bitbuffer->bits_per_row[row]);
         return DECODE_ABORT_LENGTH;
+    }
 
     bitbuffer_invert(bitbuffer);
 
     pos = bitbuffer_search(bitbuffer, row, 0, preamble_pattern, 12) + 12;
     len = bitbuffer->bits_per_row[row] - pos;
-    if (len < 48)
+    if (len < 48) {
+        decoder_logf(decoder, 0, __func__, "DECODE_ABORT_LENGTH len %d", len);
         return DECODE_ABORT_LENGTH;
+    }
     bitbuffer_extract_bytes(bitbuffer, row, pos, b, 80);
 
-    channel   = b[0] >> 4;
-    device_id = ((b[0] & 0xf) << 16) | (b[1] << 8) | b[2];
-    crc       = (b[4] << 8) | b[5];
+    if ((len == 80) && (b[0] = 0x7a)) {
+        // DW11
+        decoder_logf(decoder, 0, __func__, "Bits 0-%02x 1-%02x 2-%02x 3-%02x 4-%02x 5-%02x 6-%02x 7-%02x 8-%02x 9-%02x", b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7], b[8], b[9]);
+        count     = (b[1] << 8) | (b[2]);
+        channel   = 2;
+        device_id = ((b[4] << 24) | (b[5] << 16) | ((b[6]) << 8) | (b[7])) + 143222784;
+        crc       = (b[8] << 8) | b[9];
+        event     = b[3];
 
-    if (device_id == 0 && crc == 0)
+        decoder_logf(decoder, 0, __func__, "Counter LSB 0-%c%c%c%c%c%c%c%c 1-%c%c%c%c%c%c%c%c 2-%c%c%c%c%c%c%c%c", BYTE_TO_BINARY(b[3]), BYTE_TO_BINARY((b[2] << 2) ^ b[3]), BYTE_TO_BINARY(b[2] ^ b[3]));
+
+        decoder_logf(decoder, 0, __func__, "CRC High 0-%c%c%c%c%c%c%c%c 1-%c%c%c%c%c%c%c%c 2-%c%c%c%c%c%c%c%c", BYTE_TO_BINARY(b[3]), BYTE_TO_BINARY(b[8] ^ b[3]), BYTE_TO_BINARY(b[9] ^ b[3]));
+
+        decoder_logf(decoder, 0, __func__, "CRC Low 0-%c%c%c%c%c%c%c%c 1-%c%c%c%c%c%c%c%c 2-%c%c%c%c%c%c%c%c", BYTE_TO_BINARY(b[3]), BYTE_TO_BINARY((b[8] + b[9]) ^ b[3]), BYTE_TO_BINARY(((b[1] + b[2]) << 2) ^ b[3]));
+    }
+    else {
+        channel   = b[0] >> 4;
+        device_id = ((b[0] & 0xf) << 16) | (b[1] << 8) | b[2];
+        crc       = (b[4] << 8) | b[5];
+        event     = b[3];
+    }
+
+    if (device_id == 0 && crc == 0) {
+        decoder_logf(decoder, 0, __func__, "DECODE_ABORT_EARLY id %d, crc %d", device_id, crc);
         return DECODE_ABORT_EARLY; // Reduce collisions
+    }
 
     if (len > 50) { // DW11
-        decoder_log_bitrow(decoder, 1, __func__, b, (len > 80 ? 80 : len), "");
+        decoder_log_bitrow(decoder, 0, __func__, b, (len > 80 ? 80 : len), "");
     }
 
     if (channel == 0x2 || channel == 0x4 || channel == 0xA) {
         // 2GIG brand
         crc_calculated = crc16(b, 4, 0x8050, 0);
-    } else { // channel == 0x8
+    }
+    else { // channel == 0x8
         crc_calculated = crc16(b, 4, 0x8005, 0);
     }
-    if (crc != crc_calculated)
-        return DECODE_FAIL_MIC; // Not a valid packet
+    if (crc != crc_calculated) {
+        decoder_logf(decoder, 0, __func__, "DECODE_FAIL_MIC crc %d, crc_calculated %d", crc, crc_calculated);
+        //        return DECODE_FAIL_MIC; // Not a valid packet
+    }
 
-    event = b[3];
     // decoded event bits: CTRABHUU
     // NOTE: not sure if these apply to all device types
     contact     = (event & 0x80) >> 7;
@@ -116,9 +170,11 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "battery_ok",   "Battery",  DATA_INT,    !battery_low,
             "heartbeat",    "",         DATA_INT,    heartbeat,
             "mic",          "Integrity",    DATA_STRING, "CRC",
+            "count",        "",         DATA_INT,    count,
             NULL);
     /* clang-format on */
 
+    decoder_logf(decoder, 0, __func__, "honeywell_decode - end");
     decoder_output_data(decoder, data);
     return 1;
 }
@@ -136,6 +192,7 @@ static char const *const output_fields[] = {
         "battery_ok",
         "heartbeat",
         "mic",
+        "count",
         NULL,
 };
 


### PR DESCRIPTION
This is my test build where I have been playing around with different things, this is not ready for release but hopefully will offer some inspiration around the events obfuscation algorithm.

I have been running this with the command line

`make ; src/rtl_433 -f 344988000  -vvv  -F log`

And it outputs this

```
honeywell_decode: honeywell_decode - start
honeywell_decode: Bits 0-7a 1-01 2-6b 3-34 4-01 5-05 6-73 7-25 8-a7 9-6f
honeywell_decode: Counter LSB 0-00110100 1-10011000 2-01011111
honeywell_decode: CRC High 0-00110100 1-10010011 2-01011011
honeywell_decode: CRC Low 0-00110100 1-00100010 2-10000100
honeywell_decode:  codes {80}7a016b3401057325a76f
honeywell_decode: DECODE_FAIL_MIC crc 42863, crc_calculated 25584
honeywell_decode: honeywell_decode - end
{"time" : "2023-12-04 18:55:22", "model" : "Honeywell-Security", "id" : 160357157, "channel" : 2, "event" : 52, "state" : "closed", "contact_open" : 0, "reed_open" : 1, "alarm" : 1, "tamper" : 0, "battery_ok" : 1, "heartbeat" : 1, "mic" : "CRC", "count" : 363}
```

The lines `Counter LSB`, `CRC High`, and `CRC Low` are my quick attempts at trying out various decode approaches.