### PR TITLE
Fix Badger-ORION return on decode success

### DIFF
--- a/src/devices/badger_water.c
+++ b/src/devices/badger_water.c
@@ -134,7 +134,7 @@ static int badger_orion_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     /* clang-format on */
 
     decoder_output_data(decoder, data);
-    return 0;
+    return 1;
 }
 
 // Note: At this time the exact meaning of the flags is not known.


### PR DESCRIPTION
Changed the return code issued on decode success from a 0 to a 1.  When this is set to a 0, the "-E quit" flag fails and the system gets stuck forever decoding badger_water.  When this is set to a 1, the "-E quit" flag performs as expected.