### PR TITLE
Add support for Geevon TX19-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [272]  Landis & Gyr Gridstream Power Meters 19.2k
     [273]  Landis & Gyr Gridstream Power Meters 38.4k
     [274]  Revolt ZX-7717 power meter
+    [275]  Geevon TX19-1 outdoor sensor
 
 * Disabled by default, use -R n or a conf file to enable
 

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -504,6 +504,7 @@ convert si
   protocol 272 # Landis & Gyr Gridstream Power Meters 19.2k
   protocol 273 # Landis & Gyr Gridstream Power Meters 38.4k
   protocol 274 # Revolt ZX-7717 power meter
+  protocol 275 # Geevon TX19-1 outdoor sensor
 
 ## Flex devices (command line option "-X")
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -268,7 +268,7 @@
     DECL(chamberlain_cwpirc) \
     DECL(thermopro_tp829b) \
     DECL(arad_ms_meter) \
-    DECL(geevon) \
+    DECL(geevon_tx16_3) \
     DECL(fineoffset_wh46) \
     DECL(vevor_7in1) \
     DECL(arexx_ml) \
@@ -282,6 +282,7 @@
     DECL(gridstream192) \
     DECL(gridstream384) \
     DECL(revolt_zx7717) \
+    DECL(geevon_tx19_1) \
 
     /* Add new decoders here. */
 


### PR DESCRIPTION
The device itself can be found at Amazon, e.g. https://www.amazon.ca/Geevon-Wireless-Outdoor-Thermometer-Replacement/dp/B0BMLRJ61Q

The protocol is essentially the same as with TX16-3, the only difference is that checksum algorithm has changed. I tried feeding the data into reveng, but unfortunately it's enable to find CRC model.