### PR TITLE
The pressure unit should be pressure_PSI, not pressure_psi.

### DIFF
--- a/src/devices/tpms_nissan.c
+++ b/src/devices/tpms_nissan.c
@@ -98,7 +98,7 @@ static char const *const output_fields[] = {
         "type",
         "id",
         "mode",
-        "pressure_psi",
+        "pressure_PSI",
         "unknown",
         NULL,
 };


### PR DESCRIPTION
With this change, the pressure reported by a Nissan TPMS will be correctly converted to kPa when using the "-C si" option.