### PR TITLE
examples: Remove obsolete sigrok example scripts

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -89,11 +89,6 @@ lead to better understanding, and bits of code may be useful..
   - rtl_433_http_stream.py: Custom data handling example for rtl_433's HTTP (line) streaming API of JSON events
   - rtl_433_http_ws.py: Custom data handling example for rtl_433's HTTP WebSocket API of JSON events
 
-## Not Understood
-
-  - sigrok-conv.sh: print a hint
-  - sigrok-open.sh: print a hint
-
 ## Uncategorized
 
 These scripts are in the directory but have not been sorted and described.

--- a/examples/sigrok-conv.sh
+++ b/examples/sigrok-conv.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-echo 'Please use "rtl_433 [-s <samplerate>] -w <output>.sr -r <input>.cu8"'

--- a/examples/sigrok-open.sh
+++ b/examples/sigrok-open.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-echo 'Please use "rtl_433 [-s <samplerate>] -W <output>.sr -r <input>.cu8"'


### PR DESCRIPTION
Per a comment in #2976 these are no longer necessary.