### PR TITLE
examples: Improve: Round battery level to display friendly format

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -206,7 +206,7 @@ mappings = {
             "device_class": "battery",
             "name": "Battery",
             "unit_of_measurement": "%",
-            "value_template": "{{ ((float(value) * 99)|round(1)) + 1 }}",
+            "value_template": "{{ ((float(value) * 99)|round(0)) + 1 }}",
             "state_class": "measurement",
             "entity_category": "diagnostic"
         }

--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -206,7 +206,7 @@ mappings = {
             "device_class": "battery",
             "name": "Battery",
             "unit_of_measurement": "%",
-            "value_template": "{{ float(value) * 99 + 1 }}",
+            "value_template": "{{ ((float(value) * 99)|round(1)) + 1 }}",
             "state_class": "measurement",
             "entity_category": "diagnostic"
         }


### PR DESCRIPTION
Current code, after fix from #1887, generates sometimes weird results. For example, for battery level 0.99 is the result  90.10000000000001, due to float conversions. 

I propose a fix that rounds the result to one decimal place, which should be fine for battery levels expressed in percentages. Rounding to whole numbers might even work well in this case.