### PR TITLE
Add support for Hornbach MSRC-SAL Awning remote

### DIFF
--- a/conf/hornbach-msrc-sal.conf
+++ b/conf/hornbach-msrc-sal.conf
@@ -1,0 +1,79 @@
+# Decoder for Hornbach awning remotes.
+#
+# The remote is labeled MSRC-SAL and has article number 6196477 printed on the
+# label [0]. On the inside there's a chip with its markings removed, but it
+# looks like an off-the-shelf, generic remote. There are multiple LED positions,
+# where only one is soldered. There's unused keys, an unlabeled one on the
+# front, which does not even emit an RC signal, and one on the back, 'time',
+# without even a button behind it, nor was there a spot on the PCB for a key.
+#
+# There is also another sort of remote, which includes a wind-sensor [1].
+# It is assumed that it functions just like a remote, taking light and wind
+# into account to send the close signal.
+#
+# It should probably be mentioned, that Hornbach itself is likely not the
+# manufacturer itself.
+#
+# The remote operates on a 433.92 MHz frequency. The PCB is labeled
+# 'DC104-HD V1.3' and seems to be produced in 2019-07-04.
+#
+# Hornbach awnings use OOK_PWM encoding.
+# - 0 is defined as a 372 µs pulse followed by a 744 µs gap.
+# - 1 is defined as a 744 µs pulse followed by a 372 µs gap.
+# - reset is defined as a 1116 gap followed by a 7812 µs gap.
+# - sync is defined as a 4836 µs pulse, followed by a 1488 µs gap.
+#
+# > __Note:__ It is unclear if the last space (gap) of a bit is always extended
+# to a certain length, or if this is an additional delimiter. One could argue
+# the reset/delimiter is a 8928 µs gap.
+#
+# Transmissions starts with a sync and gap pulse, followed by 40 bits, closed
+# off with a gap and reset pulse.
+# These seem to be repeated at least 4 times, depending on how long the button
+# is kept pressed. The exception is the light, which is never repeated more than
+# 4 times, which is also visible on the remotes activity LED.
+#
+# Possible packet layout:
+# It starts with 32 bits Remote ID, possibly a combination of vendor + function
+# as commonly seen in infra-red remote controls. These are likely remote-unique.
+# When programming the awning to match a new/different remote, one is expected
+# to press `P2` during power-on, which the awning will acknowledge with some
+# beeps. Since the code does not change when pushing `P2`, this is a fair
+# assumption, but an assumption still.
+#
+# Following the remote ID we have a single byte that indicates the button.
+#
+#   | Button   | Byte | Bits             | Function                            |
+#   |----------|------|------------------|-------------------------------------|
+#   | P2       |   33 | 0 0 1 1  0 0 1 1 | Program/Learn remote                |
+#   | MODE     |   3e | 0 0 1 1  1 1 1 0 | Unknown/Undocumented                |
+#   | STOP     |   aa | 1 0 1 0  1 0 1 0 | Stop awning at current position     |
+#   | DOWN rel |   c3 | 1 1 0 0  0 0 1 1 | Release of button DOWN              |
+#   | DOWN     |   cc | 1 1 0 0  1 1 0 0 | Open awning (via internal endstop)  |
+#   | UP rel   |   e1 | 1 1 1 0  0 0 0 1 | Release of button UP                |
+#   | UP       |   ee | 1 1 1 0  1 1 1 0 | Close awning (via internal endstop) |
+#   | LIGHT    |   f0 | 1 1 1 1  0 0 0 0 | Light high/low/off                  |
+#
+# The UP/DOWN buttons are the only buttons that sends a release event when the
+# key is released on the remote. If the button is kept pressed until the remote
+# stops the signal, the UP/DOWN (release) key is not sent. Interestingly the
+# release events is the inverse of the last nibble of the press event. They are
+# ignored by the awning, which makes sense, as it is already moving.
+
+frequency 433.92M
+
+decoder {
+    name       = MSRC-SAL,
+    modulation = OOK_PWM,
+    bits       = 40,
+    short      = 372,
+    long       = 744,
+    reset      = 7812,
+    sync       = 4836,
+    gap        = 1488,
+    get        = RUID:@0:{32}:%x,
+    get        = button:@32:{8}:[0x33:P2 0x3E:MODE 0xAA:STOP 0xC3:DOWN_(release) 0xCC:DOWN 0xE1 UP_(release) 0xEE:UP 0xF0:LIGHT],
+}
+
+# [0]: https://www.hornbach.nl/p/reserveonderdeel-afstandsbediening-voor-zonnescherm-6145050-6145051-6145052-10178611-10178638-10178639-10178640-6823732-6823733-6823734-10461615-104961614-10328334-10328335-10468366-10468367-10468368-10468369-10468370/6196477/
+# [1]: https://www.hornbach.de/p/windwaechter-fuer-motor-markisen-weiss-inkl-1-5-m-netzanschlussleitung/10178681/


### PR DESCRIPTION
This commit adds support for the Hornbach Awning 433.92Mhz remote.

Some uncertainty remains on the Remote controls Unique ID, as it was only possible to test with a single remote.

As this is my first time analyzing RF data, I'm also not certain on the timings. Triq PDV was used (and some spreadsheet weighted averages) to find these values. The sync, reset and gap timings are the most uncertain, as well as possible tolerances etc.

I figured that there must be some logic too it, and having a fairly accurate sense for the 'short' of 374; I made everything else multiples thereof. I have no idea if this makes sense.


Here's a (concattenated) compressed dump of all keys pressed a few times, kept pressed etc.
[Uploading g000_433.92M_250k.cu8.zip…]()
