### PR TITLE
Fix example rtl_433_mqtt_hass.py rain_in sensor value template

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -434,8 +434,8 @@ mappings = {
         "config": {
             "device_class": "precipitation",
             "name": "Rain Total",
-            "unit_of_measurement": "mm",
-            "value_template": "{{ (float(value|float) * 25.4) | round(2) }}",
+            "unit_of_measurement": "in",
+            "value_template": "{{ value|float|round(2) }}",
             "state_class": "total_increasing"
         }
     },


### PR DESCRIPTION
This PR fixes the `rain_in` sensor in `examples/rtl_433_mqtt_hass.py` to return the measured rainfall in inches.

Previously, the sensor would return the value in mm, causing inconsistencies when setting the units using the `-C` option.