### PR TITLE
"state" binary "ON"/"OFF" casing consistency for Waveman-Switch decoder

### DIFF
--- a/src/devices/waveman.c
+++ b/src/devices/waveman.c
@@ -71,7 +71,7 @@ static int waveman_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             "id",       "",     DATA_STRING,    id_str,
             "channel",  "",     DATA_INT,       (nb[1] >> 2) + 1,
             "button",   "",     DATA_INT,       (nb[1] & 3) + 1,
-            "state",    "",     DATA_STRING,    (nb[2] == 0xe) ? "on" : "off",
+            "state",    "",     DATA_STRING,    (nb[2] == 0xe) ? "ON" : "OFF",
             NULL);
     /* clang-format on */
     decoder_output_data(decoder, data);


### PR DESCRIPTION
There are several decoders with the "state" key being a binary "ON"/"OFF" option.

To be able to create a single Home Assistant discovery routine for all of them, without having to create a separate one just for the Waveman-Switch decoder, brining the casing in line with all the others makes things more consistent and easier for discovery implementation.

See
Brennenstuhl RCS 2044
Nexa
Proove

