### PR TITLE
Add log rotate support for dumper files

### DIFF
--- a/include/r_api.h
+++ b/include/r_api.h
@@ -97,6 +97,8 @@ void start_outputs(struct r_cfg *cfg, char const *const *well_known);
 
 void add_sr_dumper(struct r_cfg *cfg, char const *spec, int overwrite);
 
+void reopen_dumpers(struct r_cfg *cfg);
+
 void close_dumpers(struct r_cfg *cfg);
 
 void add_dumper(struct r_cfg *cfg, char const *spec, int overwrite);

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -43,6 +43,10 @@
 #include "fatal.h"
 #include "http_server.h"
 
+#ifndef _WIN32
+#include <sys/stat.h>
+#endif
+
 #ifdef _WIN32
 #include <io.h>
 #include <fcntl.h>
@@ -1152,6 +1156,47 @@ void add_sr_dumper(r_cfg_t *cfg, char const *spec, int overwrite)
     add_dumper(cfg, "F32:FM:analog-1-7-1", overwrite);
     cfg->sr_filename = spec;
     cfg->sr_execopen = overwrite;
+}
+
+void reopen_dumpers(struct r_cfg *cfg)
+{
+#ifndef _WIN32
+    for (void **iter = cfg->demod->dumper.elems; iter && *iter; ++iter) {
+        file_info_t *dumper = *iter;
+        if (dumper->file && (dumper->file != stdout)) {
+            // Get current file inode
+            struct stat old_st = {0};
+            int ret = fstat(fileno(dumper->file), &old_st);
+            if (ret) {
+                fprintf(stderr, "Failed to fstat %s (%d)\n", dumper->path, errno);
+                exit(1);
+            }
+
+            // Get new path inode if available
+            struct stat new_st = {0};
+            stat(dumper->path, &new_st);
+            // ok for stat() to fail, the file might not exist
+            if (old_st.st_ino == new_st.st_ino) {
+                continue;
+            }
+
+            // Reopen the file
+            print_logf(LOG_INFO, "Dumper", "Reopening \"%s\"", dumper->path);
+            fclose(dumper->file);
+            dumper->file = fopen(dumper->path, "wb");
+            if (!dumper->file) {
+                fprintf(stderr, "Failed to open %s\n", dumper->path);
+                exit(1);
+            }
+            if (dumper->format == VCD_LOGIC) {
+                pulse_data_print_vcd_header(dumper->file, cfg->samp_rate);
+            }
+            if (dumper->format == PULSE_OOK) {
+                pulse_data_print_pulse_header(dumper->file);
+            }
+        }
+    }
+#endif
 }
 
 void close_dumpers(struct r_cfg *cfg)


### PR DESCRIPTION
Adds basic log rotate support, i.e. reopening renamed files for dumpers.

This should now work:
```
rtl_433 -w OOK:my.ook &
sleep 10
ls -al my*ook
mv my.ook my-old.ook
sleep 10
ls -al my*ook
fg
```

S.a. discussion #2874

Adding this for file outputs (e.g. json) would be more involved but should later also be implemented.