### PR TITLE
rtl_433_mqtt_relay: Use id in topic even if there is a channel

### DIFF
--- a/examples/rtl_433_mqtt_relay.py
+++ b/examples/rtl_433_mqtt_relay.py
@@ -75,7 +75,7 @@ def publish_sensor_to_mqtt(mqttc, data, line):
         path += "/" + sanitize(data["model"])
     if "channel" in data:
         path += "/" + str(data["channel"])
-    elif "id" in data:
+    if "id" in data:
         path += "/" + str(data["id"])
 
     if MQTT_INDIVIDUAL_TOPICS:


### PR DESCRIPTION
Previously, this example program appended /channel if present, and if not present and id was present, appended /id.  Typically channel is from an A/B/C switch on the device or fixed for kind of device, and id is from a 16 bit or larger space, sometimes static, and sometimes random on powerup.  Using only channel is bad if 1) one has more than one device, or more than 3 if A/B/C or 2) one's neighbor gets such a device.  Because it is essentially impossible to rule out point 2, id should always be used.