### PR TITLE
RollEaseAcmedia pulse time refinement

### DIFF
--- a/conf/oma-blind-remote.conf
+++ b/conf/oma-blind-remote.conf
@@ -1,0 +1,63 @@
+# Decoder for oma battery powered roller blind motor controller
+# Tested with blind motor with electronic limit switch. Mechanical limit 
+# switch motors not tested.
+# Instructions (LKC040902 ver 1.0) reference motors C-C16/C-C17.
+
+# The device tested is model 8C-C18-DC-WA-A101 5 channels
+# 433.92MHz
+# https://www.omaautomation.com/
+# FCC ID: Unknown
+
+# Note. There is another controller of similar apearance, which has 
+# programmable date/time functions, which uses a different (incompatable)
+# protocol. 
+
+# Manual: LKC040902 ver 1.0 (hardcopy)
+
+# FCC ID: Unknown
+
+# I have tested commands for blind up, blind stop and blind down. 
+
+# Initial protocol derived from remote control transmission observed by SDR-SDR with RTL_433, then refined the timing
+# of the long and short pulses, by experimentation with a blind motor, to establish operational limits for the short
+# and long pulses (with long = 2*short), uning LiliGo LoRa ESP32. Initial timing indicated by RTL_433 was 380us,
+# experiments indicated operation OK from 400 to 350 us, so I've used (400+350)/2= 375us for short and 750us for
+# long.
+
+# Schema of signal is <2 hex byte command><7 hex byte controller address><1 hex byte 1's compliment of channel number>
+# Up and down commands are sent as a pair of repeated commands.
+# Stop command is sent as a single repeated command.
+# The number of repeats received is quite variable, usually around 10.
+
+# Channel number is 1's complement of the eigth hex byte. Thus 0xf = channel 0
+#                                                              0xe = channel 1
+#                                                                ...
+#                                                              0x0 = channel 15    
+
+# Up commands are:
+#    Burst of about 6 repeats of:                <ee><7 byte controler address><1 byte channel>
+#    followed by a burst of about 6 repeats of:  <e1><7 byte controler address><1 byte channel>
+
+# Stop commands are:    
+#    Burst of about 6 repeats of:                <aa><7 byte controler address><1 byte channel>
+
+# Down commands are:
+#    Burst of about 6 repeats of:                <cc><7 byte controler address><1 byte channel>
+#    followed by a burst of about 6 repeats of:  <c3><7 byte controler address><1 byte channel>
+
+decoder {
+        n=oma,
+        m=OOK_PWM,
+        s=375,
+        l=750,
+        r=11760,
+        g=0,t=0,
+        y=4824,
+        bits=40,
+        rows>=2,
+        get=command:@0:{8}:[238:up 225:up 170:stop 204:down 195:down],
+        get=@8:{28}:controller_id,
+        get=channel:@36:{4}:[15:0 14:1 13:2 12:3 11:4 10:5 9:6 8:7 7:8 6:9 5:10 4:11 3:12 2:13 1:14 0:15],
+        unique
+        }
+

--- a/conf/oma-blind-remote.conf
+++ b/conf/oma-blind-remote.conf
@@ -18,11 +18,7 @@
 
 # I have tested commands for blind up, blind stop and blind down. 
 
-# Initial protocol derived from remote control transmission observed by SDR-SDR with RTL_433, then refined the timing
-# of the long and short pulses, by experimentation with a blind motor, to establish operational limits for the short
-# and long pulses (with long = 2*short), uning LiliGo LoRa ESP32. Initial timing indicated by RTL_433 was 380us,
-# experiments indicated operation OK from 400 to 350 us, so I've used (400+350)/2= 375us for short and 750us for
-# long.
+# Short pulses have been found to work between 400 to 350 us, with long pulses twice that.
 
 # Schema of signal is <2 hex byte command><7 hex byte controller address><1 hex byte 1's compliment of channel number>
 # Up and down commands are sent as a pair of repeated commands.

--- a/conf/rolleaseacmedia.conf
+++ b/conf/rolleaseacmedia.conf
@@ -38,6 +38,8 @@
 #    Burst of about 6 repeats of:                <7 byte controler address><1 byte channel><cc>
 #    followed by a burst of about 6 repeats of:  <7 byte controler address><1 byte channel><c3>
 
+# Short pulses have been found to work between 350 to 460 us, with long pulses twice that.
+
 decoder {
         n=rolleaseacmedia,
         m=OOK_PWM,

--- a/conf/rolleaseacmedia.conf
+++ b/conf/rolleaseacmedia.conf
@@ -41,8 +41,8 @@
 decoder {
         n=rolleaseacmedia,
         m=OOK_PWM,
-        s=352,
-        l=725,
+        s=405,
+        l=810,
         r=8734,
         g=0,
         t=0,


### PR DESCRIPTION
Refine the pulse timing by exploring the limits of pulse timings that work and choosing the mid points. Tested an verified against 10 different blind motors on 2 different address and found improved (now 100%) reliability. 