### PR TITLE
Change support for qx-30x to extract device and button ID

### DIFF
--- a/conf/qx-30x.conf
+++ b/conf/qx-30x.conf
@@ -1,6 +1,10 @@
 # QX-30X
 #
-# This decoder reads button presses from QX-302, QX-305 self powered switches.
+# This decoder reads button presses from QX-302, QX-304 and QX-305 self powered
+# switches. These switches appear to use an EV1527 based encoding, where the
+# first 20 bits contain the device ID, the next 4 bits identify which button on
+# the device was pushed, and there may be a trailing sync bit. A sample rate of
+# around 1MHz is recommended to reliably detect these devices.
 #
 
 decoder {
@@ -10,6 +14,9 @@ decoder {
         long        = 100,
         gap         = 150,
         reset       = 1500,
-        bits       >= 25,
-	unique
+        bits       >= 24,
+        bits       <= 25,
+        unique,
+        get         = get=@0:{20}:id,
+        get         = get=@20:{4}:button
 }


### PR DESCRIPTION
Per [my comment](https://github.com/merbanan/rtl_433/issues/2902#issuecomment-2094812165) on the initial support request for these devices, this PR adds ID and button extraction based on the EV1527 encoding.

@adminy would you be able to give this a try with your switches and share the ID and button values extracted? I'm hoping you've got a 2-gang QX-302, but I'm keen to see the output regardless.