### PR TITLE
Add support for paho-mqtt >= 2.0.0 via legacy callback API.

### DIFF
--- a/examples/mqtt_rtl_433_test_client.py
+++ b/examples/mqtt_rtl_433_test_client.py
@@ -30,7 +30,10 @@ TIMEOUT_STALE_SENSOR = 600  # Seconds before showing a timeout indicator
 
 # log = logging.getLogger()  # Single process logger
 log = mp.log_to_stderr()  # Multiprocessing capable logger
-mqtt_client = mqtt.Client("RTL_433_Test")
+if hasattr(mqtt, 'CallbackAPIVersion'):  # paho >= 2.0.0
+    mqtt_client = mqtt.Client(callback_api_version=mqtt.CallbackAPIVersion.VERSION1, client_id="RTL_433_Test")
+else:
+    mqtt_client = mqtt.Client(client_id="RTL_433_Test")
 
 sensor_state = dict()  # Dictionary containing accumulated sensor state
 

--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -984,7 +984,10 @@ def bridge_event_to_hass(mqttc, topic_prefix, data):
 def rtl_433_bridge():
     """Run a MQTT Home Assistant auto discovery bridge for rtl_433."""
 
-    mqttc = mqtt.Client()
+    if hasattr(mqtt, 'CallbackAPIVersion'):  # paho >= 2.0.0
+        mqttc = mqtt.Client(callback_api_version=mqtt.CallbackAPIVersion.VERSION1)
+    else:
+        mqttc = mqtt.Client()
 
     if args.debug:
         mqttc.enable_logger()

--- a/examples/rtl_433_mqtt_relay.py
+++ b/examples/rtl_433_mqtt_relay.py
@@ -111,7 +111,10 @@ def rtl_433_probe():
     """Run a rtl_433 UDP listener."""
 
     ## Connect to MQTT
-    mqttc = mqtt.Client()
+    if hasattr(mqtt, 'CallbackAPIVersion'):  # paho >= 2.0.0
+        mqttc = mqtt.Client(callback_api_version=mqtt.CallbackAPIVersion.VERSION1)
+    else:
+        mqttc = mqtt.Client()
     mqttc.on_connect = mqtt_connect
     mqttc.on_disconnect = mqtt_disconnect
     if MQTT_USERNAME != None:


### PR DESCRIPTION
This is all that's required to make these scripts work properly on paho-mqtt 2.0.0, but it doesn't use the new callback API.  Per the documentation, VERSION1 callbacks are deprecated but will be supported until paho-mqtt 3.