### PR TITLE
Added mappings for event, state, and contact_open for Honeywell 58XX devices in rtl_433_mqtt_hass.py

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -452,25 +452,14 @@ mappings = {
         }
     },
 
-    "event": {
-        "device_type": "sensor",
-        "object_suffix": "event",
-        "config": {
-            "name": "Event",
-            "value_template": "{{ value|int }}",
-            "state_class": "measurement",
-            "entity_category": "diagnostic"
-        }
-    },
-
-    "state": {
+    "reed_open": {
         "device_type": "binary_sensor",
-        "object_suffix": "state",
+        "object_suffix": "reed_open",
         "config": {
             "device_class": "safety",
             "force_update": "true",
-            "payload_on": "open",
-            "payload_off": "closed",
+            "payload_on": "1",
+            "payload_off": "0",
             "entity_category": "diagnostic"
         }
     },

--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -452,6 +452,41 @@ mappings = {
         }
     },
 
+    "event": {
+        "device_type": "sensor",
+        "object_suffix": "event",
+        "config": {
+            "name": "Event",
+            "value_template": "{{ value|int }}",
+            "state_class": "measurement",
+            "entity_category": "diagnostic"
+        }
+    },
+
+    "state": {
+        "device_type": "binary_sensor",
+        "object_suffix": "state",
+        "config": {
+            "device_class": "safety",
+            "force_update": "true",
+            "payload_on": "open",
+            "payload_off": "closed",
+            "entity_category": "diagnostic"
+        }
+    },
+
+    "contact_open": {
+        "device_type": "binary_sensor",
+        "object_suffix": "contact_open",
+        "config": {
+            "device_class": "safety",
+            "force_update": "true",
+            "payload_on": "1",
+            "payload_off": "0",
+            "entity_category": "diagnostic"
+        }
+    },
+
     "tamper": {
         "device_type": "binary_sensor",
         "object_suffix": "tamper",


### PR DESCRIPTION
Author:David M. Zendzian (dmz@dmzs.com)
Date: Wed Mar 20 00:34:00 2024 -0500

Added mappings for event, state, and contact_open for Honeywell 58XX devices.

- Event is an event ID. I've not mapped them yet but I've seen 0, 4, 60, 57, 120, 128, 248 and others as the devices change state
- State is either "open" | "closed" and corresponds to the state of the door sensor
- contact_open appears to be tied to state

On the 5800 devices I tested alarm state did not correspond with device state or contact_open and doesn't appear to change with opening or closing door/window