### PR TITLE
Read rtl_433_mqtt_hass.py configuration from rtl_433.conf

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -980,7 +980,7 @@ def bridge_event_to_hass(mqttc, topic_prefix, data):
 def rtl_433_bridge():
     """Run a MQTT Home Assistant auto discovery bridge for rtl_433."""
 
-    mqttc = mqtt.Client()
+    mqttc = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1)
 
     if args.debug:
         mqttc.enable_logger()
@@ -1126,7 +1126,7 @@ if __name__ == "__main__":
             args.password = password
         if retain:
             logging.info(f"Using retain {retain} from config")
-            args.retain = retain
+            args.retain = int(retain)
         if devices:
             logging.info(f"Using device_topic_suffix {devices} from config")
             args.device_topic_suffix = devices

--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -105,6 +105,26 @@ import re
 
 discovery_timeouts = {}
 
+CONFIG_PATHS = [
+    "/etc/rtl_433",
+    "/usr/local/etc/rtl_433",
+    os.path.expanduser("~/.config/rtl_433"),
+    os.path.dirname(os.path.realpath(__file__)),
+    os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
+]
+CONFIG_PATHS = [p for p in CONFIG_PATHS if os.path.exists(p)]
+
+CONFIG_FILENAME = "rtl_433.conf"
+
+def find_file_in_path(filename, paths, success_log=None):
+    for path in paths:
+        fullpath = os.path.join(path, filename)
+        if os.path.exists(fullpath):
+            if success_log:
+                logging.info(success_log % path)
+            return fullpath
+    raise FileNotFoundError(f"File {filename} not found in paths: {paths}")
+
 # Fields that get ignored when publishing to Home Assistant
 # (reduces noise to help spot missing field mappings)
 SKIP_KEYS = [ "type", "model", "subtype", "channel", "id", "mic", "mod",


### PR DESCRIPTION
As the title suggests, a reasonably self contained change to load the configuration for HASS from the rtl_433.conf file if it exists.