### PR TITLE
Update fineoffset_ws90.c to longer length

### DIFF
--- a/src/devices/fineoffset_ws90.c
+++ b/src/devices/fineoffset_ws90.c
@@ -63,7 +63,7 @@ static int fineoffset_ws90_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     uint8_t b[32];
 
     // Validate package, WS90 nominal size is 345 bit periods
-    if (bitbuffer->bits_per_row[0] < 168 || bitbuffer->bits_per_row[0] > 400) {
+    if (bitbuffer->bits_per_row[0] < 168 || bitbuffer->bits_per_row[0] > 500) {
         decoder_logf_bitbuffer(decoder, 2, __func__, bitbuffer, "abort length" );
         return DECODE_ABORT_LENGTH;
     }


### PR DESCRIPTION
Looks like packet size on ws90 increased again on newer FW

```
[SDR] Using device 0: RTLSDRBlog, Blog V4, SN: 00000001, "Generic RTL2832U OEM"
Exact sample rate is: 1000000.026491 Hz
[fineoffset_ws90_decode] WS90 detected, buffer is 411 bits length
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
time      : 2024-09-30 21:58:39
model     : Fineoffset-WS90                        ID        : 006ce6
Battery   : 1.000        Battery Voltage: 3220 mV  Temperature: 7.4 C        Humidity  : 31 %          Wind direction: 87
Wind speed: 6.6 m/s      Gust speed: 8.5 m/s       UVI       : 0.0           Light     : 0.0 lux
Flags     : 81           Total Rain: 24.2 mm       Supercap Voltage: 5.1 V   Firmware Version: 143
Extra Data: 3fff024857------ca43ffbffb0000         Integrity : CRC
[pulse_slicer_pcm] Fine Offset Electronics WS90 weather station
codes     : {411}aaaaaaaaaaaa2dd490006ce60000a181da1f425755003fff02485700f233ca43ffbffb00008f064a3b5ffc3f690000000000000
[fineoffset_ws90_decode] WS90 detected, buffer is 411 bits length
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
time      : 2024-09-30 21:58:48
model     : Fineoffset-WS90                        ID        : 006ce6
Battery   : 1.000        Battery Voltage: 3220 mV  Temperature: 7.4 C        Humidity  : 31 %          Wind direction: 82
Wind speed: 7.3 m/s      Gust speed: 8.4 m/s       UVI       : 0.0           Light     : 0.0 lux
Flags     : 81           Total Rain: 24.2 mm       Supercap Voltage: 5.1 V   Firmware Version: 143
Extra Data: 3fff024857------ca43ffbffb0000         Integrity : CRC
[pulse_slicer_pcm] Fine Offset Electronics WS90 weather station
codes     : {411}aaaaaaaaaaaa2dd490006ce60000a181da1f495254003fff02485700f233ca43ffbffb00008f30753b5ffcf9790000000000000
```