### PR TITLE
Fix duplicate device trigger error in HA 2024.2

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -694,7 +694,7 @@ mappings = {
         "config": {
            "automation_type": "trigger",
            "type": "button_short_release",
-           "subtype": "button_1",
+           "subtype": "button_2",
         }
     },
 


### PR DESCRIPTION
Change the subtype of the BTN device trigger to avoid creating a duplicate trigger.

In HA 2024.2, device triggers are now identified as `f"{device_id}_{trigger_type}_{trigger_subtype}"`, so each trigger must have a unique type/subtype combination per device.

> Also note that the combination of type and subtype should be unique for a device.
Per https://www.home-assistant.io/integrations/device_trigger.mqtt/

https://github.com/home-assistant/core/issues/110072#issuecomment-1935432495