### PR TITLE
Update BUILDING.md

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -41,7 +41,7 @@ Debian:
 * If you require TLS connections, install `libssl-dev`.
 
 ````
-sudo apt-get install libtool libusb-1.0-0-dev librtlsdr-dev rtl-sdr build-essential cmake pkg-config
+sudo apt-get install libtool libusb-1.0-0-dev librtlsdr-dev rtl-sdr libssl-dev build-essential cmake pkg-config
 ````
 
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -38,12 +38,11 @@ Depending on your system, you may need to install the following libraries.
 
 Debian:
 
-* If you require TLS connections, install `libssl-dev`.
-
 ````
-sudo apt-get install libtool libusb-1.0-0-dev librtlsdr-dev rtl-sdr libssl-dev build-essential cmake pkg-config
+sudo apt-get install libtool libusb-1.0-0-dev librtlsdr-dev rtl-sdr build-essential cmake pkg-config
 ````
 
+* If you require TLS connections, also install `libssl-dev` (`sudo apt-get install libssl-dev`).
 
 Centos/Fedora/RHEL with EPEL repo using cmake:
 


### PR DESCRIPTION
When compiling on ubuntu 24.04 support for ttls was not available until i install 

sudo apt install libssl-dev

not sure if those previously mentionned libraries in sudo-apt-get install are required but without this line above it didn't work

-- Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the system variable OPENSSL_ROOT_DIR (missing: OPENSSL_CRYPTO_LIBRARY OPENSSL_INCLUDE_DIR)  -- OpenSSL development files not found, TLS won't be possible.