### PR TITLE
Improve Acurite-606TX decoder to also decode the Technoline TX960 sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [52]  Bresser Thermo-/Hygro-Sensor 3CH
     [53]  Springfield Temperature and Soil Moisture
     [54]  Oregon Scientific SL109H Remote Thermal Hygro Sensor
-    [55]  Acurite 606TX Temperature Sensor
+    [55]  Acurite 606TX / Technoline TX960 Temperature Sensor
     [56]  TFA pool temperature sensor
     [57]  Kedsum Temperature & Humidity Sensor, Pearl NC-7415
     [58]  Blyss DC5-UK-WH

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -283,7 +283,7 @@ convert si
   protocol 52  # Bresser Thermo-/Hygro-Sensor 3CH
   protocol 53  # Springfield Temperature and Soil Moisture
   protocol 54  # Oregon Scientific SL109H Remote Thermal Hygro Sensor
-  protocol 55  # Acurite 606TX Temperature Sensor
+  protocol 55  # Acurite 606TX / Technoline TX960 Temperature Sensor
   protocol 56  # TFA pool temperature sensor
   protocol 57  # Kedsum Temperature & Humidity Sensor, Pearl NC-7415
   protocol 58  # Blyss DC5-UK-WH

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -22,7 +22,7 @@ Devices decoded:
 - Acurite 609TXC "TH" temperature and humidity sensor (609A1TX)
 - Acurite 986 Refrigerator / Freezer Thermometer
 - Acurite 515 Refrigerator / Freezer Thermometer
-- Acurite 606TX temperature sensor, optional with channels and [TX]Button
+- Acurite 606TX / Technoline TX960 temperature sensor, optional with channels and [TX]Button
 - Acurite 6045M Lightning Detector
 - Acurite 00275rm and 00276rm temp. and humidity with optional probe.
 - Acurite 1190/1192 leak/water detector

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -1608,8 +1608,29 @@ static int acurite_986_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 /**
-Acurite 606 Temperature sensor
+Acurite 606TX / Technoline TX960 Temperature sensor decoder.
 
+Specs:
+- Temperature -40 to 158 F / -40 to 70 C
+
+Status Information sent
+- button pressed
+- low battery
+- channel
+- id
+
+Message format:
+
+    Byte 0   Byte 1   Byte 2   Byte 3   Byte 4
+    IIIIIIII BbCCTTTT TTTTTTTT KKKKKKKK f
+
+- I = Sensor ID (8 bits, changes with every battery replacement)
+- B = Battery OK (cleared for low)
+- b = Button pressed
+- C = Channel (2 bits, Channels 0, 1 or 2)
+- T = Temperature (12 bits)
+- K = Checksum (8 bits)
+- f = Final bit (== 0 for Acurite sensor, == !B for Technoline sensor)
 */
 static int acurite_606_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
@@ -1630,9 +1651,6 @@ static int acurite_606_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_ABORT_LENGTH;
 
     b = bitbuffer->bb[row];
-
-    if (b[4] != 0)
-        return DECODE_FAIL_SANITY;
 
     // reject all blank messages
     if (b[0] == 0 && b[1] == 0 && b[2] == 0 && b[3] == 0)
@@ -1986,7 +2004,7 @@ static char const *const acurite_590_output_fields[] = {
 //.gap_limit      = 1200,
 //.reset_limit    = 12000,
 r_device const acurite_606 = {
-        .name        = "Acurite 606TX Temperature Sensor",
+        .name        = "Acurite 606TX / Technoline TX960 Temperature Sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 2000,
         .long_width  = 4000,


### PR DESCRIPTION
Fixes https://github.com/merbanan/rtl_433/issues/3074, see that issue for background. 

In short: The Technoline TX960 is almost identical to the existing Acurite 606TX temperature sensor. The only difference seems to be the final bit of each message, which is zero for Acurite but is the negated battery bit for the Technoline sensor.

By removing a sanity check on this last bit, both sensors get decoded reliably.