### PR TITLE
docker: Add official local docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+examples/

--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -1,0 +1,73 @@
+name: Create and publish Container image
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '[0-9]+.[0-9]+*'
+  pull_request:
+    branches:
+      - master
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - container: ./dist/Containerfile
+            autotag: auto
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=edge
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+          flavor: |
+            latest=${{ matrix.autotag }}
+            suffix=${{ matrix.suffix }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
+          context: .
+          file: ${{ matrix.container }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,24 @@ On FreeBSD, `pkg install rtl-433`.
 
 On MacOS, `brew install rtl_433`.
 
-Docker images with rtl_433 are available [on the github page of hertzg](https://github.com/hertzg/rtl_433_docker).
+## Docker
+
+Running the application through docker is easy with the offical docker image from this repository. Either use `latest` for the latest stable, a tagged version or `master` for the latest build from master. See https://github.com/merbanan/rtl_433/pkgs/container/rtl_433 for available releases.
+
+```console
+$ docker run \
+         --device '/dev/bus/usb:/dev/bus/usb' \
+         --interactive \
+         --rm \
+         --tty \
+         --volume '/path/for/dumps:/dumps' \
+         --workdir '/dumps' \
+         ghcr.io/merbanan/rtl_433/rtl_433:latest --help
+```
+
+> __Note:__ The volume (and workdir) arguments are only needed to store (and load) dumps.
+
+> __Warning:__ The `--device` flag still exposes all usb devices to the container, this can be trimmed down by using the exact endpoint for more security, the trouble is that this changes every time a dongle is put in a different USB port. The `--privileged` flag might be needed instead of the `--device` flag in certain cases if the USB devices cannot be enumerated and accessed from within the container. Also the container could be run as the current user by using `--user "$(id -u):$(id -g)"`, but then care with user mapping and the use of udev rules is needed. This left as an exercise to the reader.
 
 ## How to add support for unsupported sensors
 

--- a/dist/Containerfile
+++ b/dist/Containerfile
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (C) 2024 Olliver Schinagl <oliver@schinagl.nl>
+
+ARG ALPINE_VERSION="latest"
+ARG TARGET_ARCH="library"
+
+FROM docker.io/${TARGET_ARCH}/alpine:${ALPINE_VERSION} AS builder
+
+WORKDIR /src
+
+COPY . /src/
+
+RUN apk add --no-cache \
+        'build-base' \
+        'cmake' \
+        'git' \
+        'librtlsdr-dev' \
+        'libusb-dev' \
+        'ninja' \
+        'openssl-dev>3' \
+        'soapy-sdr-dev' \
+    && \
+    cmake -B '.build' -GNinja \
+          -DFORCE_COLORED_BUILD:BOOL=ON \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX='/usr' \
+          -DCMAKE_INSTALL_SYSCONFDIR='/etc' \
+          -DENABLE_OPENSSL=ON \
+    && \
+    cmake --build '.build' -j $(($(nproc) -1 )) && \
+    DESTDIR='/rtl_433' cmake --build '.build' --target install && \
+    rm -f -r '/rtl_433/include' && \
+    rm -f -r '/rtl_433/usr/share'
+
+FROM docker.io/${TARGET_ARCH}/alpine:${ALPINE_VERSION}
+
+LABEL maintainer="Olliver Schinagl <oliver@schinagl.nl>"
+
+RUN apk add --no-cache \
+        'librtlsdr' \
+        'libusb' \
+        'openssl' \
+        'soapy-sdr-libs' \
+        'tini' \
+        'tzdata' \
+    ;
+
+COPY --from=builder "/rtl_433" "/"
+COPY "dist/container-entrypoint.sh" "/init"
+
+ENTRYPOINT [ "/sbin/tini", "--", "/init" ]

--- a/dist/container-entrypoint.sh
+++ b/dist/container-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (C) 2024 Olliver Schinagl <oliver@schinagl.nl>
+#
+# A beginning user should be able to docker run image bash (or sh) without
+# needing to learn about --entrypoint
+# https://github.com/docker-library/official-images#consistency
+
+set -eu
+if [ -n "${DEBUG_TRACE_SH:-}" ] && \
+   [ "${DEBUG_TRACE_SH:-}" != "${DEBUG_TRACE_SH#*"$(basename "${0}")"*}" ] || \
+   [ "${DEBUG_TRACE_SH:-}" = 'all' ]; then
+	set -x
+fi
+
+bin='rtl_433'
+
+# Prefix args with $bin if $1 is not a valid command
+if ! command -v -- "${1:-}" > '/dev/null' 2>&1; then
+	set -- "${bin:?}" "${@}"
+fi
+exec "${@}"
+
+exit 0

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -107,6 +107,20 @@ Purge all SoapySDR packages and source installation from /usr/local.
 Then install only from packages (version 0.7) or only from source (version 0.8).
 :::
 
+## Docker
+
+To build the container (and thus the application) from source:
+
+```console
+$ docker build \
+         --rm \
+         --tag 'rtl_433:MR123' \
+         --file dist/Containerfile \
+         './'
+```
+
+and then can be run as above, with `rtl_433:MR123` as container name instead when running the container.
+
 ## Package maintainers
 
 To properly configure builds without relying on automatic feature detection you should set all options explicitly, e.g.


### PR DESCRIPTION
Lets add our own docker container and use github actions to build and push it.

For now, only the alpine container is built and pushed, but we can very easily add a matrix entry for a debian container if there's enough demand.

```patch
@@ -25,21 +25,24 @@
         include:
           - container: ./dist/Containerfile
             autotag: auto
+          - container: ./dist/Containerfile.debian
+            autotag: false
+            suffix: -debian
```

But the build is done for multiple architectures, so there's that.

Best to reduce the amount of configurations we offer, as it also means more that can break.

Note, that there's a good chance tagged-builds will fail, because this repository is using so called 'lightweight' tags, instead of properly 'annotated' tags! See https://git-scm.com/book/en/v2/Git-Basics-Tagging for more details. This also could be the reason some additional complexity is added to the `git get tags` cmake stuff.

A nice addition could be to also run the tests as part of the build process, but I already saw that it's not as simple as `make test` so I figured better keep the current CI way of testing :)

Note, that I've pushed this code to my personal master branch and this shows how releases would look like here https://github.com/oliv3r/rtl_433/pkgs/container/rtl_433.