### PR TITLE
sudo apt install libssl-dev for Ubuntu  

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -44,6 +44,13 @@ Debian:
 sudo apt-get install libtool libusb-1.0-0-dev librtlsdr-dev rtl-sdr build-essential cmake pkg-config
 ````
 
+Ubutu:
+
+* As for Debian but it might be necessary to add additionally the following line, if when compiling you have a message about the missing TLS connection support
+  
+````
+sudo apt install libssl-dev
+````  
 
 Centos/Fedora/RHEL with EPEL repo using cmake:
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -46,7 +46,7 @@ sudo apt-get install libtool libusb-1.0-0-dev librtlsdr-dev rtl-sdr build-essent
 
 Ubutu:
 
-* As for Debian but it might be necessary to add additionally the following line, if when compiling you have a message about the missing TLS connection support
+* As for Debian but it might be necessary to add additionally the following line, if when compiling you have a message about the missing OpenSSL support (Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the system variable OPENSSL_ROOT_DIR (missing: OPENSSL_CRYPTO_LIBRARY OPENSSL_INCLUDE_DIR) -- OpenSSL development files not found, TLS won't be possible.)
   
 ````
 sudo apt install libssl-dev


### PR DESCRIPTION
Adding sudo apt install libssl-dev for Ubuntu  when message about missing OpenSSL support
