### PR TITLE
Added Dewenwils BH-V configuration.

### DIFF
--- a/conf/Dewenwils_BHV.conf
+++ b/conf/Dewenwils_BHV.conf
@@ -1,0 +1,40 @@
+# Dewenwils BH-V 5-channel AC socket remote.
+#
+# These use the standard xx2260C-R4 encoder chips, with the oscillator
+# set with a 4.7M resistor, resulting in very short (~168usec) pulses.
+#
+# Decoded key values:
+#
+# 1-ON:  codes : {25}eaaacc8, {25}eaaaff8    1110 1010 1010 1010 1100 1100 1000
+# 1-OFF: codes : {25}eaaac38, {25}eaaaff8    1110 1010 1010 1010 1100 0011 1000
+#
+# 2-ON:  codes : {25}eaaa3c8, {25}eaaaff8    1110 1010 1010 1010 0011 1100 1000
+# 2-OFF: codes : {25}eaaa338, {25}eaaaff8    1110 1010 1010 1010 0011 0011 1000
+#
+# 3-ON:  codes : {25}eaa8fc8, {25}eaa8ff8    1110 1010 1010 1000 1111 1100 1000
+# 3-OFF: codes : {25}eaa8f38, {25}eaa8ff8    1110 1010 1010 1000 1111 0011 1000
+#
+# 4-ON:  codes : {25}eaa2fc8, {25}eaa2ff8    1110 1010 1010 0010 1111 1100 1000
+# 4-OFF: codes : {25}eaa2f38, {25}eaa2ff8    1110 1010 1010 0010 1111 0011 1000
+#
+# 5-ON:  codes : {25}ea8afc8, {25}ea8aff8    1110 1010 1000 1010 1111 1100 1000
+# 5-OFF: codes : {25}ea8af38, {25}ea8aff8    1110 1010 1000 1010 1111 0011 1000
+#
+# The code for this remote is 0301.
+#
+# Fred N. van Kempen <decwiz@yahoo.com> 2024/05/11.
+
+decoder {
+        n=Dewenwils BH-V (PT2260) Remote,
+        m=OOK_PWM,
+        s=150,
+        l=500,
+        g=800,
+        r=6000,
+        t=50,
+        bits=25,
+        get=@4:{4}:code:[10:0301 14:0304],
+        get=@8:{12}:button:[2732:1 2723:2 2703:3 2607:4 2223:5],
+	get=@20:{4}:state:[12:ON 3:OFF],
+        unique
+}


### PR DESCRIPTION
Configuration data for the Dewenwils BH-V series of remote control AC sockets added.

Tested with 0301 and 0304 coded controllers.
