### PR TITLE
Add oma blind remote conf

### DIFF
--- a/conf/oma-blind-remote.conf
+++ b/conf/oma-blind-remote.conf
@@ -1,0 +1,61 @@
+# Decoder for oma battery powered roller blind motor controller
+# Tested with blind motor with electronic limit switch. Mechanical limit 
+# switch motors not tested.
+# Instructions (LKC040902 ver 1.0) reference motors C-C16/C-C17.
+
+# The device tested is model 8C-C18-DC-WA-A101 5 channels
+# 433.92MHz
+# https://www.omaautomation.com/
+# FCC ID: Unknown
+
+# Note. There is another controller of similar apearance, which has 
+# programmable date/time functions, which uses a different (incompatable)
+# protocol. 
+
+# User manual: LKC040902 ver 1.0 (hardcopy)
+
+# FCC ID: Unknown
+
+# I have tested commands for blind up, blind stop and blind down. 
+
+# Short pulses have been found to work between 400 to 350 us, with long pulses
+# twice that.
+
+# Schema of signal is   <2 byte command>
+#                       <7 byte controller address>
+#                       <1 byte 1's compliment of channel number>
+# Up and down commands are sent as a pair of repeated commands.
+# Stop command is sent as a single repeated command.
+# The number of repeats received is quite variable, usually around 10.
+
+# Channel number is 1's complement of the eigth byte. Thus 0xf = channel 0
+#                                                          0xe = channel 1
+#                                                          ...
+#                                                          0x0 = channel 15    
+
+# Up commands are:
+#   Burst of about 6 repeats of:                <ee><7 byte controler address><1 byte channel>
+#   followed by a burst of about 6 repeats of:  <e1><7 byte controler address><1 byte channel>
+
+# Stop commands are:    
+#   Burst of about 6 repeats of:                <aa><7 byte controler address><1 byte channel>
+
+# Down commands are:
+#   Burst of about 6 repeats of:                <cc><7 byte controler address><1 byte channel>
+#   followed by a burst of about 6 repeats of:  <c3><7 byte controler address><1 byte channel>
+
+decoder {
+        n=oma,
+        m=OOK_PWM,
+        s=375,
+        l=750,
+        r=11760,
+        g=0,t=0,
+        y=4824,
+        bits=40,
+        rows>=2,
+        get=command:@0:{8}:[238:up 225:up 170:stop 204:down 195:down],
+        get=@8:{28}:controller_id,
+        get=channel:@36:{4}:[15:0 14:1 13:2 12:3 11:4 10:5 9:6 8:7 7:8 6:9 5:10 4:11 3:12 2:13 1:14 0:15],
+        unique
+}


### PR DESCRIPTION
Add a conf file for decoding the oma automation 5 channel remote roller blind motor controller, model 8C-C18-DC-WH-A101.