### PR TITLE
Add support for ThermoPro TP829b and Improve rtl_433_mqtt_hass.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [256]  ThermoPro TP28b Super Long Range Wireless Meat Thermometer for Smoker BBQ Grill
     [257]  BMW Gen3 TPMS
     [258]  Chamberlain CWPIRC PIR Sensor
+    [259]  ThermoPro TP829b Meat Thermometer 4 coated probes
 
 * Disabled by default, use -R n or a conf file to enable
 

--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -149,6 +149,28 @@ mappings = {
             "state_class": "measurement"
         }
     },
+    "temperature_3_C": {
+        "device_type": "sensor",
+        "object_suffix": "T3",
+        "config": {
+            "device_class": "temperature",
+            "name": "Temperature 3",
+            "unit_of_measurement": "°C",
+            "value_template": "{{ value|float|round(1) }}",
+            "state_class": "measurement"
+        }
+    },
+    "temperature_4_C": {
+        "device_type": "sensor",
+        "object_suffix": "T4",
+        "config": {
+            "device_class": "temperature",
+            "name": "Temperature 4",
+            "unit_of_measurement": "°C",
+            "value_template": "{{ value|float|round(1) }}",
+            "state_class": "measurement"
+        }
+    },
     "temperature_F": {
         "device_type": "sensor",
         "object_suffix": "F",

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -266,6 +266,7 @@
     DECL(thermopro_tp28b) \
     DECL(tpms_bmwg3) \
     DECL(chamberlain_cwpirc) \
+    DECL(thermopro_tp829b) \
 
     /* Add new decoders here. */
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -231,6 +231,7 @@ add_library(r_433 STATIC
     devices/thermopro_tp11.c
     devices/thermopro_tp12.c
     devices/thermopro_tp28b.c
+    devices/thermopro_tp829b.c
     devices/thermopro_tx2.c
     devices/thermopro_tx2c.c
     devices/thermor.c

--- a/src/devices/thermopro_tp829b.c
+++ b/src/devices/thermopro_tp829b.c
@@ -1,0 +1,127 @@
+/** @file
+    ThermoPro TP829b Meat Thermometer four probes.
+
+    Copyright (C) 2024 Bruno OCTAU (\@ProfBoc75)
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#include "decoder.h"
+
+/**
+ThermoPro TP829b Meat Thermometer four probes.
+
+Issue #2961 open by \@AryehGielchinsky
+Product web page : https://buythermopro.com/product/tp829/
+
+Flex decoder:
+
+    rtl_433 -X "n=tp829b,m=FSK_PCM,s=102,l=102,r=5500,preamble=d2552dd4" *.cu8 2>&1 | grep codes
+
+    codes     : {164}082f2efeddeddedde8d2d2d2d2d20000000000000
+
+Data layout:
+
+    Byte Position              0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20
+                              II II 11 12 22 33 34 44 CC TT TT TT TT TT TT TT TT TT TT TT T
+    Sample        d2 55 2d d4 08 2f 2e fe dd ed de dd e8 d2 d2 d2 d2 d2 00 00 00 00 00 00 0
+
+- II: {16} Sensor ID, to be confirmed as the battery low not identified,
+- 111:{12} Temp probe 1, °C, offset 500, scale 10,
+- 222:{12} Temp probe 2, °C, offset 500, scale 10,
+- 333:{12} Temp probe 3, °C, offset 500, scale 10,
+- 444:{12} Temp probe 4, °C, offset 500, scale 10,
+- CC: {8}  Checksum, Galois Bit Reflect Byte Reflect, gen 0x98, key 0x55, final XOR 00
+- TT: Trailed bytes, not used (always d2 d2 ...... 00 00 ).
+
+*/
+static int thermopro_tp829b_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    uint8_t const preamble_pattern[] = {0xd2, 0x55, 0x2d, 0xd4};
+
+    uint8_t b[9];
+
+    if (bitbuffer->num_rows > 1) {
+        decoder_logf(decoder, 1, __func__, "Too many rows: %d", bitbuffer->num_rows);
+        return DECODE_FAIL_SANITY;
+    }
+    int msg_len = bitbuffer->bits_per_row[0];
+
+    if (msg_len > 260) {
+        decoder_logf(decoder, 1, __func__, "Packet too long: %d bits", msg_len);
+        return DECODE_ABORT_LENGTH;
+    }
+
+    int offset = bitbuffer_search(bitbuffer, 0, 0, preamble_pattern, sizeof(preamble_pattern) * 8);
+
+    if (offset >= msg_len) {
+        decoder_log(decoder, 1, __func__, "Sync word not found");
+        return DECODE_ABORT_EARLY;
+    }
+
+    if ((msg_len - offset ) < 104 ) {
+        decoder_logf(decoder, 1, __func__, "Packet too short: %d bits", msg_len);
+        return DECODE_ABORT_LENGTH;
+    }
+
+    offset += sizeof(preamble_pattern) * 8;
+    bitbuffer_extract_bytes(bitbuffer, 0, offset, b, 9 * 8);
+
+    // checksum is a Galois bit reflect and byte reflect
+    // need first to reverse byte order then the galois bit reflect.
+    uint8_t b_reflect[8];
+    for (int p = 7; p != -1; p += -1)
+        b_reflect[7 - p] = b[p];
+    int checksum = lfsr_digest8(b_reflect, 8, 0x98, 0x55);
+    if (checksum != b[8]) {
+        decoder_logf(decoder, 1, __func__, "Checksum error, calculated %x, expected %x", checksum, b[8]);
+        return DECODE_FAIL_MIC;
+    }
+
+    decoder_log_bitrow(decoder, 2, __func__, b, 72, "MSG");
+
+    uint16_t id     = b[0] << 8 | b[1];
+    float p1_temp   = ((b[2] << 4 | (b[3] & 0xF0) >> 4) - 500) * 0.1f;
+    float p2_temp   = (((b[3] & 0x0F) << 8 | b[4]) - 500) * 0.1f;
+    float p3_temp   = ((b[5] << 4 | (b[6] & 0xF0) >> 4) - 500) * 0.1f;
+    float p4_temp   = (((b[6] & 0x0F) << 8 | b[7]) - 500) * 0.1f;
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",                "",                             DATA_STRING,    "ThermoPro-TP829b",
+            "id",                   "",                             DATA_FORMAT,    "%04x",   DATA_INT,    id,
+            "temperature_1_C",      "Temperature 1",                DATA_COND, p1_temp != 330.5 , DATA_FORMAT, "%.1f C", DATA_DOUBLE, p1_temp,
+            "temperature_2_C",      "Temperature 2",                DATA_COND, p2_temp != 330.5 , DATA_FORMAT, "%.1f C", DATA_DOUBLE, p2_temp,
+            "temperature_3_C",      "Temperature 3",                DATA_COND, p3_temp != 330.5 , DATA_FORMAT, "%.1f C", DATA_DOUBLE, p3_temp,
+            "temperature_4_C",      "Temperature 4",                DATA_COND, p4_temp != 330.5 , DATA_FORMAT, "%.1f C", DATA_DOUBLE, p4_temp,
+            "mic",                  "Integrity",                    DATA_STRING,    "CHECKSUM",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+static char const *const output_fields[] = {
+        "model",
+        "id",
+        "temperature_1_C",
+        "temperature_2_C",
+        "temperature_3_C",
+        "temperature_4_C",
+        "mic",
+        NULL,
+};
+
+r_device const thermopro_tp829b = {
+        .name        = "ThermoPro TP829b Meat Thermometer 4 coated probes",
+        .modulation  = FSK_PULSE_PCM,
+        .short_width = 102,
+        .long_width  = 102,
+        .reset_limit = 5500,
+        .decode_fn   = &thermopro_tp829b_decode,
+        .fields      = output_fields,
+};


### PR DESCRIPTION
Related to #2961 

This decoder is decoding 4 temp probes, the reason why rtl_433_mqtt_hass.py is also updated accordingly (2 temp probes in previous version)
