### PR TITLE
Docs: Add compatible model TST-507 TPMS to EezTire T618

### DIFF
--- a/src/devices/tpms_eezrv.c
+++ b/src/devices/tpms_eezrv.c
@@ -159,7 +159,7 @@ static char const *const output_fields[] = {
 };
 
 r_device const tpms_eezrv = {
-        .name        = "EezTire E618, Carchet TPMS",
+        .name        = "EezTire E618, Carchet TPMS, TST-507 TPMS",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 50,
         .long_width  = 50,


### PR DESCRIPTION
Related to #2819 