### PR TITLE
Add new binary builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,167 @@ jobs:
         #draft: true
         prerelease: ${{ env.PRERELEASE }}
 
+  macos_build_job:
+    needs: release_job
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-12, macos-14]
+        feat: [rtlsdr, soapysdr]
+        include:
+          - os: macos-12
+            arch: x86_64
+          - os: macos-14
+            arch: arm64
+    runs-on: ${{ matrix.os }}
+    name: Build ${{ matrix.feat }} on ${{ matrix.os }} for ${{ matrix.arch }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup tools
+        run: brew install librtlsdr openssl@3
+      - name: Setup SoapySDR deps
+        if: matrix.feat == 'soapysdr'
+        run: brew install soapysdr
+      - name: Build
+        run: |
+          cmake -B build
+          cmake --build build
+      - name: Adjust binary to run with MacPorts or Homebrew
+        # Homebrew has x86 in /usr/local and arm64 in /opt/homebrew
+        run: >
+          install_name_tool
+          -change /opt/homebrew/opt/openssl@3/lib/libssl.3.dylib @rpath/libssl.3.dylib
+          -change /opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib @rpath/libcrypto.3.dylib
+          -change /opt/homebrew/opt/libusb/lib/libusb-1.0.0.dylib @rpath/libusb-1.0.0.dylib
+          -change /opt/homebrew/opt/librtlsdr/lib/librtlsdr.2.dylib @rpath/librtlsdr.2.dylib
+          -change /opt/homebrew/opt/soapysdr/lib/libSoapySDR.0.8.dylib @rpath/libSoapySDR.0.8.dylib
+          -change /usr/local/opt/openssl@3/lib/libssl.3.dylib @rpath/libssl.3.dylib
+          -change /usr/local/opt/openssl@3/lib/libcrypto.3.dylib @rpath/libcrypto.3.dylib
+          -change /usr/local/opt/libusb/lib/libusb-1.0.0.dylib @rpath/libusb-1.0.0.dylib
+          -change /usr/local/opt/librtlsdr/lib/librtlsdr.2.dylib @rpath/librtlsdr.2.dylib
+          -change /usr/local/opt/soapysdr/lib/libSoapySDR.0.8.dylib @rpath/libSoapySDR.0.8.dylib
+          -add_rpath /opt/homebrew/opt/openssl@3/lib
+          -add_rpath /opt/homebrew/opt/libusb/lib
+          -add_rpath /opt/homebrew/opt/librtlsdr/lib
+          -add_rpath /opt/homebrew/opt/soapysdr/lib
+          -add_rpath /usr/local/opt/openssl@3/lib
+          -add_rpath /usr/local/opt/libusb/lib
+          -add_rpath /usr/local/opt/librtlsdr/lib
+          -add_rpath /usr/local/opt/soapysdr/lib
+          -add_rpath /opt/local/libexec/openssl3/lib
+          -add_rpath /opt/local/lib
+          build/src/rtl_433
+      - name: Check final binary
+        run: otool -L build/src/rtl_433
+      - name: "Upload Release Asset"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZIP_FILE: rtl_433-${{ matrix.feat }}-MacOS-${{ matrix.arch }}-${{ needs.release_job.outputs.release_version }}.zip
+        run: |
+          zip --junk-paths $ZIP_FILE build/src/rtl_433
+          gh release upload ${{ needs.release_job.outputs.release_version }} $ZIP_FILE
+
+  # 22.04 jammy / bookworm uses OpenSSL 3
+  # 20.04 focal / bullseye uses OpenSSL 1.1
+  native_build_job:
+    needs: release_job
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
+        feat: [rtlsdr, soapysdr]
+        include:
+          - os: ubuntu-20.04
+            libs: openssl11
+          - os: ubuntu-22.04
+            libs: openssl3
+    runs-on: ${{ matrix.os }}
+    name: Build ${{ matrix.feat }} on ${{ matrix.os }} for amd64
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup tools
+        run: |
+          sudo apt-get update -q -y
+          sudo apt-get install -y --no-install-recommends cmake ninja-build
+      - name: Setup deps
+        run: |
+          sudo apt-get install -q -y librtlsdr-dev libssl-dev
+      - name: Setup SoapySDR deps
+        if: matrix.feat == 'soapysdr'
+        run: |
+          sudo apt-get install -q -y libsoapysdr-dev
+      - name: Build
+        run: |
+          cmake -GNinja -B build
+          cmake --build build
+      - name: Check final binary
+        run: ldd build/src/rtl_433
+      - name: "Upload Release Asset"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZIP_FILE: rtl_433-${{ matrix.feat }}-${{ matrix.libs }}-Linux-amd64-${{ needs.release_job.outputs.release_version }}.zip
+        run: |
+          zip --junk-paths $ZIP_FILE build/src/rtl_433
+          gh release upload ${{ needs.release_job.outputs.release_version }} $ZIP_FILE
+
+  cross_build_job:
+    needs: release_job
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
+        arch: [armhf, arm64]
+        feat: [rtlsdr, soapysdr]
+        include:
+          - arch: armhf
+            compiler: arm-linux-gnueabihf
+          - arch: arm64
+            compiler: aarch64-linux-gnu
+          - os: ubuntu-20.04
+            libs: openssl11
+          - os: ubuntu-22.04
+            libs: openssl3
+    runs-on: ${{ matrix.os }}
+    name: Build ${{ matrix.feat }} on ${{ matrix.os }} for ${{ matrix.arch }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup tools
+        run: |
+          sudo apt-get update -q -y
+          sudo apt-get install -y --no-install-recommends cmake ninja-build
+      - name: Purge conflicting dev that confuse cross linking
+        run: |
+          sudo apt-get purge -y libssl-dev libusb-1.0-0-dev
+      - name: Setup compiler
+        run: |
+          sudo apt-get install -q -y gcc-${{ matrix.compiler }} g++-${{ matrix.compiler }}
+      - name: Restrict sources.list
+        run: |
+          sudo sed -i'' -E 's/^(deb|deb-src) mirror\+file/\1 [arch=amd64,i386] mirror\+file/' /etc/apt/sources.list
+      - uses: ryankurte/action-apt@v0.4.0
+        if: matrix.feat != 'soapysdr'
+        with:
+          arch: ${{ matrix.arch }}
+          packages: "librtlsdr-dev:${{ matrix.arch }} libssl-dev:${{ matrix.arch }}"
+      - uses: ryankurte/action-apt@v0.4.0
+        if: matrix.feat == 'soapysdr'
+        with:
+          arch: ${{ matrix.arch }}
+          packages: "librtlsdr-dev:${{ matrix.arch }} libssl-dev:${{ matrix.arch }} libsoapysdr-dev:${{ matrix.arch }}"
+      - name: Build
+        run: |
+          cmake -DCMAKE_TOOLCHAIN_FILE="$(pwd)/cmake/Toolchain-${{ matrix.compiler }}.cmake" -GNinja -B build
+          cmake --build build
+      - name: Check final binary
+        run: ${{ matrix.compiler }}-readelf -a build/src/rtl_433 | grep "Shared library:"
+      - name: "Upload Release Asset"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZIP_FILE: rtl_433-${{ matrix.feat }}-${{ matrix.libs }}-Linux-${{ matrix.arch }}-${{ needs.release_job.outputs.release_version }}.zip
+        run: |
+          zip --junk-paths $ZIP_FILE build/src/rtl_433
+          gh release upload ${{ needs.release_job.outputs.release_version }} $ZIP_FILE
+
   build_mingw_job:
     needs: release_job
     if: ${{ needs.release_job.result != 'failure' }}
@@ -89,16 +250,18 @@ jobs:
       if: matrix.arch == 'x86-64'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ZIP_FILE: rtl_433-win-x64-${{ needs.release_job.outputs.release_version }}.zip
       run: |
-        mv rtl_433-win-x64.zip rtl_433-win-x64-${{ needs.release_job.outputs.release_version }}.zip
-        gh release upload ${{ needs.release_job.outputs.release_version }} rtl_433-win-x64-${{ needs.release_job.outputs.release_version }}.zip
+        mv rtl_433-win-x64.zip $ZIP_FILE
+        gh release upload ${{ needs.release_job.outputs.release_version }} $ZIP_FILE
     - name: "Upload Release Asset"
       if: matrix.arch == 'x86-64'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ZIP_FILE: rtl_433-win-x32-${{ needs.release_job.outputs.release_version }}.zip
       run: |
-        mv rtl_433-win-x32.zip rtl_433-win-x32-${{ needs.release_job.outputs.release_version }}.zip
-        gh release upload ${{ needs.release_job.outputs.release_version }} rtl_433-win-x32-${{ needs.release_job.outputs.release_version }}.zip
+        mv rtl_433-win-x32.zip $ZIP_FILE
+        gh release upload ${{ needs.release_job.outputs.release_version }} $ZIP_FILE
 
   build_msvc_job:
     needs: [downloads_job, release_job]
@@ -211,41 +374,12 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_TOKEN: ${{ github.token }}
         GH_REPO: ${{ github.repository }}
+        ZIP_FILE: rtl_433-win-msvc-x64-${{ needs.release_job.outputs.release_version }}.zip
       shell: bash
       working-directory: ${{ runner.workspace }}
       run: |
-        mv rtl_433-win-msvc-x64.zip rtl_433-win-msvc-x64-${{ needs.release_job.outputs.release_version }}.zip
-        gh release upload ${{ needs.release_job.outputs.release_version }} rtl_433-win-msvc-x64-${{ needs.release_job.outputs.release_version }}.zip
-
-  build_linux_job:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
-    runs-on: ${{ matrix.os }}
-    name: Build with CMake on ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install SDR
-      run: |
-        sudo apt-get update -q
-        sudo apt-get install -y librtlsdr-dev libsoapysdr-dev libssl-dev
-    - name: Get latest CMake and Ninja
-      uses: lukka/get-cmake@latest
-    - name: Run CMake+Ninja
-      uses: lukka/run-cmake@v10
-      with:
-        configurePreset: dummy
-        configurePresetCmdString: "[`-B`, `${{ runner.workspace }}/b/ninja`, `-GNinja`, `-DENABLE_RTLSDR=ON`, `-DENABLE_SOAPYSDR=ON`, `-DENABLE_OPENSSL=ON`]"
-        buildPreset: dummy
-        buildPresetCmdString: "[`--build`, `${{ runner.workspace }}/b/ninja`, `--config`, `Release`]"
-    - name: Run CMake+UnixMakefiles
-      uses: lukka/run-cmake@v10
-      with:
-        configurePreset: dummy
-        configurePresetCmdString: "[`-B`, `${{ runner.workspace }}/b/unixmakefiles`, `-GUnix Makefiles`, `-DENABLE_RTLSDR=ON`, `-DENABLE_SOAPYSDR=ON`, `-DENABLE_OPENSSL=ON`]"
-        buildPreset: dummy
-        buildPresetCmdString: "[`--build`, `${{ runner.workspace }}/b/unixmakefiles`, `--config`, `Release`]"
+        mv rtl_433-win-msvc-x64.zip $ZIP_FILE
+        gh release upload ${{ needs.release_job.outputs.release_version }} $ZIP_FILE
 
   build_arch_job:
     if: ${{ false }}  # disable for now

--- a/cmake/Toolchain-aarch64-linux-gnu.cmake
+++ b/cmake/Toolchain-aarch64-linux-gnu.cmake
@@ -1,0 +1,4 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+set(CMAKE_C_COMPILER /usr/bin/aarch64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER /usr/bin/aarch64-linux-gnu-g++)

--- a/cmake/Toolchain-arm-linux-gnueabihf.cmake
+++ b/cmake/Toolchain-arm-linux-gnueabihf.cmake
@@ -1,0 +1,4 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+set(CMAKE_C_COMPILER /usr/bin/arm-linux-gnueabihf-gcc)
+set(CMAKE_CXX_COMPILER /usr/bin/arm-linux-gnueabihf-g++)

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -32,6 +32,7 @@ module.exports = {
     sidebar: [
       { text: 'Overview', link: '/' },
       'BUILDING',
+      'BINARY_BUILDS',
       'STARTING',
       'CHANGELOG',
       'CONTRIBUTING',

--- a/docs/BINARY_BUILDS.md
+++ b/docs/BINARY_BUILDS.md
@@ -1,0 +1,116 @@
+# Binary Builds
+
+First check to see if your distribution already has a recent enough version packaged for you.
+E.g. check [Repology](https://repology.org/project/rtl-433/versions) for a quick overview.
+
+We currently provide 18 [binary builds](https://github.com/merbanan/rtl_433/releases) for different OS, Platform, Version and Features.
+This is intended to quickly test out `rtl_433` or update to the newest version.
+Due to library dependencies and versions we can't guarantee our binaries to work
+(safe to try though, the worst is a "executable not supported" or "library is missing" message).
+
+Let us know in [with a comment](https://github.com/merbanan/rtl_433/issues/2859) if a binary unexpectedly does work or does not work.
+
+OS and Platform:
+- Windows: x32 and x64
+- MacOS: x86_64/Intel and arm64/M1
+- Linux: x86_64/amd64, arm64 (Raspberry Pi OS 64-bit), and armhf (Raspberry Pi OS 64-bit)
+
+Version (only Linux):
+- Variant for OpenSSL 1.1: Ubuntu 20.04 focal, Debian 11 Bullseye, Raspberry Pi OS Legacy
+- Variant for OpenSSL 3: Ubuntu 22.04 jammy, Debian 12 Bookworm, Raspberry Pi OS
+
+Features:
+- with only rtlsdr
+- with rtlsdr and SoapySDR
+
+## Choosing a binary
+
+Without SoapySDR:
+- `rtl_433-rtlsdr-MacOS-arm64.zip`: MacOS-14 for arm64/M1
+- `rtl_433-rtlsdr-MacOS-x86_64.zip`: MacOS-12 for x86_64/Intel
+- `rtl_433-rtlsdr-openssl11-Linux-amd64.zip`: Linux for x86_64/amd64 with OpenSSL 1.1
+- `rtl_433-rtlsdr-openssl11-Linux-arm64.zip`: Linux for aarch64/arm64 with OpenSSL 1.1
+- `rtl_433-rtlsdr-openssl11-Linux-armhf.zip`: Linux for armhf with OpenSSL 1.1
+- `rtl_433-rtlsdr-openssl3-Linux-amd64.zip`: Linux for x86_64/amd64 with OpenSSL 3
+- `rtl_433-rtlsdr-openssl3-Linux-arm64.zip`: Linux for aarch64/arm64 with OpenSSL 3
+- `rtl_433-rtlsdr-openssl3-Linux-armhf.zip`: Linux for armhf with OpenSSL 3
+
+With SoapySDR:
+- `rtl_433-soapysdr-MacOS-arm64.zip`: MacOS-arm64
+- `rtl_433-soapysdr-MacOS-x86_64.zip`: MacOS-x86_64
+- `rtl_433-soapysdr-openssl11-Linux-amd64.zip`: Linux for x86_64/amd64 with OpenSSL 1.1
+- `rtl_433-soapysdr-openssl11-Linux-arm64.zip`: Linux for aarch64/arm64 with OpenSSL 1.1
+- `rtl_433-soapysdr-openssl11-Linux-armhf.zip`: Linux for armhf with OpenSSL 1.1
+- `rtl_433-soapysdr-openssl3-Linux-amd64.zip`: Linux for x86_64/amd64 with OpenSSL 3
+- `rtl_433-soapysdr-openssl3-Linux-arm64.zip`: Linux for aarch64/arm64 with OpenSSL 3
+- `rtl_433-soapysdr-openssl3-Linux-armhf.zip`: Linux for armhf with OpenSSL 3
+
+
+## Easy Install
+
+Easiest install would be to first install a distribution provided `rtl_433` package for the dependencies,
+then use one of these binaries instead.
+
+## Install
+
+Otherwise you need to install libusb, openssl (1.1 or 3), librtlsdr, and optionally SoapySDR (plus driver modules).
+
+### MacOS
+
+After unpacking the binary you need to clear the file attributes:
+```
+xattr -c rtl_433
+```
+Note that `com.apple.quarantine` attributes are a useful safety feature and you should only perform this with genuine downloads from trusted sources.
+
+::: warning
+Note that [Homebrew](https://formulae.brew.sh/formula/librtlsdr) uses librtlsdr version 2.0 (with rtl-sdr blog v4 support)
+while [MacPorts](https://ports.macports.org/port/rtl-sdr/details/) uses version 0.6
+but those are compatible.
+You'll need to update the binary to run on MacPorts:
+```
+install_name_tool -change @rpath/librtlsdr.2.dylib @rpath/librtlsdr.0.dylib rtl_433
+```
+:::
+
+#### MacPorts
+
+(s.a. the [MacPorts port](https://ports.macports.org/port/rtl_433/))
+```
+sudo port install libusb openssl3 rtl-sdr
+```
+optionally add
+```
+sudo port install SoapySDR
+```
+
+#### HomeBrew
+
+(s.a. the [Homebrew Formula](https://formulae.brew.sh/formula/rtl_433))
+```
+brew install libusb
+brew install openssl@3
+brew install librtlsdr
+```
+optionally add
+```
+brew install soapysdr
+```
+
+### Linux
+
+On Debian, Ubuntu, and Raspberry Pi OS (and similar Debian-based OS supporting the `apt` package manager):
+
+```
+sudo apt-get install -y rtl-sdr openssl soapysdr-tools
+```
+
+Or with out any tools, just the libs for Bullseye / Focal
+```
+sudo apt-get install -y librtlsdr0 libssl1.1 libsoapysdr0.7
+```
+
+Similar for Bookworm / Jammy
+```
+sudo apt-get install -y librtlsdr0 libssl3 libsoapysdr0.8
+```


### PR DESCRIPTION
Provides 16 additional [binary builds](https://github.com/merbanan/rtl_433/releases) for different OS, Platform, Version and Features.
This is intended to quickly test out `rtl_433` or update to the newest version.

An overview is available at https://triq.org/rtl_433/BUILDING.html

Let us know if a binary unexpectedly does work or does not work.