### PR TITLE
Update rtl_433_mqtt_hass.py to support storm_dist_km by WH31L

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -615,6 +615,17 @@ mappings = {
         }
     },
 
+    "storm_dist_km": {
+        "device_type": "sensor",
+        "object_suffix": "stdist",
+        "config": {
+            "name": "Lightning Distance",
+            "unit_of_measurement": "km",
+            "value_template": "{{ value|int }}",
+            "state_class": "measurement"
+        }
+    },
+  
     "storm_dist": {
         "device_type": "sensor",
         "object_suffix": "stdist",


### PR DESCRIPTION
This adds support for the storm_dist_km field in WH31L