### PR TITLE
Change Smoke-GS558, Akhan-100F14 to default disabled BREAKING CHANGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [45]  emonTx OpenEnergyMonitor
     [46]  HT680 Remote control
     [47]  Conrad S3318P, FreeTec NC-5849-913 temperature humidity sensor, ORIA WA50 ST389 temperature sensor
-    [48]  Akhan 100F14 remote keyless entry
+    [48]* Akhan 100F14 remote keyless entry
     [49]  Quhwa
     [50]  OSv1 Temperature Sensor
     [51]  Proove / Nexa / KlikAanKlikUit Wireless Switch
@@ -171,7 +171,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [83]  Oil Ultrasonic STANDARD ASK
     [84]  Thermopro TP11 Thermometer
     [85]  Solight TE44/TE66, EMOS E0107T, NX-6876-917
-    [86]  Wireless Smoke and Heat Detector GS 558
+    [86]* Wireless Smoke and Heat Detector GS 558
     [87]  Generic wireless motion sensor
     [88]  Toyota TPMS
     [89]  Ford TPMS

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -276,7 +276,7 @@ convert si
   protocol 45  # emonTx OpenEnergyMonitor
   protocol 46  # HT680 Remote control
   protocol 47  # Conrad S3318P, FreeTec NC-5849-913 temperature humidity sensor, ORIA WA50 ST389 temperature sensor
-  protocol 48  # Akhan 100F14 remote keyless entry
+# protocol 48  # Akhan 100F14 remote keyless entry
   protocol 49  # Quhwa
   protocol 50  # OSv1 Temperature Sensor
   protocol 51  # Proove / Nexa / KlikAanKlikUit Wireless Switch
@@ -312,7 +312,7 @@ convert si
   protocol 83  # Oil Ultrasonic STANDARD ASK
   protocol 84  # Thermopro TP11 Thermometer
   protocol 85  # Solight TE44/TE66, EMOS E0107T, NX-6876-917
-  protocol 86  # Wireless Smoke and Heat Detector GS 558
+# protocol 86  # Wireless Smoke and Heat Detector GS 558
   protocol 87  # Generic wireless motion sensor
   protocol 88  # Toyota TPMS
   protocol 89  # Ford TPMS
@@ -447,7 +447,7 @@ convert si
   protocol 218 # Microchip HCS200/HCS300 KeeLoq Hopping Encoder based remotes (FSK)
   protocol 219 # Fine Offset Electronics WH45 air quality sensor
   protocol 220 # Maverick XR-30 BBQ Sensor
-  protocol 221 # Fine Offset Electronics WN34 temperature sensor
+  protocol 221 # Fine Offset Electronics WN34S/L/D and Froggit DP150/D35 temperature sensor
   protocol 222 # Rubicson Pool Thermometer 48942
   protocol 223 # Badger ORION water meter, 100kbps (-f 916.45M -s 1200k)
   protocol 224 # GEO minim+ energy monitor

--- a/src/devices/akhan_100F14.c
+++ b/src/devices/akhan_100F14.c
@@ -79,4 +79,5 @@ r_device const akhan_100F14 = {
         .tolerance   = 80, // us
         .decode_fn   = &akhan_rke_callback,
         .fields      = output_fields,
+        .disabled    = 1, // false positives with generic EV1527 devices
 };

--- a/src/devices/smoke_gs558.c
+++ b/src/devices/smoke_gs558.c
@@ -134,4 +134,5 @@ r_device const smoke_gs558 = {
         .reset_limit = 11764 * 1.2f, // Maximum gap size before End Of Message [us]
         .decode_fn   = &smoke_gs558_callback,
         .fields      = output_fields,
+        .disabled    = 1, // false positives with generic EV1527 devices
 };


### PR DESCRIPTION
Akhan-100F14 and esp. Smoke-GS558 are prone to false positives with other generic EV1527 devies.
Change to default disabled.

This is BREAKING for Akhan-100F14 and Smoke-GS558 users. You need to use 
- `-R 48` to decode Akhan 100F14 remote keyless entry
- `-R 86`to decode Wireless Smoke and Heat Detector GS 558