### PR TITLE
Change data_make to type-safe calls

### DIFF
--- a/src/devices/abmt.c
+++ b/src/devices/abmt.c
@@ -70,11 +70,10 @@ static int abmt_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     temp_c = (float)temp;
 
     /* clang-format off */
-    data_t *data = data_make(
-             "model",         "",            DATA_STRING, "Basics-Meat",
-             "id",            "Id",          DATA_INT,    id,
-             "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-             NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",         "",            NULL,         "Basics-Meat");
+    data = data_int(data, "id",            "Id",          NULL,         id);
+    data = data_dbl(data, "temperature_C", "Temperature", "%.1f C",     temp_c);
     /* clang-format on */
     decoder_output_data(decoder, data);
     return 1;

--- a/src/devices/acurite.c
+++ b/src/devices/acurite.c
@@ -168,11 +168,10 @@ static int acurite_rain_896_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     decoder_log_bitrow(decoder, 2, __func__, b, bitbuffer->bits_per_row[0], "Raw Message ");
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",                "",             DATA_STRING, "Acurite-Rain",
-            "id",                   "",             DATA_INT,    id,
-            "rain_mm",              "Total Rain",   DATA_FORMAT, "%.1f mm", DATA_DOUBLE, total_rain,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",                "",             NULL,         "Acurite-Rain");
+    data = data_int(data, "id",                   "",             NULL,         id);
+    data = data_dbl(data, "rain_mm",              "Total Rain",   "%.1f mm",    total_rain);
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -234,15 +233,14 @@ static int acurite_th_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         }
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",            "",             DATA_STRING, "Acurite-609TXC",
-                "id",               "",             DATA_INT,    id,
-                "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-                "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, tempc,
-                "humidity",         "Humidity",     DATA_FORMAT, "%u %%", DATA_INT,    humidity,
-                "status",           "",             DATA_INT,    status,
-                "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",            "",             NULL,         "Acurite-609TXC");
+        data = data_int(data, "id",               "",             NULL,         id);
+        data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+        data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     tempc);
+        data = data_int(data, "humidity",         "Humidity",     "%u %%",      humidity);
+        data = data_int(data, "status",           "",             NULL,         status);
+        data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);
@@ -428,19 +426,18 @@ static int acurite_6045_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
         exception++;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",                 DATA_STRING, "Acurite-6045M",
-            "id",               NULL,               DATA_INT,    sensor_id,
-            "channel",          NULL,               DATA_STRING, channel_str,
-            "battery_ok",       "Battery",          DATA_INT,    !battery_low,
-            "temperature_F",    "Temperature",      DATA_FORMAT, "%.1f F",     DATA_DOUBLE,     tempf,
-            "humidity",         "Humidity",         DATA_FORMAT, "%u %%", DATA_INT,    humidity,
-            "strike_count",     "Strike Count",     DATA_INT,    strike_count,
-            "storm_dist",       "Storm Distance",   DATA_INT,    strike_distance,
-            "active",           "Active Mode",      DATA_INT,    active,
-            "rfi",              "RFI Detect",       DATA_INT,    rfi_detect,
-            "exception",        "Data Exception",   DATA_INT,    exception,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "Acurite-6045M");
+    data = data_int(data, "id",               NULL,               NULL,         sensor_id);
+    data = data_str(data, "channel",          NULL,               NULL,         channel_str);
+    data = data_int(data, "battery_ok",       "Battery",          NULL,         !battery_low);
+    data = data_dbl(data, "temperature_F",    "Temperature",      "%.1f F",     tempf);
+    data = data_int(data, "humidity",         "Humidity",         "%u %%",      humidity);
+    data = data_int(data, "strike_count",     "Strike Count",     NULL,         strike_count);
+    data = data_int(data, "storm_dist",       "Storm Distance",   NULL,         strike_distance);
+    data = data_int(data, "active",           "Active Mode",      NULL,         active);
+    data = data_int(data, "rfi",              "RFI Detect",       NULL,         rfi_detect);
+    data = data_int(data, "exception",        "Data Exception",   NULL,         exception);
     /* clang-format on */
 
     /*
@@ -490,15 +487,14 @@ static int acurite_899_decode(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t
     int raincounter = ((bb[5] & 0x7f) << 7) | (bb[6] & 0x7f);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",                         DATA_STRING, "Acurite-Rain899",
-            "id",               "",                         DATA_INT,    sensor_id,
-            "channel",          "",                         DATA_INT,    channel,
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",                         NULL,         "Acurite-Rain899");
+    data = data_int(data, "id",               "",                         NULL,         sensor_id);
+    data = data_int(data, "channel",          "",                         NULL,         channel);
             // "channel",              NULL,           DATA_STRING, channel_str,
-            "battery_ok",       "Battery",                  DATA_INT,    !battery_low,
-            "rain_mm",          "Rainfall Accumulation",    DATA_FORMAT, "%.2f mm", DATA_DOUBLE, raincounter * 0.254,
-            "mic",              "Integrity",                DATA_STRING, "CHECKSUM",
-            NULL);
+    data = data_int(data, "battery_ok",       "Battery",                  NULL,         !battery_low);
+    data = data_dbl(data, "rain_mm",          "Rainfall Accumulation",    "%.2f mm",    raincounter * 0.254);
+    data = data_str(data, "mic",              "Integrity",                NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -567,18 +563,17 @@ static int acurite_3n1_decode(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t
     float wind_speed_mph = bb[6] & 0x7f; // seems to be plain MPH
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING,    "Acurite-3n1",
-            "message_type",     NULL,           DATA_INT,       message_type,
-            "id",               NULL,           DATA_FORMAT,    "0x%02X",   DATA_INT,       sensor_id,
-            "channel",          NULL,           DATA_STRING,    channel_str,
-            "sequence_num",     NULL,           DATA_INT,       sequence_num,
-            "battery_ok",       "Battery",      DATA_INT,       !battery_low,
-            "wind_avg_mi_h",    "Wind Speed",   DATA_FORMAT,    "%.1f mi/h", DATA_DOUBLE,     wind_speed_mph,
-            "temperature_F",    "Temperature",  DATA_FORMAT,    "%.1f F", DATA_DOUBLE,    tempf,
-            "humidity",         NULL,           DATA_FORMAT,    "%u %%",   DATA_INT,   humidity,
-            "mic",              "Integrity",    DATA_STRING,    "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Acurite-3n1");
+    data = data_int(data, "message_type",     NULL,           NULL,         message_type);
+    data = data_int(data, "id",               NULL,           "0x%02X",     sensor_id);
+    data = data_str(data, "channel",          NULL,           NULL,         channel_str);
+    data = data_int(data, "sequence_num",     NULL,           NULL,         sequence_num);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_dbl(data, "wind_avg_mi_h",    "Wind Speed",   "%.1f mi/h",  wind_speed_mph);
+    data = data_dbl(data, "temperature_F",    "Temperature",  "%.1f F",     tempf);
+    data = data_int(data, "humidity",         NULL,           "%u %%",      humidity);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -621,18 +616,17 @@ static int acurite_5n1_decode(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t
         int raincounter = ((bb[5] & 0x7f) << 7) | (bb[6] & 0x7F);
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",            "",                         DATA_STRING,    "Acurite-5n1",
-                "message_type",     NULL,                       DATA_INT,       message_type,
-                "id",               NULL,                       DATA_INT,       sensor_id,
-                "channel",          NULL,                       DATA_STRING,    channel_str,
-                "sequence_num",     NULL,                       DATA_INT,       sequence_num,
-                "battery_ok",       "Battery",                  DATA_INT,       !battery_low,
-                "wind_avg_km_h",    "Wind Speed",               DATA_FORMAT,    "%.1f km/h", DATA_DOUBLE,     wind_speed_kph,
-                "wind_dir_deg",     NULL,                       DATA_FORMAT,    "%.1f", DATA_DOUBLE,    wind_dir,
-                "rain_in",          "Rainfall Accumulation",    DATA_FORMAT,    "%.2f in", DATA_DOUBLE, raincounter * 0.01f,
-                "mic",              "Integrity",                DATA_STRING,    "CHECKSUM",
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",            "",                         NULL,         "Acurite-5n1");
+        data = data_int(data, "message_type",     NULL,                       NULL,         message_type);
+        data = data_int(data, "id",               NULL,                       NULL,         sensor_id);
+        data = data_str(data, "channel",          NULL,                       NULL,         channel_str);
+        data = data_int(data, "sequence_num",     NULL,                       NULL,         sequence_num);
+        data = data_int(data, "battery_ok",       "Battery",                  NULL,         !battery_low);
+        data = data_dbl(data, "wind_avg_km_h",    "Wind Speed",               "%.1f km/h",  wind_speed_kph);
+        data = data_dbl(data, "wind_dir_deg",     NULL,                       "%.1f",       wind_dir);
+        data = data_dbl(data, "rain_in",          "Rainfall Accumulation",    "%.2f in",    raincounter * 0.01f);
+        data = data_str(data, "mic",              "Integrity",                NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);
@@ -659,18 +653,17 @@ static int acurite_5n1_decode(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t
 
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",            "",             DATA_STRING,    "Acurite-5n1",
-                "message_type",     NULL,           DATA_INT,       message_type,
-                "id",               NULL,           DATA_INT,       sensor_id,
-                "channel",          NULL,           DATA_STRING,    channel_str,
-                "sequence_num",     NULL,           DATA_INT,       sequence_num,
-                "battery_ok",       "Battery",      DATA_INT,       !battery_low,
-                "wind_avg_km_h",    "wind_speed",   DATA_FORMAT,    "%.1f km/h", DATA_DOUBLE,     wind_speed_kph,
-                "temperature_F",    "temperature",  DATA_FORMAT,    "%.1f F", DATA_DOUBLE,    tempf,
-                "humidity",         NULL,           DATA_FORMAT,    "%u %%",   DATA_INT,   humidity,
-                "mic",              "Integrity",    DATA_STRING,    "CHECKSUM",
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",            "",             NULL,         "Acurite-5n1");
+        data = data_int(data, "message_type",     NULL,           NULL,         message_type);
+        data = data_int(data, "id",               NULL,           NULL,         sensor_id);
+        data = data_str(data, "channel",          NULL,           NULL,         channel_str);
+        data = data_int(data, "sequence_num",     NULL,           NULL,         sequence_num);
+        data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+        data = data_dbl(data, "wind_avg_km_h",    "wind_speed",   "%.1f km/h",  wind_speed_kph);
+        data = data_dbl(data, "temperature_F",    "temperature",  "%.1f F",     tempf);
+        data = data_int(data, "humidity",         NULL,           "%u %%",      humidity);
+        data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);
@@ -783,15 +776,14 @@ static int acurite_atlas_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsig
     }
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",                "",             DATA_STRING, "Acurite-Atlas",
-            "id",                   NULL,           DATA_INT,    sensor_id,
-            "channel",              NULL,           DATA_STRING, channel_str,
-            "sequence_num",         NULL,           DATA_INT,    sequence_num,
-            "battery_ok",           "Battery",      DATA_INT,    !battery_low,
-            "message_type",         NULL,           DATA_INT,    message_type,
-            "wind_avg_mi_h",        "Wind Speed",   DATA_FORMAT, "%.1f mi/h", DATA_DOUBLE, wind_speed_mph,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",                "",             NULL,         "Acurite-Atlas");
+    data = data_int(data, "id",                   NULL,           NULL,         sensor_id);
+    data = data_str(data, "channel",              NULL,           NULL,         channel_str);
+    data = data_int(data, "sequence_num",         NULL,           NULL,         sequence_num);
+    data = data_int(data, "battery_ok",           "Battery",      NULL,         !battery_low);
+    data = data_int(data, "message_type",         NULL,           NULL,         message_type);
+    data = data_dbl(data, "wind_avg_mi_h",        "Wind Speed",   "%.1f mi/h",  wind_speed_mph);
     /* clang-format on */
 
     if (message_type == ACURITE_MSGTYPE_ATLAS_WNDSPD_TEMP_HUM ||
@@ -984,15 +976,16 @@ static int acurite_tower_decode(r_device *decoder, bitbuffer_t *bitbuffer, uint8
         exception++;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",                "",             DATA_STRING, "Acurite-Tower",
-            "id",                   "",             DATA_INT,    sensor_id,
-            "channel",              NULL,           DATA_STRING, channel_str,
-            "battery_ok",           "Battery",      DATA_INT,    !battery_low,
-            "temperature_C",        "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, tempc,
-            "humidity",             "Humidity",     DATA_COND, humidity != 127, DATA_FORMAT, "%u %%", DATA_INT,    humidity,
-            "mic",                  "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",                "",             NULL,         "Acurite-Tower");
+    data = data_int(data, "id",                   "",             NULL,         sensor_id);
+    data = data_str(data, "channel",              NULL,           NULL,         channel_str);
+    data = data_int(data, "battery_ok",           "Battery",      NULL,         !battery_low);
+    data = data_dbl(data, "temperature_C",        "Temperature",  "%.1f C",     tempc);
+    if (humidity != 127) {
+        data = data_int(data, "humidity",             "Humidity",     "%u %%",      humidity);
+    }
+    data = data_str(data, "mic",                  "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     if (exception) {
@@ -1036,14 +1029,13 @@ static int acurite_1190_decode(r_device *decoder, bitbuffer_t *bitbuffer, uint8_
     int is_wet = (bb[3] & 0x10) >> 4;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",                "",             DATA_STRING, "Acurite-Leak",
-            "id",                   "",             DATA_INT,    sensor_id,
-            "channel",              NULL,           DATA_STRING, channel_str,
-            "battery_ok",           "Battery",      DATA_INT,    !battery_low,
-            "leak_detected",        "Leak",         DATA_INT,    is_wet,
-            "mic",                  "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",                "",             NULL,         "Acurite-Leak");
+    data = data_int(data, "id",                   "",             NULL,         sensor_id);
+    data = data_str(data, "channel",              NULL,           NULL,         channel_str);
+    data = data_int(data, "battery_ok",           "Battery",      NULL,         !battery_low);
+    data = data_int(data, "leak_detected",        "Leak",         NULL,         is_wet);
+    data = data_str(data, "mic",                  "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -1119,14 +1111,13 @@ static int acurite_515_decode(r_device *decoder, bitbuffer_t *bitbuffer, uint8_t
     int battery_low = (bb[2] & 0x40) == 0;
 
     /* clang-format off */
-    data_t *data = data_make(
-        "model",                "",             DATA_STRING, "Acurite-515",
-        "id",                   "",             DATA_INT,    sensor_id,
-        "channel",              NULL,           DATA_STRING, channel_type_str,
-        "battery_ok",           "Battery",      DATA_INT,    !battery_low,
-        "temperature_F",        "Temperature",  DATA_FORMAT, "%.1f F", DATA_DOUBLE, tempf,
-        "mic",                  "Integrity",    DATA_STRING, "CHECKSUM",
-        NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",                "",             NULL,         "Acurite-515");
+    data = data_int(data, "id",                   "",             NULL,         sensor_id);
+    data = data_str(data, "channel",              NULL,           NULL,         channel_type_str);
+    data = data_int(data, "battery_ok",           "Battery",      NULL,         !battery_low);
+    data = data_dbl(data, "temperature_F",        "Temperature",  "%.1f F",     tempf);
+    data = data_str(data, "mic",                  "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     if (exception) {
@@ -1570,15 +1561,14 @@ static int acurite_986_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         decoder_logf(decoder, 1, __func__, "sensor 0x%04x - %d%c: %d F", sensor_id, sensor_num, sensor_type, tempf);
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",            "",             DATA_STRING, "Acurite-986",
-                "id",               NULL,           DATA_INT,    sensor_id,
-                "channel",          NULL,           DATA_STRING, channel_str,
-                "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-                "temperature_F",    "temperature",  DATA_FORMAT, "%f F", DATA_DOUBLE,    (float)tempf,
-                "status",           "Status",       DATA_INT,    status,
-                "mic",              "Integrity",    DATA_STRING, "CRC",
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",            "",             NULL,         "Acurite-986");
+        data = data_int(data, "id",               NULL,           NULL,         sensor_id);
+        data = data_str(data, "channel",          NULL,           NULL,         channel_str);
+        data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+        data = data_dbl(data, "temperature_F",    "temperature",  "%f F",       (float)tempf);
+        data = data_int(data, "status",           "Status",       NULL,         status);
+        data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
         /* clang-format on */
 
         decoder_output_data(decoder, data);
@@ -1658,15 +1648,14 @@ static int acurite_606_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     temp_c     = temp_raw * 0.1f;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Acurite-606TX",
-            "id",               "",             DATA_INT, sensor_id,
-            "channel",          "Channel",      DATA_INT,   channel,
-            "battery_ok",       "Battery",      DATA_INT,    battery_ok,
-            "button",           "Button",       DATA_INT,   button,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Acurite-606TX");
+    data = data_int(data, "id",               "",             NULL,         sensor_id);
+    data = data_int(data, "channel",          "Channel",      NULL,         channel);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         battery_ok);
+    data = data_int(data, "button",           "Button",       NULL,         button);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -1732,15 +1721,18 @@ static int acurite_590tx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Acurite-590TX",
-            "id",               "",             DATA_INT,    sensor_id,
-            "channel",          "Channel",      DATA_INT,    channel,
-            "battery_ok",       "Battery",      DATA_INT,    battery_ok,
-            "humidity",         "Humidity",     DATA_COND,   humidity != -1,    DATA_INT,    humidity,
-            "temperature_C",    "Temperature",  DATA_COND,   humidity == -1,    DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "mic",              "Integrity",    DATA_STRING, "PARITY",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Acurite-590TX");
+    data = data_int(data, "id",               "",             NULL,         sensor_id);
+    data = data_int(data, "channel",          "Channel",      NULL,         channel);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         battery_ok);
+    if (humidity != -1) {
+        data = data_int(data, "humidity",         "Humidity",     NULL,         humidity);
+    }
+    if (humidity == -1) {
+        data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    }
+    data = data_str(data, "mic",              "Integrity",    NULL,         "PARITY");
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -1812,19 +1804,26 @@ static int acurite_00275rm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         int phumidity = b[9] & 0x7f; // valid only if (probe == 3)
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",            "",             DATA_STRING,    model_flag ? "Acurite-00275rm" : "Acurite-00276rm",
-                "subtype",          "Probe",        DATA_INT,       probe,
-                "id",               "",             DATA_INT,       id,
-                "battery_ok",       "Battery",      DATA_INT,       !battery_low,
-                "temperature_C",    "Celsius",      DATA_FORMAT,    "%.1f C",  DATA_DOUBLE, tempc,
-                "humidity",         "Humidity",     DATA_FORMAT,    "%u %%", DATA_INT,      humidity,
-                "water",            "",             DATA_COND, probe == 1, DATA_INT,        water,
-                "temperature_1_C",  "Celsius",      DATA_COND, probe == 2, DATA_FORMAT, "%.1f C",   DATA_DOUBLE, ptempc,
-                "temperature_1_C",  "Celsius",      DATA_COND, probe == 3, DATA_FORMAT, "%.1f C",   DATA_DOUBLE, ptempc,
-                "humidity_1",       "Humidity",     DATA_COND, probe == 3, DATA_FORMAT, "%u %%",    DATA_INT,    phumidity,
-                "mic",              "Integrity",    DATA_STRING,    "CRC",
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",            "",             NULL,         model_flag ? "Acurite-00275rm" : "Acurite-00276rm");
+        data = data_int(data, "subtype",          "Probe",        NULL,         probe);
+        data = data_int(data, "id",               "",             NULL,         id);
+        data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+        data = data_dbl(data, "temperature_C",    "Celsius",      "%.1f C",     tempc);
+        data = data_int(data, "humidity",         "Humidity",     "%u %%",      humidity);
+        if (probe == 1) {
+            data = data_int(data, "water",            "",             NULL,         water);
+        }
+        if (probe == 2) {
+            data = data_dbl(data, "temperature_1_C",  "Celsius",      "%.1f C",     ptempc);
+        }
+        if (probe == 3) {
+            data = data_dbl(data, "temperature_1_C",  "Celsius",      "%.1f C",     ptempc);
+        }
+        if (probe == 3) {
+            data = data_int(data, "humidity_1",       "Humidity",     "%u %%",      phumidity);
+        }
+        data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/acurite_01185m.c
+++ b/src/devices/acurite_01185m.c
@@ -95,15 +95,18 @@ static int acurite_01185m_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         float temp2_f = (temp2_raw - 900) * 0.1f;
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",            "",             DATA_STRING,    "Acurite-01185M",
-                "id",               "",             DATA_INT,       id,
-                "channel",          "",             DATA_INT,       channel,
-                "battery_ok",       "Battery",      DATA_INT,       !batt_low,
-                "temperature_1_F",  "Meat",         DATA_COND, temp1_ok, DATA_FORMAT, "%.1f F",   DATA_DOUBLE, temp1_f,
-                "temperature_2_F",  "Ambient",      DATA_COND, temp2_ok, DATA_FORMAT, "%.1f F",   DATA_DOUBLE, temp2_f,
-                "mic",              "Integrity",    DATA_STRING,    "CHECKSUM",
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",            "",             NULL,         "Acurite-01185M");
+        data = data_int(data, "id",               "",             NULL,         id);
+        data = data_int(data, "channel",          "",             NULL,         channel);
+        data = data_int(data, "battery_ok",       "Battery",      NULL,         !batt_low);
+        if (temp1_ok) {
+            data = data_dbl(data, "temperature_1_F",  "Meat",         "%.1f F",     temp1_f);
+        }
+        if (temp2_ok) {
+            data = data_dbl(data, "temperature_2_F",  "Ambient",      "%.1f F",     temp2_f);
+        }
+        data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/akhan_100F14.c
+++ b/src/devices/akhan_100F14.c
@@ -51,11 +51,10 @@ static int akhan_rke_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_FAIL_SANITY;
 
     /* clang-format off */
-    data = data_make(
-            "model",    "",             DATA_STRING, "Akhan-100F14",
-            "id",       "ID (20bit)",   DATA_FORMAT, "0x%x", DATA_INT, id,
-            "data",     "Data (4bit)",  DATA_STRING, cmd_str,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",    "",             NULL,         "Akhan-100F14");
+    data = data_int(data, "id",       "ID (20bit)",   "0x%x",       id);
+    data = data_str(data, "data",     "Data (4bit)",  NULL,         cmd_str);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/alecto.c
+++ b/src/devices/alecto.c
@@ -145,16 +145,15 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             int direction = (reverse8(bb[5 + skip][2]) << 1) | (bb[5 + skip][1] & 0x1);
 
             /* clang-format off */
-            data = data_make(
-                    "model",            "",                 DATA_STRING, "AlectoV1-Wind",
-                    "id",               "House Code",       DATA_INT,    sensor_id,
-                    "channel",          "Channel",          DATA_INT,    channel,
-                    "battery_ok",       "Battery",          DATA_INT,    !battery_low,
-                    "wind_avg_m_s",     "Wind speed",       DATA_FORMAT, "%.2f m/s", DATA_DOUBLE, speed * 0.2F,
-                    "wind_max_m_s",     "Wind gust",        DATA_FORMAT, "%.2f m/s", DATA_DOUBLE, gust * 0.2F,
-                    "wind_dir_deg",     "Wind Direction",   DATA_INT,    direction,
-                    "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
-                    NULL);
+            data = NULL;
+            data = data_str(data, "model",            "",                 NULL,         "AlectoV1-Wind");
+            data = data_int(data, "id",               "House Code",       NULL,         sensor_id);
+            data = data_int(data, "channel",          "Channel",          NULL,         channel);
+            data = data_int(data, "battery_ok",       "Battery",          NULL,         !battery_low);
+            data = data_dbl(data, "wind_avg_m_s",     "Wind speed",       "%.2f m/s",   speed * 0.2F);
+            data = data_dbl(data, "wind_max_m_s",     "Wind gust",        "%.2f m/s",   gust * 0.2F);
+            data = data_int(data, "wind_dir_deg",     "Wind Direction",   NULL,         direction);
+            data = data_str(data, "mic",              "Integrity",        NULL,         "CHECKSUM");
             /* clang-format on */
             decoder_output_data(decoder, data);
             return 1;
@@ -166,14 +165,13 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         double rain_mm = ((reverse8(b[3]) << 8) | reverse8(b[2])) * 0.25F;
 
         /* clang-format off */
-        data = data_make(
-                "model",        "",             DATA_STRING, "AlectoV1-Rain",
-                "id",           "House Code",   DATA_INT,    sensor_id,
-                "channel",      "Channel",      DATA_INT,    channel,
-                "battery_ok",   "Battery",      DATA_INT,    !battery_low,
-                "rain_mm",      "Total Rain",   DATA_FORMAT, "%.2f mm", DATA_DOUBLE, rain_mm,
-                "mic",          "Integrity",    DATA_STRING, "CHECKSUM",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",        "",             NULL,         "AlectoV1-Rain");
+        data = data_int(data, "id",           "House Code",   NULL,         sensor_id);
+        data = data_int(data, "channel",      "Channel",      NULL,         channel);
+        data = data_int(data, "battery_ok",   "Battery",      NULL,         !battery_low);
+        data = data_dbl(data, "rain_mm",      "Total Rain",   "%.2f mm",    rain_mm);
+        data = data_str(data, "mic",          "Integrity",    NULL,         "CHECKSUM");
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -191,15 +189,14 @@ static int alectov1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             return DECODE_FAIL_SANITY; // detect false positive, prologue is also 36bits and sometimes detected as alecto
 
         /* clang-format off */
-        data = data_make(
-                "model",         "",            DATA_STRING, "AlectoV1-Temperature",
-                "id",            "House Code",  DATA_INT,    sensor_id,
-                "channel",       "Channel",     DATA_INT,    channel,
-                "battery_ok",    "Battery",     DATA_INT,    !battery_low,
-                "temperature_C", "Temperature", DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-                "humidity",      "Humidity",    DATA_FORMAT, "%u %%",   DATA_INT, humidity,
-                "mic",           "Integrity",   DATA_STRING, "CHECKSUM",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",         "",            NULL,         "AlectoV1-Temperature");
+        data = data_int(data, "id",            "House Code",  NULL,         sensor_id);
+        data = data_int(data, "channel",       "Channel",     NULL,         channel);
+        data = data_int(data, "battery_ok",    "Battery",     NULL,         !battery_low);
+        data = data_dbl(data, "temperature_C", "Temperature", "%.2f C",     temp_c);
+        data = data_int(data, "humidity",      "Humidity",    "%u %%",      humidity);
+        data = data_str(data, "mic",           "Integrity",   NULL,         "CHECKSUM");
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;

--- a/src/devices/ambient_weather.c
+++ b/src/devices/ambient_weather.c
@@ -101,15 +101,14 @@ static int ambient_weather_decode(r_device *decoder, bitbuffer_t *bitbuffer, uns
 
 
     /* clang-format off */
-    data = data_make(
-            "model",          "",             DATA_STRING, "Ambientweather-F007TH",
-            "id",             "House Code",   DATA_INT,    deviceID,
-            "channel",        "Channel",      DATA_INT,    channel,
-            "battery_ok",     "Battery",      DATA_INT,    !isBatteryLow,
-            "temperature_F",  "Temperature",  DATA_FORMAT, "%.1f F", DATA_DOUBLE, temperature,
-            "humidity",       "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "mic",            "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",          "",             NULL,         "Ambientweather-F007TH");
+    data = data_int(data, "id",             "House Code",   NULL,         deviceID);
+    data = data_int(data, "channel",        "Channel",      NULL,         channel);
+    data = data_int(data, "battery_ok",     "Battery",      NULL,         !isBatteryLow);
+    data = data_dbl(data, "temperature_F",  "Temperature",  "%.1f F",     temperature);
+    data = data_int(data, "humidity",       "Humidity",     "%u %%",      humidity);
+    data = data_str(data, "mic",            "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/ambientweather_tx8300.c
+++ b/src/devices/ambientweather_tx8300.c
@@ -103,15 +103,16 @@ static int ambientweather_tx8300_callback(r_device *decoder, bitbuffer_t *bitbuf
         humidity = -1;
 
     /* clang-format off */
-    data = data_make(
-            "model",         "",            DATA_STRING, "AmbientWeather-TX8300",
-            "id",            "",            DATA_INT,    sensor_id,
-            "channel",       "",            DATA_INT,    channel,
-            "battery",       "Battery",     DATA_INT,    battery_low, // mapping unknown
-            "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "humidity",      "Humidity",    DATA_COND,   humidity >= 0, DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "mic",           "MIC",         DATA_STRING, "CHECKSUM",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",         "",            NULL,         "AmbientWeather-TX8300");
+    data = data_int(data, "id",            "",            NULL,         sensor_id);
+    data = data_int(data, "channel",       "",            NULL,         channel);
+    data = data_int(data, "battery",       "Battery",     NULL,         battery_low); // mapping unknown
+    data = data_dbl(data, "temperature_C", "Temperature", "%.1f C",     temp_c);
+    if (humidity >= 0) {
+        data = data_int(data, "humidity",      "Humidity",    "%u %%",      humidity);
+    }
+    data = data_str(data, "mic",           "MIC",         NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/ambientweather_wh31e.c
+++ b/src/devices/ambientweather_wh31e.c
@@ -222,17 +222,20 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             snprintf(extra, sizeof(extra), "%02x%02x%02x%02x%02x", b[6], b[7], b[8], b[9], b[10]);
 
             /* clang-format off */
-            data_t *data = data_make(
-                    "model",            "",             DATA_COND, msg_type == 0x30, DATA_STRING, "AmbientWeather-WH31E",
-                    "model",            "",             DATA_COND, msg_type == 0x37, DATA_STRING, "AmbientWeather-WH31B",
-                    "id",               "",             DATA_INT,    id,
-                    "channel",          "Channel",      DATA_INT,    channel,
-                    "battery_ok",       "Battery",      DATA_INT,    !batt_low,
-                    "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-                    "humidity",         "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, humidity,
-                    "data",             "Extra Data",   DATA_STRING, extra,
-                    "mic",              "Integrity",    DATA_STRING, "CRC",
-                    NULL);
+            data_t *data = NULL;
+            if (msg_type == 0x30) {
+                data = data_str(data, "model",            "",             NULL,         "AmbientWeather-WH31E");
+            }
+            if (msg_type == 0x37) {
+                data = data_str(data, "model",            "",             NULL,         "AmbientWeather-WH31B");
+            }
+            data = data_int(data, "id",               "",             NULL,         id);
+            data = data_int(data, "channel",          "Channel",      NULL,         channel);
+            data = data_int(data, "battery_ok",       "Battery",      NULL,         !batt_low);
+            data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+            data = data_int(data, "humidity",         "Humidity",     "%u %%",      humidity);
+            data = data_str(data, "data",             "Extra Data",   NULL,         extra);
+            data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
             /* clang-format on */
             decoder_output_data(decoder, data);
             events++;
@@ -265,13 +268,12 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                     year, month, day, hours, minutes, seconds);
 
             /* clang-format off */
-            data_t *data = data_make(
-                    "model",        "",             DATA_STRING,    "AmbientWeather-WH31E",
-                    "id",           "Station ID",   DATA_INT,       id,
-                    "data",         "Unknown",      DATA_INT,       unknown,
-                    "radio_clock",  "Radio Clock",  DATA_STRING,    clock_str,
-                    "mic",          "Integrity",    DATA_STRING,    "CRC",
-                    NULL);
+            data_t *data = NULL;
+            data = data_str(data, "model",        "",             NULL,         "AmbientWeather-WH31E");
+            data = data_int(data, "id",           "Station ID",   NULL,         id);
+            data = data_int(data, "data",         "Unknown",      NULL,         unknown);
+            data = data_str(data, "radio_clock",  "Radio Clock",  NULL,         clock_str);
+            data = data_str(data, "mic",          "Integrity",    NULL,         "CRC");
             /* clang-format on */
             decoder_output_data(decoder, data);
             events++;
@@ -301,15 +303,18 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 battery_lvl = 100;
 
             /* clang-format off */
-            data_t *data = data_make(
-                    "model",            "",                DATA_STRING, "EcoWitt-WH40",
-                    "id",               "",                DATA_INT,    id,
-                    "battery_V",        "Battery Voltage", DATA_COND, battery_v != 0, DATA_FORMAT, "%f V", DATA_DOUBLE, battery_v * 0.1f,
-                    "battery_ok",       "Battery",         DATA_COND, battery_v != 0, DATA_DOUBLE, battery_lvl * 0.01f,
-                    "rain_mm",          "Total Rain",      DATA_FORMAT, "%.1f mm", DATA_DOUBLE, rain_raw * 0.1,
-                    "data",             "Extra Data",      DATA_STRING, extra,
-                    "mic",              "Integrity",       DATA_STRING, "CRC",
-                    NULL);
+            data_t *data = NULL;
+            data = data_str(data, "model",            "",                NULL,         "EcoWitt-WH40");
+            data = data_int(data, "id",               "",                NULL,         id);
+            if (battery_v != 0) {
+                data = data_dbl(data, "battery_V",        "Battery Voltage", "%f V",       battery_v * 0.1f);
+            }
+            if (battery_v != 0) {
+                data = data_dbl(data, "battery_ok",       "Battery",         NULL,         battery_lvl * 0.01f);
+            }
+            data = data_dbl(data, "rain_mm",          "Total Rain",      "%.1f mm",    rain_raw * 0.1);
+            data = data_str(data, "data",             "Extra Data",      NULL,         extra);
+            data = data_str(data, "mic",              "Integrity",       NULL,         "CRC");
             /* clang-format on */
 
             decoder_output_data(decoder, data);
@@ -342,19 +347,18 @@ static int ambientweather_whx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             snprintf(extra, sizeof(extra), "%02x%01x", b[16], b[17] >> 4);
 
             /* clang-format off */
-            data_t *data = data_make(
-                    "model",            "",             DATA_STRING, "EcoWitt-WS68",
-                    "id",               "",             DATA_INT,    id,
-                    "battery_raw",      "Battery Raw",  DATA_INT,    batt,
-                    "battery_ok",       "Battery OK",   DATA_INT,    batt_ok,
-                    "light_lux",        "Lux",          DATA_FORMAT, "%u lux",   DATA_INT,    light_lux,
-                    "wind_avg_m_s",     "Wind Speed",   DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wspeed * 0.1f,
-                    "wind_max_m_s",     "Wind Gust",    DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wgust * 0.1f,
-                    "uvi",              "UVI",          DATA_INT,    uvindex,
-                    "wind_dir_deg",     "Wind dir",     DATA_INT,    wdir,
-                    "data",             "Extra Data",   DATA_STRING, extra,
-                    "mic",              "Integrity",    DATA_STRING, "CRC",
-                    NULL);
+            data_t *data = NULL;
+            data = data_str(data, "model",            "",             NULL,         "EcoWitt-WS68");
+            data = data_int(data, "id",               "",             NULL,         id);
+            data = data_int(data, "battery_raw",      "Battery Raw",  NULL,         batt);
+            data = data_int(data, "battery_ok",       "Battery OK",   NULL,         batt_ok);
+            data = data_int(data, "light_lux",        "Lux",          "%u lux",     light_lux);
+            data = data_dbl(data, "wind_avg_m_s",     "Wind Speed",   "%.1f m/s",   wspeed * 0.1f);
+            data = data_dbl(data, "wind_max_m_s",     "Wind Gust",    "%.1f m/s",   wgust * 0.1f);
+            data = data_int(data, "uvi",              "UVI",          NULL,         uvindex);
+            data = data_int(data, "wind_dir_deg",     "Wind dir",     NULL,         wdir);
+            data = data_str(data, "data",             "Extra Data",   NULL,         extra);
+            data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
             /* clang-format on */
             decoder_output_data(decoder, data);
             events++;

--- a/src/devices/ant_antplus.c
+++ b/src/devices/ant_antplus.c
@@ -122,17 +122,20 @@ static int ant_antplus_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         antplus_flag = 1;
 
     /* clang-format off */
-    data_t *data = data_make(
-        "model",       "",               DATA_STRING, "Garmin-ANT",
-        "network",     "Network",        DATA_COND,   antplus_flag == 1,  DATA_STRING, "ANT+",
-        "network",     "Network",        DATA_COND,   antplus_flag == 0,  DATA_STRING, "ANT",
-        "channel",     "Net key",        DATA_FORMAT, "0x%04x", DATA_INT, net_key,
-        "id",          "Device #",       DATA_FORMAT, "0x%04x", DATA_INT, id,
-        "device_type", "Device type",    DATA_INT,    device_type,
-        "tx_type",     "TX type",        DATA_INT,    tx_type,
-        "payload",     "Payload",        DATA_STRING, payload,
-        "mic",         "Integrity",      DATA_STRING, "CRC",
-        NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",       "",               NULL,         "Garmin-ANT");
+    if (antplus_flag == 1) {
+        data = data_str(data, "network",     "Network",        NULL,         "ANT+");
+    }
+    if (antplus_flag == 0) {
+        data = data_str(data, "network",     "Network",        NULL,         "ANT");
+    }
+    data = data_int(data, "channel",     "Net key",        "0x%04x",     net_key);
+    data = data_int(data, "id",          "Device #",       "0x%04x",     id);
+    data = data_int(data, "device_type", "Device type",    NULL,         device_type);
+    data = data_int(data, "tx_type",     "TX type",        NULL,         tx_type);
+    data = data_str(data, "payload",     "Payload",        NULL,         payload);
+    data = data_str(data, "mic",         "Integrity",      NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/arad_ms_meter.c
+++ b/src/devices/arad_ms_meter.c
@@ -69,12 +69,11 @@ static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     sprintf(sernoout, "%08u%c", serno, b[3] - 32);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",       "",               DATA_STRING,    "AradMsMeter-Dialog3G",
-            "id",          "Serial No",      DATA_STRING,    sernoout,
-            "volume_m3",    "Volume",        DATA_FORMAT,    "%.1f m3",  DATA_DOUBLE, wread,
+    data_t *data = NULL;
+    data = data_str(data, "model",       "",               NULL,         "AradMsMeter-Dialog3G");
+    data = data_str(data, "id",          "Serial No",      NULL,         sernoout);
+    data = data_dbl(data, "volume_m3",    "Volume",        "%.1f m3",    wread);
             //"mic",         "Integrity",      DATA_STRING,    "CHECKSUM",
-            NULL);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/archos_tbh.c
+++ b/src/devices/archos_tbh.c
@@ -147,14 +147,13 @@ static int archos_tbh_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                     idx, ts, maxPower);
 
         /* clang-format off */
-        data = data_make(
-                "model",        "",                 DATA_STRING, "Archos-TBH",
-                "id",           "Station ID",       DATA_FORMAT, "%08X", DATA_INT, id,
-                "power_idx",    "Power index",      DATA_FORMAT, "%d", DATA_INT, idx,
-                "power_max",    "Power max",        DATA_FORMAT, "%d", DATA_INT, maxPower,
-                "timestamp",    "Timestamp",        DATA_FORMAT, "%d s", DATA_INT, ts / 8,
-                "mic",          "Integrity",        DATA_STRING, "CRC",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",        "",                 NULL,         "Archos-TBH");
+        data = data_int(data, "id",           "Station ID",       "%08X",       id);
+        data = data_int(data, "power_idx",    "Power index",      "%d",         idx);
+        data = data_int(data, "power_max",    "Power max",        "%d",         maxPower);
+        data = data_int(data, "timestamp",    "Timestamp",        "%d s",       ts / 8);
+        data = data_str(data, "mic",          "Integrity",        NULL,         "CRC");
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -166,13 +165,12 @@ static int archos_tbh_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         int humidity = payload[7];
 
         /* clang-format off */
-        data = data_make(
-                "model",        "",                 DATA_STRING, "Archos-TBH",
-                "id",           "Station ID",       DATA_FORMAT, "%08X", DATA_INT, id,
-                "temperature_C", "Temperature",     DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-                "humidity",     "Humidity",         DATA_FORMAT, "%d %%", DATA_INT, humidity,
-                "mic",          "Integrity",        DATA_STRING, "CRC",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",        "",                 NULL,         "Archos-TBH");
+        data = data_int(data, "id",           "Station ID",       "%08X",       id);
+        data = data_dbl(data, "temperature_C", "Temperature",     "%.1f C",     temp_c);
+        data = data_int(data, "humidity",     "Humidity",         "%d %%",      humidity);
+        data = data_str(data, "mic",          "Integrity",        NULL,         "CRC");
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -182,12 +180,11 @@ static int archos_tbh_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         int batt_level = payload[5];
 
         /* clang-format off */
-        data = data_make(
-                "model",        "",                 DATA_STRING, "Archos-TBH",
-                "id",           "Station ID",       DATA_FORMAT, "%08X", DATA_INT, id,
-                "battery_ok",   "Battery level",    DATA_FORMAT, "%0.2f", DATA_DOUBLE, batt_level * 0.01,
-                "mic",          "Integrity",        DATA_STRING, "CRC",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",        "",                 NULL,         "Archos-TBH");
+        data = data_int(data, "id",           "Station ID",       "%08X",       id);
+        data = data_dbl(data, "battery_ok",   "Battery level",    "%0.2f",      batt_level * 0.01);
+        data = data_str(data, "mic",          "Integrity",        NULL,         "CRC");
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -196,12 +193,11 @@ static int archos_tbh_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         // battery low
 
         /* clang-format off */
-        data = data_make(
-                "model",        "",                 DATA_STRING, "Archos-TBH",
-                "id",           "Station ID",       DATA_FORMAT, "%08X", DATA_INT, id,
-                "battery_ok",   "Battery level",    DATA_INT,    0, // fixed
-                "mic",          "Integrity",        DATA_STRING, "CRC",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",        "",                 NULL,         "Archos-TBH");
+        data = data_int(data, "id",           "Station ID",       "%08X",       id);
+        data = data_int(data, "battery_ok",   "Battery level",    NULL,         0); // fixed
+        data = data_str(data, "mic",          "Integrity",        NULL,         "CRC");
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;

--- a/src/devices/arexx_ml.c
+++ b/src/devices/arexx_ml.c
@@ -139,15 +139,20 @@ static int arexx_ml_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",                 DATA_STRING, "Arexx-ML",
-            "id",               "ID",               DATA_FORMAT, "%04x",    DATA_INT, id,
-            "temperature_C",    "Temperature",      DATA_COND, is_temp,     DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-            "temperature_alert","Alert",            DATA_COND, is_alert,    DATA_FORMAT, "%x", DATA_INT, temp_alert,
-            "humidity",         "Humidity",         DATA_COND, is_humi,     DATA_FORMAT, "%.1f %%", DATA_DOUBLE, humidity,
-            "sensor_raw",       "Sensor Raw",       DATA_FORMAT, "%04x",    DATA_INT, sens_val,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "Arexx-ML");
+    data = data_int(data, "id",               "ID",               "%04x",       id);
+    if (is_temp) {
+        data = data_dbl(data, "temperature_C",    "Temperature",      "%.2f C",     temp_c);
+    }
+    if (is_alert) {
+        data = data_int(data, "temperature_alert","Alert",            "%x",         temp_alert);
+    }
+    if (is_humi) {
+        data = data_dbl(data, "humidity",         "Humidity",         "%.1f %%",    humidity);
+    }
+    data = data_int(data, "sensor_raw",       "Sensor Raw",       "%04x",       sens_val);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/atech_ws308.c
+++ b/src/devices/atech_ws308.c
@@ -107,12 +107,11 @@ static int atech_ws308_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     float temp_c = sign * temp_raw * 0.1f;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Atech-WS308",
-            "id",               "Fixed ID",     DATA_INT,    id,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "mic",              "Integrity",    DATA_STRING, "PARITY",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Atech-WS308");
+    data = data_int(data, "id",               "Fixed ID",     NULL,         id);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "PARITY");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/auriol_4ld5661.c
+++ b/src/devices/auriol_4ld5661.c
@@ -68,14 +68,13 @@ static int auriol_4ld5661_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         float rain   = rain_raw * 1.0F;
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",            "Model",        DATA_STRING, "Auriol-4LD5661",
-                "id",               "ID",           DATA_FORMAT, "%02x", DATA_INT, id,
-                "battery_ok",       "Battery OK",   DATA_INT, batt_ok,
-                "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-                "rain_mm",          "Rain",         DATA_FORMAT, "%.1f mm", DATA_DOUBLE, rain,
-                "rain",             "Rain tips",    DATA_INT, rain_raw,
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",            "Model",        NULL,         "Auriol-4LD5661");
+        data = data_int(data, "id",               "ID",           "%02x",       id);
+        data = data_int(data, "battery_ok",       "Battery OK",   NULL,         batt_ok);
+        data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+        data = data_dbl(data, "rain_mm",          "Rain",         "%.1f mm",    rain);
+        data = data_int(data, "rain",             "Rain tips",    NULL,         rain_raw);
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/auriol_aft77b2.c
+++ b/src/devices/auriol_aft77b2.c
@@ -125,12 +125,11 @@ static int auriol_aft77_b2_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         temp_raw = -temp_raw;
 
     /* clang-format off */
-    data = data_make(
-            "model",         "",            DATA_STRING, "Auriol-AFT77B2",
-            "id",            "",            DATA_INT, id,
-            "temperature_C", "Temperature", DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_raw * 0.1,
-            "mic",              "Integrity",         DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",         "",            NULL,         "Auriol-AFT77B2");
+    data = data_int(data, "id",            "",            NULL,         id);
+    data = data_dbl(data, "temperature_C", "Temperature", "%.2f C",     temp_raw * 0.1);
+    data = data_str(data, "mic",              "Integrity",         NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/auriol_afw2a1.c
+++ b/src/devices/auriol_afw2a1.c
@@ -90,15 +90,14 @@ static int auriol_afw2a1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",                  DATA_STRING, "Auriol-AFW2A1",
-            "id",               "",                  DATA_INT,    id,
-            "channel",          "Channel",           DATA_INT,    channel + 1,
-            "battery_ok",       "Battery",           DATA_INT,    battery_ok,
-            "button",           "Button",            DATA_INT,    tx_button,
-            "temperature_C",    "Temperature",       DATA_FORMAT, "%.1f C",  DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",          DATA_FORMAT, "%.0f %%", DATA_DOUBLE, (float)humidity,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",                  NULL,         "Auriol-AFW2A1");
+    data = data_int(data, "id",               "",                  NULL,         id);
+    data = data_int(data, "channel",          "Channel",           NULL,         channel + 1);
+    data = data_int(data, "battery_ok",       "Battery",           NULL,         battery_ok);
+    data = data_int(data, "button",           "Button",            NULL,         tx_button);
+    data = data_dbl(data, "temperature_C",    "Temperature",       "%.1f C",     temp_c);
+    data = data_dbl(data, "humidity",         "Humidity",          "%.0f %%",    (float)humidity);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/auriol_ahfl.c
+++ b/src/devices/auriol_ahfl.c
@@ -80,16 +80,15 @@ static int auriol_ahfl_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     humidity   = b[3] >> 1;
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",                  DATA_STRING, "Auriol-AHFL",
-            "id",               "",                  DATA_INT,    id,
-            "channel",          "Channel",           DATA_INT,    channel + 1,
-            "battery_ok",       "Battery",           DATA_INT,    battery_ok,
-            "button",           "Button",            DATA_INT,    tx_button,
-            "temperature_C",    "Temperature",       DATA_FORMAT, "%.1f C",  DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",          DATA_FORMAT, "%d %%", DATA_INT, humidity,
-            "mic",              "Integrity",         DATA_STRING, "CHECKSUM",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",                  NULL,         "Auriol-AHFL");
+    data = data_int(data, "id",               "",                  NULL,         id);
+    data = data_int(data, "channel",          "Channel",           NULL,         channel + 1);
+    data = data_int(data, "battery_ok",       "Battery",           NULL,         battery_ok);
+    data = data_int(data, "button",           "Button",            NULL,         tx_button);
+    data = data_dbl(data, "temperature_C",    "Temperature",       "%.1f C",     temp_c);
+    data = data_int(data, "humidity",         "Humidity",          "%d %%",      humidity);
+    data = data_str(data, "mic",              "Integrity",         NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/auriol_hg02832.c
+++ b/src/devices/auriol_hg02832.c
@@ -73,16 +73,15 @@ static int auriol_hg02832_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     temp_c   = (temp_raw >> 4) * 0.1f;
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "Auriol-HG02832",
-            "id",               "",             DATA_INT,    id,
-            "channel",          "",             DATA_INT,    channel + 1,
-            "battery_ok",       "Battery",      DATA_INT,    !batt_low,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",     DATA_FORMAT, "%.0f %%", DATA_DOUBLE, (float)humidity,
-            "button",           "Button",       DATA_INT,    button,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Auriol-HG02832");
+    data = data_int(data, "id",               "",             NULL,         id);
+    data = data_int(data, "channel",          "",             NULL,         channel + 1);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !batt_low);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    data = data_dbl(data, "humidity",         "Humidity",     "%.0f %%",    (float)humidity);
+    data = data_int(data, "button",           "Button",       NULL,         button);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/badger_water.c
+++ b/src/devices/badger_water.c
@@ -123,14 +123,13 @@ static int badger_orion_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     uint8_t flags_2 = data_in[7];
 
     /* clang-format off */
-    data = data_make(
-            "model",      "",          DATA_STRING, "Badger-ORION",
-            "id",         "ID",        DATA_INT,    device_id,
-            "flags_1",    "Flags-1",   DATA_INT,    flags_1,
-            "volume_gal", "Volume",    DATA_INT,    volume,
-            "flags_2",    "Flags-2",   DATA_INT,    flags_2,
-            "mic",        "Integrity", DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",      "",          NULL,         "Badger-ORION");
+    data = data_int(data, "id",         "ID",        NULL,         device_id);
+    data = data_int(data, "flags_1",    "Flags-1",   NULL,         flags_1);
+    data = data_int(data, "volume_gal", "Volume",    NULL,         volume);
+    data = data_int(data, "flags_2",    "Flags-2",   NULL,         flags_2);
+    data = data_str(data, "mic",        "Integrity", NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/baldr_rain.c
+++ b/src/devices/baldr_rain.c
@@ -73,12 +73,11 @@ static int baldr_rain_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int rain_in = (b[2] << 12) | (b[3] << 4) | (b[4] >> 4);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",        "",         DATA_STRING, "Baldr-Rain",
-            "id",           "",         DATA_FORMAT, "%03x", DATA_INT, id,
-            "flags",        "Flags",    DATA_FORMAT, "%x", DATA_INT, flags,
-            "rain_in",      "Rain",     DATA_FORMAT, "%.3f in", DATA_DOUBLE, rain_in * 0.001,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",        "",         NULL,         "Baldr-Rain");
+    data = data_int(data, "id",           "",         "%03x",       id);
+    data = data_int(data, "flags",        "Flags",    "%x",         flags);
+    data = data_dbl(data, "rain_in",      "Rain",     "%.3f in",    rain_in * 0.001);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/blueline.c
+++ b/src/devices/blueline.c
@@ -297,11 +297,10 @@ static int blueline_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         if (message_type == BLUELINE_TXID_MSG) {
             const uint16_t received_sensor_id = ((current_row[2] << 8) | current_row[1]);
             /* clang-format off */
-            data = data_make(
-                    "model",        "",             DATA_STRING, "Blueline-PowerCost",
-                    "id",           "",             DATA_INT,    received_sensor_id,
-                    "mic",          "Integrity",    DATA_STRING, "CRC",
-                    NULL);
+            data = NULL;
+            data = data_str(data, "model",        "",             NULL,         "Blueline-PowerCost");
+            data = data_int(data, "id",           "",             NULL,         received_sensor_id);
+            data = data_str(data, "mic",          "Integrity",    NULL,         "CRC");
             /* clang-format on */
             decoder_output_data(decoder, data);
             payloads_decoded++;
@@ -313,12 +312,11 @@ static int blueline_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         } else if (message_type == BLUELINE_POWER_MSG) {
             const uint16_t ms_per_pulse = offset_payload_u16;
             /* clang-format off */
-            data = data_make(
-                    "model",        "",             DATA_STRING, "Blueline-PowerCost",
-                    "id",           "",             DATA_INT,    context->current_sensor_id,
-                    "gap",          "",             DATA_INT,    ms_per_pulse,
-                    "mic",          "Integrity",    DATA_STRING, "CRC",
-                    NULL);
+            data = NULL;
+            data = data_str(data, "model",        "",             NULL,         "Blueline-PowerCost");
+            data = data_int(data, "id",           "",             NULL,         context->current_sensor_id);
+            data = data_int(data, "gap",          "",             NULL,         ms_per_pulse);
+            data = data_str(data, "mic",          "Integrity",    NULL,         "CRC");
             /* clang-format on */
             decoder_output_data(decoder, data);
             payloads_decoded++;
@@ -353,14 +351,13 @@ static int blueline_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             const uint8_t battery = (flags & 0x20) >> 5;
             const float temperature_C = (0.436f * temperature) - 30.36f;
             /* clang-format off */
-            data = data_make(
-                    "model",            "",             DATA_STRING, "Blueline-PowerCost",
-                    "id",               "",             DATA_INT,    context->current_sensor_id,
-                    "flags",            "",             DATA_FORMAT, "%02x", DATA_INT, flags,
-                    "battery_ok",       "Battery",      DATA_INT,    !battery,
-                    "temperature_C",    "",             DATA_DOUBLE, temperature_C,
-                    "mic",              "Integrity",    DATA_STRING, "CRC",
-                    NULL);
+            data = NULL;
+            data = data_str(data, "model",            "",             NULL,         "Blueline-PowerCost");
+            data = data_int(data, "id",               "",             NULL,         context->current_sensor_id);
+            data = data_int(data, "flags",            "",             "%02x",       flags);
+            data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery);
+            data = data_dbl(data, "temperature_C",    "",             NULL,         temperature_C);
+            data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
             /* clang-format on */
             decoder_output_data(decoder, data);
             payloads_decoded++;
@@ -368,12 +365,11 @@ static int blueline_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             // (The lowest two bits of the pulse count will always be the same because message_type is overlaid there)
             const uint16_t pulses = offset_payload_u16;
             /* clang-format off */
-            data = data_make(
-                    "model",            "",             DATA_STRING, "Blueline-PowerCost",
-                    "id",               "",             DATA_INT, context->current_sensor_id,
-                    "impulses",         "",             DATA_INT,    pulses,
-                    "mic",              "Integrity",    DATA_STRING, "CRC",
-                    NULL);
+            data = NULL;
+            data = data_str(data, "model",            "",             NULL,         "Blueline-PowerCost");
+            data = data_int(data, "id",               "",             NULL,         context->current_sensor_id);
+            data = data_int(data, "impulses",         "",             NULL,         pulses);
+            data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
             /* clang-format on */
             decoder_output_data(decoder, data);
             payloads_decoded++;

--- a/src/devices/blyss.c
+++ b/src/devices/blyss.c
@@ -40,10 +40,9 @@ static int blyss_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         snprintf(id_str, sizeof(id_str), "%02x%02x%02x%02x", b[0], b[1], b[2], b[3]);
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",    "", DATA_STRING, "Blyss-DC5ukwh",
-                "id",       "", DATA_STRING, id_str,
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",    "", NULL,         "Blyss-DC5ukwh");
+        data = data_str(data, "id",       "", NULL,         id_str);
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/brennenstuhl_rcs_2044.c
+++ b/src/devices/brennenstuhl_rcs_2044.c
@@ -91,12 +91,11 @@ static int brennenstuhl_rcs_2044_process_row(r_device *decoder, bitbuffer_t *bit
         return 0; /* Pressing simultaneously ON and OFF key is not useful either */
 
     /* clang-format off */
-    data = data_make(
-            "model",    "Model",    DATA_STRING, "Brennenstuhl-RCS2044",
-            "id",       "id",       DATA_INT, system_code,
-            "key",      "key",      DATA_STRING, key,
-            "state",    "state",    DATA_STRING, (on_off == 0x02 ? "ON" : "OFF"),
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",    "Model",    NULL,         "Brennenstuhl-RCS2044");
+    data = data_int(data, "id",       "id",       NULL,         system_code);
+    data = data_str(data, "key",      "key",      NULL,         key);
+    data = data_str(data, "state",    "state",    NULL,         (on_off == 0x02 ? "ON" : "OFF"));
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/bresser_3ch.c
+++ b/src/devices/bresser_3ch.c
@@ -82,15 +82,14 @@ static int bresser_3ch_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data = data_make(
-            "model",         "",            DATA_STRING, "Bresser-3CH",
-            "id",            "Id",          DATA_INT,    id,
-            "channel",       "Channel",     DATA_INT,    channel,
-            "battery_ok",    "Battery",     DATA_INT,    !battery_low,
-            "temperature_F", "Temperature", DATA_FORMAT, "%.2f F", DATA_DOUBLE, temp_f,
-            "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "mic",           "Integrity",   DATA_STRING, "CHECKSUM",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",         "",            NULL,         "Bresser-3CH");
+    data = data_int(data, "id",            "Id",          NULL,         id);
+    data = data_int(data, "channel",       "Channel",     NULL,         channel);
+    data = data_int(data, "battery_ok",    "Battery",     NULL,         !battery_low);
+    data = data_dbl(data, "temperature_F", "Temperature", "%.2f F",     temp_f);
+    data = data_int(data, "humidity",      "Humidity",    "%u %%",      humidity);
+    data = data_str(data, "mic",           "Integrity",   NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/bresser_5in1.c
+++ b/src/devices/bresser_5in1.c
@@ -139,30 +139,34 @@ static int bresser_5in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         // rescale the rain sensor readings
         rain = rain * 2.5f;
         /* clang-format off */
-        data = data_make(
-                "model",            "",             DATA_STRING, "Bresser-ProRainGauge",
-                "id",               "",             DATA_INT,    sensor_id,
-                "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-                "temperature_C",    "Temperature",  DATA_COND,   temp_ok,       DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
-                "rain_mm",          "Rain",         DATA_FORMAT, "%.1f mm",     DATA_DOUBLE, rain,
-                "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",             NULL,         "Bresser-ProRainGauge");
+        data = data_int(data, "id",               "",             NULL,         sensor_id);
+        data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+        if (temp_ok) {
+            data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temperature);
+        }
+        data = data_dbl(data, "rain_mm",          "Rain",         "%.1f mm",    rain);
+        data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
         /* clang-format on */
     } else {
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",             DATA_STRING, "Bresser-5in1",
-                "id",               "",             DATA_INT,    sensor_id,
-                "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-                "temperature_C",    "Temperature",  DATA_COND,   temp_ok,       DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
-                "humidity",         "Humidity",     DATA_COND,   humidity_ok,   DATA_INT,    humidity,
-                "wind_max_m_s",     "Wind Gust",    DATA_FORMAT, "%.1f m/s",    DATA_DOUBLE, wind_gust,
-                "wind_avg_m_s",     "Wind Speed",   DATA_FORMAT, "%.1f m/s",    DATA_DOUBLE, wind_avg,
-                "wind_dir_deg",     "Direction",    DATA_FORMAT, "%.1f",        DATA_DOUBLE, wind_direction_deg,
-                "rain_mm",          "Rain",         DATA_FORMAT, "%.1f mm",     DATA_DOUBLE, rain,
-                "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",             NULL,         "Bresser-5in1");
+        data = data_int(data, "id",               "",             NULL,         sensor_id);
+        data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+        if (temp_ok) {
+            data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temperature);
+        }
+        if (humidity_ok) {
+            data = data_int(data, "humidity",         "Humidity",     NULL,         humidity);
+        }
+        data = data_dbl(data, "wind_max_m_s",     "Wind Gust",    "%.1f m/s",   wind_gust);
+        data = data_dbl(data, "wind_avg_m_s",     "Wind Speed",   "%.1f m/s",   wind_avg);
+        data = data_dbl(data, "wind_dir_deg",     "Direction",    "%.1f",       wind_direction_deg);
+        data = data_dbl(data, "rain_mm",          "Rain",         "%.1f mm",    rain);
+        data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
         /* clang-format on */
     }
     decoder_output_data(decoder, data);

--- a/src/devices/bresser_6in1.c
+++ b/src/devices/bresser_6in1.c
@@ -205,25 +205,44 @@ static int bresser_6in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         moisture = moisture_map[humidity - 1];
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Bresser-6in1",
-            "id",               "",             DATA_FORMAT, "%08x", DATA_INT,    id,
-            "channel",          "",             DATA_INT,    chan,
-            "battery_ok",       "Battery",      DATA_COND, !rain_ok, DATA_INT,    battery,
-            "temperature_C",    "Temperature",  DATA_COND, temp_ok, DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",     DATA_COND, temp_ok && moisture < 0, DATA_INT,    humidity,
-            "sensor_type",      "Sensor type",  DATA_INT,    s_type,
-            "moisture",         "Moisture",     DATA_COND, moisture >= 0, DATA_FORMAT, "%d %%", DATA_INT, moisture,
-            "wind_max_m_s",     "Wind Gust",    DATA_COND, wind_ok, DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wind_gust,
-            "wind_avg_m_s",     "Wind Speed",   DATA_COND, wind_ok, DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wind_avg,
-            "wind_dir_deg",     "Direction",    DATA_COND, wind_ok, DATA_INT,    wind_dir,
-            "rain_mm",          "Rain",         DATA_COND, rain_ok, DATA_FORMAT, "%.1f mm", DATA_DOUBLE, rain_mm,
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Bresser-6in1");
+    data = data_int(data, "id",               "",             "%08x",       id);
+    data = data_int(data, "channel",          "",             NULL,         chan);
+    if (!rain_ok) {
+        data = data_int(data, "battery_ok",       "Battery",      NULL,         battery);
+    }
+    if (temp_ok) {
+        data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    }
+    if (temp_ok && moisture < 0) {
+        data = data_int(data, "humidity",         "Humidity",     NULL,         humidity);
+    }
+    data = data_int(data, "sensor_type",      "Sensor type",  NULL,         s_type);
+    if (moisture >= 0) {
+        data = data_int(data, "moisture",         "Moisture",     "%d %%",      moisture);
+    }
+    if (wind_ok) {
+        data = data_dbl(data, "wind_max_m_s",     "Wind Gust",    "%.1f m/s",   wind_gust);
+    }
+    if (wind_ok) {
+        data = data_dbl(data, "wind_avg_m_s",     "Wind Speed",   "%.1f m/s",   wind_avg);
+    }
+    if (wind_ok) {
+        data = data_int(data, "wind_dir_deg",     "Direction",    NULL,         wind_dir);
+    }
+    if (rain_ok) {
+        data = data_dbl(data, "rain_mm",          "Rain",         "%.1f mm",    rain_mm);
+    }
             //"unknown",          "Unknown",      DATA_COND, unk_ok, DATA_INT,    unk_raw,
-            "uv",               "UV",           DATA_COND, uv_ok, DATA_FORMAT, "%.1f", DATA_DOUBLE,    uv,
-            "startup",          "Startup",      DATA_COND,   startup,   DATA_INT,    startup,
-            "flags",            "Flags",        DATA_INT,    flags,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    if (uv_ok) {
+        data = data_dbl(data, "uv",               "UV",           "%.1f",       uv);
+    }
+    if (startup) {
+        data = data_int(data, "startup",          "Startup",      NULL,         startup);
+    }
+    data = data_int(data, "flags",            "Flags",        NULL,         flags);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/bresser_7in1.c
+++ b/src/devices/bresser_7in1.c
@@ -205,22 +205,23 @@ static int bresser_7in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         float uv_index = uv_raw * 0.1f;
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",             DATA_STRING, "Bresser-7in1",
-                "id",               "",             DATA_INT,    id,
-                "startup",          "Startup",      DATA_COND,   !nstartup,  DATA_INT, !nstartup,
-                "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-                "humidity",         "Humidity",     DATA_INT,    humidity,
-                "wind_max_m_s",     "Wind Gust",    DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wgst_raw * 0.1f,
-                "wind_avg_m_s",     "Wind Speed",   DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wavg_raw * 0.1f,
-                "wind_dir_deg",     "Direction",    DATA_INT,    wdir,
-                "rain_mm",          "Rain",         DATA_FORMAT, "%.1f mm", DATA_DOUBLE, rain_mm,
-                "light_klx",        "Light",        DATA_FORMAT, "%.3f klx", DATA_DOUBLE, light_klx, // TODO: remove this
-                "light_lux",        "Light",        DATA_FORMAT, "%.3f lux", DATA_DOUBLE, light_lux,
-                "uv",               "UV Index",     DATA_FORMAT, "%.1f", DATA_DOUBLE, uv_index,
-                "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-                "mic",              "Integrity",    DATA_STRING, "CRC",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",             NULL,         "Bresser-7in1");
+        data = data_int(data, "id",               "",             NULL,         id);
+        if (!nstartup) {
+            data = data_int(data, "startup",          "Startup",      NULL,         !nstartup);
+        }
+        data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+        data = data_int(data, "humidity",         "Humidity",     NULL,         humidity);
+        data = data_dbl(data, "wind_max_m_s",     "Wind Gust",    "%.1f m/s",   wgst_raw * 0.1f);
+        data = data_dbl(data, "wind_avg_m_s",     "Wind Speed",   "%.1f m/s",   wavg_raw * 0.1f);
+        data = data_int(data, "wind_dir_deg",     "Direction",    NULL,         wdir);
+        data = data_dbl(data, "rain_mm",          "Rain",         "%.1f mm",    rain_mm);
+        data = data_dbl(data, "light_klx",        "Light",        "%.3f klx",   light_klx); // TODO: remove this
+        data = data_dbl(data, "light_lux",        "Light",        "%.3f lux",   light_lux);
+        data = data_dbl(data, "uv",               "UV Index",     "%.1f",       uv_index);
+        data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+        data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
         /* clang-format on */
 
         decoder_output_data(decoder, data);
@@ -233,16 +234,21 @@ static int bresser_7in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         int pm_10_init  = (msg[12] & 0x0f) == 0x0f; // confirmed by https://github.com/merbanan/rtl_433/issues/2816#issuecomment-1935439318
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",                         DATA_STRING, "Bresser-7in1",  // should be Bresser-Air-PM
-                "id",               "",                         DATA_INT,    id,
-                "channel",          "",                         DATA_INT,    chan,
-                "startup",          "Startup",                  DATA_COND,   !nstartup,   DATA_INT, !nstartup,
-                "battery_ok",       "Battery",                  DATA_INT,    !battery_low,
-                "pm2_5_ug_m3",      "PM2.5 Mass Concentration", DATA_COND,   !pm_2_5_init,   DATA_INT, pm_2_5,
-                "pm10_0_ug_m3",     "PM10 Mass Concentraton",   DATA_COND,   !pm_10_init,    DATA_INT, pm_10,
-                "mic",              "Integrity",                DATA_STRING, "CRC",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                         NULL,         "Bresser-7in1"); // should be Bresser-Air-PM
+        data = data_int(data, "id",               "",                         NULL,         id);
+        data = data_int(data, "channel",          "",                         NULL,         chan);
+        if (!nstartup) {
+            data = data_int(data, "startup",          "Startup",                  NULL,         !nstartup);
+        }
+        data = data_int(data, "battery_ok",       "Battery",                  NULL,         !battery_low);
+        if (!pm_2_5_init) {
+            data = data_int(data, "pm2_5_ug_m3",      "PM2.5 Mass Concentration", NULL,         pm_2_5);
+        }
+        if (!pm_10_init) {
+            data = data_int(data, "pm10_0_ug_m3",     "PM10 Mass Concentraton",   NULL,         pm_10);
+        }
+        data = data_str(data, "mic",              "Integrity",                NULL,         "CRC");
         /* clang-format on */
 
         decoder_output_data(decoder, data);
@@ -253,15 +259,18 @@ static int bresser_7in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         int co2_init = (msg[5] & 0x0f) == 0x0f;
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",                         DATA_STRING, "Bresser-CO2",
-                "id",               "",                         DATA_INT,    id,
-                "channel",          "",                         DATA_INT,    chan,
-                "startup",          "Startup",                  DATA_COND,   !nstartup,  DATA_INT, !nstartup,
-                "battery_ok",       "Battery",                  DATA_INT,    !battery_low,
-                "co2_ppm",          "Carbon Dioxide",           DATA_COND,   !co2_init,     DATA_FORMAT, "%d ppm", DATA_INT, co2,
-                "mic",              "Integrity",                DATA_STRING, "CRC",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                         NULL,         "Bresser-CO2");
+        data = data_int(data, "id",               "",                         NULL,         id);
+        data = data_int(data, "channel",          "",                         NULL,         chan);
+        if (!nstartup) {
+            data = data_int(data, "startup",          "Startup",                  NULL,         !nstartup);
+        }
+        data = data_int(data, "battery_ok",       "Battery",                  NULL,         !battery_low);
+        if (!co2_init) {
+            data = data_int(data, "co2_ppm",          "Carbon Dioxide",           "%d ppm",     co2);
+        }
+        data = data_str(data, "mic",              "Integrity",                NULL,         "CRC");
         /* clang-format on */
 
         decoder_output_data(decoder, data);
@@ -274,16 +283,21 @@ static int bresser_7in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         int voc_init  = voc == 0x0f;
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",                           DATA_STRING, "Bresser-HCHOVOC",
-                "id",               "",                           DATA_INT,    id,
-                "channel",          "",                           DATA_INT,    chan,
-                "startup",          "Startup",                    DATA_COND,   !nstartup,  DATA_INT, !nstartup,
-                "battery_ok",       "Battery",                    DATA_INT,    !battery_low,
-                "hcho_ppb",         "Formaldehyde",               DATA_COND,   !hcho_init, DATA_FORMAT, "%d ppb", DATA_INT, hcho,
-                "voc_level",        "Volatile Organic Compounds", DATA_COND,   !voc_init,  DATA_FORMAT, "%d",     DATA_INT, voc, // from 1 bad air quality to 5 very good air quality
-                "mic",              "Integrity",                  DATA_STRING, "CRC",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                           NULL,         "Bresser-HCHOVOC");
+        data = data_int(data, "id",               "",                           NULL,         id);
+        data = data_int(data, "channel",          "",                           NULL,         chan);
+        if (!nstartup) {
+            data = data_int(data, "startup",          "Startup",                    NULL,         !nstartup);
+        }
+        data = data_int(data, "battery_ok",       "Battery",                    NULL,         !battery_low);
+        if (!hcho_init) {
+            data = data_int(data, "hcho_ppb",         "Formaldehyde",               "%d ppb",     hcho);
+        }
+        if (!voc_init) {
+            data = data_int(data, "voc_level",        "Volatile Organic Compounds", "%d",         voc); // from 1 bad air quality to 5 very good air quality
+        }
+        data = data_str(data, "mic",              "Integrity",                  NULL,         "CRC");
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/bresser_leakage.c
+++ b/src/devices/bresser_leakage.c
@@ -123,14 +123,15 @@ static int bresser_leakage_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Bresser-Leakage",
-            "id",               "",             DATA_FORMAT, "%08x",   DATA_INT,    sensor_id,
-            "channel",          "",             DATA_INT,    chan,
-            "battery_ok",       "Battery",      DATA_INT,    battery_ok,
-            "alarm",            "Alarm",        DATA_INT,    alarm,
-            "startup",          "Startup",      DATA_COND,   !nstartup,  DATA_INT,  !nstartup,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Bresser-Leakage");
+    data = data_int(data, "id",               "",             "%08x",       sensor_id);
+    data = data_int(data, "channel",          "",             NULL,         chan);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         battery_ok);
+    data = data_int(data, "alarm",            "Alarm",        NULL,         alarm);
+    if (!nstartup) {
+        data = data_int(data, "startup",          "Startup",      NULL,         !nstartup);
+    }
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/bresser_lightning.c
+++ b/src/devices/bresser_lightning.c
@@ -97,17 +97,18 @@ static int bresser_lightning_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",                     DATA_STRING, "Bresser-Lightning",
-            "id",               "",                     DATA_FORMAT, "%08x",      DATA_INT,    sensor_id,
-            "startup",          "Startup",              DATA_COND,   !nstartup,   DATA_INT,    !nstartup,
-            "battery_ok",       "Battery",              DATA_INT,    !battery_low,
-            "storm_dist_km",    "Storm Distance",       DATA_FORMAT, "%d km",     DATA_INT,    distance_km,
-            "strike_count",     "Strike Count",         DATA_INT,    count,
-            "unknown1",         "Unknown1",             DATA_FORMAT, "%03x",      DATA_INT,    unknown1,
-            "unknown2",         "Unknown2",             DATA_FORMAT, "%04x",      DATA_INT,    unknown2,
-            "mic",              "Integrity",            DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",                     NULL,         "Bresser-Lightning");
+    data = data_int(data, "id",               "",                     "%08x",       sensor_id);
+    if (!nstartup) {
+        data = data_int(data, "startup",          "Startup",              NULL,         !nstartup);
+    }
+    data = data_int(data, "battery_ok",       "Battery",              NULL,         !battery_low);
+    data = data_int(data, "storm_dist_km",    "Storm Distance",       "%d km",      distance_km);
+    data = data_int(data, "strike_count",     "Strike Count",         NULL,         count);
+    data = data_int(data, "unknown1",         "Unknown1",             "%03x",       unknown1);
+    data = data_int(data, "unknown2",         "Unknown2",             "%04x",       unknown2);
+    data = data_str(data, "mic",              "Integrity",            NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/bresser_st1005h.c
+++ b/src/devices/bresser_st1005h.c
@@ -130,16 +130,15 @@ static int bresser_st1005h_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",         "",            DATA_STRING, "Bresser-ST1005H",
-            "id",            "Id",          DATA_INT,    id,
-            "channel",       "Channel",     DATA_INT,    channel,
-            "battery_ok",    "Battery",     DATA_INT,    !battery_low,
-            "button",        "Button",      DATA_INT,    button,
-            "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "mic",           "Integrity",   DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",         "",            NULL,         "Bresser-ST1005H");
+    data = data_int(data, "id",            "Id",          NULL,         id);
+    data = data_int(data, "channel",       "Channel",     NULL,         channel);
+    data = data_int(data, "battery_ok",    "Battery",     NULL,         !battery_low);
+    data = data_int(data, "button",        "Button",      NULL,         button);
+    data = data_dbl(data, "temperature_C", "Temperature", "%.1f C",     temp_c);
+    data = data_int(data, "humidity",      "Humidity",    "%u %%",      humidity);
+    data = data_str(data, "mic",           "Integrity",   NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/bt_rain.c
+++ b/src/devices/bt_rain.c
@@ -68,16 +68,15 @@ static int bt_rain_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     rainrate = rain * 0.052f; // 19.23mm per tip
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",                 DATA_STRING, "Biltema-Rain",
-            "id",               "ID",               DATA_INT,    id,
-            "channel",          "Channel",          DATA_INT,    channel,
-            "battery_ok",       "Battery",          DATA_INT,    !battery,
-            "transmit",         "Transmit",         DATA_STRING, button ? "MANUAL" : "AUTO", // TODO: delete this
-            "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "rain_rate_mm_h",   "Rain per hour",    DATA_FORMAT, "%.2f mm/h", DATA_DOUBLE, rainrate,
-            "button",           "Button",       DATA_INT, button,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "Biltema-Rain");
+    data = data_int(data, "id",               "ID",               NULL,         id);
+    data = data_int(data, "channel",          "Channel",          NULL,         channel);
+    data = data_int(data, "battery_ok",       "Battery",          NULL,         !battery);
+    data = data_str(data, "transmit",         "Transmit",         NULL,         button ? "MANUAL" : "AUTO"); // TODO: delete this
+    data = data_dbl(data, "temperature_C",    "Temperature",      "%.1f C",     temp_c);
+    data = data_dbl(data, "rain_rate_mm_h",   "Rain per hour",    "%.2f mm/h",  rainrate);
+    data = data_int(data, "button",           "Button",       NULL,         button);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/burnhardbbq.c
+++ b/src/devices/burnhardbbq.c
@@ -97,19 +97,24 @@ static int burnhardbbq_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         }
 
         /* clang-format off */
-        data = data_make(
-                "model",             "",                     DATA_STRING, "BurnhardBBQ",
-                "id",                "ID",                   DATA_INT,    id,
-                "channel",           "Channel",              DATA_INT,    channel,
-                "temperature_C",     "Temperature",          DATA_COND,   temp_raw != 0, DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-                "setpoint_C",        "Temperature setpoint", DATA_FORMAT, "%.0f C", DATA_DOUBLE, setpoint_c,
-                "temperature_alarm", "Temperature alarm",    DATA_INT,    temp_alarm,
-                "timer",             "Timer",                DATA_STRING, timer_str,
-                "timer_active",      "Timer active",         DATA_INT,    timer_active,
-                "timer_alarm",       "Timer alarm",          DATA_INT,    timer_alarm,
-                "meat",              "Meat",                 DATA_COND,   meat[0] != '\0', DATA_STRING, meat,
-                "taste",             "Taste",                DATA_COND,   taste[0] != '\0', DATA_STRING, taste,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",             "",                     NULL,         "BurnhardBBQ");
+        data = data_int(data, "id",                "ID",                   NULL,         id);
+        data = data_int(data, "channel",           "Channel",              NULL,         channel);
+        if (temp_raw != 0) {
+            data = data_dbl(data, "temperature_C",     "Temperature",          "%.1f C",     temp_c);
+        }
+        data = data_dbl(data, "setpoint_C",        "Temperature setpoint", "%.0f C",     setpoint_c);
+        data = data_int(data, "temperature_alarm", "Temperature alarm",    NULL,         temp_alarm);
+        data = data_str(data, "timer",             "Timer",                NULL,         timer_str);
+        data = data_int(data, "timer_active",      "Timer active",         NULL,         timer_active);
+        data = data_int(data, "timer_alarm",       "Timer alarm",          NULL,         timer_alarm);
+        if (meat[0] != '\0') {
+            data = data_str(data, "meat",              "Meat",                 NULL,         meat);
+        }
+        if (taste[0] != '\0') {
+            data = data_str(data, "taste",             "Taste",                NULL,         taste);
+        }
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/calibeur.c
+++ b/src/devices/calibeur.c
@@ -104,13 +104,12 @@ static int calibeur_rf104_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     humidity = bits;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",         "",            DATA_STRING, "Calibeur-RF104",
-            "id",            "ID",          DATA_INT,    id,
-            "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
-            "humidity",      "Humidity",    DATA_FORMAT, "%.0f %%", DATA_DOUBLE, humidity,
-            "mic",           "Integrity",   DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",         "",            NULL,         "Calibeur-RF104");
+    data = data_int(data, "id",            "ID",          NULL,         id);
+    data = data_dbl(data, "temperature_C", "Temperature", "%.1f C",     temperature);
+    data = data_dbl(data, "humidity",      "Humidity",    "%.0f %%",    humidity);
+    data = data_str(data, "mic",           "Integrity",   NULL,         "CRC");
     /* clang-format on */
     decoder_output_data(decoder, data);
     return 1;

--- a/src/devices/cardin.c
+++ b/src/devices/cardin.c
@@ -98,11 +98,10 @@ static int cardin_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",      "",                       DATA_STRING, "Cardin-S466",
-            "dipswitch",  "dipswitch",              DATA_STRING, dip,
-            "rbutton",    "right button switches",  DATA_STRING, rbutton[((b[2] & 15) / 3)-1],
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",      "",                       NULL,         "Cardin-S466");
+    data = data_str(data, "dipswitch",  "dipswitch",              NULL,         dip);
+    data = data_str(data, "rbutton",    "right button switches",  NULL,         rbutton[((b[2] & 15) / 3)-1]);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/cavius.c
+++ b/src/devices/cavius.c
@@ -103,15 +103,14 @@ static int cavius_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",        "",             DATA_STRING, "Cavius-Security",
-            "id",           "Device ID",    DATA_INT,    sender_id,
-            "battery_ok",   "Battery",      DATA_INT,    !batt_low,
-            "net_id",       "Net ID",       DATA_INT,    net_id,
-            "message",      "Message",      DATA_INT,    message,
-            "text",         "Description",  DATA_STRING, text,
-            "mic",          "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",        "",             NULL,         "Cavius-Security");
+    data = data_int(data, "id",           "Device ID",    NULL,         sender_id);
+    data = data_int(data, "battery_ok",   "Battery",      NULL,         !batt_low);
+    data = data_int(data, "net_id",       "Net ID",       NULL,         net_id);
+    data = data_int(data, "message",      "Message",      NULL,         message);
+    data = data_str(data, "text",         "Description",  NULL,         text);
+    data = data_str(data, "mic",          "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/ced7000.c
+++ b/src/devices/ced7000.c
@@ -80,13 +80,12 @@ static int ced7000_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     float split = (b[7] & 0xF) * 100 + (b[7] >> 4) * 10 + (b[6] & 0xF) + (b[6] >> 4) * 0.1 + (b[5] & 0xF) * 0.01f;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",    "Model",       DATA_STRING, "CED7000",
-            "id",       "ID",          DATA_FORMAT, "%04u",    DATA_INT, id,
-            "count",    "Shot Count",  DATA_INT,    count,
-            "final",    "Final Time",  DATA_FORMAT, "%.2f s", DATA_DOUBLE, final,
-            "split",    "Split Time",  DATA_FORMAT, "%.2f s", DATA_DOUBLE, split,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",    "Model",       NULL,         "CED7000");
+    data = data_int(data, "id",       "ID",          "%04u",       id);
+    data = data_int(data, "count",    "Shot Count",  NULL,         count);
+    data = data_dbl(data, "final",    "Final Time",  "%.2f s",     final);
+    data = data_dbl(data, "split",    "Split Time",  "%.2f s",     split);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/celsia_czc1.c
+++ b/src/devices/celsia_czc1.c
@@ -120,12 +120,13 @@ static int celsia_czc1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int heat    = reverse8(b[3]); // command packet only
 
     /* clang-format off */
-    data_t *data = data_make(
-        "model",    "",             DATA_STRING, "Celsia-CZC1",
-        "id",       "",             DATA_FORMAT, "%x",    DATA_INT, id,
-        "heat",     "Heat",         DATA_COND,   heat_ok, DATA_INT, heat,
-        "mic",      "Integrity",    DATA_STRING, "CRC",
-        NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",    "",             NULL,         "Celsia-CZC1");
+    data = data_int(data, "id",       "",             "%x",         id);
+    if (heat_ok) {
+        data = data_int(data, "heat",     "Heat",         NULL,         heat);
+    }
+    data = data_str(data, "mic",      "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/chamberlain_cwpirc.c
+++ b/src/devices/chamberlain_cwpirc.c
@@ -81,12 +81,11 @@ static int chamberlain_cwpirc_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     sprintf(msg1, "%02x%02x%02x%02x%02x", b[7], b[8], b[9], b[10], b[11]);
 
     /* clang-format off */
-    data = data_make(
-        "model",   "Model",     DATA_STRING,   "Chamberlain-CWPIRC",
-        "msg_0",   "Message 0", DATA_STRING,    msg0,
-        "msg_1",   "Message 1", DATA_STRING,    msg1,
-        "mic",     "Integrity", DATA_STRING,   "CRC",
-        NULL);
+    data = NULL;
+    data = data_str(data, "model",   "Model",     NULL,         "Chamberlain-CWPIRC");
+    data = data_str(data, "msg_0",   "Message 0", NULL,         msg0);
+    data = data_str(data, "msg_1",   "Message 1", NULL,         msg1);
+    data = data_str(data, "mic",     "Integrity", NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/chuango.c
+++ b/src/devices/chuango.c
@@ -76,12 +76,11 @@ static int chuango_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data = data_make(
-            "model",    "",             DATA_STRING, "Chuango-Security",
-            "id",       "ID",           DATA_INT,    id,
-            "cmd",      "CMD",          DATA_STRING, cmd_str,
-            "cmd_id",   "CMD_ID",       DATA_INT,    cmd,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",    "",             NULL,         "Chuango-Security");
+    data = data_int(data, "id",       "ID",           NULL,         id);
+    data = data_str(data, "cmd",      "CMD",          NULL,         cmd_str);
+    data = data_int(data, "cmd_id",   "CMD_ID",       NULL,         cmd);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/cmr113.c
+++ b/src/devices/cmr113.c
@@ -97,12 +97,11 @@ static int cmr113_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data = data_make(
-            "model",        "",             DATA_STRING, "Clipsal-CMR113",
-            "current_1_A",  "Current 1",    DATA_FORMAT, "%.1f A", DATA_DOUBLE, current[0],
-            "current_2_A",  "Current 2",    DATA_FORMAT, "%.1f A", DATA_DOUBLE, current[1],
-            "current_3_A",  "Current 3",    DATA_FORMAT, "%.1f A", DATA_DOUBLE, current[2],
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",        "",             NULL,         "Clipsal-CMR113");
+    data = data_dbl(data, "current_1_A",  "Current 1",    "%.1f A",     current[0]);
+    data = data_dbl(data, "current_2_A",  "Current 2",    "%.1f A",     current[1]);
+    data = data_dbl(data, "current_3_A",  "Current 3",    "%.1f A",     current[2]);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/companion_wtr001.c
+++ b/src/devices/companion_wtr001.c
@@ -115,11 +115,10 @@ static int companion_wtr001_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     temperature = (temp_whole_raw + (temp_tenth_raw * 0.1f)) - 41.0f;
 
     /* clang-format off */
-    data = data_make(
-            "model",         "",            DATA_STRING, "Companion-WTR001",
-            "temperature_C", "Temperature", DATA_FORMAT, "%.1f", DATA_DOUBLE, temperature,
-            "mic",           "Integrity",   DATA_STRING, "PARITY",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",         "",            NULL,         "Companion-WTR001");
+    data = data_dbl(data, "temperature_C", "Temperature", "%.1f",       temperature);
+    data = data_str(data, "mic",           "Integrity",   NULL,         "PARITY");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/cotech_36_7959.c
+++ b/src/devices/cotech_36_7959.c
@@ -116,21 +116,24 @@ static int cotech_36_7959_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int light_is_valid = (uv <= 150); // error value seems to be 0xfb, lux would be 0xfffb
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",                 DATA_STRING, "Cotech-367959",
+    data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "Cotech-367959");
             //"subtype",          "Type code",        DATA_INT, subtype,
-            "id",               "ID",               DATA_INT,    id,
-            "battery_ok",       "Battery",          DATA_INT,    !batt_low,
-            "temperature_F",    "Temperature",      DATA_FORMAT, "%.1f F", DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",         DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "rain_mm",          "Rain",             DATA_FORMAT, "%.1f mm", DATA_DOUBLE, rain * 0.1f,
-            "wind_dir_deg",     "Wind direction",   DATA_INT,    wind_dir,
-            "wind_avg_m_s",     "Wind",             DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wind * 0.1f,
-            "wind_max_m_s",     "Gust",             DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, gust * 0.1f,
-            "light_lux",        "Light Intensity",  DATA_COND, light_is_valid, DATA_FORMAT, "%u lux", DATA_INT, light_lux,
-            "uv",               "UV Index",         DATA_COND, light_is_valid, DATA_FORMAT, "%.1f", DATA_DOUBLE, uv * 0.1f,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data = data_int(data, "id",               "ID",               NULL,         id);
+    data = data_int(data, "battery_ok",       "Battery",          NULL,         !batt_low);
+    data = data_dbl(data, "temperature_F",    "Temperature",      "%.1f F",     temp_c);
+    data = data_int(data, "humidity",         "Humidity",         "%u %%",      humidity);
+    data = data_dbl(data, "rain_mm",          "Rain",             "%.1f mm",    rain * 0.1f);
+    data = data_int(data, "wind_dir_deg",     "Wind direction",   NULL,         wind_dir);
+    data = data_dbl(data, "wind_avg_m_s",     "Wind",             "%.1f m/s",   wind * 0.1f);
+    data = data_dbl(data, "wind_max_m_s",     "Gust",             "%.1f m/s",   gust * 0.1f);
+    if (light_is_valid) {
+        data = data_int(data, "light_lux",        "Light Intensity",  "%u lux",     light_lux);
+    }
+    if (light_is_valid) {
+        data = data_dbl(data, "uv",               "UV Index",         "%.1f",       uv * 0.1f);
+    }
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/current_cost.c
+++ b/src/devices/current_cost.c
@@ -77,15 +77,14 @@ static int current_cost_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         if ((b[6] & 0x80) == 128)
             watt2 = (b[6] & 0x7F) << 8 | b[7];
         /* clang-format off */
-        data = data_make(
-                "model",        "",              DATA_STRING, is_envir ? "CurrentCost-EnviR" : "CurrentCost-TX", //TODO: it may have different CC Model ? any ref ?
+        data = NULL;
+        data = data_str(data, "model",        "",              NULL,         is_envir ? "CurrentCost-EnviR" : "CurrentCost-TX"); //TODO: it may have different CC Model ? any ref ?
                 //"rc",           "Rolling Code",  DATA_INT, rc, //TODO: add rolling code b[1] ? test needed
-                "id",           "Device Id",     DATA_FORMAT, "%d", DATA_INT, device_id,
-                "power0_W",     "Power 0",       DATA_FORMAT, "%d W", DATA_INT, watt0,
-                "power1_W",     "Power 1",       DATA_FORMAT, "%d W", DATA_INT, watt1,
-                "power2_W",     "Power 2",       DATA_FORMAT, "%d W", DATA_INT, watt2,
+        data = data_int(data, "id",           "Device Id",     "%d",         device_id);
+        data = data_int(data, "power0_W",     "Power 0",       "%d W",       watt0);
+        data = data_int(data, "power1_W",     "Power 1",       "%d W",       watt1);
+        data = data_int(data, "power2_W",     "Power 2",       "%d W",       watt2);
                 //"battery_ok",   "Battery",       DATA_INT,    !battery_low, //TODO is there some low battery indicator ?
-                NULL);
         /* clang-format on */
 
         decoder_output_data(decoder, data);
@@ -98,13 +97,12 @@ static int current_cost_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         uint16_t sensor_type = b[3]; // Sensor type. Valid values are: 2-Electric, 3-Gas, 4-Water
         uint32_t c_impulse   = (unsigned)b[4] << 24 | b[5] << 16 | b[6] << 8 | b[7];
         /* clang-format off */
-        data = data_make(
-               "model",         "",              DATA_STRING, is_envir ? "CurrentCost-EnviRCounter" : "CurrentCost-Counter", //TODO: it may have different CC Model ? any ref ?
-               "subtype",       "Sensor Id",     DATA_FORMAT, "%d", DATA_INT, sensor_type, //Could "friendly name" this?
-               "id",            "Device Id",     DATA_FORMAT, "%d", DATA_INT, device_id,
+        data = NULL;
+        data = data_str(data, "model",         "",              NULL,         is_envir ? "CurrentCost-EnviRCounter" : "CurrentCost-Counter"); //TODO: it may have different CC Model ? any ref ?
+        data = data_int(data, "subtype",       "Sensor Id",     "%d",         sensor_type); //Could "friendly name" this?
+        data = data_int(data, "id",            "Device Id",     "%d",         device_id);
                //"counter",       "Counter",       DATA_FORMAT, "%d", DATA_INT, c_impulse,
-               "power0",        "Counter",       DATA_FORMAT, "%d", DATA_INT, c_impulse,
-               NULL);
+        data = data_int(data, "power0",        "Counter",       "%d",         c_impulse);
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/danfoss.c
+++ b/src/devices/danfoss.c
@@ -130,14 +130,13 @@ static int danfoss_cfr_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         float temp_setp = (float)bytes[7] + (float)bytes[6] / 256.0f;
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",             DATA_STRING, "Danfoss-CFR",
-                "id",               "ID",           DATA_INT,    id,
-                "temperature_C",    "Temperature",  DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_meas,
-                "setpoint_C",       "Setpoint",     DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_setp,
-                "switch",           "Switch",       DATA_STRING, str_sw,
-                "mic",              "Integrity",    DATA_STRING, "CRC",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",             NULL,         "Danfoss-CFR");
+        data = data_int(data, "id",               "ID",           NULL,         id);
+        data = data_dbl(data, "temperature_C",    "Temperature",  "%.2f C",     temp_meas);
+        data = data_dbl(data, "setpoint_C",       "Setpoint",     "%.2f C",     temp_setp);
+        data = data_str(data, "switch",           "Switch",       NULL,         str_sw);
+        data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/deltadore_x3d.c
+++ b/src/devices/deltadore_x3d.c
@@ -336,15 +336,14 @@ static int deltadore_x3d_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
 
     /* clang-format off */
-    data = data_make(
-            "model",   "",            DATA_STRING, "DeltaDore-X3D",
-            "id",      "",            DATA_INT,    head.device_id,
-            "network", "Net",         DATA_INT,    head.network,
-            "subtype", "Class",       DATA_FORMAT, "%s", DATA_STRING, class,
-            "msg_id",  "Message Id",  DATA_INT,    head.message_id,
-            "msg_no",  "Message No.", DATA_INT,    head.number,
-            "mic",     "Integrity",   DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",   "",            NULL,         "DeltaDore-X3D");
+    data = data_int(data, "id",      "",            NULL,         head.device_id);
+    data = data_int(data, "network", "Net",         NULL,         head.network);
+    data = data_str(data, "subtype", "Class",       "%s",         class);
+    data = data_int(data, "msg_id",  "Message Id",  NULL,         head.message_id);
+    data = data_int(data, "msg_no",  "Message No.", NULL,         head.number);
+    data = data_str(data, "mic",     "Integrity",   NULL,         "CRC");
     /* clang-format on */
 
     // message from thermostate

--- a/src/devices/digitech_xc0324.c
+++ b/src/devices/digitech_xc0324.c
@@ -115,13 +115,12 @@ static int decode_xc0324_message(r_device *decoder, bitbuffer_t *bitbuffer,
         int humidity = reverse8(b[4]);
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",            "Device Type",      DATA_STRING, "Digitech-XC0324",
-                "id",               "ID",               DATA_STRING, id,
-                "temperature_C",    "Temperature C",    DATA_FORMAT, "%.1f", DATA_DOUBLE, temperature,
-                "humidity",         "Humidity",         DATA_FORMAT, "%u %%", DATA_INT, humidity,
-                "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",            "Device Type",      NULL,         "Digitech-XC0324");
+        data = data_str(data, "id",               "ID",               NULL,         id);
+        data = data_dbl(data, "temperature_C",    "Temperature C",    "%.1f",       temperature);
+        data = data_int(data, "humidity",         "Humidity",         "%u %%",      humidity);
+        data = data_str(data, "mic",              "Integrity",        NULL,         "CHECKSUM");
         /* clang-format on */
 
         *data_out = data;

--- a/src/devices/directv.c
+++ b/src/devices/directv.c
@@ -345,14 +345,13 @@ static int directv_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // Populate our return fields
     /* clang-format off */
-    data = data_make(
-            "model",         "",            DATA_STRING, "DirecTV-RC66RX",
-            "id",            "",            DATA_FORMAT, "%06d", DATA_INT, dtv_device_id,
-            "button_id",     "",            DATA_FORMAT, "0x%02X", DATA_INT, dtv_button_id,
-            "button_name",   "",            DATA_STRING, get_dtv_button_label(dtv_button_id),
-            "event",         "",            DATA_STRING, row_sync_len > ROW_SYNC_SHORT_LEN ? "INITIAL" : "REPEAT",
-            "mic",           "Integrity",   DATA_STRING, "CHECKSUM",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",         "",            NULL,         "DirecTV-RC66RX");
+    data = data_int(data, "id",            "",            "%06d",       dtv_device_id);
+    data = data_int(data, "button_id",     "",            "0x%02X",     dtv_button_id);
+    data = data_str(data, "button_name",   "",            NULL,         get_dtv_button_label(dtv_button_id));
+    data = data_str(data, "event",         "",            NULL,         row_sync_len > ROW_SYNC_SHORT_LEN ? "INITIAL" : "REPEAT");
+    data = data_str(data, "mic",           "Integrity",   NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/dish_remote_6_3.c
+++ b/src/devices/dish_remote_6_3.c
@@ -123,10 +123,9 @@ static int dish_remote_6_3_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     button_string = button_map[button];
 
     /* clang-format off */
-    data = data_make(
-            "model",    "",     DATA_STRING, "Dish-RC63",
-            "button",   "",     DATA_STRING, button_string,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",    "",     NULL,         "Dish-RC63");
+    data = data_str(data, "button",   "",     NULL,         button_string);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/dsc.c
+++ b/src/devices/dsc.c
@@ -212,24 +212,23 @@ static int dsc_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         snprintf(esn_str, sizeof(esn_str), "%06x", esn);
 
         /* clang-format off */
-        data = data_make(
-                "model",        "",             DATA_STRING, "DSC-Security",
-                "id",           "",             DATA_INT,    esn,
-                "closed",       "",             DATA_INT,    s_closed, // @todo make bool
-                "event",        "",             DATA_INT,    s_event, // @todo make bool
-                "tamper",       "",             DATA_INT,    s_tamper, // @todo make bool
-                "battery_ok",   "Battery",      DATA_INT,    !s_battery_low,
-                "xactivity",    "",             DATA_INT,    s_xactivity, // @todo make bool
+        data = NULL;
+        data = data_str(data, "model",        "",             NULL,         "DSC-Security");
+        data = data_int(data, "id",           "",             NULL,         esn);
+        data = data_int(data, "closed",       "",             NULL,         s_closed); // @todo make bool
+        data = data_int(data, "event",        "",             NULL,         s_event); // @todo make bool
+        data = data_int(data, "tamper",       "",             NULL,         s_tamper); // @todo make bool
+        data = data_int(data, "battery_ok",   "Battery",      NULL,         !s_battery_low);
+        data = data_int(data, "xactivity",    "",             NULL,         s_xactivity); // @todo make bool
 
                 // Note: the following may change or be removed
-                "xtamper1",     "",             DATA_INT,    s_xtamper1, // @todo make bool
-                "xtamper2",     "",             DATA_INT,    s_xtamper2, // @todo make bool
-                "exception",    "",             DATA_INT,    s_exception, // @todo make bool
-                "esn",          "",             DATA_STRING, esn_str, // to be removed - transitional
-                "status",       "",             DATA_INT,    status,
-                "status_hex",   "",             DATA_STRING, status_str, // to be removed - once bits are output
-                "mic",          "Integrity",    DATA_STRING, "CRC",
-                NULL);
+        data = data_int(data, "xtamper1",     "",             NULL,         s_xtamper1); // @todo make bool
+        data = data_int(data, "xtamper2",     "",             NULL,         s_xtamper2); // @todo make bool
+        data = data_int(data, "exception",    "",             NULL,         s_exception); // @todo make bool
+        data = data_str(data, "esn",          "",             NULL,         esn_str); // to be removed - transitional
+        data = data_int(data, "status",       "",             NULL,         status);
+        data = data_str(data, "status_hex",   "",             NULL,         status_str); // to be removed - once bits are output
+        data = data_str(data, "mic",          "Integrity",    NULL,         "CRC");
         /* clang-format on */
         decoder_output_data(decoder, data);
 

--- a/src/devices/ecodhome.c
+++ b/src/devices/ecodhome.c
@@ -127,15 +127,16 @@ static int ecodhome_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         int power_w = (msg[9] << 8) | (msg[8]);
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",                 DATA_STRING, "EcoDHOME-SmartSocket",
-                "id",               "",                 DATA_FORMAT, "%08x",   DATA_INT, id,
-                "message_type",     "Message Type",     DATA_FORMAT, "%04x",   DATA_INT, m_type,
-                "message_subtype",  "Message Subtype",  DATA_FORMAT, "%04x",   DATA_INT, m_subtype,
-                "power_W",          "Power",            DATA_COND, m_subtype == 0x414b, DATA_FORMAT, "%.1f W",   DATA_DOUBLE, (double)power_w,
-                "raw",              "Raw data",         DATA_FORMAT, "%06x",   DATA_INT, raw,
-                "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                 NULL,         "EcoDHOME-SmartSocket");
+        data = data_int(data, "id",               "",                 "%08x",       id);
+        data = data_int(data, "message_type",     "Message Type",     "%04x",       m_type);
+        data = data_int(data, "message_subtype",  "Message Subtype",  "%04x",       m_subtype);
+        if (m_subtype == 0x414b) {
+            data = data_dbl(data, "power_W",          "Power",            "%.1f W",     (double)power_w);
+        }
+        data = data_int(data, "raw",              "Raw data",         "%06x",       raw);
+        data = data_str(data, "mic",              "Integrity",        NULL,         "CHECKSUM");
         /* clang-format on */
     }
     else {
@@ -156,14 +157,15 @@ static int ecodhome_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         int power_w = ((uint8_t)(msg[7] - 0x33) << 8) | (uint8_t)(msg[6] - 0x33);
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",                 DATA_STRING, "EcoDHOME-Transmitter",
-                "id",               "",                 DATA_FORMAT, "%08x",   DATA_INT, id,
-                "message_type",     "Message Type",     DATA_FORMAT, "%04x",   DATA_INT, m_type,
-                "power_W",          "Power",            DATA_COND, m_type == 0x3eb3, DATA_FORMAT, "%.1f W",   DATA_DOUBLE, (double)power_w,
-                "raw",              "Raw data",         DATA_FORMAT, "%06x",   DATA_INT, raw,
-                "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                 NULL,         "EcoDHOME-Transmitter");
+        data = data_int(data, "id",               "",                 "%08x",       id);
+        data = data_int(data, "message_type",     "Message Type",     "%04x",       m_type);
+        if (m_type == 0x3eb3) {
+            data = data_dbl(data, "power_W",          "Power",            "%.1f W",     (double)power_w);
+        }
+        data = data_int(data, "raw",              "Raw data",         "%06x",       raw);
+        data = data_str(data, "mic",              "Integrity",        NULL,         "CHECKSUM");
         /* clang-format on */
     }
 

--- a/src/devices/ecowitt.c
+++ b/src/devices/ecowitt.c
@@ -88,13 +88,12 @@ static int ecowitt_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",         "",            DATA_STRING, "Ecowitt-WH53",
-            "id",            "Id",          DATA_INT,    sensor_id,
-            "channel",       "Channel",     DATA_INT,    channel,
-            "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "mic",           "Integrity",   DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",         "",            NULL,         "Ecowitt-WH53");
+    data = data_int(data, "id",            "Id",          NULL,         sensor_id);
+    data = data_int(data, "channel",       "Channel",     NULL,         channel);
+    data = data_dbl(data, "temperature_C", "Temperature", "%.1f C",     temp_c);
+    data = data_str(data, "mic",           "Integrity",   NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/efergy_e2_classic.c
+++ b/src/devices/efergy_e2_classic.c
@@ -95,15 +95,14 @@ static int efergy_e2_classic_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     float current_adc = (float)(bytes[4] << 8 | bytes[5]) / (1 << fact);
 
     /* clang-format off */
-    data = data_make(
-            "model",        "",                 DATA_STRING, "Efergy-e2CT",
-            "id",           "Transmitter ID",   DATA_INT,    address,
-            "battery_ok",   "Battery",          DATA_INT,    !!battery,
-            "current",      "Current",          DATA_FORMAT, "%.2f A", DATA_DOUBLE, current_adc,
-            "interval",     "Interval",         DATA_FORMAT, "%ds", DATA_INT, interval,
-            "learn",        "Learning",         DATA_STRING, learn ? "YES" : "NO",
-            "mic",          "Integrity",        DATA_STRING, "CHECKSUM",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",        "",                 NULL,         "Efergy-e2CT");
+    data = data_int(data, "id",           "Transmitter ID",   NULL,         address);
+    data = data_int(data, "battery_ok",   "Battery",          NULL,         !!battery);
+    data = data_dbl(data, "current",      "Current",          "%.2f A",     current_adc);
+    data = data_int(data, "interval",     "Interval",         "%ds",        interval);
+    data = data_str(data, "learn",        "Learning",         NULL,         learn ? "YES" : "NO");
+    data = data_str(data, "mic",          "Integrity",        NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/efergy_optical.c
+++ b/src/devices/efergy_optical.c
@@ -100,14 +100,13 @@ static int efergy_optical_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         float energy = (((float)pulsecount / imp_kwh[i]) * (3600 / seconds));
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",        "Model",        DATA_STRING, "Efergy-Optical",
-                "id",           "",             DATA_INT,   id,
-                "pulses",       "Pulse-rate",   DATA_INT, imp_kwh[i],
-                "pulsecount",   "Pulse-count",  DATA_INT, pulsecount,
-                "energy_kWh",   "Energy",       DATA_FORMAT, "%.3f kWh", DATA_DOUBLE, energy,
-                "mic",          "Integrity",    DATA_STRING, "CRC",
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",        "Model",        NULL,         "Efergy-Optical");
+        data = data_int(data, "id",           "",             NULL,         id);
+        data = data_int(data, "pulses",       "Pulse-rate",   NULL,         imp_kwh[i]);
+        data = data_int(data, "pulsecount",   "Pulse-count",  NULL,         pulsecount);
+        data = data_dbl(data, "energy_kWh",   "Energy",       "%.3f kWh",   energy);
+        data = data_str(data, "mic",          "Integrity",    NULL,         "CRC");
         /* clang-format on */
         decoder_output_data(decoder, data);
     }

--- a/src/devices/efth800.c
+++ b/src/devices/efth800.c
@@ -106,16 +106,17 @@ static int eurochron_efth800_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int humidity    = (b[4] >> 4) * 10 + (b[4] & 0xf); // BCD
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Eurochron-EFTH800",
-            "id",               "",             DATA_INT,    id,
-            "channel",          "",             DATA_INT,    channel + 1,
-            "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",     DATA_INT,    humidity,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            "radio_clock",      "Radio Clock",  DATA_COND,   *dcf77_str, DATA_STRING, dcf77_str,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Eurochron-EFTH800");
+    data = data_int(data, "id",               "",             NULL,         id);
+    data = data_int(data, "channel",          "",             NULL,         channel + 1);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    data = data_int(data, "humidity",         "Humidity",     NULL,         humidity);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
+    if (*dcf77_str) {
+        data = data_str(data, "radio_clock",      "Radio Clock",  NULL,         dcf77_str);
+    }
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/elro_db286a.c
+++ b/src/devices/elro_db286a.c
@@ -39,10 +39,9 @@ static int elro_db286a_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     snprintf(id_str, sizeof(id_str), "%02x%02x%02x%02x", b[0], b[1], b[2], b[3]);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",    "",        DATA_STRING, "Elro-DB286A",
-            "id",       "ID",      DATA_STRING, id_str,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",    "",        NULL,         "Elro-DB286A");
+    data = data_str(data, "id",       "ID",      NULL,         id_str);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/elv.c
+++ b/src/devices/elv.c
@@ -81,14 +81,13 @@ static int em1000_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     int peak      = dec[7] | dec[8] << 8;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",    "", DATA_STRING, "ELV-EM1000",
-            "id",       "", DATA_INT, code,
-            "seq",      "", DATA_INT, seqno,
-            "total",    "", DATA_INT, total,
-            "current",  "", DATA_INT, current,
-            "peak",     "", DATA_INT, peak,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",    "", NULL,         "ELV-EM1000");
+    data = data_int(data, "id",       "", NULL,         code);
+    data = data_int(data, "seq",      "", NULL,         seqno);
+    data = data_int(data, "total",    "", NULL,         total);
+    data = data_int(data, "current",  "", NULL,         current);
+    data = data_int(data, "peak",     "", NULL,         peak);
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -242,20 +241,31 @@ static int ws2000_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "", DATA_STRING, "ELV-WS2000",
-            "subtype",          "", DATA_STRING, subtype,
-            "id",               "", DATA_INT,    code,
-            "temperature_C",    "", DATA_FORMAT, "%.1f C", DATA_DOUBLE, (double)temp,
-            "humidity",         "", DATA_FORMAT, "%.1f %%", DATA_DOUBLE, (double)humidity,
-            "pressure_hPa",     "", DATA_COND, pressure, DATA_FORMAT, "%d hPa", DATA_INT, pressure,
+    data_t *data = NULL;
+    data = data_str(data, "model",            "", NULL,         "ELV-WS2000");
+    data = data_str(data, "subtype",          "", NULL,         subtype);
+    data = data_int(data, "id",               "", NULL,         code);
+    data = data_dbl(data, "temperature_C",    "", "%.1f C",     (double)temp);
+    data = data_dbl(data, "humidity",         "", "%.1f %%",    (double)humidity);
+    if (pressure) {
+        data = data_int(data, "pressure_hPa",     "", "%d hPa",     pressure);
+    }
             //KS200 / KS300
-            "wind_avg_km_h",    "", DATA_COND, is_ksx00, DATA_FORMAT, "%.1f kmh", DATA_DOUBLE, (double)wind,
-            "rain_count",       "", DATA_COND, is_ksx00, DATA_FORMAT, "%d", DATA_INT, rainsum,
-            "rain_mm",          "", DATA_COND, is_ksx00, DATA_FORMAT, "%.1f", DATA_DOUBLE, (double)rainsum * 0.295,
-            "is_raining",       "", DATA_COND, is_ksx00, DATA_FORMAT, "%d", DATA_INT, it_rains,
-            "unknown",          "", DATA_COND, is_ksx00, DATA_FORMAT, "%d", DATA_INT, unknown,
-            NULL);
+    if (is_ksx00) {
+        data = data_dbl(data, "wind_avg_km_h",    "", "%.1f kmh",   (double)wind);
+    }
+    if (is_ksx00) {
+        data = data_int(data, "rain_count",       "", "%d",         rainsum);
+    }
+    if (is_ksx00) {
+        data = data_dbl(data, "rain_mm",          "", "%.1f",       (double)rainsum * 0.295);
+    }
+    if (is_ksx00) {
+        data = data_int(data, "is_raining",       "", "%d",         it_rains);
+    }
+    if (is_ksx00) {
+        data = data_int(data, "unknown",          "", "%d",         unknown);
+    }
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/emontx.c
+++ b/src/devices/emontx.c
@@ -113,24 +113,35 @@ static int emontx_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         vrms = (float)words[4] / 100.0f;
 
         /* clang-format off */
-        data = data_make(
-                "model",        "",             DATA_STRING, "emonTx-Energy",
-                "node",         "",             DATA_FORMAT, "%02x", DATA_INT, pkt.p.node & 0x1f,
-                "ct1",          "",             DATA_FORMAT, "%d", DATA_INT, (int16_t)words[0],
-                "ct2",          "",             DATA_FORMAT, "%d", DATA_INT, (int16_t)words[1],
-                "ct3",          "",             DATA_FORMAT, "%d", DATA_INT, (int16_t)words[2],
-                "ct4",          "",             DATA_FORMAT, "%d", DATA_INT, (int16_t)words[3],
-                "batt_Vrms",    "",             DATA_FORMAT, "%.2f", DATA_DOUBLE, vrms,
-                "pulse",        "",             DATA_FORMAT, "%u", DATA_INT, words[11] | ((uint32_t)words[12] << 16),
+        data = NULL;
+        data = data_str(data, "model",        "",             NULL,         "emonTx-Energy");
+        data = data_int(data, "node",         "",             "%02x",       pkt.p.node & 0x1f);
+        data = data_int(data, "ct1",          "",             "%d",         (int16_t)words[0]);
+        data = data_int(data, "ct2",          "",             "%d",         (int16_t)words[1]);
+        data = data_int(data, "ct3",          "",             "%d",         (int16_t)words[2]);
+        data = data_int(data, "ct4",          "",             "%d",         (int16_t)words[3]);
+        data = data_dbl(data, "batt_Vrms",    "",             "%.2f",       vrms);
+        data = data_int(data, "pulse",        "",             "%u",         words[11] | ((uint32_t)words[12] << 16));
                 // Slightly horrid... a value of 300.0°C means 'no reading'. So omit them completely.
-                "temp1_C",      "",             DATA_COND, words[5] != 3000, DATA_FORMAT, "%.1f", DATA_DOUBLE, words[5] * 0.1f,
-                "temp2_C",      "",             DATA_COND, words[6] != 3000, DATA_FORMAT, "%.1f", DATA_DOUBLE, words[6] * 0.1f,
-                "temp3_C",      "",             DATA_COND, words[7] != 3000, DATA_FORMAT, "%.1f", DATA_DOUBLE, words[7] * 0.1f,
-                "temp4_C",      "",             DATA_COND, words[8] != 3000, DATA_FORMAT, "%.1f", DATA_DOUBLE, words[8] * 0.1f,
-                "temp5_C",      "",             DATA_COND, words[9] != 3000, DATA_FORMAT, "%.1f", DATA_DOUBLE, words[9] * 0.1f,
-                "temp6_C",      "",             DATA_COND, words[10] != 3000, DATA_FORMAT, "%.1f", DATA_DOUBLE, words[10] * 0.1f,
-                "mic",          "Integrity",    DATA_STRING, "CRC",
-                NULL);
+        if (words[5] != 3000) {
+            data = data_dbl(data, "temp1_C",      "",             "%.1f",       words[5] * 0.1f);
+        }
+        if (words[6] != 3000) {
+            data = data_dbl(data, "temp2_C",      "",             "%.1f",       words[6] * 0.1f);
+        }
+        if (words[7] != 3000) {
+            data = data_dbl(data, "temp3_C",      "",             "%.1f",       words[7] * 0.1f);
+        }
+        if (words[8] != 3000) {
+            data = data_dbl(data, "temp4_C",      "",             "%.1f",       words[8] * 0.1f);
+        }
+        if (words[9] != 3000) {
+            data = data_dbl(data, "temp5_C",      "",             "%.1f",       words[9] * 0.1f);
+        }
+        if (words[10] != 3000) {
+            data = data_dbl(data, "temp6_C",      "",             "%.1f",       words[10] * 0.1f);
+        }
+        data = data_str(data, "mic",          "Integrity",    NULL,         "CRC");
         /* clang-format on */
         decoder_output_data(decoder, data);
         events++;

--- a/src/devices/emos_e6016.c
+++ b/src/devices/emos_e6016.c
@@ -106,18 +106,17 @@ static int emos_e6016_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     snprintf(dcf77_str, sizeof(dcf77_str), "%4d-%02d-%02dT%02d:%02d:%02d", dcf77_year + 2000, dcf77_mth, dcf77_day, dcf77_hour, dcf77_min, dcf77_sec);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",                 DATA_STRING, "EMOS-E6016",
-            "id",               "House Code",       DATA_INT,    id,
-            "channel",          "Channel",          DATA_INT,    channel,
-            "battery_ok",       "Battery_OK",       DATA_INT,    battery,
-            "temperature_C",    "Temperature_C",    DATA_FORMAT, "%.1f", DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",         DATA_FORMAT, "%u", DATA_INT, humidity,
-            "wind_avg_m_s",     "WindSpeed m_s",    DATA_FORMAT, "%.1f",  DATA_DOUBLE, speed_ms,
-            "wind_dir_deg",     "Wind direction",   DATA_FORMAT, "%.1f",  DATA_DOUBLE, dir_deg,
-            "radio_clock",      "Radio Clock",      DATA_STRING, dcf77_str,
-            "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "EMOS-E6016");
+    data = data_int(data, "id",               "House Code",       NULL,         id);
+    data = data_int(data, "channel",          "Channel",          NULL,         channel);
+    data = data_int(data, "battery_ok",       "Battery_OK",       NULL,         battery);
+    data = data_dbl(data, "temperature_C",    "Temperature_C",    "%.1f",       temp_c);
+    data = data_int(data, "humidity",         "Humidity",         "%u",         humidity);
+    data = data_dbl(data, "wind_avg_m_s",     "WindSpeed m_s",    "%.1f",       speed_ms);
+    data = data_dbl(data, "wind_dir_deg",     "Wind direction",   "%.1f",       dir_deg);
+    data = data_str(data, "radio_clock",      "Radio Clock",      NULL,         dcf77_str);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/emos_e6016_rain.c
+++ b/src/devices/emos_e6016_rain.c
@@ -86,13 +86,12 @@ static int emos_e6016_rain_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     float rain_mm = rain_raw * 0.7f;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",                 DATA_STRING, "EMOS-E6016R",
-            "id",               "House Code",       DATA_INT,    id,
-            "battery_ok",       "Battery_OK",       DATA_INT,    !!battery,
-            "rain_mm",          "Rain_mm",          DATA_FORMAT, "%.1f mm", DATA_DOUBLE, rain_mm,
-            "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "EMOS-E6016R");
+    data = data_int(data, "id",               "House Code",       NULL,         id);
+    data = data_int(data, "battery_ok",       "Battery_OK",       NULL,         !!battery);
+    data = data_dbl(data, "rain_mm",          "Rain_mm",          "%.1f mm",    rain_mm);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/enocean_erp1.c
+++ b/src/devices/enocean_erp1.c
@@ -79,11 +79,10 @@ static int enocean_erp1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     bitrow_snprint(bytes.bb[0], bytes.bits_per_row[0], tstr, sizeof(tstr));
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",    "",             DATA_STRING, "EnOcean-ERP1",
-            "telegram", "",             DATA_STRING, tstr,
-            "mic",      "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",    "",             NULL,         "EnOcean-ERP1");
+    data = data_str(data, "telegram", "",             NULL,         tstr);
+    data = data_str(data, "mic",      "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/ert_idm.c
+++ b/src/devices/ert_idm.c
@@ -261,35 +261,34 @@ static int ert_idm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     */
 
     /* clang-format off */
-    data = data_make(
-            "model",                            "",    DATA_STRING, "IDM",
+    data = NULL;
+    data = data_str(data, "model",                            "",    NULL,         "IDM");
 
             // "PacketTypeID",             "",             DATA_FORMAT, "0x%02X", DATA_INT, PacketTypeID,
-            "PacketTypeID",                     "",    DATA_STRING,       PacketTypeID_str,
-            "PacketLength",                     "",    DATA_INT,       PacketLength,
+    data = data_str(data, "PacketTypeID",                     "",    NULL,         PacketTypeID_str);
+    data = data_int(data, "PacketLength",                     "",    NULL,         PacketLength);
             // "HammingCode",              "",             DATA_INT,          HammingCode,
-            "ApplicationVersion",               "",     DATA_INT,       ApplicationVersion,
-            "ERTType",                          "",     DATA_FORMAT,  "0x%02X", DATA_INT,    ERTType,
+    data = data_int(data, "ApplicationVersion",               "",     NULL,         ApplicationVersion);
+    data = data_int(data, "ERTType",                          "",     "0x%02X",     ERTType);
             // "ERTType",                          "",     DATA_INT,       ERTType,
-            "ERTSerialNumber",                  "",     DATA_INT,       ERTSerialNumber,
-            "ConsumptionIntervalCount",         "",     DATA_INT,       ConsumptionIntervalCount,
+    data = data_int(data, "ERTSerialNumber",                  "",     NULL,         ERTSerialNumber);
+    data = data_int(data, "ConsumptionIntervalCount",         "",     NULL,         ConsumptionIntervalCount);
             // "ModuleProgrammingState",           "",     DATA_FORMAT, "0x%02X", DATA_INT, ModuleProgrammingState,
-            "ModuleProgrammingState",           "",     DATA_FORMAT, "0x%02X", DATA_INT, ModuleProgrammingState,
+    data = data_int(data, "ModuleProgrammingState",           "",     "0x%02X",     ModuleProgrammingState);
             // "ModuleProgrammingState",           "",     DATA_INT,      ModuleProgrammingState,
-            "TamperCounters",                   "",     DATA_STRING,       TamperCounters_str,
-            "AsynchronousCounters",             "",     DATA_FORMAT, "0x%02X", DATA_INT, AsynchronousCounters,
+    data = data_str(data, "TamperCounters",                   "",     NULL,         TamperCounters_str);
+    data = data_int(data, "AsynchronousCounters",             "",     "0x%02X",     AsynchronousCounters);
             // "AsynchronousCounters",             "",     DATA_INT,    AsynchronousCounters,
 
-            "PowerOutageFlags",                 "",     DATA_STRING,       PowerOutageFlags_str ,
-            "LastConsumptionCount",             "",     DATA_INT,       LastConsumptionCount,
-            "DifferentialConsumptionIntervals", "",     DATA_ARRAY, data_array(47, DATA_INT, DifferentialConsumptionIntervals),
-            "TransmitTimeOffset",               "",     DATA_INT,       TransmitTimeOffset,
-            "MeterIdCRC",                       "",     DATA_FORMAT, "0x%04X", DATA_INT, MeterIdCRC,
-            "PacketCRC",                        "",     DATA_FORMAT, "0x%04X", DATA_INT, PacketCRC,
+    data = data_str(data, "PowerOutageFlags",                 "",     NULL,         PowerOutageFlags_str );
+    data = data_int(data, "LastConsumptionCount",             "",     NULL,         LastConsumptionCount);
+    data = data_ary(data, "DifferentialConsumptionIntervals", "",     NULL,         data_array(47, DATA_INT, DifferentialConsumptionIntervals));
+    data = data_int(data, "TransmitTimeOffset",               "",     NULL,         TransmitTimeOffset);
+    data = data_int(data, "MeterIdCRC",                       "",     "0x%04X",     MeterIdCRC);
+    data = data_int(data, "PacketCRC",                        "",     "0x%04X",     PacketCRC);
 
-            "MeterType",                        "Meter_Type",       DATA_STRING, meter_type,
-            "mic",                              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data = data_str(data, "MeterType",                        "Meter_Type",       NULL,         meter_type);
+    data = data_str(data, "mic",                              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -549,37 +548,36 @@ static int ert_netidm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     */
 
     /* clang-format off */
-    data = data_make(
-            "model",                            "",     DATA_STRING, "NETIDM",
+    data = NULL;
+    data = data_str(data, "model",                            "",     NULL,         "NETIDM");
 
-            "PacketTypeID",                     "",     DATA_STRING,       PacketTypeID_str,
-            "PacketLength",                     "",     DATA_INT,       PacketLength,
+    data = data_str(data, "PacketTypeID",                     "",     NULL,         PacketTypeID_str);
+    data = data_int(data, "PacketLength",                     "",     NULL,         PacketLength);
             // "HammingCode",              "",             DATA_FORMAT, "0x%02X", DATA_INT, HammingCode,
-            "ApplicationVersion",               "",     DATA_INT,       ApplicationVersion,
+    data = data_int(data, "ApplicationVersion",               "",     NULL,         ApplicationVersion);
 
-            "ERTType",                          "",     DATA_FORMAT,  "0x%02X", DATA_INT,    ERTType,
-            "ERTSerialNumber",                  "",     DATA_INT,       ERTSerialNumber,
-            "ConsumptionIntervalCount",         "",     DATA_INT,       ConsumptionIntervalCount,
-            "ModuleProgrammingState",           "",     DATA_FORMAT, "0x%02X", DATA_INT, ModuleProgrammingState,
+    data = data_int(data, "ERTType",                          "",     "0x%02X",     ERTType);
+    data = data_int(data, "ERTSerialNumber",                  "",     NULL,         ERTSerialNumber);
+    data = data_int(data, "ConsumptionIntervalCount",         "",     NULL,         ConsumptionIntervalCount);
+    data = data_int(data, "ModuleProgrammingState",           "",     "0x%02X",     ModuleProgrammingState);
             // "ModuleProgrammingState",           "",     DATA_STRING,    ModuleProgrammingState_str,
-            "TamperCounters",                   "",     DATA_STRING,       TamperCounters_str,
+    data = data_str(data, "TamperCounters",                   "",     NULL,         TamperCounters_str);
             // "AsynchronousCounters",             "",     DATA_FORMAT, "0x%02X", DATA_INT, AsynchronousCounters,
-            "Unknown_field_1",                  "",     DATA_STRING,    Unknown_field_1_str,
-            "LastGenerationCount",              "",     DATA_INT,       LastGenerationCount,
-            "Unknown_field_2",                  "",     DATA_STRING,    Unknown_field_2_str,
+    data = data_str(data, "Unknown_field_1",                  "",     NULL,         Unknown_field_1_str);
+    data = data_int(data, "LastGenerationCount",              "",     NULL,         LastGenerationCount);
+    data = data_str(data, "Unknown_field_2",                  "",     NULL,         Unknown_field_2_str);
 
             // "AsynchronousCounters",             "",     DATA_STRING,    AsynchronousCounters_str,
 
             // "PowerOutageFlags",                 "",     DATA_STRING,       PowerOutageFlags_str ,
-            "LastConsumptionCount",             "",     DATA_INT,       LastConsumptionCount,
-            "DifferentialConsumptionIntervals", "",     DATA_ARRAY, data_array(27, DATA_INT, DifferentialConsumptionIntervals),
-            "TransmitTimeOffset",               "",     DATA_INT,       TransmitTimeOffset,
-            "MeterIdCRC",                       "",     DATA_FORMAT, "0x%04X", DATA_INT, MeterIdCRC,
-            "PacketCRC",                        "",     DATA_FORMAT, "0x%04X", DATA_INT, PacketCRC,
+    data = data_int(data, "LastConsumptionCount",             "",     NULL,         LastConsumptionCount);
+    data = data_ary(data, "DifferentialConsumptionIntervals", "",     NULL,         data_array(27, DATA_INT, DifferentialConsumptionIntervals));
+    data = data_int(data, "TransmitTimeOffset",               "",     NULL,         TransmitTimeOffset);
+    data = data_int(data, "MeterIdCRC",                       "",     "0x%04X",     MeterIdCRC);
+    data = data_int(data, "PacketCRC",                        "",     "0x%04X",     PacketCRC);
 
-            "MeterType",                        "",       DATA_STRING, meter_type,
-            "mic",                              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data = data_str(data, "MeterType",                        "",       NULL,         meter_type);
+    data = data_str(data, "mic",                              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/ert_scm.c
+++ b/src/devices/ert_scm.c
@@ -80,15 +80,14 @@ static int ert_scm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     ert_id = ((b[2]&0x06)<<23) | (b[7]<<16) | (b[8]<<8) | b[9];
 
     /* clang-format off */
-    data = data_make(
-            "model",           "",                 DATA_STRING, "ERT-SCM",
-            "id",              "Id",               DATA_INT,    ert_id,
-            "physical_tamper", "Physical Tamper",  DATA_INT, physical_tamper,
-            "ert_type",        "ERT Type",         DATA_INT, ert_type,
-            "encoder_tamper",  "Encoder Tamper",   DATA_INT, encoder_tamper,
-            "consumption_data","Consumption Data", DATA_INT, consumption_data,
-            "mic",             "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",           "",                 NULL,         "ERT-SCM");
+    data = data_int(data, "id",              "Id",               NULL,         ert_id);
+    data = data_int(data, "physical_tamper", "Physical Tamper",  NULL,         physical_tamper);
+    data = data_int(data, "ert_type",        "ERT Type",         NULL,         ert_type);
+    data = data_int(data, "encoder_tamper",  "Encoder Tamper",   NULL,         encoder_tamper);
+    data = data_int(data, "consumption_data","Consumption Data", NULL,         consumption_data);
+    data = data_str(data, "mic",             "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/esa.c
+++ b/src/devices/esa.c
@@ -69,18 +69,17 @@ static int esa_cost_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     energy_impulse_val = 1.0f * impulses_val / impulse_constant;
 
     /* clang-format off */
-    data = data_make(
-            "model",            "Model",            DATA_STRING, "ESA-x000",
-            "id",               "Id",               DATA_INT, deviceid,
-            "impulses",         "Impulses",          DATA_INT, impulses,
-            "impulses_total",   "Impulses Total",   DATA_INT, impulses_total,
-            "impulse_constant", "Impulse Constant", DATA_INT, impulse_constant,
-            "total_kWh",        "Energy Total",     DATA_DOUBLE, energy_total_val,
-            "impulse_kWh",      "Energy Impulse",   DATA_DOUBLE, energy_impulse_val,
-            "sequence_id",      "Sequence ID",      DATA_INT, sequence_id,
-            "is_retry",         "Is Retry",         DATA_INT, is_retry,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "Model",            NULL,         "ESA-x000");
+    data = data_int(data, "id",               "Id",               NULL,         deviceid);
+    data = data_int(data, "impulses",         "Impulses",          NULL,         impulses);
+    data = data_int(data, "impulses_total",   "Impulses Total",   NULL,         impulses_total);
+    data = data_int(data, "impulse_constant", "Impulse Constant", NULL,         impulse_constant);
+    data = data_dbl(data, "total_kWh",        "Energy Total",     NULL,         energy_total_val);
+    data = data_dbl(data, "impulse_kWh",      "Energy Impulse",   NULL,         energy_impulse_val);
+    data = data_int(data, "sequence_id",      "Sequence ID",      NULL,         sequence_id);
+    data = data_int(data, "is_retry",         "Is Retry",         NULL,         is_retry);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/esic_emt7110.c
+++ b/src/devices/esic_emt7110.c
@@ -74,17 +74,16 @@ static int esic_emt7110_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     float energy_kwh = energy_raw * 0.01f;
 
     /* clang-format off */
-    data = data_make(
-            "model",        "",             DATA_STRING, "ESIC-EMT7110",
-            "id",           "Sensor ID",    DATA_FORMAT, "%08x",     DATA_INT,    id,
-            "power_W",      "Power",        DATA_FORMAT, "%.1f W",   DATA_DOUBLE, power_w,
-            "current_A",    "Current",      DATA_FORMAT, "%.3f A",   DATA_DOUBLE, current_a,
-            "voltage_V",    "Voltage",      DATA_FORMAT, "%.1f V",   DATA_DOUBLE, voltage_v,
-            "energy_kWh",   "Energy",       DATA_FORMAT, "%.2f kWh", DATA_DOUBLE, energy_kwh,
-            "pairing",      "Pairing?",     DATA_INT,    pairing,
-            "connected",    "Connected?",   DATA_INT,    connected,
-            "mic",          "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",        "",             NULL,         "ESIC-EMT7110");
+    data = data_int(data, "id",           "Sensor ID",    "%08x",       id);
+    data = data_dbl(data, "power_W",      "Power",        "%.1f W",     power_w);
+    data = data_dbl(data, "current_A",    "Current",      "%.3f A",     current_a);
+    data = data_dbl(data, "voltage_V",    "Voltage",      "%.1f V",     voltage_v);
+    data = data_dbl(data, "energy_kWh",   "Energy",       "%.2f kWh",   energy_kwh);
+    data = data_int(data, "pairing",      "Pairing?",     NULL,         pairing);
+    data = data_int(data, "connected",    "Connected?",   NULL,         connected);
+    data = data_str(data, "mic",          "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/esperanza_ews.c
+++ b/src/devices/esperanza_ews.c
@@ -97,15 +97,14 @@ static int esperanza_ews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     int humidity  = ((b[3] & 0x0f) << 4) | ((b[3] & 0xf0) >> 4);
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "Esperanza-EWS",
-            "id",               "ID",           DATA_INT, device_id,
-            "channel",          "Channel",      DATA_INT, channel,
-            "battery_ok",       "Battery",      DATA_INT, !battery_low,
-            "temperature_F",    "Temperature",  DATA_FORMAT, "%.2f F", DATA_DOUBLE, temp_f,
-            "humidity",         "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Esperanza-EWS");
+    data = data_int(data, "id",               "ID",           NULL,         device_id);
+    data = data_int(data, "channel",          "Channel",      NULL,         channel);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_dbl(data, "temperature_F",    "Temperature",  "%.2f F",     temp_f);
+    data = data_int(data, "humidity",         "Humidity",     "%u %%",      humidity);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/eurochron.c
+++ b/src/devices/eurochron.c
@@ -69,14 +69,13 @@ static int eurochron_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     button = (b[1] & 0x10) >> 4;
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "Eurochron-TH",
-            "id",               "",             DATA_INT,    device,
-            "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",     DATA_INT,    humidity,
-            "button",           "Button",       DATA_INT,    button,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Eurochron-TH");
+    data = data_int(data, "id",               "",             NULL,         device);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    data = data_int(data, "humidity",         "Humidity",     NULL,         humidity);
+    data = data_int(data, "button",           "Button",       NULL,         button);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -131,17 +131,28 @@ static int fineoffset_WH2_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     humidity = b[3];
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_COND, model_num == MODEL_WH2,  DATA_STRING, "Fineoffset-WH2",
-            "model",            "",             DATA_COND, model_num == MODEL_WH2A, DATA_STRING, "Fineoffset-WH2A",
-            "model",            "",             DATA_COND, model_num == MODEL_WH5,  DATA_STRING, "Fineoffset-WH5",
-            "model",            "",             DATA_COND, model_num == MODEL_RB,   DATA_STRING, "Rosenborg-66796",
-            "model",            "",             DATA_COND, model_num == MODEL_TP,   DATA_STRING, "Fineoffset-TelldusProove",
-            "id",               "ID",           DATA_INT, id,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
-            "humidity",         "Humidity",     DATA_COND, humidity != 0xff, DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    if (model_num == MODEL_WH2) {
+        data = data_str(data, "model",            "",             NULL,         "Fineoffset-WH2");
+    }
+    if (model_num == MODEL_WH2A) {
+        data = data_str(data, "model",            "",             NULL,         "Fineoffset-WH2A");
+    }
+    if (model_num == MODEL_WH5) {
+        data = data_str(data, "model",            "",             NULL,         "Fineoffset-WH5");
+    }
+    if (model_num == MODEL_RB) {
+        data = data_str(data, "model",            "",             NULL,         "Rosenborg-66796");
+    }
+    if (model_num == MODEL_TP) {
+        data = data_str(data, "model",            "",             NULL,         "Fineoffset-TelldusProove");
+    }
+    data = data_int(data, "id",               "ID",           NULL,         id);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temperature);
+    if (humidity != 0xff) {
+        data = data_int(data, "humidity",         "Humidity",     "%u %%",      humidity);
+    }
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -285,21 +296,36 @@ static int fineoffset_WH24_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     while (uv_index < 13 && uvi_upper[uv_index] < uv_raw) ++uv_index;
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",                 DATA_STRING, type == MODEL_WH24 ? "Fineoffset-WH24" : "Fineoffset-WH65B",
-            "id",               "ID",               DATA_INT,    id,
-            "battery_ok",       "Battery",          DATA_INT,    !low_battery,
-            "temperature_C",    "Temperature",      DATA_COND, temp_raw != 0x7ff, DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
-            "humidity",         "Humidity",         DATA_COND, humidity != 0xff, DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "wind_dir_deg",     "Wind direction",   DATA_COND, wind_dir != 0x1ff, DATA_INT, wind_dir,
-            "wind_avg_m_s",     "Wind speed",       DATA_COND, wind_speed_raw != 0x1ff, DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wind_speed_ms,
-            "wind_max_m_s",     "Gust speed",       DATA_COND, gust_speed_raw != 0xff, DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, gust_speed_ms,
-            "rain_mm",          "Rainfall",         DATA_FORMAT, "%.1f mm", DATA_DOUBLE, rainfall_mm,
-            "uv",               "UV",               DATA_COND, uv_raw != 0xffff, DATA_INT, uv_raw,
-            "uvi",              "UVI",              DATA_COND, uv_raw != 0xffff, DATA_INT, uv_index,
-            "light_lux",        "Light",            DATA_COND, light_raw != 0xffffff, DATA_FORMAT, "%.1f lux", DATA_DOUBLE, light_lux,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         type == MODEL_WH24 ? "Fineoffset-WH24" : "Fineoffset-WH65B");
+    data = data_int(data, "id",               "ID",               NULL,         id);
+    data = data_int(data, "battery_ok",       "Battery",          NULL,         !low_battery);
+    if (temp_raw != 0x7ff) {
+        data = data_dbl(data, "temperature_C",    "Temperature",      "%.1f C",     temperature);
+    }
+    if (humidity != 0xff) {
+        data = data_int(data, "humidity",         "Humidity",         "%u %%",      humidity);
+    }
+    if (wind_dir != 0x1ff) {
+        data = data_int(data, "wind_dir_deg",     "Wind direction",   NULL,         wind_dir);
+    }
+    if (wind_speed_raw != 0x1ff) {
+        data = data_dbl(data, "wind_avg_m_s",     "Wind speed",       "%.1f m/s",   wind_speed_ms);
+    }
+    if (gust_speed_raw != 0xff) {
+        data = data_dbl(data, "wind_max_m_s",     "Gust speed",       "%.1f m/s",   gust_speed_ms);
+    }
+    data = data_dbl(data, "rain_mm",          "Rainfall",         "%.1f mm",    rainfall_mm);
+    if (uv_raw != 0xffff) {
+        data = data_int(data, "uv",               "UV",               NULL,         uv_raw);
+    }
+    if (uv_raw != 0xffff) {
+        data = data_int(data, "uvi",              "UVI",              NULL,         uv_index);
+    }
+    if (light_raw != 0xffffff) {
+        data = data_dbl(data, "light_lux",        "Light",            "%.1f lux",   light_lux);
+    }
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -414,16 +440,15 @@ static int fineoffset_WH0290_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     float battery_ok  = battery_bars * 0.2f; //convert out of 5 bars to 0 (0 bars) to 1 (5 bars)
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "Fineoffset-WH0290",
-            "id",               "ID",           DATA_INT,    id,
-            "battery_ok",       "Battery Level",  DATA_FORMAT, "%.1f", DATA_DOUBLE, battery_ok,
-            "pm2_5_ug_m3",      "2.5um Fine Particulate Matter",  DATA_FORMAT, "%d ug/m3", DATA_INT, pm25/10,
-            "estimated_pm10_0_ug_m3",     "Estimate of 10um Coarse Particulate Matter",  DATA_FORMAT, "%d ug/m3", DATA_INT, pm100/10,
-            "family",           "FAMILY",       DATA_INT,    family,
-            "unknown1",         "UNKNOWN1",     DATA_INT,    unknown1,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Fineoffset-WH0290");
+    data = data_int(data, "id",               "ID",           NULL,         id);
+    data = data_dbl(data, "battery_ok",       "Battery Level",  "%.1f",       battery_ok);
+    data = data_int(data, "pm2_5_ug_m3",      "2.5um Fine Particulate Matter",  "%d ug/m3",   pm25/10);
+    data = data_int(data, "estimated_pm10_0_ug_m3",     "Estimate of 10um Coarse Particulate Matter",  "%d ug/m3",   pm100/10);
+    data = data_int(data, "family",           "FAMILY",       NULL,         family);
+    data = data_int(data, "unknown1",         "UNKNOWN1",     NULL,         unknown1);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -534,17 +559,24 @@ static int fineoffset_WH25_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     float pressure    = pressure_raw * 0.1f;
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_COND, type == 31, DATA_STRING, "Fineoffset-WH32",
-            "model",            "",             DATA_COND, type == 32, DATA_STRING, "Fineoffset-WH32B",
-            "model",            "",             DATA_COND, type == 25, DATA_STRING, "Fineoffset-WH25",
-            "id",               "ID",           DATA_INT,    id,
-            "battery_ok",       "Battery",      DATA_INT,    !low_battery,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
-            "humidity",         "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "pressure_hPa",     "Pressure",     DATA_COND,   pressure_raw != 0xffff, DATA_FORMAT, "%.1f hPa", DATA_DOUBLE, pressure,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    if (type == 31) {
+        data = data_str(data, "model",            "",             NULL,         "Fineoffset-WH32");
+    }
+    if (type == 32) {
+        data = data_str(data, "model",            "",             NULL,         "Fineoffset-WH32B");
+    }
+    if (type == 25) {
+        data = data_str(data, "model",            "",             NULL,         "Fineoffset-WH25");
+    }
+    data = data_int(data, "id",               "ID",           NULL,         id);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !low_battery);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temperature);
+    data = data_int(data, "humidity",         "Humidity",     "%u %%",      humidity);
+    if (pressure_raw != 0xffff) {
+        data = data_dbl(data, "pressure_hPa",     "Pressure",     "%.1f hPa",   pressure);
+    }
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -638,16 +670,15 @@ static int fineoffset_WH51_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     int moisture        = b[6];
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",                 DATA_STRING, "Fineoffset-WH51",
-            "id",               "ID",               DATA_STRING, id,
-            "battery_ok",       "Battery level",    DATA_DOUBLE, battery_level,
-            "battery_mV",       "Battery",          DATA_FORMAT, "%d mV", DATA_INT, battery_mv,
-            "moisture",         "Moisture",         DATA_FORMAT, "%u %%", DATA_INT, moisture,
-            "boost",            "Transmission boost", DATA_INT, boost,
-            "ad_raw",           "AD raw",           DATA_INT, ad_raw,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "Fineoffset-WH51");
+    data = data_str(data, "id",               "ID",               NULL,         id);
+    data = data_dbl(data, "battery_ok",       "Battery level",    NULL,         battery_level);
+    data = data_int(data, "battery_mV",       "Battery",          "%d mV",      battery_mv);
+    data = data_int(data, "moisture",         "Moisture",         "%u %%",      moisture);
+    data = data_int(data, "boost",            "Transmission boost", NULL,         boost);
+    data = data_int(data, "ad_raw",           "AD raw",           NULL,         ad_raw);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -708,14 +739,13 @@ static int alecto_ws1200v1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     float rainfall    = rainfall_raw * 0.3f; // each tip is 0.3mm
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "Alecto-WS1200v1",
-            "id",               "ID",           DATA_INT,    id,
-            "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
-            "rain_mm",          "Rain",         DATA_FORMAT, "%.1f mm", DATA_DOUBLE, rainfall,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Alecto-WS1200v1");
+    data = data_int(data, "id",               "ID",           NULL,         id);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temperature);
+    data = data_dbl(data, "rain_mm",          "Rain",         "%.1f mm",    rainfall);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -792,13 +822,12 @@ static int alecto_ws1200v2_dcf_callback(r_device *decoder, bitbuffer_t *bitbuffe
             date_y, date_m, date_d, time_h, time_m, time_s);
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "Alecto-WS1200v2",
-            "id",               "ID",           DATA_INT,    id,
-            "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-            "radio_clock",      "Radio Clock",  DATA_STRING, clock_str,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Alecto-WS1200v2");
+    data = data_int(data, "id",               "ID",           NULL,         id);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_str(data, "radio_clock",      "Radio Clock",  NULL,         clock_str);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -866,14 +895,13 @@ static int alecto_ws1200v2_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     float rainfall    = rainfall_raw * 0.3f; // each tip is 0.3mm
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "Alecto-WS1200v2",
-            "id",               "ID",           DATA_INT,    id,
-            "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
-            "rain_mm",          "Rain",         DATA_FORMAT, "%.1f mm", DATA_DOUBLE, rainfall,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Alecto-WS1200v2");
+    data = data_int(data, "id",               "ID",           NULL,         id);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temperature);
+    data = data_dbl(data, "rain_mm",          "Rain",         "%.1f mm",    rainfall);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -939,14 +967,13 @@ static int fineoffset_WH0530_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     float rainfall    = rainfall_raw * 0.3f; // each tip is 0.3mm
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "Fineoffset-WH0530",
-            "id",               "ID",           DATA_INT,    id,
-            "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
-            "rain_mm",          "Rain",         DATA_FORMAT, "%.1f mm", DATA_DOUBLE, rainfall,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Fineoffset-WH0530");
+    data = data_int(data, "id",               "ID",           NULL,         id);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temperature);
+    data = data_dbl(data, "rain_mm",          "Rain",         "%.1f mm",    rainfall);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/fineoffset_wh1050.c
+++ b/src/devices/fineoffset_wh1050.c
@@ -143,19 +143,22 @@ static int fineoffset_wh1050_decode(r_device *decoder, bitbuffer_t *bitbuffer, u
         int battery_low   = br[1] & 0x04;
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",                 DATA_COND, type == TYPE_OOK, DATA_STRING, "Fineoffset-WH1050",
-                "model",            "",                 DATA_COND, type == TYPE_FSK, DATA_STRING, "TFA-303151",
-                "id",               "Station ID",       DATA_FORMAT, "%02X",    DATA_INT,    device_id,
-                "msg_type",         "Msg type",         DATA_INT,    msg_type,
-                "battery_ok",       "Battery",          DATA_INT,    !battery_low,
-                "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
-                "humidity",         "Humidity",         DATA_FORMAT, "%u %%",   DATA_INT,    humidity,
-                "wind_avg_km_h",    "Wind avg speed",   DATA_FORMAT, "%.2f km/h",   DATA_DOUBLE, speed,
-                "wind_max_km_h",    "Wind gust",        DATA_FORMAT, "%.2f km/h ",   DATA_DOUBLE, gust,
-                "rain_mm",          "Total rainfall",   DATA_FORMAT, "%.1f mm",   DATA_DOUBLE, rain,
-                "mic",              "Integrity",        DATA_STRING, "CRC",
-                NULL);
+        data = NULL;
+        if (type == TYPE_OOK) {
+            data = data_str(data, "model",            "",                 NULL,         "Fineoffset-WH1050");
+        }
+        if (type == TYPE_FSK) {
+            data = data_str(data, "model",            "",                 NULL,         "TFA-303151");
+        }
+        data = data_int(data, "id",               "Station ID",       "%02X",       device_id);
+        data = data_int(data, "msg_type",         "Msg type",         NULL,         msg_type);
+        data = data_int(data, "battery_ok",       "Battery",          NULL,         !battery_low);
+        data = data_dbl(data, "temperature_C",    "Temperature",      "%.1f C",     temperature);
+        data = data_int(data, "humidity",         "Humidity",         "%u %%",      humidity);
+        data = data_dbl(data, "wind_avg_km_h",    "Wind avg speed",   "%.2f km/h",  speed);
+        data = data_dbl(data, "wind_max_km_h",    "Wind gust",        "%.2f km/h ", gust);
+        data = data_dbl(data, "rain_mm",          "Total rainfall",   "%.1f mm",    rain);
+        data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
         /* clang-format on */
     }
     else if (msg_type == 6) {
@@ -174,15 +177,18 @@ static int fineoffset_wh1050_decode(r_device *decoder, bitbuffer_t *bitbuffer, u
                 year, month, day, hours, minutes, seconds);
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",                 DATA_COND, type == TYPE_OOK, DATA_STRING, "Fineoffset-WH1050",
-                "model",            "",                 DATA_COND, type == TYPE_FSK, DATA_STRING, "TFA-303151",
-                "id",               "Station ID",       DATA_FORMAT, "%02X",    DATA_INT,    device_id,
-                "msg_type",         "Msg type",         DATA_INT,       msg_type,
-                "battery_ok",       "Battery",          DATA_INT,       !battery_low,
-                "radio_clock",      "Radio Clock",      DATA_STRING,    clock_str,
-                "mic",              "Integrity",        DATA_STRING,    "CRC",
-                NULL);
+        data = NULL;
+        if (type == TYPE_OOK) {
+            data = data_str(data, "model",            "",                 NULL,         "Fineoffset-WH1050");
+        }
+        if (type == TYPE_FSK) {
+            data = data_str(data, "model",            "",                 NULL,         "TFA-303151");
+        }
+        data = data_int(data, "id",               "Station ID",       "%02X",       device_id);
+        data = data_int(data, "msg_type",         "Msg type",         NULL,         msg_type);
+        data = data_int(data, "battery_ok",       "Battery",          NULL,         !battery_low);
+        data = data_str(data, "radio_clock",      "Radio Clock",      NULL,         clock_str);
+        data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
         /* clang-format on */
     }
     else {

--- a/src/devices/fineoffset_wh1080.c
+++ b/src/devices/fineoffset_wh1080.c
@@ -259,19 +259,18 @@ static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer,
     // PRESENTING DATA
     if (msg_type == 0) {
         /* clang-format off */
-        data = data_make(
-                "model",            "",                 DATA_STRING,    "Fineoffset-WHx080",
-                "subtype",          "Msg type",         DATA_INT,       msg_type,
-                "id",               "Station ID",       DATA_INT,       device_id,
-                "battery_ok",       "Battery",          DATA_INT,       !battery_low,
-                "temperature_C",    "Temperature",      DATA_FORMAT,    "%.1f C",  DATA_DOUBLE,    temperature,
-                "humidity",         "Humidity",         DATA_FORMAT,    "%u %%",    DATA_INT,       humidity,
-                "wind_dir_deg",     "Wind Direction",   DATA_INT, direction_deg,
-                "wind_avg_km_h",    "Wind avg speed",   DATA_FORMAT,    "%.2f",    DATA_DOUBLE,    speed,
-                "wind_max_km_h",    "Wind gust",        DATA_FORMAT,    "%.2f",    DATA_DOUBLE,    gust,
-                "rain_mm",          "Total rainfall",   DATA_FORMAT,    "%.1f",    DATA_DOUBLE,    rain,
-                "mic",              "Integrity",        DATA_STRING,    "CRC",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                 NULL,         "Fineoffset-WHx080");
+        data = data_int(data, "subtype",          "Msg type",         NULL,         msg_type);
+        data = data_int(data, "id",               "Station ID",       NULL,         device_id);
+        data = data_int(data, "battery_ok",       "Battery",          NULL,         !battery_low);
+        data = data_dbl(data, "temperature_C",    "Temperature",      "%.1f C",     temperature);
+        data = data_int(data, "humidity",         "Humidity",         "%u %%",      humidity);
+        data = data_int(data, "wind_dir_deg",     "Wind Direction",   NULL,         direction_deg);
+        data = data_dbl(data, "wind_avg_km_h",    "Wind avg speed",   "%.2f",       speed);
+        data = data_dbl(data, "wind_max_km_h",    "Wind gust",        "%.2f",       gust);
+        data = data_dbl(data, "rain_mm",          "Total rainfall",   "%.1f",       rain);
+        data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
         /* clang-format on */
     }
     else if (msg_type == 1) {
@@ -280,28 +279,26 @@ static int fineoffset_wh1080_callback(r_device *decoder, bitbuffer_t *bitbuffer,
                 year, month, day, hours, minutes, seconds);
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",                 DATA_STRING,    "Fineoffset-WHx080",
-                "subtype",          "Msg type",         DATA_INT,       msg_type,
-                "id",               "Station ID",       DATA_INT,       device_id,
-                "signal",           "Signal Type",      DATA_STRING,    signal_type_str,
-                "radio_clock",      "Radio Clock",      DATA_STRING,    clock_str,
-                "mic",              "Integrity",        DATA_STRING,    "CRC",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                 NULL,         "Fineoffset-WHx080");
+        data = data_int(data, "subtype",          "Msg type",         NULL,         msg_type);
+        data = data_int(data, "id",               "Station ID",       NULL,         device_id);
+        data = data_str(data, "signal",           "Signal Type",      NULL,         signal_type_str);
+        data = data_str(data, "radio_clock",      "Radio Clock",      NULL,         clock_str);
+        data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
         /* clang-format on */
     }
     else {
         /* clang-format off */
-        data = data_make(
-                "model",            "",                 DATA_STRING,    "Fineoffset-WHx080",
-                "subtype",          "Msg type",         DATA_INT,       msg_type,
-                "uv_sensor_id",     "UV Sensor ID",     DATA_INT,       uv_sensor_id,
-                "uv_status",        "Sensor Status",    DATA_STRING,    uv_status_ok ? "OK" : "ERROR",
-                "uv_index",         "UV Index",         DATA_INT,       uv_index,
-                "lux",              "Lux",              DATA_FORMAT,    "%.1f",     DATA_DOUBLE,    lux,
-                "wm",               "Watts/m",          DATA_FORMAT,    "%.2f",     DATA_DOUBLE,    wm,
-                "mic",              "Integrity",        DATA_STRING,    "CRC",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                 NULL,         "Fineoffset-WHx080");
+        data = data_int(data, "subtype",          "Msg type",         NULL,         msg_type);
+        data = data_int(data, "uv_sensor_id",     "UV Sensor ID",     NULL,         uv_sensor_id);
+        data = data_str(data, "uv_status",        "Sensor Status",    NULL,         uv_status_ok ? "OK" : "ERROR");
+        data = data_int(data, "uv_index",         "UV Index",         NULL,         uv_index);
+        data = data_dbl(data, "lux",              "Lux",              "%.1f",       lux);
+        data = data_dbl(data, "wm",               "Watts/m",          "%.2f",       wm);
+        data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
         /* clang-format on */
     }
     decoder_output_data(decoder, data);

--- a/src/devices/fineoffset_wh31l.c
+++ b/src/devices/fineoffset_wh31l.c
@@ -138,16 +138,17 @@ static int fineoffset_wh31l_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         state_str = "unknown";
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",                 DATA_STRING, "FineOffset-WH31L",
-            "id",               "",                 DATA_INT,    id,
-            "battery_ok",       "Battery",          DATA_DOUBLE, battery_ok * 0.5f,
-            "state",            "State",            DATA_STRING, state_str,
-            "flags",            "Flags",            DATA_FORMAT, "%04x", DATA_INT,    flags,
-            "storm_dist_km",    "Storm Distance",   DATA_COND, s_dist != 63, DATA_FORMAT, "%d km", DATA_INT,    s_dist,
-            "strike_count",     "Strike Count",     DATA_INT,    s_count,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "FineOffset-WH31L");
+    data = data_int(data, "id",               "",                 NULL,         id);
+    data = data_dbl(data, "battery_ok",       "Battery",          NULL,         battery_ok * 0.5f);
+    data = data_str(data, "state",            "State",            NULL,         state_str);
+    data = data_int(data, "flags",            "Flags",            "%04x",       flags);
+    if (s_dist != 63) {
+        data = data_int(data, "storm_dist_km",    "Storm Distance",   "%d km",      s_dist);
+    }
+    data = data_int(data, "strike_count",     "Strike Count",     NULL,         s_count);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/fineoffset_wh45.c
+++ b/src/devices/fineoffset_wh45.c
@@ -110,18 +110,17 @@ static int fineoffset_wh45_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int co2           = (b[11] << 8) | b[12];
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Fineoffset-WH45",
-            "id",               "ID",           DATA_FORMAT, "%06x", DATA_INT, id,
-            "battery_ok",       "Battery Level",  DATA_FORMAT, "%.1f", DATA_DOUBLE, battery_ok,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "pm2_5_ug_m3",      "2.5um Fine Particulate Matter",  DATA_FORMAT, "%.1f ug/m3", DATA_DOUBLE, pm2_5,
-            "pm10_ug_m3",       "10um Coarse Particulate Matter",  DATA_FORMAT, "%.1f ug/m3", DATA_DOUBLE, pm10,
-            "co2_ppm",          "Carbon Dioxide", DATA_FORMAT, "%d ppm", DATA_INT, co2,
-            "ext_power",        "External Power", DATA_INT, ext_power,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Fineoffset-WH45");
+    data = data_int(data, "id",               "ID",           "%06x",       id);
+    data = data_dbl(data, "battery_ok",       "Battery Level",  "%.1f",       battery_ok);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    data = data_int(data, "humidity",         "Humidity",     "%u %%",      humidity);
+    data = data_dbl(data, "pm2_5_ug_m3",      "2.5um Fine Particulate Matter",  "%.1f ug/m3", pm2_5);
+    data = data_dbl(data, "pm10_ug_m3",       "10um Coarse Particulate Matter",  "%.1f ug/m3", pm10);
+    data = data_int(data, "co2_ppm",          "Carbon Dioxide", "%d ppm",     co2);
+    data = data_int(data, "ext_power",        "External Power", NULL,         ext_power);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/fineoffset_wh46.c
+++ b/src/devices/fineoffset_wh46.c
@@ -107,21 +107,20 @@ static int fineoffset_wh46_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int unknown      = (b[17] << 8) | b[18];
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Fineoffset-WH46",
-            "id",               "ID",           DATA_FORMAT, "%06x", DATA_INT, id,
-            "battery_ok",       "Battery Level",  DATA_FORMAT, "%.1f", DATA_DOUBLE, battery_ok,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "pm1_ug_m3",        "1um Fine PM",  DATA_FORMAT, "%.1f ug/m3", DATA_DOUBLE, pm1,
-            "pm2_5_ug_m3",      "2.5um Fine PM",  DATA_FORMAT, "%.1f ug/m3", DATA_DOUBLE, pm2_5,
-            "pm4_ug_m3",        "4um Coarse PM",  DATA_FORMAT, "%.1f ug/m3", DATA_DOUBLE, pm4,
-            "pm10_ug_m3",       "10um Coarse PM",  DATA_FORMAT, "%.1f ug/m3", DATA_DOUBLE, pm10,
-            "co2_ppm",          "Carbon Dioxide", DATA_FORMAT, "%d ppm", DATA_INT, co2,
-            "unknown",          "Do not know", DATA_FORMAT, "%d ?", DATA_INT, unknown,
-            "ext_power",        "External Power", DATA_INT, ext_power,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Fineoffset-WH46");
+    data = data_int(data, "id",               "ID",           "%06x",       id);
+    data = data_dbl(data, "battery_ok",       "Battery Level",  "%.1f",       battery_ok);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    data = data_int(data, "humidity",         "Humidity",     "%u %%",      humidity);
+    data = data_dbl(data, "pm1_ug_m3",        "1um Fine PM",  "%.1f ug/m3", pm1);
+    data = data_dbl(data, "pm2_5_ug_m3",      "2.5um Fine PM",  "%.1f ug/m3", pm2_5);
+    data = data_dbl(data, "pm4_ug_m3",        "4um Coarse PM",  "%.1f ug/m3", pm4);
+    data = data_dbl(data, "pm10_ug_m3",       "10um Coarse PM",  "%.1f ug/m3", pm10);
+    data = data_int(data, "co2_ppm",          "Carbon Dioxide", "%d ppm",     co2);
+    data = data_int(data, "unknown",          "Do not know", "%d ?",       unknown);
+    data = data_int(data, "ext_power",        "External Power", NULL,         ext_power);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/fineoffset_wh55.c
+++ b/src/devices/fineoffset_wh55.c
@@ -80,16 +80,15 @@ static int fineoffset_wh55_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int alarm = (b[7] >> 6) & 1;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",                 DATA_STRING, "Fineoffset-WH55",
-            "id",               "ID",               DATA_FORMAT, "%05X",    DATA_INT,    device_id,
-            "channel",          "Channel",          DATA_INT,    channel,
-            "battery_ok",       "Battery",          DATA_DOUBLE, battery,
-            "raw_value",        "Raw Value",        DATA_INT, raw_value,
-            "sensitivity",      "Sensitivity",      DATA_INT, sensitivity,
-            "alarm",            "Alarm",            DATA_INT, alarm,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "Fineoffset-WH55");
+    data = data_int(data, "id",               "ID",               "%05X",       device_id);
+    data = data_int(data, "channel",          "Channel",          NULL,         channel);
+    data = data_dbl(data, "battery_ok",       "Battery",          NULL,         battery);
+    data = data_int(data, "raw_value",        "Raw Value",        NULL,         raw_value);
+    data = data_int(data, "sensitivity",      "Sensitivity",      NULL,         sensitivity);
+    data = data_int(data, "alarm",            "Alarm",            NULL,         alarm);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/fineoffset_wn34.c
+++ b/src/devices/fineoffset_wn34.c
@@ -107,15 +107,18 @@ static int fineoffset_wn34_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     float battery_ok  = (battery_bars - 1) * 0.25f;
 
     /* clang-format off */
-    data = data_make(
-            "model",         "",                DATA_COND, sub_type != 4, DATA_STRING, "Fineoffset-WN34",
-            "model",         "",                DATA_COND, sub_type == 4, DATA_STRING, "Fineoffset-WN34D",
-            "id",            "ID",              DATA_FORMAT, "%x",     DATA_INT,    id,
-            "battery_ok",    "Battery",         DATA_FORMAT, "%.1f",   DATA_DOUBLE, battery_ok,
-            "battery_mV",    "Battery Voltage", DATA_FORMAT, "%d mV",  DATA_INT,    battery_mv,
-            "temperature_C", "Temperature",     DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
-            "mic",           "Integrity",       DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    if (sub_type != 4) {
+        data = data_str(data, "model",         "",                NULL,         "Fineoffset-WN34");
+    }
+    if (sub_type == 4) {
+        data = data_str(data, "model",         "",                NULL,         "Fineoffset-WN34D");
+    }
+    data = data_int(data, "id",            "ID",              "%x",         id);
+    data = data_dbl(data, "battery_ok",    "Battery",         "%.1f",       battery_ok);
+    data = data_int(data, "battery_mV",    "Battery Voltage", "%d mV",      battery_mv);
+    data = data_dbl(data, "temperature_C", "Temperature",     "%.1f C",     temperature);
+    data = data_str(data, "mic",           "Integrity",       NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/fineoffset_ws80.c
+++ b/src/devices/fineoffset_ws80.c
@@ -91,22 +91,37 @@ static int fineoffset_ws80_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int unknown     = (b[14] << 8) | (b[15]);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",                 DATA_STRING, "Fineoffset-WS80",
-            "id",               "ID",               DATA_FORMAT, "%06x", DATA_INT,    id,
-            "battery_ok",       "Battery",          DATA_DOUBLE, battery_lvl * 0.01f,
-            "battery_mV",       "Battery Voltage",  DATA_FORMAT, "%d mV", DATA_INT,    battery_mv,
-            "temperature_C",    "Temperature",      DATA_COND, temp_raw != 0x3ff,   DATA_FORMAT, "%.1f C",   DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",         DATA_COND, humidity != 0xff,    DATA_FORMAT, "%u %%",    DATA_INT, humidity,
-            "wind_dir_deg",     "Wind direction",   DATA_COND, wind_dir != 0x1ff,   DATA_INT, wind_dir,
-            "wind_avg_m_s",     "Wind speed",       DATA_COND, wind_avg != 0x1ff,   DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wind_avg * 0.1f,
-            "wind_max_m_s",     "Gust speed",       DATA_COND, wind_max != 0x1ff,   DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wind_max * 0.1f,
-            "uvi",              "UVI",              DATA_COND, uv_index != 0xff,    DATA_FORMAT, "%.1f",     DATA_DOUBLE, uv_index * 0.1f,
-            "light_lux",        "Light",            DATA_COND, light_raw != 0xffff, DATA_FORMAT, "%.1f lux", DATA_DOUBLE, (double)light_lux,
-            "flags",            "Flags",            DATA_FORMAT, "%02x", DATA_INT, flags,
-            "unknown",          "Unknown",          DATA_COND, unknown != 0x3fff, DATA_INT, unknown,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "Fineoffset-WS80");
+    data = data_int(data, "id",               "ID",               "%06x",       id);
+    data = data_dbl(data, "battery_ok",       "Battery",          NULL,         battery_lvl * 0.01f);
+    data = data_int(data, "battery_mV",       "Battery Voltage",  "%d mV",      battery_mv);
+    if (temp_raw != 0x3ff) {
+        data = data_dbl(data, "temperature_C",    "Temperature",      "%.1f C",     temp_c);
+    }
+    if (humidity != 0xff) {
+        data = data_int(data, "humidity",         "Humidity",         "%u %%",      humidity);
+    }
+    if (wind_dir != 0x1ff) {
+        data = data_int(data, "wind_dir_deg",     "Wind direction",   NULL,         wind_dir);
+    }
+    if (wind_avg != 0x1ff) {
+        data = data_dbl(data, "wind_avg_m_s",     "Wind speed",       "%.1f m/s",   wind_avg * 0.1f);
+    }
+    if (wind_max != 0x1ff) {
+        data = data_dbl(data, "wind_max_m_s",     "Gust speed",       "%.1f m/s",   wind_max * 0.1f);
+    }
+    if (uv_index != 0xff) {
+        data = data_dbl(data, "uvi",              "UVI",              "%.1f",       uv_index * 0.1f);
+    }
+    if (light_raw != 0xffff) {
+        data = data_dbl(data, "light_lux",        "Light",            "%.1f lux",   (double)light_lux);
+    }
+    data = data_int(data, "flags",            "Flags",            "%02x",       flags);
+    if (unknown != 0x3fff) {
+        data = data_int(data, "unknown",          "Unknown",          NULL,         unknown);
+    }
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/fineoffset_ws90.c
+++ b/src/devices/fineoffset_ws90.c
@@ -116,25 +116,40 @@ static int fineoffset_ws90_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     snprintf(extra, sizeof(extra), "%02x%02x%02x%02x%02x------%02x%02x%02x%02x%02x%02x%02x", b[14], b[15], b[16], b[17], b[18], /* b[19,20] is the rain sensor, b[21] is supercap_V */ b[22], b[23], b[24], b[25], b[26], b[27], b[28]);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",                 DATA_STRING, "Fineoffset-WS90",
-            "id",               "ID",               DATA_FORMAT, "%06x", DATA_INT,    id,
-            "battery_ok",       "Battery",          DATA_DOUBLE, battery_lvl * 0.01f,
-            "battery_mV",       "Battery Voltage",  DATA_FORMAT, "%d mV", DATA_INT,    battery_mv,
-            "temperature_C",    "Temperature",      DATA_COND, temp_raw != 0x3ff,   DATA_FORMAT, "%.1f C",   DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",         DATA_COND, humidity != 0xff,    DATA_FORMAT, "%u %%",    DATA_INT, humidity,
-            "wind_dir_deg",     "Wind direction",   DATA_COND, wind_dir != 0x1ff,   DATA_INT, wind_dir,
-            "wind_avg_m_s",     "Wind speed",       DATA_COND, wind_avg != 0x1ff,   DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wind_avg * 0.1f,
-            "wind_max_m_s",     "Gust speed",       DATA_COND, wind_max != 0x1ff,   DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wind_max * 0.1f,
-            "uvi",              "UVI",              DATA_COND, uv_index != 0xff,    DATA_FORMAT, "%.1f",     DATA_DOUBLE, uv_index * 0.1f,
-            "light_lux",        "Light",            DATA_COND, light_raw != 0xffff, DATA_FORMAT, "%.1f lux", DATA_DOUBLE, (double)light_lux,
-            "flags",            "Flags",            DATA_FORMAT, "%02x", DATA_INT, flags,
-            "rain_mm",          "Total Rain",       DATA_FORMAT, "%.1f mm", DATA_DOUBLE, rain_raw * 0.1f,
-            "supercap_V",       "Supercap Voltage", DATA_COND, supercap_V != 0xff, DATA_FORMAT, "%.1f V", DATA_DOUBLE, supercap_V * 0.1f,
-            "firmware",         "Firmware Version", DATA_INT, firmware,
-            "data",             "Extra Data",       DATA_STRING, extra,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "Fineoffset-WS90");
+    data = data_int(data, "id",               "ID",               "%06x",       id);
+    data = data_dbl(data, "battery_ok",       "Battery",          NULL,         battery_lvl * 0.01f);
+    data = data_int(data, "battery_mV",       "Battery Voltage",  "%d mV",      battery_mv);
+    if (temp_raw != 0x3ff) {
+        data = data_dbl(data, "temperature_C",    "Temperature",      "%.1f C",     temp_c);
+    }
+    if (humidity != 0xff) {
+        data = data_int(data, "humidity",         "Humidity",         "%u %%",      humidity);
+    }
+    if (wind_dir != 0x1ff) {
+        data = data_int(data, "wind_dir_deg",     "Wind direction",   NULL,         wind_dir);
+    }
+    if (wind_avg != 0x1ff) {
+        data = data_dbl(data, "wind_avg_m_s",     "Wind speed",       "%.1f m/s",   wind_avg * 0.1f);
+    }
+    if (wind_max != 0x1ff) {
+        data = data_dbl(data, "wind_max_m_s",     "Gust speed",       "%.1f m/s",   wind_max * 0.1f);
+    }
+    if (uv_index != 0xff) {
+        data = data_dbl(data, "uvi",              "UVI",              "%.1f",       uv_index * 0.1f);
+    }
+    if (light_raw != 0xffff) {
+        data = data_dbl(data, "light_lux",        "Light",            "%.1f lux",   (double)light_lux);
+    }
+    data = data_int(data, "flags",            "Flags",            "%02x",       flags);
+    data = data_dbl(data, "rain_mm",          "Total Rain",       "%.1f mm",    rain_raw * 0.1f);
+    if (supercap_V != 0xff) {
+        data = data_dbl(data, "supercap_V",       "Supercap Voltage", "%.1f V",     supercap_V * 0.1f);
+    }
+    data = data_int(data, "firmware",         "Firmware Version", NULL,         firmware);
+    data = data_str(data, "data",             "Extra Data",       NULL,         extra);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -264,13 +264,12 @@ static int flex_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         print_row_bytes(row_bytes, bitbuffer->bb[r], bitbuffer->bits_per_row[r]);
 
         /* clang-format off */
-        data = data_make(
-                "model", "", DATA_STRING, params->name, // "User-defined"
-                "count", "", DATA_INT, match_count,
-                "num_rows", "", DATA_INT, bitbuffer->num_rows,
-                "len", "", DATA_INT, bitbuffer->bits_per_row[r],
-                "data", "", DATA_STRING, row_bytes,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model", "", NULL,         params->name); // "User-defined"
+        data = data_int(data, "count", "", NULL,         match_count);
+        data = data_int(data, "num_rows", "", NULL,         bitbuffer->num_rows);
+        data = data_int(data, "len", "", NULL,         bitbuffer->bits_per_row[r]);
+        data = data_str(data, "data", "", NULL,         row_bytes);
         /* clang-format on */
 
         // add a data line for each getter
@@ -282,10 +281,9 @@ static int flex_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     if (params->count_only) {
         /* clang-format off */
-        data = data_make(
-                "model", "", DATA_STRING, params->name, // "User-defined"
-                "count", "", DATA_INT, match_count,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model", "", NULL,         params->name); // "User-defined"
+        data = data_int(data, "count", "", NULL,         match_count);
         /* clang-format on */
 
         decoder_output_data(decoder, data);
@@ -296,10 +294,9 @@ static int flex_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         print_row_bytes(row_bytes, bitbuffer->bb[i], bitbuffer->bits_per_row[i]);
 
         /* clang-format off */
-        data = data_make(
-                "len", "", DATA_INT, bitbuffer->bits_per_row[i],
-                "data", "", DATA_STRING, row_bytes,
-                NULL);
+        data = NULL;
+        data = data_int(data, "len", "", NULL,         bitbuffer->bits_per_row[i]);
+        data = data_str(data, "data", "", NULL,         row_bytes);
         /* clang-format on */
         row_data[i] = data;
 
@@ -319,13 +316,12 @@ static int flex_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             sprintf(row_codes[i], "{%d}%s", bitbuffer->bits_per_row[i], row_bytes);
     }
     /* clang-format off */
-    data = data_make(
-            "model", "", DATA_STRING, params->name, // "User-defined"
-            "count", "", DATA_INT, match_count,
-            "num_rows", "", DATA_INT, bitbuffer->num_rows,
-            "rows", "", DATA_ARRAY, data_array(bitbuffer->num_rows, DATA_DATA, row_data),
-            "codes", "", DATA_ARRAY, data_array(bitbuffer->num_rows, DATA_STRING, row_codes),
-            NULL);
+    data = NULL;
+    data = data_str(data, "model", "", NULL,         params->name); // "User-defined"
+    data = data_int(data, "count", "", NULL,         match_count);
+    data = data_int(data, "num_rows", "", NULL,         bitbuffer->num_rows);
+    data = data_ary(data, "rows", "", NULL,         data_array(bitbuffer->num_rows, DATA_DATA, row_data));
+    data = data_ary(data, "codes", "", NULL,         data_array(bitbuffer->num_rows, DATA_STRING, row_codes));
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/flowis.c
+++ b/src/devices/flowis.c
@@ -104,16 +104,15 @@ static int flowis_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     snprintf(fts_str, sizeof(fts_str), "%4d-%02d-%02dT%02d:%02d:%02d", fts_year + 2000, fts_mth, fts_day, fts_hour, fts_min, fts_sec);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",        "",             DATA_STRING, "Flowis",
-            "id",           "Meter id",     DATA_INT,    id,
-            "type",         "Type",         DATA_INT,    type,
-            "volume_m3",    "Volume",       DATA_FORMAT, "%.3f m3", DATA_DOUBLE, volume/1000.0,
-            "device_time",  "Device time",  DATA_STRING, fts_str,
-            "alarm",        "Alarm",        DATA_INT,    b[15],
-            "backflow",     "Backflow",     DATA_INT,    b[14],
-            "mic",          "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",        "",             NULL,         "Flowis");
+    data = data_int(data, "id",           "Meter id",     NULL,         id);
+    data = data_int(data, "type",         "Type",         NULL,         type);
+    data = data_dbl(data, "volume_m3",    "Volume",       "%.3f m3",    volume/1000.0);
+    data = data_str(data, "device_time",  "Device time",  NULL,         fts_str);
+    data = data_int(data, "alarm",        "Alarm",        NULL,         b[15]);
+    data = data_int(data, "backflow",     "Backflow",     NULL,         b[14]);
+    data = data_str(data, "mic",          "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/fordremote.c
+++ b/src/devices/fordremote.c
@@ -49,11 +49,10 @@ static int fordremote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         code      = bytes[7];
 
         /* clang-format off */
-        data = data_make(
-                "model",    "model",        DATA_STRING, "Ford-CarRemote",
-                "id",       "device-id",    DATA_INT,    device_id,
-                "code",     "data",         DATA_INT,    code,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",    "model",        NULL,         "Ford-CarRemote");
+        data = data_int(data, "id",       "device-id",    NULL,         device_id);
+        data = data_int(data, "code",     "data",         NULL,         code);
         decoder_output_data(decoder, data);
         /* clang-format on */
 

--- a/src/devices/fs20.c
+++ b/src/devices/fs20.c
@@ -249,16 +249,19 @@ static int fs20_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data = data_make(
-            "model",        "", DATA_COND,  (sum < 0xc),    DATA_STRING,    "FS20",
-            "model",        "", DATA_COND, !(sum < 0xc),    DATA_STRING,    "FHT",
-            "housecode",    "", DATA_FORMAT, "%x", DATA_INT, hc_b4,
-            "address",      "", DATA_FORMAT, "%x", DATA_INT, ad_b4,
-            "command",      "", DATA_STRING, (sum < 0xc) ? cmd_tab[cmd & 0x1f] : fht_cmd_tab[cmd & 0xf],
-            "flags",        "", DATA_STRING, (sum < 0xc) ? flags_tab[cmd >> 5] : fht_flags_tab[cmd >> 5],
-            "ext",          "", DATA_FORMAT, "%x", DATA_INT, ext,
-            "mic",          "Integrity",    DATA_STRING, "PARITY",
-            NULL);
+    data = NULL;
+    if ((sum < 0xc)) {
+        data = data_str(data, "model",        "", NULL,         "FS20");
+    }
+    if (!(sum < 0xc)) {
+        data = data_str(data, "model",        "", NULL,         "FHT");
+    }
+    data = data_int(data, "housecode",    "", "%x",         hc_b4);
+    data = data_int(data, "address",      "", "%x",         ad_b4);
+    data = data_str(data, "command",      "", NULL,         (sum < 0xc) ? cmd_tab[cmd & 0x1f] : fht_cmd_tab[cmd & 0xf]);
+    data = data_str(data, "flags",        "", NULL,         (sum < 0xc) ? flags_tab[cmd >> 5] : fht_flags_tab[cmd >> 5]);
+    data = data_int(data, "ext",          "", "%x",         ext);
+    data = data_str(data, "mic",          "Integrity",    NULL,         "PARITY");
     /* clang-format on */
     decoder_output_data(decoder, data);
 

--- a/src/devices/ft004b.c
+++ b/src/devices/ft004b.c
@@ -55,10 +55,9 @@ static int ft004b_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     temperature  = (temp_raw * 0.05f) - 40.0f;
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "FT-004B",
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f", DATA_DOUBLE, temperature,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "FT-004B");
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f",       temperature);
     /* clang-format on */
     decoder_output_data(decoder, data);
 

--- a/src/devices/funkbus.c
+++ b/src/devices/funkbus.c
@@ -137,17 +137,16 @@ static int funkbus_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         }
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",        "",                DATA_STRING, "Funkbus-Remote",
-                "id",           "Serial number",   DATA_INT, sn,
-                "battery_ok",   "Battery",         DATA_INT, bat ? 0 : 1,
-                "command",      "Switch",          DATA_INT, command,
-                "group",        "Group",           DATA_INT, group,
-                "action",       "Action",          DATA_INT, action,
-                "repeat",       "Repeat",          DATA_INT, repeat,
-                "longpress",    "Longpress",       DATA_INT, longpress,
-                "mic",          "Integrity",       DATA_STRING, "CHECKSUM",
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",        "",                NULL,         "Funkbus-Remote");
+        data = data_int(data, "id",           "Serial number",   NULL,         sn);
+        data = data_int(data, "battery_ok",   "Battery",         NULL,         bat ? 0 : 1);
+        data = data_int(data, "command",      "Switch",          NULL,         command);
+        data = data_int(data, "group",        "Group",           NULL,         group);
+        data = data_int(data, "action",       "Action",          NULL,         action);
+        data = data_int(data, "repeat",       "Repeat",          NULL,         repeat);
+        data = data_int(data, "longpress",    "Longpress",       NULL,         longpress);
+        data = data_str(data, "mic",          "Integrity",       NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/gasmate_ba1008.c
+++ b/src/devices/gasmate_ba1008.c
@@ -80,12 +80,11 @@ static int gasmate_ba1008_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int unknown1 = (b[2] << 4) | (b[3] >> 4);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",                 DATA_STRING, "Gasmate-BA1008",
-            "temperature_C",    "Temperature_C",    DATA_FORMAT, "%d C", DATA_INT, temp_c,
-            "unknown_1",        "Unknown Value",    DATA_FORMAT, "%03x", DATA_INT,    unknown1,
-            "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "Gasmate-BA1008");
+    data = data_int(data, "temperature_C",    "Temperature_C",    "%d C",       temp_c);
+    data = data_int(data, "unknown_1",        "Unknown Value",    "%03x",       unknown1);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/ge_coloreffects.c
+++ b/src/devices/ge_coloreffects.c
@@ -108,11 +108,10 @@ static int ge_coloreffects_decode(r_device *decoder, bitbuffer_t *bitbuffer, uns
 
     // Format data
     /* clang-format off */
-    data = data_make(
-            "model",        "",     DATA_STRING, "GE-ColorEffects",
-            "id",           "",     DATA_FORMAT, "0x%x", DATA_INT, device_id,
-            "command",      "",     DATA_STRING, cmd,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",        "",     NULL,         "GE-ColorEffects");
+    data = data_int(data, "id",           "",     "0x%x",       device_id);
+    data = data_str(data, "command",      "",     NULL,         cmd);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/geevon.c
+++ b/src/devices/geevon.c
@@ -88,15 +88,14 @@ static int geevon_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // Store the decoded data
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Geevon-TX163",
-            "id",               "",             DATA_INT,    b[0],
-            "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-            "channel",          "Channel",      DATA_INT,    channel,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",     DATA_FORMAT, "%u %%", DATA_INT,     humidity,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Geevon-TX163");
+    data = data_int(data, "id",               "",             NULL,         b[0]);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_int(data, "channel",          "Channel",      NULL,         channel);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    data = data_int(data, "humidity",         "Humidity",     "%u %%",      humidity);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/generic_motion.c
+++ b/src/devices/generic_motion.c
@@ -46,10 +46,9 @@ static int generic_motion_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         snprintf(code_str, sizeof(code_str), "%05x", code);
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",    "",  DATA_STRING, "Generic-Motion",
-                "code",     "",  DATA_STRING, code_str,
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",    "",  NULL,         "Generic-Motion");
+        data = data_str(data, "code",     "",  NULL,         code_str);
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/generic_remote.c
+++ b/src/devices/generic_remote.c
@@ -58,12 +58,11 @@ static int generic_remote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     *p = '\0';
 
     /* clang-format off */
-    data = data_make(
-            "model",        "",             DATA_STRING, "Generic-Remote",
-            "id",           "House Code",   DATA_INT, id_16b,
-            "cmd",          "Command",      DATA_INT, cmd_8b,
-            "tristate",     "Tri-State",    DATA_STRING, tristate,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",        "",             NULL,         "Generic-Remote");
+    data = data_int(data, "id",           "House Code",   NULL,         id_16b);
+    data = data_int(data, "cmd",          "Command",      NULL,         cmd_8b);
+    data = data_str(data, "tristate",     "Tri-State",    NULL,         tristate);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/generic_temperature_sensor.c
+++ b/src/devices/generic_temperature_sensor.c
@@ -48,12 +48,11 @@ static int generic_temperature_sensor_callback(r_device *decoder, bitbuffer_t *b
     temp_f  = (temp_raw >> 4) * 0.1f;
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING,    "Generic-Temperature",
-            "id",               "Id",           DATA_INT,       device,
-            "battery_ok",       "Battery?",     DATA_INT,       battery,
-            "temperature_C",    "Temperature",  DATA_FORMAT,    "%.2f C",  DATA_DOUBLE,    temp_f,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Generic-Temperature");
+    data = data_int(data, "id",               "Id",           NULL,         device);
+    data = data_int(data, "battery_ok",       "Battery?",     NULL,         battery);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.2f C",     temp_f);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/geo_minim.c
+++ b/src/devices/geo_minim.c
@@ -120,14 +120,15 @@ static int geo_minim_ct_sensor_decode(r_device *decoder, bitbuffer_t *bitbuffer,
     unsigned flags4 = buf[4] & ~0x4f;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",        "",             DATA_STRING, "GEO-minimCT",
-            "id",           "",             DATA_STRING, id,
-            "power_VA",     "Power",        DATA_FORMAT, "%u VA", DATA_INT, va,
-            "flags4",       "Flags",        DATA_COND, flags4 != 0x30, DATA_FORMAT, "%#x", DATA_INT, flags4,
-            "uptime_s",     "Uptime",       DATA_INT, uptime_s,
-            "mic",          "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",        "",             NULL,         "GEO-minimCT");
+    data = data_str(data, "id",           "",             NULL,         id);
+    data = data_int(data, "power_VA",     "Power",        "%u VA",      va);
+    if (flags4 != 0x30) {
+        data = data_int(data, "flags4",       "Flags",        "%#x",        flags4);
+    }
+    data = data_int(data, "uptime_s",     "Uptime",       NULL,         uptime_s);
+    data = data_str(data, "mic",          "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -240,16 +241,19 @@ static int geo_minim_display_decode(r_device *decoder, bitbuffer_t *bitbuffer, u
             1900 + t.tm_year, 1 + t.tm_mon, t.tm_mday, t.tm_hour, t.tm_min);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",        "",             DATA_STRING, "GEO-minimDP",
-            "id",           "",             DATA_STRING, id,
-            "power_W",      "Power",        DATA_FORMAT, "%u W", DATA_INT, watts,
-            "energy_kWh",   "Energy",       DATA_FORMAT, "%.3f kWh", DATA_DOUBLE, wh * 0.001,
-            "clock",         "Clock",         DATA_STRING, now,
-            "flags5",       "Flags5",       DATA_COND, flags5 != 0, DATA_FORMAT, "%#x", DATA_INT, flags5,
-            "flags15",      "Flags15",      DATA_COND, flags15 != 0x40, DATA_FORMAT, "%#x", DATA_INT, flags15,
-            "mic",          "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",        "",             NULL,         "GEO-minimDP");
+    data = data_str(data, "id",           "",             NULL,         id);
+    data = data_int(data, "power_W",      "Power",        "%u W",       watts);
+    data = data_dbl(data, "energy_kWh",   "Energy",       "%.3f kWh",   wh * 0.001);
+    data = data_str(data, "clock",         "Clock",         NULL,         now);
+    if (flags5 != 0) {
+        data = data_int(data, "flags5",       "Flags5",       "%#x",        flags5);
+    }
+    if (flags15 != 0x40) {
+        data = data_int(data, "flags15",      "Flags15",      "%#x",        flags15);
+    }
+    data = data_str(data, "mic",          "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/govee.c
+++ b/src/devices/govee.c
@@ -234,17 +234,26 @@ static int govee_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",        "",                 DATA_COND,   model_num == GOVEE_WATER,   DATA_STRING, "Govee-Water",
-            "model",        "",                 DATA_COND,   model_num == GOVEE_CONTACT, DATA_STRING, "Govee-Contact",
-            "id",           "",                 DATA_INT,    id,
-            "battery_ok",   "Battery level",    DATA_COND,   battery, DATA_DOUBLE, battery_level,
-            "battery_mV",   "Battery",          DATA_COND,   battery, DATA_FORMAT, "%d mV", DATA_INT, battery_mv,
-            "detect_wet",   "",                 DATA_COND,   wet >= 0, DATA_INT, wet,
-            "event",        "",                 DATA_STRING, event_str,
-            "code",         "Raw Code",         DATA_STRING, code_str,
-            "mic",          "Integrity",        DATA_STRING, "PARITY",
-            NULL);
+    data_t *data = NULL;
+    if (model_num == GOVEE_WATER) {
+        data = data_str(data, "model",        "",                 NULL,         "Govee-Water");
+    }
+    if (model_num == GOVEE_CONTACT) {
+        data = data_str(data, "model",        "",                 NULL,         "Govee-Contact");
+    }
+    data = data_int(data, "id",           "",                 NULL,         id);
+    if (battery) {
+        data = data_dbl(data, "battery_ok",   "Battery level",    NULL,         battery_level);
+    }
+    if (battery) {
+        data = data_int(data, "battery_mV",   "Battery",          "%d mV",      battery_mv);
+    }
+    if (wet >= 0) {
+        data = data_int(data, "detect_wet",   "",                 NULL,         wet);
+    }
+    data = data_str(data, "event",        "",                 NULL,         event_str);
+    data = data_str(data, "code",         "Raw Code",         NULL,         code_str);
+    data = data_str(data, "mic",          "Integrity",        NULL,         "PARITY");
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -396,17 +405,24 @@ static int govee_h5054_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int battery_mv      = 1800 + 12 * battery;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",        "",                 DATA_STRING, "Govee-Water",
-            "id",           "",                 DATA_INT,    id,
-            "battery_ok",   "Battery level",    DATA_COND,   battery >= 0, DATA_DOUBLE, battery_level,
-            "battery_mV",   "Battery",          DATA_COND,   battery >= 0, DATA_FORMAT, "%d mV", DATA_INT, battery_mv,
-            "event",        "",                 DATA_STRING, event_str,
-            "detect_wet",   "",                 DATA_COND,   wet >= 0, DATA_INT, wet,
-            "leak_num",     "Leak Num",         DATA_COND,   leak_num >= 0, DATA_INT, leak_num,
-            "code",         "Raw Code",         DATA_STRING, code_str,
-            "mic",          "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",        "",                 NULL,         "Govee-Water");
+    data = data_int(data, "id",           "",                 NULL,         id);
+    if (battery >= 0) {
+        data = data_dbl(data, "battery_ok",   "Battery level",    NULL,         battery_level);
+    }
+    if (battery >= 0) {
+        data = data_int(data, "battery_mV",   "Battery",          "%d mV",      battery_mv);
+    }
+    data = data_str(data, "event",        "",                 NULL,         event_str);
+    if (wet >= 0) {
+        data = data_int(data, "detect_wet",   "",                 NULL,         wet);
+    }
+    if (leak_num >= 0) {
+        data = data_int(data, "leak_num",     "Leak Num",         NULL,         leak_num);
+    }
+    data = data_str(data, "code",         "Raw Code",         NULL,         code_str);
+    data = data_str(data, "mic",          "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/gridstream.c
+++ b/src/devices/gridstream.c
@@ -198,21 +198,32 @@ static int gridstream_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             }
 
             /* clang-format off */
-            data = data_make(
-                "model",        "",                     DATA_STRING,    "LandisGyr-GS",
-                "networkID",    "Network ID",           DATA_STRING,    found_crc,
-                "location",     "Location",             DATA_STRING,    known_crc_init[crcidx].location,
-                "provider",     "Provider",             DATA_STRING,    known_crc_init[crcidx].provider,
-                "subtype",      "",                     DATA_INT,       subtype,
-                "protoversion", "",                     DATA_INT,       protocol_version,
-                "mic",          "Integrity",            DATA_STRING,    "CRC",
-                "id",           "Source Meter ID",      DATA_COND,      subtype != 0xD2, DATA_STRING, srcaddress_str,
-                "wanaddress",   "Source Meter WAN ID",  DATA_COND,      srcwanaddress == 1, DATA_STRING, srcwanaddress_str,
-                "destaddress",  "Target Meter WAN ID",  DATA_COND,      subtype == 0x55, DATA_STRING, destwanaddress_str,
-                "destaddress",  "Target Meter ID",      DATA_COND,      subtype == 0xD5, DATA_STRING, destaddress_str,
-                "timestamp",    "Timestamp",            DATA_COND,      subtype == 0xD5 && stream_len == 0x47, DATA_INT, clock,
-                "uptime",       "Uptime",               DATA_COND,      uptime > 0, DATA_INT, uptime,
-                NULL);
+            data = NULL;
+            data = data_str(data, "model",        "",                     NULL,         "LandisGyr-GS");
+            data = data_str(data, "networkID",    "Network ID",           NULL,         found_crc);
+            data = data_str(data, "location",     "Location",             NULL,         known_crc_init[crcidx].location);
+            data = data_str(data, "provider",     "Provider",             NULL,         known_crc_init[crcidx].provider);
+            data = data_int(data, "subtype",      "",                     NULL,         subtype);
+            data = data_int(data, "protoversion", "",                     NULL,         protocol_version);
+            data = data_str(data, "mic",          "Integrity",            NULL,         "CRC");
+            if (subtype != 0xD2) {
+                data = data_str(data, "id",           "Source Meter ID",      NULL,         srcaddress_str);
+            }
+            if (srcwanaddress == 1) {
+                data = data_str(data, "wanaddress",   "Source Meter WAN ID",  NULL,         srcwanaddress_str);
+            }
+            if (subtype == 0x55) {
+                data = data_str(data, "destaddress",  "Target Meter WAN ID",  NULL,         destwanaddress_str);
+            }
+            if (subtype == 0xD5) {
+                data = data_str(data, "destaddress",  "Target Meter ID",      NULL,         destaddress_str);
+            }
+            if (subtype == 0xD5 && stream_len == 0x47) {
+                data = data_int(data, "timestamp",    "Timestamp",            NULL,         clock);
+            }
+            if (uptime > 0) {
+                data = data_int(data, "uptime",       "Uptime",               NULL,         uptime);
+            }
             /* clang-format on */
 
             decoder_output_data(decoder, data);

--- a/src/devices/gt_tmbbq05.c
+++ b/src/devices/gt_tmbbq05.c
@@ -115,12 +115,11 @@ static int gt_tmbbq05_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int device_id = (b[0] << 8) | b[2];
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "GT-TMBBQ05",
-            "id",               "ID Code",      DATA_INT,    device_id,
-            "temperature_F",    "Temperature",  DATA_FORMAT, "%.2f F", DATA_DOUBLE, (float)tempf,
-            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "GT-TMBBQ05");
+    data = data_int(data, "id",               "ID Code",      NULL,         device_id);
+    data = data_dbl(data, "temperature_F",    "Temperature",  "%.2f F",     (float)tempf);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/gt_wt_02.c
+++ b/src/devices/gt_wt_02.c
@@ -89,16 +89,15 @@ static int gt_wt_02_process_row(r_device *decoder, bitbuffer_t *bitbuffer, int r
     float temp_c       = (temp_raw >> 4) * 0.1F;
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "GT-WT02",
-            "id",               "ID Code",      DATA_INT,    sensor_id,
-            "channel",          "Channel",      DATA_INT,    channel + 1,
-            "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",     DATA_FORMAT, "%.0f %%", DATA_DOUBLE, (double)humidity,
-            "button",           "Button ",      DATA_INT,    button_pressed,
-            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "GT-WT02");
+    data = data_int(data, "id",               "ID Code",      NULL,         sensor_id);
+    data = data_int(data, "channel",          "Channel",      NULL,         channel + 1);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    data = data_dbl(data, "humidity",         "Humidity",     "%.0f %%",    (double)humidity);
+    data = data_int(data, "button",           "Button ",      NULL,         button_pressed);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/gt_wt_03.c
+++ b/src/devices/gt_wt_03.c
@@ -130,16 +130,15 @@ static int gt_wt_03_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     float temp_c       = (temp_raw >> 4) * 0.1F;
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "GT-WT03",
-            "id",               "ID Code",      DATA_INT,    sensor_id,
-            "channel",          "Channel",      DATA_INT,    channel + 1,
-            "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",     DATA_FORMAT, "%.0f %%", DATA_DOUBLE, (double)humidity,
-            "button",           "Button",       DATA_INT,    button_pressed,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "GT-WT03");
+    data = data_int(data, "id",               "ID Code",      NULL,         sensor_id);
+    data = data_int(data, "channel",          "Channel",      NULL,         channel + 1);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    data = data_dbl(data, "humidity",         "Humidity",     "%.0f %%",    (double)humidity);
+    data = data_int(data, "button",           "Button",       NULL,         button_pressed);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/hcs200.c
+++ b/src/devices/hcs200.c
@@ -71,15 +71,14 @@ static int hcs200_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     snprintf(serial_str, sizeof(serial_str), "%07X", serial);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING,    "Microchip-HCS200",
-            "id",               "",             DATA_STRING,    serial_str,
-            "battery_ok",       "Battery",      DATA_INT,       !battery_low,
-            "button",           "Button",       DATA_INT,       btn_num,
-            "learn",            "Learn mode",   DATA_INT,       learn,
-            "repeat",           "Repeat",       DATA_INT,       repeat,
-            "encrypted",        "",             DATA_STRING,    encrypted_str,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Microchip-HCS200");
+    data = data_str(data, "id",               "",             NULL,         serial_str);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_int(data, "button",           "Button",       NULL,         btn_num);
+    data = data_int(data, "learn",            "Learn mode",   NULL,         learn);
+    data = data_int(data, "repeat",           "Repeat",       NULL,         repeat);
+    data = data_str(data, "encrypted",        "",             NULL,         encrypted_str);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/hideki.c
+++ b/src/devices/hideki.c
@@ -151,15 +151,14 @@ static int hideki_ts04_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         if (sensortype == HIDEKI_TS04) {
             int humidity = ((packet[5] & 0xF0) >> 4) * 10 + (packet[5] & 0x0F);
             /* clang-format off */
-            data_t *data = data_make(
-                    "model",            "",                 DATA_STRING, "Hideki-TS04",
-                    "id",               "Rolling Code",     DATA_INT,    rc,
-                    "channel",          "Channel",          DATA_INT,    channel,
-                    "battery_ok",       "Battery",          DATA_INT,    battery_ok,
-                    "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp/10.f,
-                    "humidity",         "Humidity",         DATA_FORMAT, "%u %%", DATA_INT, humidity,
-                    "mic",              "Integrity",        DATA_STRING, "CRC",
-                    NULL);
+            data_t *data = NULL;
+            data = data_str(data, "model",            "",                 NULL,         "Hideki-TS04");
+            data = data_int(data, "id",               "Rolling Code",     NULL,         rc);
+            data = data_int(data, "channel",          "Channel",          NULL,         channel);
+            data = data_int(data, "battery_ok",       "Battery",          NULL,         battery_ok);
+            data = data_dbl(data, "temperature_C",    "Temperature",      "%.1f C",     temp/10.f);
+            data = data_int(data, "humidity",         "Humidity",         "%u %%",      humidity);
+            data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
             /* clang-format on */
             decoder_output_data(decoder, data);
             return 1;
@@ -173,32 +172,30 @@ static int hideki_ts04_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             int wind_approach = ad[(packet[10] >> 2) & 0x03];
 
             /* clang-format off */
-            data_t *data = data_make(
-                    "model",            "",                 DATA_STRING, "Hideki-Wind",
-                    "id",               "Rolling Code",     DATA_INT,    rc,
-                    "channel",          "Channel",          DATA_INT,    channel,
-                    "battery_ok",       "Battery",          DATA_INT,    battery_ok,
-                    "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp * 0.1f,
-                    "wind_avg_mi_h",    "Wind Speed",       DATA_FORMAT, "%.2f mi/h", DATA_DOUBLE, wind_speed * 0.1f,
-                    "wind_max_mi_h",    "Gust Speed",       DATA_FORMAT, "%.2f mi/h", DATA_DOUBLE, gust_speed * 0.1f,
-                    "wind_approach",    "Wind Approach",    DATA_INT,    wind_approach,
-                    "wind_dir_deg",     "Wind Direction",   DATA_FORMAT, "%.1f", DATA_DOUBLE, wind_direction * 0.1f,
-                    "mic",              "Integrity",        DATA_STRING, "CRC",
-                    NULL);
+            data_t *data = NULL;
+            data = data_str(data, "model",            "",                 NULL,         "Hideki-Wind");
+            data = data_int(data, "id",               "Rolling Code",     NULL,         rc);
+            data = data_int(data, "channel",          "Channel",          NULL,         channel);
+            data = data_int(data, "battery_ok",       "Battery",          NULL,         battery_ok);
+            data = data_dbl(data, "temperature_C",    "Temperature",      "%.1f C",     temp * 0.1f);
+            data = data_dbl(data, "wind_avg_mi_h",    "Wind Speed",       "%.2f mi/h",  wind_speed * 0.1f);
+            data = data_dbl(data, "wind_max_mi_h",    "Gust Speed",       "%.2f mi/h",  gust_speed * 0.1f);
+            data = data_int(data, "wind_approach",    "Wind Approach",    NULL,         wind_approach);
+            data = data_dbl(data, "wind_dir_deg",     "Wind Direction",   "%.1f",       wind_direction * 0.1f);
+            data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
             /* clang-format on */
             decoder_output_data(decoder, data);
             return 1;
         }
         if (sensortype == HIDEKI_TEMP) {
             /* clang-format off */
-            data_t *data = data_make(
-                    "model",            "",                 DATA_STRING, "Hideki-Temperature",
-                    "id",               "Rolling Code",     DATA_INT,    rc,
-                    "channel",          "Channel",          DATA_INT,    channel,
-                    "battery_ok",       "Battery",          DATA_INT,    battery_ok,
-                    "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp * 0.1f,
-                    "mic",              "Integrity",        DATA_STRING, "CRC",
-                    NULL);
+            data_t *data = NULL;
+            data = data_str(data, "model",            "",                 NULL,         "Hideki-Temperature");
+            data = data_int(data, "id",               "Rolling Code",     NULL,         rc);
+            data = data_int(data, "channel",          "Channel",          NULL,         channel);
+            data = data_int(data, "battery_ok",       "Battery",          NULL,         battery_ok);
+            data = data_dbl(data, "temperature_C",    "Temperature",      "%.1f C",     temp * 0.1f);
+            data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
             /* clang-format on */
             decoder_output_data(decoder, data);
             return 1;
@@ -208,14 +205,13 @@ static int hideki_ts04_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             battery_ok = (packet[1] >> 6) & 1;
 
             /* clang-format off */
-            data_t *data = data_make(
-                    "model",            "",                 DATA_STRING, "Hideki-Rain",
-                    "id",               "Rolling Code",     DATA_INT,    rc,
-                    "channel",          "Channel",          DATA_INT,    channel,
-                    "battery_ok",       "Battery",          DATA_INT,    battery_ok,
-                    "rain_mm",          "Rain",             DATA_FORMAT, "%.1f mm", DATA_DOUBLE, rain_units * 0.7f,
-                    "mic",              "Integrity",        DATA_STRING, "CRC",
-                    NULL);
+            data_t *data = NULL;
+            data = data_str(data, "model",            "",                 NULL,         "Hideki-Rain");
+            data = data_int(data, "id",               "Rolling Code",     NULL,         rc);
+            data = data_int(data, "channel",          "Channel",          NULL,         channel);
+            data = data_int(data, "battery_ok",       "Battery",          NULL,         battery_ok);
+            data = data_dbl(data, "rain_mm",          "Rain",             "%.1f mm",    rain_units * 0.7f);
+            data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
             /* clang-format on */
             decoder_output_data(decoder, data);
             return 1;

--- a/src/devices/holman_ws5029.c
+++ b/src/devices/holman_ws5029.c
@@ -140,16 +140,15 @@ static int holman_ws5029pcm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         float rain_mm     = rain_raw * 0.79f;
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",                 DATA_STRING, "Holman-WS5029",
-                "id",               "Station ID",        DATA_FORMAT, "%04X",       DATA_INT,    device_id,
-                "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C",     DATA_DOUBLE, temp_c,
-                "humidity",         "Humidity",         DATA_FORMAT, "%u %%",      DATA_INT,    humidity,
-                "rain_mm",          "Total rainfall",   DATA_FORMAT, "%.1f mm",    DATA_DOUBLE, rain_mm,
-                "wind_avg_km_h",    "Wind avg speed",   DATA_FORMAT, "%.1f km/h",  DATA_DOUBLE, speed_kmh,
-                "wind_dir_deg",     "Wind Direction",   DATA_INT, direction_deg,
-                "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                 NULL,         "Holman-WS5029");
+        data = data_int(data, "id",               "Station ID",        "%04X",       device_id);
+        data = data_dbl(data, "temperature_C",    "Temperature",      "%.1f C",     temp_c);
+        data = data_int(data, "humidity",         "Humidity",         "%u %%",      humidity);
+        data = data_dbl(data, "rain_mm",          "Total rainfall",   "%.1f mm",    rain_mm);
+        data = data_dbl(data, "wind_avg_km_h",    "Wind avg speed",   "%.1f km/h",  speed_kmh);
+        data = data_int(data, "wind_dir_deg",     "Wind Direction",   NULL,         direction_deg);
+        data = data_str(data, "mic",              "Integrity",        NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);
@@ -161,20 +160,19 @@ static int holman_ws5029pcm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         int battery_low  = ((b[10] & 0x30) >> 4);
         int counter      = ((b[10] & 0x0f) << 8 | b[11]);
         /* clang-format off */
-        data = data_make(
-                "model",            "",                 DATA_STRING, "AOK-5056",
-                "id",               "Station ID",        DATA_FORMAT, "%04X",      DATA_INT,    device_id,
-                "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C",    DATA_DOUBLE, temp_c,
-                "humidity",         "Humidity",         DATA_FORMAT, "%u %%",     DATA_INT,    humidity,
-                "rain_mm",          "Total rainfall",   DATA_FORMAT, "%.1f mm",   DATA_DOUBLE, rain_mm,
-                "wind_avg_km_h",    "Wind avg speed",   DATA_FORMAT, "%.1f km/h", DATA_DOUBLE, speed_kmh,
-                "wind_dir_deg",     "Wind Direction",   DATA_INT,                              direction_deg,
-                "uv",               "UV Index",         DATA_FORMAT, "%u",        DATA_INT,    uv_index,
-                "light_lux",        "Lux",              DATA_FORMAT, "%u",        DATA_INT,    light_lux,
-                "counter",          "Counter",          DATA_FORMAT, "%u",        DATA_INT,    counter,
-                "battery_ok",       "battery",          DATA_FORMAT, "%u",        DATA_INT,    !battery_low,
-                "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                 NULL,         "AOK-5056");
+        data = data_int(data, "id",               "Station ID",        "%04X",       device_id);
+        data = data_dbl(data, "temperature_C",    "Temperature",      "%.1f C",     temp_c);
+        data = data_int(data, "humidity",         "Humidity",         "%u %%",      humidity);
+        data = data_dbl(data, "rain_mm",          "Total rainfall",   "%.1f mm",    rain_mm);
+        data = data_dbl(data, "wind_avg_km_h",    "Wind avg speed",   "%.1f km/h",  speed_kmh);
+        data = data_int(data, "wind_dir_deg",     "Wind Direction",   NULL,         direction_deg);
+        data = data_int(data, "uv",               "UV Index",         "%u",         uv_index);
+        data = data_int(data, "light_lux",        "Lux",              "%u",         light_lux);
+        data = data_int(data, "counter",          "Counter",          "%u",         counter);
+        data = data_int(data, "battery_ok",       "battery",          "%u",         !battery_low);
+        data = data_str(data, "mic",              "Integrity",        NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);
@@ -300,17 +298,16 @@ static int holman_ws5029pwm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     wind_dir    = b[9] & 0xF;                                          // 4 bit wind direction, clockwise from North
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",                 DATA_STRING, "Holman-WS5029",
-            "id",               "",                 DATA_INT,    id,
-            "battery_ok",       "Battery",          DATA_INT,    !battery_low,
-            "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C",     DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",         DATA_FORMAT, "%u %%",       DATA_INT,    humidity,
-            "rain_mm",          "Total rainfall",   DATA_FORMAT, "%.1f mm",    DATA_DOUBLE, rain_mm,
-            "wind_avg_km_h",    "Wind avg speed",   DATA_FORMAT, "%.1f km/h",  DATA_DOUBLE, speed_kmh,
-            "wind_dir_deg",     "Wind Direction",   DATA_INT,    (int)(wind_dir * 22.5),
-            "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "Holman-WS5029");
+    data = data_int(data, "id",               "",                 NULL,         id);
+    data = data_int(data, "battery_ok",       "Battery",          NULL,         !battery_low);
+    data = data_dbl(data, "temperature_C",    "Temperature",      "%.1f C",     temp_c);
+    data = data_int(data, "humidity",         "Humidity",         "%u %%",      humidity);
+    data = data_dbl(data, "rain_mm",          "Total rainfall",   "%.1f mm",    rain_mm);
+    data = data_dbl(data, "wind_avg_km_h",    "Wind avg speed",   "%.1f km/h",  speed_kmh);
+    data = data_int(data, "wind_dir_deg",     "Wind Direction",   NULL,         (int)(wind_dir * 22.5));
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/hondaremote.c
+++ b/src/devices/hondaremote.c
@@ -48,11 +48,10 @@ static int hondaremote_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         device_id = b[44]<<8 | b[45];
 
         /* clang-format off */
-        data = data_make(
-                "model",        "",     DATA_STRING, "Honda-CarRemote",
-                "id",           "",     DATA_INT, device_id,
-                "code",         "",     DATA_STRING, code,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",        "",     NULL,         "Honda-CarRemote");
+        data = data_int(data, "id",           "",     NULL,         device_id);
+        data = data_str(data, "code",         "",     NULL,         code);
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/honeywell.c
+++ b/src/devices/honeywell.c
@@ -103,20 +103,19 @@ static int honeywell_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     heartbeat   = (event & 0x04) >> 2;
 
     /* clang-format off */
-    data = data_make(
-            "model",        "",         DATA_STRING, "Honeywell-Security",
-            "id",           "",         DATA_FORMAT, "%05x", DATA_INT, device_id,
-            "channel",      "",         DATA_INT,    channel,
-            "event",        "",         DATA_FORMAT, "%02x", DATA_INT, event,
-            "state",        "",         DATA_STRING, contact ? "open" : "closed", // Ignore the reed switch legacy.
-            "contact_open", "",         DATA_INT,    contact,
-            "reed_open",    "",         DATA_INT,    reed,
-            "alarm",        "",         DATA_INT,    alarm,
-            "tamper",       "",         DATA_INT,    tamper,
-            "battery_ok",   "Battery",  DATA_INT,    !battery_low,
-            "heartbeat",    "",         DATA_INT,    heartbeat,
-            "mic",          "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",        "",         NULL,         "Honeywell-Security");
+    data = data_int(data, "id",           "",         "%05x",       device_id);
+    data = data_int(data, "channel",      "",         NULL,         channel);
+    data = data_int(data, "event",        "",         "%02x",       event);
+    data = data_str(data, "state",        "",         NULL,         contact ? "open" : "closed"); // Ignore the reed switch legacy.
+    data = data_int(data, "contact_open", "",         NULL,         contact);
+    data = data_int(data, "reed_open",    "",         NULL,         reed);
+    data = data_int(data, "alarm",        "",         NULL,         alarm);
+    data = data_int(data, "tamper",       "",         NULL,         tamper);
+    data = data_int(data, "battery_ok",   "Battery",  NULL,         !battery_low);
+    data = data_int(data, "heartbeat",    "",         NULL,         heartbeat);
+    data = data_str(data, "mic",          "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/honeywell_wdb.c
+++ b/src/devices/honeywell_wdb.c
@@ -97,16 +97,15 @@ static int honeywell_wdb_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     battery = (bytes[5] & 0x2) >> 1;
 
     /* clang-format off */
-    data = data_make(
-            "model",         "",            DATA_STRING, "Honeywell-ActivLink",
-            "subtype",       "Class",       DATA_STRING, class,
-            "id",            "Id",          DATA_FORMAT, "%x",   DATA_INT,    device,
-            "battery_ok",    "Battery",     DATA_INT,    !battery,
-            "alert",         "Alert",       DATA_STRING, alert,
-            "secret_knock",  "Secret Knock",DATA_FORMAT, "%d",   DATA_INT,    secret_knock,
-            "relay",         "Relay",       DATA_FORMAT, "%d",   DATA_INT,    relay,
-            "mic",           "Integrity",   DATA_STRING, "PARITY",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",         "",            NULL,         "Honeywell-ActivLink");
+    data = data_str(data, "subtype",       "Class",       NULL,         class);
+    data = data_int(data, "id",            "Id",          "%x",         device);
+    data = data_int(data, "battery_ok",    "Battery",     NULL,         !battery);
+    data = data_str(data, "alert",         "Alert",       NULL,         alert);
+    data = data_int(data, "secret_knock",  "Secret Knock","%d",         secret_knock);
+    data = data_int(data, "relay",         "Relay",       "%d",         relay);
+    data = data_str(data, "mic",           "Integrity",   NULL,         "PARITY");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/ht680.c
+++ b/src/devices/ht680.c
@@ -62,15 +62,14 @@ static int ht680_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         int button4 = (b[2]>>0) & 0x03;
 
         /* clang-format off */
-        data = data_make(
-                "model",    "",                 DATA_STRING, "HT680-Remote",
-                "id",       "Address",          DATA_FORMAT, "0x%06X", DATA_INT, address,
-                "button1",  "Button 1",         DATA_STRING, button1 == 3 ? "PRESSED" : "",
-                "button2",  "Button 2",         DATA_STRING, button2 == 3 ? "PRESSED" : "",
-                "button3",  "Button 3",         DATA_STRING, button3 == 3 ? "PRESSED" : "",
-                "button4",  "Button 4",         DATA_STRING, button4 == 3 ? "PRESSED" : "",
-                "tristate", "Tristate code",    DATA_STRING, tristate,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",    "",                 NULL,         "HT680-Remote");
+        data = data_int(data, "id",       "Address",          "0x%06X",     address);
+        data = data_str(data, "button1",  "Button 1",         NULL,         button1 == 3 ? "PRESSED" : "");
+        data = data_str(data, "button2",  "Button 2",         NULL,         button2 == 3 ? "PRESSED" : "");
+        data = data_str(data, "button3",  "Button 3",         NULL,         button3 == 3 ? "PRESSED" : "");
+        data = data_str(data, "button4",  "Button 4",         NULL,         button4 == 3 ? "PRESSED" : "");
+        data = data_str(data, "tristate", "Tristate code",    NULL,         tristate);
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/ibis_beacon.c
+++ b/src/devices/ibis_beacon.c
@@ -67,13 +67,12 @@ static int ibis_beacon_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data = data_make(
-            "model",    "",             DATA_STRING,    "IBIS-Beacon",
-            "id",       "Vehicle No.",  DATA_INT,       id,
-            "counter",  "Counter",      DATA_INT,       counter,
-            "code",     "Code data",    DATA_STRING,    code_str,
-            "mic",      "Integrity",    DATA_STRING,    "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",    "",             NULL,         "IBIS-Beacon");
+    data = data_int(data, "id",       "Vehicle No.",  NULL,         id);
+    data = data_int(data, "counter",  "Counter",      NULL,         counter);
+    data = data_str(data, "code",     "Code data",    NULL,         code_str);
+    data = data_str(data, "mic",      "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/ikea_sparsnas.c
+++ b/src/devices/ikea_sparsnas.c
@@ -211,11 +211,10 @@ static int ikea_sparsnas_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     if ((!ikea_sparsnas_sensor_id) || (rcv_sensor_id != ikea_sparsnas_sensor_id)) {
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",         "Model",               DATA_STRING, "Ikea-Sparsnas",
-                "id",            "Sensor ID",           DATA_INT, ikea_sparsnas_sensor_id,
-                "mic",           "Integrity",           DATA_STRING,    "CRC",
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",         "Model",               NULL,         "Ikea-Sparsnas");
+        data = data_int(data, "id",            "Sensor ID",           NULL,         ikea_sparsnas_sensor_id);
+        data = data_str(data, "mic",           "Integrity",           NULL,         "CRC");
         /* clang-format on */
 
         decoder_output_data(decoder, data);
@@ -249,18 +248,17 @@ static int ikea_sparsnas_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     float cumulative_kWh = ((float)pulses) / ((float)ikea_sparsnas_pulses_per_kwh);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",         "Model",               DATA_STRING, "Ikea-Sparsnas",
-            "id",            "Sensor ID",           DATA_INT,    rcv_sensor_id,
-            "sequence",      "Sequence Number",     DATA_INT,    sequence_number,
-            "battery_ok",    "Battery level",       DATA_INT,    battery * 0.01f, // 0-100
-            "pulses_per_kWh", "Pulses per kWh",     DATA_INT,    ikea_sparsnas_pulses_per_kwh,
-            "cumulative_kWh", "Cumulative kWh",     DATA_FORMAT, "%7.3fkWh", DATA_DOUBLE,  cumulative_kWh,
-            "effect",        "Effect",              DATA_FORMAT, "%dW", DATA_INT,  effect,
-            "pulses",        "Pulses",              DATA_INT,    pulses,
-            "mode",          "Mode",                DATA_INT,    mode,
-            "mic",           "Integrity",           DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",         "Model",               NULL,         "Ikea-Sparsnas");
+    data = data_int(data, "id",            "Sensor ID",           NULL,         rcv_sensor_id);
+    data = data_int(data, "sequence",      "Sequence Number",     NULL,         sequence_number);
+    data = data_int(data, "battery_ok",    "Battery level",       NULL,         battery * 0.01f); // 0-100
+    data = data_int(data, "pulses_per_kWh", "Pulses per kWh",     NULL,         ikea_sparsnas_pulses_per_kwh);
+    data = data_dbl(data, "cumulative_kWh", "Cumulative kWh",     "%7.3fkWh",   cumulative_kWh);
+    data = data_int(data, "effect",        "Effect",              "%dW",        effect);
+    data = data_int(data, "pulses",        "Pulses",              NULL,         pulses);
+    data = data_int(data, "mode",          "Mode",                NULL,         mode);
+    data = data_str(data, "mic",           "Integrity",           NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/infactory.c
+++ b/src/devices/infactory.c
@@ -88,16 +88,15 @@ static int infactory_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     float temp_f    = (temp_raw - 900) * 0.1f;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "inFactory-TH",
-            "id",               "ID",           DATA_INT,    id,
-            "channel",          "Channel",      DATA_INT,    channel,
-            "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-            "button",           "Button",       DATA_INT,    button,
-            "temperature_F",    "Temperature",  DATA_FORMAT, "%.2f F", DATA_DOUBLE, temp_f,
-            "humidity",         "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "inFactory-TH");
+    data = data_int(data, "id",               "ID",           NULL,         id);
+    data = data_int(data, "channel",          "Channel",      NULL,         channel);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_int(data, "button",           "Button",       NULL,         button);
+    data = data_dbl(data, "temperature_F",    "Temperature",  "%.2f F",     temp_f);
+    data = data_int(data, "humidity",         "Humidity",     "%u %%",      humidity);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/inkbird_ith20r.c
+++ b/src/devices/inkbird_ith20r.c
@@ -112,16 +112,15 @@ static int inkbird_ith20r_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     decoder_logf(decoder, 1, __func__, "dword0-3= 0x%08X word5-6= 0x%04X byte18= 0x%02X", subtype, word56, word18);
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "Inkbird-ITH20R",
-            "id",               "",             DATA_INT,    sensor_id,
-            "battery_ok",       "Battery",      DATA_DOUBLE, battery_ok,
-            "sensor_num",       "",             DATA_INT,    sensor_num,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
-            "temperature_2_C",  "Temperature2", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature_ext,
-            "humidity",         "Humidity",     DATA_FORMAT, "%.1f %%", DATA_DOUBLE, humidity,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Inkbird-ITH20R");
+    data = data_int(data, "id",               "",             NULL,         sensor_id);
+    data = data_dbl(data, "battery_ok",       "Battery",      NULL,         battery_ok);
+    data = data_int(data, "sensor_num",       "",             NULL,         sensor_num);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temperature);
+    data = data_dbl(data, "temperature_2_C",  "Temperature2", "%.1f C",     temperature_ext);
+    data = data_dbl(data, "humidity",         "Humidity",     "%.1f %%",    humidity);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/inovalley-kw9015b.c
+++ b/src/devices/inovalley-kw9015b.c
@@ -60,14 +60,13 @@ static int kw9015b_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_FAIL_MIC;
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "Inovalley-kw9015b",
-            "id",               "",             DATA_INT,    device,
-            "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "rain",             "Rain Count",   DATA_INT,    rain, // TODO: remove this
-            "rain_mm",          "Rain Total",   DATA_DOUBLE, rain * 0.45f,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Inovalley-kw9015b");
+    data = data_int(data, "id",               "",             NULL,         device);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    data = data_int(data, "rain",             "Rain Count",   NULL,         rain); // TODO: remove this
+    data = data_dbl(data, "rain_mm",          "Rain Total",   NULL,         rain * 0.45f);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/insteon.c
+++ b/src/devices/insteon.c
@@ -344,25 +344,24 @@ static int parse_insteon_pkt(r_device *decoder, bitbuffer_t *bits, unsigned int 
     */
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",     "",                DATA_STRING, "Insteon",
+    data_t *data = NULL;
+    data = data_str(data, "model",     "",                NULL,         "Insteon");
          // "id",        "",                DATA_INT,    sensor_id,
          // "data",     "Data",             DATA_INT,    value,
-            "from_id",   "From_Addr",       DATA_STRING, pkt_from_addr,
-            "to_id",     "To_Addr",         DATA_STRING, pkt_to_addr,
-            "msg_type",  "Message_Type",    DATA_INT,    pkt_type,
-            "msg_str",   "Message_Str",     DATA_STRING, pkt_type_str,
+    data = data_str(data, "from_id",   "From_Addr",       NULL,         pkt_from_addr);
+    data = data_str(data, "to_id",     "To_Addr",         NULL,         pkt_to_addr);
+    data = data_int(data, "msg_type",  "Message_Type",    NULL,         pkt_type);
+    data = data_str(data, "msg_str",   "Message_Str",     NULL,         pkt_type_str);
          //   "command",   "Command",         DATA_STRING, cmd_str,
-            "extended",  "Extended",        DATA_INT,    extended,
+    data = data_int(data, "extended",  "Extended",        NULL,         extended);
          // "hops",      "Hops",            DATA_STRING, hops_str,
-            "hopsmax",   "Hops_Max",        DATA_INT,    hopsmax,
-            "hopsleft",  "Hops_Left",       DATA_INT,    hopsleft,
-            "formatted", "Packet",          DATA_STRING, pkt_formatted,
-            "mic",       "Integrity",       DATA_STRING, "CRC",
-            "payload",   "Payload",         DATA_STRING, payload,
-            "cmd_dat",   "CMD_Data",        DATA_ARRAY,  data_array(cmd_array_len, DATA_INT, cmd_array),
+    data = data_int(data, "hopsmax",   "Hops_Max",        NULL,         hopsmax);
+    data = data_int(data, "hopsleft",  "Hops_Left",       NULL,         hopsleft);
+    data = data_str(data, "formatted", "Packet",          NULL,         pkt_formatted);
+    data = data_str(data, "mic",       "Integrity",       NULL,         "CRC");
+    data = data_str(data, "payload",   "Payload",         NULL,         payload);
+    data = data_ary(data, "cmd_dat",   "CMD_Data",        NULL,         data_array(cmd_array_len, DATA_INT, cmd_array));
         //  "payload",   "Payload",         DATA_ARRAY,  data_array(min_pkt_len, DATA_INT, data_payload),
-            NULL);
 
     /* clang-format on */
     decoder_output_data(decoder, data);

--- a/src/devices/interlogix.c
+++ b/src/devices/interlogix.c
@@ -196,18 +196,17 @@ static int interlogix_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data = data_make(
-            "model",       "Model",         DATA_STRING, "Interlogix-Security",
-            "subtype",     "Device Type",   DATA_STRING, device_type,
-            "id",          "ID",            DATA_STRING, device_serial,
-            "battery_ok",  "Battery",       DATA_INT,    !low_battery,
-            "switch1",     "Switch1 State", DATA_STRING, f1_latch_state,
-            "switch2",     "Switch2 State", DATA_STRING, f2_latch_state,
-            "switch3",     "Switch3 State", DATA_STRING, f3_latch_state,
-            "switch4",     "Switch4 State", DATA_STRING, f4_latch_state,
-            "switch5",     "Switch5 State", DATA_STRING, f5_latch_state,
-            "raw_message", "Raw Message",   DATA_STRING, raw_message,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",       "Model",         NULL,         "Interlogix-Security");
+    data = data_str(data, "subtype",     "Device Type",   NULL,         device_type);
+    data = data_str(data, "id",          "ID",            NULL,         device_serial);
+    data = data_int(data, "battery_ok",  "Battery",       NULL,         !low_battery);
+    data = data_str(data, "switch1",     "Switch1 State", NULL,         f1_latch_state);
+    data = data_str(data, "switch2",     "Switch2 State", NULL,         f2_latch_state);
+    data = data_str(data, "switch3",     "Switch3 State", NULL,         f3_latch_state);
+    data = data_str(data, "switch4",     "Switch4 State", NULL,         f4_latch_state);
+    data = data_str(data, "switch5",     "Switch5 State", NULL,         f5_latch_state);
+    data = data_str(data, "raw_message", "Raw Message",   NULL,         raw_message);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/intertechno.c
+++ b/src/devices/intertechno.c
@@ -34,13 +34,12 @@ static int intertechno_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     int command = b[6] & 0x07;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",     DATA_STRING,    "Intertechno-Remote",
-            "id",               "",     DATA_STRING,    id_str,
-            "slave",            "",     DATA_INT,       slave,
-            "master",           "",     DATA_INT,       master,
-            "command",          "",     DATA_INT,       command,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",     NULL,         "Intertechno-Remote");
+    data = data_str(data, "id",               "",     NULL,         id_str);
+    data = data_int(data, "slave",            "",     NULL,         slave);
+    data = data_int(data, "master",           "",     NULL,         master);
+    data = data_int(data, "command",          "",     NULL,         command);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/jasco.c
+++ b/src/devices/jasco.c
@@ -57,12 +57,11 @@ static int jasco_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     // int battery = 0;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Jasco-Security",
-            "id",               "Id",           DATA_INT,    sensor_id,
-            "status",           "Closed",       DATA_INT,    s_closed,
-            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Jasco-Security");
+    data = data_int(data, "id",               "Id",           NULL,         sensor_id);
+    data = data_int(data, "status",           "Closed",       NULL,         s_closed);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/kedsum.c
+++ b/src/devices/kedsum.c
@@ -77,16 +77,15 @@ static int kedsum_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     battery = battery == 2 ? 100 : battery * 10; // level 0,1,2 -> 0,10,100
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",                 DATA_STRING, "Kedsum-TH",
-            "id",               "ID",               DATA_INT,    id,
-            "channel",          "Channel",          DATA_INT,    channel,
-            "battery_ok",       "Battery level",    DATA_DOUBLE, battery * 0.01f,
-            "flags",            "Flags2",           DATA_INT,    flags,
-            "temperature_F",    "Temperature",      DATA_FORMAT, "%.2f F", DATA_DOUBLE, temp_f,
-            "humidity",         "Humidity",         DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "Kedsum-TH");
+    data = data_int(data, "id",               "ID",               NULL,         id);
+    data = data_int(data, "channel",          "Channel",          NULL,         channel);
+    data = data_dbl(data, "battery_ok",       "Battery level",    NULL,         battery * 0.01f);
+    data = data_int(data, "flags",            "Flags2",           NULL,         flags);
+    data = data_dbl(data, "temperature_F",    "Temperature",      "%.2f F",     temp_f);
+    data = data_int(data, "humidity",         "Humidity",         "%u %%",      humidity);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/kerui.c
+++ b/src/devices/kerui.c
@@ -72,18 +72,29 @@ static int kerui_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_ABORT_EARLY;
 
     /* clang-format off */
-    data = data_make(
-            "model",        "",                 DATA_STRING, "Kerui-Security",
-            "id",           "ID (20bit)",       DATA_FORMAT, "0x%x", DATA_INT, id,
-            "cmd",          "Command (4bit)",   DATA_FORMAT, "0x%x", DATA_INT, cmd,
-            "motion",       "",                 DATA_COND, cmd == 0xa, DATA_INT, 1,
-            "opened",       "",                 DATA_COND, cmd == 0xe, DATA_INT, 1,
-            "opened",       "",                 DATA_COND, cmd == 0x7, DATA_INT, 0,
-            "tamper",       "",                 DATA_COND, cmd == 0xb, DATA_INT, 1,
-            "water",        "",                 DATA_COND, cmd == 0x5, DATA_INT, 1,
-            "battery_ok",   "Battery",          DATA_COND, cmd == 0xf, DATA_INT, 0,
-            "state",        "State",            DATA_STRING, cmd_str,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",        "",                 NULL,         "Kerui-Security");
+    data = data_int(data, "id",           "ID (20bit)",       "0x%x",       id);
+    data = data_int(data, "cmd",          "Command (4bit)",   "0x%x",       cmd);
+    if (cmd == 0xa) {
+        data = data_int(data, "motion",       "",                 NULL,         1);
+    }
+    if (cmd == 0xe) {
+        data = data_int(data, "opened",       "",                 NULL,         1);
+    }
+    if (cmd == 0x7) {
+        data = data_int(data, "opened",       "",                 NULL,         0);
+    }
+    if (cmd == 0xb) {
+        data = data_int(data, "tamper",       "",                 NULL,         1);
+    }
+    if (cmd == 0x5) {
+        data = data_int(data, "water",        "",                 NULL,         1);
+    }
+    if (cmd == 0xf) {
+        data = data_int(data, "battery_ok",   "Battery",          NULL,         0);
+    }
+    data = data_str(data, "state",        "State",            NULL,         cmd_str);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/klimalogg.c
+++ b/src/devices/klimalogg.c
@@ -84,15 +84,14 @@ static int klimalogg_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",                 DATA_STRING, "Klimalogg-Pro",
-            "id",               "Id",               DATA_FORMAT, "%04x", DATA_INT, id,
-            "battery_ok",       "Battery",          DATA_INT,    !battery_low,
-            "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C",      DATA_DOUBLE, temperature,
-            "humidity",         "Humidity",         DATA_INT,    humidity,
-            "sequence_nr",      "Sequence Number",  DATA_INT,    sequence_nr,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "Klimalogg-Pro");
+    data = data_int(data, "id",               "Id",               "%04x",       id);
+    data = data_int(data, "battery_ok",       "Battery",          NULL,         !battery_low);
+    data = data_dbl(data, "temperature_C",    "Temperature",      "%.1f C",     temperature);
+    data = data_int(data, "humidity",         "Humidity",         NULL,         humidity);
+    data = data_int(data, "sequence_nr",      "Sequence Number",  NULL,         sequence_nr);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/lacrosse.c
+++ b/src/devices/lacrosse.c
@@ -137,24 +137,24 @@ static int lacrossetx_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         if (msg_type == 0x00) {
             float temp_c = msg_value - 50.0f;
             /* clang-format off */
-            data_t *data = data_make(
-                    "model",            "",             DATA_STRING, "LaCrosse-TX",
-                    "id",               "",             DATA_INT,    sensor_id,
-                    "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-                    "mic",              "Integrity",    DATA_STRING, "PARITY",
-                    NULL);
+            data_t *data = NULL;
+            data = data_str(data, "model",            "",             NULL,         "LaCrosse-TX");
+            data = data_int(data, "id",               "",             NULL,         sensor_id);
+            data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+            data = data_str(data, "mic",              "Integrity",    NULL,         "PARITY");
             /* clang-format on */
             decoder_output_data(decoder, data);
             events++;
         }
         else if (msg_type == 0x0E) {
             /* clang-format off */
-            data_t *data = data_make(
-                    "model",            "",             DATA_STRING, "LaCrosse-TX",
-                    "id",               "",             DATA_INT,    sensor_id,
-                    "humidity",         "Humidity",     DATA_COND,   msg_value_raw != 0xff, DATA_FORMAT, "%.1f %%", DATA_DOUBLE, msg_value,
-                    "mic",              "Integrity",    DATA_STRING, "PARITY",
-                    NULL);
+            data_t *data = NULL;
+            data = data_str(data, "model",            "",             NULL,         "LaCrosse-TX");
+            data = data_int(data, "id",               "",             NULL,         sensor_id);
+            if (msg_value_raw != 0xff) {
+                data = data_dbl(data, "humidity",         "Humidity",     "%.1f %%",    msg_value);
+            }
+            data = data_str(data, "mic",              "Integrity",    NULL,         "PARITY");
             /* clang-format on */
             decoder_output_data(decoder, data);
             events++;

--- a/src/devices/lacrosse_breezepro.c
+++ b/src/devices/lacrosse_breezepro.c
@@ -135,17 +135,16 @@ static int lacrosse_breezepro_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",                 DATA_STRING, "LaCrosse-BreezePro",
-            "id",               "Sensor ID",        DATA_FORMAT, "%06x", DATA_INT, id,
-            "seq",              "Sequence",         DATA_FORMAT, "%01x", DATA_INT, seq,
-            "flags",            "unknown",          DATA_INT,     flags,
-            "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",         DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "wind_avg_km_h",    "Wind speed",       DATA_FORMAT, "%.1f km/h",  DATA_DOUBLE, speed_kmh,
-            "wind_dir_deg",     "Wind direction",   DATA_INT,    direction,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "LaCrosse-BreezePro");
+    data = data_int(data, "id",               "Sensor ID",        "%06x",       id);
+    data = data_int(data, "seq",              "Sequence",         "%01x",       seq);
+    data = data_int(data, "flags",            "unknown",          NULL,         flags);
+    data = data_dbl(data, "temperature_C",    "Temperature",      "%.1f C",     temp_c);
+    data = data_int(data, "humidity",         "Humidity",         "%u %%",      humidity);
+    data = data_dbl(data, "wind_avg_km_h",    "Wind speed",       "%.1f km/h",  speed_kmh);
+    data = data_int(data, "wind_dir_deg",     "Wind direction",   NULL,         direction);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/lacrosse_r1.c
+++ b/src/devices/lacrosse_r1.c
@@ -171,20 +171,35 @@ static int lacrosse_r1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     float wspeed_kmh = raw_wind * 0.1f;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",                 DATA_COND,   rev == 1,  DATA_STRING, "LaCrosse-R1",
-            "model",            "",                 DATA_COND,   rev == 3,  DATA_STRING, "LaCrosse-R3",
-            "model",            "",                 DATA_COND,   rev == 9,  DATA_STRING, "LaCrosse-W1",
-            "id",               "Sensor ID",        DATA_FORMAT, "%06x",    DATA_INT,    id,
-            "battery_ok",       "Battery level",    DATA_INT,    !batt_low,
-            "startup",          "Startup",          DATA_COND,   startup,   DATA_INT,    startup,
-            "seq",              "Sequence",         DATA_INT,    seq,
-            "flags",            "Unknown",          DATA_COND,   flags,     DATA_INT,    flags,
-            "rain_mm",          "Total Rain",       DATA_COND,   rev != 9,  DATA_FORMAT, "%.2f mm", DATA_DOUBLE, rain_mm,
-            "rain2_mm",         "Total Rain2",      DATA_COND,   rev == 3,  DATA_FORMAT, "%.2f mm", DATA_DOUBLE, rain2_mm,
-            "wind_avg_km_h",    "Wind Speed",       DATA_COND,   rev == 9,  DATA_FORMAT, "%.1f km/h", DATA_DOUBLE, wspeed_kmh,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    if (rev == 1) {
+        data = data_str(data, "model",            "",                 NULL,         "LaCrosse-R1");
+    }
+    if (rev == 3) {
+        data = data_str(data, "model",            "",                 NULL,         "LaCrosse-R3");
+    }
+    if (rev == 9) {
+        data = data_str(data, "model",            "",                 NULL,         "LaCrosse-W1");
+    }
+    data = data_int(data, "id",               "Sensor ID",        "%06x",       id);
+    data = data_int(data, "battery_ok",       "Battery level",    NULL,         !batt_low);
+    if (startup) {
+        data = data_int(data, "startup",          "Startup",          NULL,         startup);
+    }
+    data = data_int(data, "seq",              "Sequence",         NULL,         seq);
+    if (flags) {
+        data = data_int(data, "flags",            "Unknown",          NULL,         flags);
+    }
+    if (rev != 9) {
+        data = data_dbl(data, "rain_mm",          "Total Rain",       "%.2f mm",    rain_mm);
+    }
+    if (rev == 3) {
+        data = data_dbl(data, "rain2_mm",         "Total Rain2",      "%.2f mm",    rain2_mm);
+    }
+    if (rev == 9) {
+        data = data_dbl(data, "wind_avg_km_h",    "Wind Speed",       "%.1f km/h",  wspeed_kmh);
+    }
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/lacrosse_th3.c
+++ b/src/devices/lacrosse_th3.c
@@ -122,15 +122,14 @@ static int lacrosse_th_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_FAIL_SANITY;
 
     /* clang-format off */
-    data = data_make(
-         "model",            "",                 DATA_STRING, model_num == 3 ? "LaCrosse-TH3" : "LaCrosse-TH2",
-         "id",               "Sensor ID",        DATA_FORMAT, "%06x", DATA_INT, id,
-         "seq",              "Sequence",         DATA_INT,     seq,
-         "flags",            "unknown",          DATA_INT,     flags,
-         "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C",  DATA_DOUBLE, temp_c,
-         "humidity",         "Humidity",         DATA_FORMAT, "%u %%", DATA_INT, humidity,
-         "mic",              "Integrity",        DATA_STRING, "CRC",
-         NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         model_num == 3 ? "LaCrosse-TH3" : "LaCrosse-TH2");
+    data = data_int(data, "id",               "Sensor ID",        "%06x",       id);
+    data = data_int(data, "seq",              "Sequence",         NULL,         seq);
+    data = data_int(data, "flags",            "unknown",          NULL,         flags);
+    data = data_dbl(data, "temperature_C",    "Temperature",      "%.1f C",     temp_c);
+    data = data_int(data, "humidity",         "Humidity",         "%u %%",      humidity);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/lacrosse_tx141x.c
+++ b/src/devices/lacrosse_tx141x.c
@@ -168,16 +168,15 @@ static int lacrosse_tx141x_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             float temp_c = (temp_raw - 500) * 0.1f;
 
             /* clang-format off */
-            data = data_make(
-                    "model",            "",                 DATA_STRING, "LaCrosse-TX141W",
-                    "id",               "Sensor ID",        DATA_FORMAT, "%05x", DATA_INT, id,
-                    "channel",          "Channel",          DATA_FORMAT, "%01x", DATA_INT, channel,
-                    "battery_ok",       "Battery level",    DATA_INT,    !battery_low,
-                    "temperature_C",    "Temperature",      DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-                    "humidity",         "Humidity",         DATA_FORMAT, "%u %%", DATA_INT, humidity,
-                    "test",             "Test?",            DATA_INT,    test,
-                    "mic",              "Integrity",        DATA_STRING, "CRC",
-                    NULL);
+            data = NULL;
+            data = data_str(data, "model",            "",                 NULL,         "LaCrosse-TX141W");
+            data = data_int(data, "id",               "Sensor ID",        "%05x",       id);
+            data = data_int(data, "channel",          "Channel",          "%01x",       channel);
+            data = data_int(data, "battery_ok",       "Battery level",    NULL,         !battery_low);
+            data = data_dbl(data, "temperature_C",    "Temperature",      "%.2f C",     temp_c);
+            data = data_int(data, "humidity",         "Humidity",         "%u %%",      humidity);
+            data = data_int(data, "test",             "Test?",            NULL,         test);
+            data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
             /* clang-format on */
         }
         else if (type == 2) {
@@ -186,16 +185,15 @@ static int lacrosse_tx141x_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             // wind direction is in humidity field
 
             /* clang-format off */
-            data = data_make(
-                    "model",            "",                 DATA_STRING, "LaCrosse-TX141W",
-                    "id",               "Sensor ID",        DATA_FORMAT, "%05x", DATA_INT, id,
-                    "channel",          "Channel",          DATA_FORMAT, "%01x", DATA_INT, channel,
-                    "battery_ok",       "Battery level",    DATA_INT,    !battery_low,
-                    "wind_avg_km_h",    "Wind speed",       DATA_FORMAT, "%.1f km/h",  DATA_DOUBLE, speed_kmh,
-                    "wind_dir_deg",     "Wind direction",   DATA_INT,    humidity,
-                    "test",             "Test?",            DATA_INT,    test,
-                    "mic",              "Integrity",        DATA_STRING, "CRC",
-                    NULL);
+            data = NULL;
+            data = data_str(data, "model",            "",                 NULL,         "LaCrosse-TX141W");
+            data = data_int(data, "id",               "Sensor ID",        "%05x",       id);
+            data = data_int(data, "channel",          "Channel",          "%01x",       channel);
+            data = data_int(data, "battery_ok",       "Battery level",    NULL,         !battery_low);
+            data = data_dbl(data, "wind_avg_km_h",    "Wind speed",       "%.1f km/h",  speed_kmh);
+            data = data_int(data, "wind_dir_deg",     "Wind direction",   NULL,         humidity);
+            data = data_int(data, "test",             "Test?",            NULL,         test);
+            data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
             /* clang-format on */
         }
         else {
@@ -232,36 +230,33 @@ static int lacrosse_tx141x_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     if (device == LACROSSE_TX141B) {
         /* clang-format off */
-        data = data_make(
-                "model",         "",              DATA_STRING, "LaCrosse-TX141B",
-                "id",            "Sensor ID",     DATA_FORMAT, "%02x", DATA_INT, id,
-                "temperature_C", "Temperature",   DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-                "battery_ok",    "Battery",       DATA_INT,    !battery_low,
-                "test",          "Test?",         DATA_STRING, test ? "Yes" : "No",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",         "",              NULL,         "LaCrosse-TX141B");
+        data = data_int(data, "id",            "Sensor ID",     "%02x",       id);
+        data = data_dbl(data, "temperature_C", "Temperature",   "%.2f C",     temp_c);
+        data = data_int(data, "battery_ok",    "Battery",       NULL,         !battery_low);
+        data = data_str(data, "test",          "Test?",         NULL,         test ? "Yes" : "No");
         /* clang-format on */
     } else if (device == LACROSSE_TX141) {
         /* clang-format off */
-        data = data_make(
-                "model",         "",              DATA_STRING, "LaCrosse-TX141Bv2",
-                "id",            "Sensor ID",     DATA_FORMAT, "%02x", DATA_INT, id,
-                "channel",       "Channel",       DATA_INT, channel,
-                "temperature_C", "Temperature",   DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-                "battery_ok",    "Battery",       DATA_INT,    !battery_low,
-                "test",          "Test?",         DATA_STRING, test ? "Yes" : "No",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",         "",              NULL,         "LaCrosse-TX141Bv2");
+        data = data_int(data, "id",            "Sensor ID",     "%02x",       id);
+        data = data_int(data, "channel",       "Channel",       NULL,         channel);
+        data = data_dbl(data, "temperature_C", "Temperature",   "%.2f C",     temp_c);
+        data = data_int(data, "battery_ok",    "Battery",       NULL,         !battery_low);
+        data = data_str(data, "test",          "Test?",         NULL,         test ? "Yes" : "No");
         /* clang-format on */
     }
     else if (device == LACROSSE_TX141BV3) {
         /* clang-format off */
-        data = data_make(
-                "model",         "",              DATA_STRING, "LaCrosse-TX141Bv3",
-                "id",            "Sensor ID",     DATA_FORMAT, "%02x", DATA_INT, id,
-                "channel",       "Channel",       DATA_INT, channel,
-                "battery_ok",    "Battery",       DATA_INT,    !battery_low,
-                "temperature_C", "Temperature",   DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-                "test",          "Test?",         DATA_STRING, test ? "Yes" : "No",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",         "",              NULL,         "LaCrosse-TX141Bv3");
+        data = data_int(data, "id",            "Sensor ID",     "%02x",       id);
+        data = data_int(data, "channel",       "Channel",       NULL,         channel);
+        data = data_int(data, "battery_ok",    "Battery",       NULL,         !battery_low);
+        data = data_dbl(data, "temperature_C", "Temperature",   "%.2f C",     temp_c);
+        data = data_str(data, "test",          "Test?",         NULL,         test ? "Yes" : "No");
         /* clang-format on */
     }
     else {
@@ -271,16 +266,15 @@ static int lacrosse_tx141x_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             return DECODE_FAIL_MIC;
         }
         /* clang-format off */
-        data = data_make(
-                "model",         "",              DATA_STRING, "LaCrosse-TX141THBv2",
-                "id",            "Sensor ID",     DATA_FORMAT, "%02x", DATA_INT, id,
-                "channel",       "Channel",       DATA_INT, channel,
-                "battery_ok",    "Battery",       DATA_INT,    !battery_low,
-                "temperature_C", "Temperature",   DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-                "humidity",      "Humidity",      DATA_FORMAT, "%u %%", DATA_INT, humidity,
-                "test",          "Test?",         DATA_STRING, test ? "Yes" : "No",
-                "mic",           "Integrity",     DATA_STRING, "CRC",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",         "",              NULL,         "LaCrosse-TX141THBv2");
+        data = data_int(data, "id",            "Sensor ID",     "%02x",       id);
+        data = data_int(data, "channel",       "Channel",       NULL,         channel);
+        data = data_int(data, "battery_ok",    "Battery",       NULL,         !battery_low);
+        data = data_dbl(data, "temperature_C", "Temperature",   "%.2f C",     temp_c);
+        data = data_int(data, "humidity",      "Humidity",      "%u %%",      humidity);
+        data = data_str(data, "test",          "Test?",         NULL,         test ? "Yes" : "No");
+        data = data_str(data, "mic",           "Integrity",     NULL,         "CRC");
         /* clang-format on */
     }
 

--- a/src/devices/lacrosse_tx31u.c
+++ b/src/devices/lacrosse_tx31u.c
@@ -133,11 +133,10 @@ static int lacrosse_tx31u_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     // what we know from the header
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "LaCrosse-TX31UIT",
-            "id",               "",             DATA_INT,    sensor_id,
-            "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "LaCrosse-TX31UIT");
+    data = data_int(data, "id",               "",             NULL,         sensor_id);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
 
     // decode each measurement we get and append them.
     enum sensor_type { TEMP=0, HUMIDITY, RAIN, WIND_AVG, WIND_MAX };

--- a/src/devices/lacrosse_tx34.c
+++ b/src/devices/lacrosse_tx34.c
@@ -86,15 +86,14 @@ static int lacrosse_tx34_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         float rain_mm = rain_tick * LACROSSE_TX34_RAIN_FACTOR;
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",        "",             DATA_STRING, "LaCrosse-TX34IT",
-                "id",           "",             DATA_INT,    sensor_id,
-                "battery_ok",   "Battery",      DATA_INT,    !low_batt,
-                "newbattery",   "New battery",  DATA_INT,    new_batt,
-                "rain_mm",      "Total rain",   DATA_DOUBLE, rain_mm,
-                "rain_raw",     "Raw rain",     DATA_INT,    rain_tick,
-                "mic",          "Integrity",    DATA_STRING, "CRC",
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",        "",             NULL,         "LaCrosse-TX34IT");
+        data = data_int(data, "id",           "",             NULL,         sensor_id);
+        data = data_int(data, "battery_ok",   "Battery",      NULL,         !low_batt);
+        data = data_int(data, "newbattery",   "New battery",  NULL,         new_batt);
+        data = data_dbl(data, "rain_mm",      "Total rain",   NULL,         rain_mm);
+        data = data_int(data, "rain_raw",     "Raw rain",     NULL,         rain_tick);
+        data = data_str(data, "mic",          "Integrity",    NULL,         "CRC");
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/lacrosse_tx35.c
+++ b/src/devices/lacrosse_tx35.c
@@ -121,27 +121,25 @@ static int lacrosse_it(r_device *decoder, bitbuffer_t *bitbuffer, int device29or
             if (humidity == LACROSSE_TX25_PROBE_FLAG)
                 sensor_id += 0x40;      // Change ID to distinguish between the main and probe channels
             /* clang-format off */
-            data = data_make(
-                    "model",            "",             DATA_STRING, (device29or35 == 29 ? "LaCrosse-TX29IT" : "LaCrosse-TX35DTHIT"),
-                    "id",               "",             DATA_INT,    sensor_id,
-                    "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-                    "newbattery",       "NewBattery",   DATA_INT,    new_batt,
-                    "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-                    "mic",              "Integrity",    DATA_STRING, "CRC",
-                    NULL);
+            data = NULL;
+            data = data_str(data, "model",            "",             NULL,         (device29or35 == 29 ? "LaCrosse-TX29IT" : "LaCrosse-TX35DTHIT"));
+            data = data_int(data, "id",               "",             NULL,         sensor_id);
+            data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+            data = data_int(data, "newbattery",       "NewBattery",   NULL,         new_batt);
+            data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+            data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
             /* clang-format on */
         }
         else {
             /* clang-format off */
-            data = data_make(
-                    "model",            "",             DATA_STRING, (device29or35 == 29 ? "LaCrosse-TX29IT" : "LaCrosse-TX35DTHIT"),
-                    "id",               "",             DATA_INT,    sensor_id,
-                    "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-                    "newbattery",       "NewBattery",   DATA_INT,    new_batt,
-                    "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-                    "humidity",         "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, humidity,
-                    "mic",              "Integrity",    DATA_STRING, "CRC",
-                    NULL);
+            data = NULL;
+            data = data_str(data, "model",            "",             NULL,         (device29or35 == 29 ? "LaCrosse-TX29IT" : "LaCrosse-TX35DTHIT"));
+            data = data_int(data, "id",               "",             NULL,         sensor_id);
+            data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+            data = data_int(data, "newbattery",       "NewBattery",   NULL,         new_batt);
+            data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+            data = data_int(data, "humidity",         "Humidity",     "%u %%",      humidity);
+            data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
             /* clang-format on */
         }
 

--- a/src/devices/lacrosse_wr1.c
+++ b/src/devices/lacrosse_wr1.c
@@ -105,17 +105,16 @@ static int lacrosse_wr1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     //rain_mm   = 0.0;  // dummy until we know what raw_rain1 and raw_rain2 mean
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",                 DATA_STRING, "LaCrosse-WR1",
-            "id",               "Sensor ID",        DATA_FORMAT, "%06x", DATA_INT, id,
-            "seq",              "Sequence",         DATA_INT,     seq,
-            "flags",            "unknown",          DATA_INT,     flags,
-            "wind_avg_km_h",        "Wind speed",       DATA_FORMAT, "%.1f km/h",  DATA_DOUBLE, speed_kmh,
-            "wind_dir_deg",     "Wind direction",   DATA_INT,    direction,
-            "rain1",            "raw_rain1",        DATA_FORMAT, "%03x", DATA_INT, raw_rain1,
-            "rain2",            "raw_rain2",        DATA_FORMAT, "%03x", DATA_INT, raw_rain2,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "LaCrosse-WR1");
+    data = data_int(data, "id",               "Sensor ID",        "%06x",       id);
+    data = data_int(data, "seq",              "Sequence",         NULL,         seq);
+    data = data_int(data, "flags",            "unknown",          NULL,         flags);
+    data = data_dbl(data, "wind_avg_km_h",        "Wind speed",       "%.1f km/h",  speed_kmh);
+    data = data_int(data, "wind_dir_deg",     "Wind direction",   NULL,         direction);
+    data = data_int(data, "rain1",            "raw_rain1",        "%03x",       raw_rain1);
+    data = data_int(data, "rain2",            "raw_rain2",        "%03x",       raw_rain2);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/lacrosse_ws7000.c
+++ b/src/devices/lacrosse_ws7000.c
@@ -95,13 +95,12 @@ static int lacrosse_ws7000_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         float temperature = ((b[4] * 10) + (b[3] * 1) + (b[2] * 0.1f)) * sign;
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",                 DATA_STRING, "LaCrosse-WS700027",
-                "id",               "",                 DATA_INT,    id,
-                "channel",          "",                 DATA_INT,    addr,
-                "temperature_C",    "Temperature",      DATA_DOUBLE, temperature,
-                "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                 NULL,         "LaCrosse-WS700027");
+        data = data_int(data, "id",               "",                 NULL,         id);
+        data = data_int(data, "channel",          "",                 NULL,         addr);
+        data = data_dbl(data, "temperature_C",    "Temperature",      NULL,         temperature);
+        data = data_str(data, "mic",              "Integrity",        NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);
@@ -114,14 +113,13 @@ static int lacrosse_ws7000_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         int humidity      = (b[7] * 10) + (b[6] * 1) + (b[5] * 0.1f);
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",                 DATA_STRING, "LaCrosse-WS700022",
-                "id",               "",                 DATA_INT,    id,
-                "channel",          "",                 DATA_INT,    addr,
-                "temperature_C",    "Temperature",      DATA_DOUBLE, temperature,
-                "humidity",         "Humidity",         DATA_INT,    humidity,
-                "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                 NULL,         "LaCrosse-WS700022");
+        data = data_int(data, "id",               "",                 NULL,         id);
+        data = data_int(data, "channel",          "",                 NULL,         addr);
+        data = data_dbl(data, "temperature_C",    "Temperature",      NULL,         temperature);
+        data = data_int(data, "humidity",         "Humidity",         NULL,         humidity);
+        data = data_str(data, "mic",              "Integrity",        NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);
@@ -132,13 +130,12 @@ static int lacrosse_ws7000_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         int rain = (b[4] << 8) | (b[3] << 4) | (b[2]);
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",                 DATA_STRING, "LaCrosse-WS700016",
-                "id",               "",                 DATA_INT,    id,
-                "channel",          "",                 DATA_INT,    addr,
-                "rain_mm",          "Rain counter",     DATA_DOUBLE, rain * 0.3,
-                "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                 NULL,         "LaCrosse-WS700016");
+        data = data_int(data, "id",               "",                 NULL,         id);
+        data = data_int(data, "channel",          "",                 NULL,         addr);
+        data = data_dbl(data, "rain_mm",          "Rain counter",     NULL,         rain * 0.3);
+        data = data_str(data, "mic",              "Integrity",        NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);
@@ -151,15 +148,14 @@ static int lacrosse_ws7000_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         float deviation = (b[7] & 0x3) * 22.5f;
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",                 DATA_STRING, "LaCrosse-WS700015",
-                "id",               "",                 DATA_INT,    id,
-                "channel",          "",                 DATA_INT,    addr,
-                "wind_avg_km_h",    "Wind speed",       DATA_DOUBLE, speed,
-                "wind_dir_deg",     "Wind direction",   DATA_DOUBLE, direction,
-                "wind_dev_deg",     "Wind deviation",   DATA_DOUBLE, deviation,
-                "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                 NULL,         "LaCrosse-WS700015");
+        data = data_int(data, "id",               "",                 NULL,         id);
+        data = data_int(data, "channel",          "",                 NULL,         addr);
+        data = data_dbl(data, "wind_avg_km_h",    "Wind speed",       NULL,         speed);
+        data = data_dbl(data, "wind_dir_deg",     "Wind direction",   NULL,         direction);
+        data = data_dbl(data, "wind_dev_deg",     "Wind deviation",   NULL,         deviation);
+        data = data_str(data, "mic",              "Integrity",        NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);
@@ -173,15 +169,14 @@ static int lacrosse_ws7000_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         int pressure      = (b[10] * 100) + (b[9] * 10) + (b[8] * 1) + 200;
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",                 DATA_STRING, "LaCrosse-WS700020",
-                "id",               "",                 DATA_INT,    id,
-                "channel",          "",                 DATA_INT,    addr,
-                "temperature_C",    "Temperature",      DATA_DOUBLE, temperature,
-                "humidity",         "Humidity",         DATA_INT,    humidity,
-                "pressure_hPa",     "Pressure",         DATA_INT,    pressure,
-                "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                 NULL,         "LaCrosse-WS700020");
+        data = data_int(data, "id",               "",                 NULL,         id);
+        data = data_int(data, "channel",          "",                 NULL,         addr);
+        data = data_dbl(data, "temperature_C",    "Temperature",      NULL,         temperature);
+        data = data_int(data, "humidity",         "Humidity",         NULL,         humidity);
+        data = data_int(data, "pressure_hPa",     "Pressure",         NULL,         pressure);
+        data = data_str(data, "mic",              "Integrity",        NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);
@@ -196,14 +191,13 @@ static int lacrosse_ws7000_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             brightness *= 10;
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",                 DATA_STRING, "LaCrosse-WS250019",
-                "id",               "",                 DATA_INT,    id,
-                "channel",          "",                 DATA_INT,    addr,
-                "light_lux",        "Brightness",       DATA_INT,    brightness,
-                "exposure_mins",    "Exposition",       DATA_INT,    exposition,
-                "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                 NULL,         "LaCrosse-WS250019");
+        data = data_int(data, "id",               "",                 NULL,         id);
+        data = data_int(data, "channel",          "",                 NULL,         addr);
+        data = data_int(data, "light_lux",        "Brightness",       NULL,         brightness);
+        data = data_int(data, "exposure_mins",    "Exposition",       NULL,         exposition);
+        data = data_str(data, "mic",              "Integrity",        NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/lacrossews.c
+++ b/src/devices/lacrossews.c
@@ -121,11 +121,10 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                 temp_c = (msg_value_bcd - 300) * 0.1f;
 
             /* clang-format off */
-            data = data_make(
-                    "model",            "",             DATA_STRING, ws_id == 0x6 ? "LaCrosse-WS3600" : "LaCrosse-WS2310",
-                    "id",               "",             DATA_INT,    sensor_id,
-                    "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-                    NULL);
+            data = NULL;
+            data = data_str(data, "model",            "",             NULL,         ws_id == 0x6 ? "LaCrosse-WS3600" : "LaCrosse-WS2310");
+            data = data_int(data, "id",               "",             NULL,         sensor_id);
+            data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
             /* clang-format on */
 
             decoder_output_data(decoder, data);
@@ -140,11 +139,10 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             }
 
             /* clang-format off */
-            data = data_make(
-                    "model",            "",             DATA_STRING, ws_id == 0x6 ? "LaCrosse-WS3600" : "LaCrosse-WS2310",
-                    "id",               "",             DATA_INT,    sensor_id,
-                    "humidity",         "Humidity",     DATA_INT,    msg_value_bcd2,
-                    NULL);
+            data = NULL;
+            data = data_str(data, "model",            "",             NULL,         ws_id == 0x6 ? "LaCrosse-WS3600" : "LaCrosse-WS2310");
+            data = data_int(data, "id",               "",             NULL,         sensor_id);
+            data = data_int(data, "humidity",         "Humidity",     NULL,         msg_value_bcd2);
             /* clang-format on */
 
             decoder_output_data(decoder, data);
@@ -155,11 +153,10 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             rain_mm = 0.5180f * msg_value_bin;
 
             /* clang-format off */
-            data = data_make(
-                    "model",            "",             DATA_STRING, ws_id == 0x6 ? "LaCrosse-WS3600" : "LaCrosse-WS2310",
-                    "id",               "",             DATA_INT,    sensor_id,
-                    "rain_mm",          "Rainfall",     DATA_FORMAT, "%.2f mm", DATA_DOUBLE, rain_mm,
-                    NULL);
+            data = NULL;
+            data = data_str(data, "model",            "",             NULL,         ws_id == 0x6 ? "LaCrosse-WS3600" : "LaCrosse-WS2310");
+            data = data_int(data, "id",               "",             NULL,         sensor_id);
+            data = data_dbl(data, "rain_mm",          "Rainfall",     "%.2f mm",    rain_mm);
             /* clang-format on */
 
             decoder_output_data(decoder, data);
@@ -178,13 +175,16 @@ static int lacrossews_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             }
 
             /* clang-format off */
-            data = data_make(
-                    "model",            "",             DATA_STRING, ws_id == 0x6 ? "LaCrosse-WS3600" : "LaCrosse-WS2310",
-                    "id",               "",             DATA_INT,    sensor_id,
-                    "wind_avg_m_s",     "Wind speed",   DATA_COND,   msg_type == 3, DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wind_spd,
-                    "wind_max_m_s",     "Gust speed",   DATA_COND,   msg_type != 3, DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wind_spd,
-                    "wind_dir_deg",     "Direction",    DATA_DOUBLE, wind_dir,
-                    NULL);
+            data = NULL;
+            data = data_str(data, "model",            "",             NULL,         ws_id == 0x6 ? "LaCrosse-WS3600" : "LaCrosse-WS2310");
+            data = data_int(data, "id",               "",             NULL,         sensor_id);
+            if (msg_type == 3) {
+                data = data_dbl(data, "wind_avg_m_s",     "Wind speed",   "%.1f m/s",   wind_spd);
+            }
+            if (msg_type != 3) {
+                data = data_dbl(data, "wind_max_m_s",     "Gust speed",   "%.1f m/s",   wind_spd);
+            }
+            data = data_dbl(data, "wind_dir_deg",     "Direction",    NULL,         wind_dir);
             /* clang-format on */
 
             decoder_output_data(decoder, data);

--- a/src/devices/lightwave_rf.c
+++ b/src/devices/lightwave_rf.c
@@ -122,13 +122,12 @@ static int lightwave_rf_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     decoder_log_bitbuffer(decoder, 1, __func__, bitbuffer, "Row 0 = Input, Row 1 = Zero bit stuffing, Row 2 = Stripped delimiters, Row 3 = Decoded nibbles");
 
     /* clang-format off */
-    data = data_make(
-            "model",        "", DATA_STRING, "Lightwave-RF",
-            "id",           "", DATA_FORMAT, "%06x", DATA_INT, id,
-            "subunit",      "", DATA_INT,    subunit,
-            "command",      "", DATA_INT,    command,
-            "parameter",    "", DATA_INT,    parameter,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",        "", NULL,         "Lightwave-RF");
+    data = data_int(data, "id",           "", "%06x",       id);
+    data = data_int(data, "subunit",      "", NULL,         subunit);
+    data = data_int(data, "command",      "", NULL,         command);
+    data = data_int(data, "parameter",    "", NULL,         parameter);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/m_bus.c
+++ b/src/devices/m_bus.c
@@ -874,36 +874,34 @@ static int m_bus_output_data(r_device *decoder, bitbuffer_t *bitbuffer, const m_
         for (unsigned n=0; n<6; n++) { sprintf(sn_str+n*2, "%02x", block1->knx_sn[n]); }
 
         /* clang-format off */
-        data = data_make(
-                "model",    "",             DATA_STRING,    "KNX-RF",
-                "sn",       "SN",           DATA_STRING,    sn_str,
-                "knx_ctrl", "KNX-Ctrl",     DATA_FORMAT,    "0x%02X", DATA_INT, block1->block2.knx_ctrl,
-                "src",      "Src",          DATA_FORMAT,    "0x%04X", DATA_INT, block1->block2.src,
-                "dst",      "Dst",          DATA_FORMAT,    "0x%04X", DATA_INT, block1->block2.dst,
-                "l_npci",   "L/NPCI",       DATA_FORMAT,    "0x%02X", DATA_INT, block1->block2.l_npci,
-                "tpci",     "TPCI",         DATA_FORMAT,    "0x%02X", DATA_INT, block1->block2.tpci,
-                "apci",     "APCI",         DATA_FORMAT,    "0x%02X", DATA_INT, block1->block2.apci,
-                "data_length","Data Length",DATA_INT,       out->length,
-                "data",     "Data",         DATA_STRING,    str_buf,
-                "mic",      "Integrity",    DATA_STRING,    "CRC",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",    "",             NULL,         "KNX-RF");
+        data = data_str(data, "sn",       "SN",           NULL,         sn_str);
+        data = data_int(data, "knx_ctrl", "KNX-Ctrl",     "0x%02X",     block1->block2.knx_ctrl);
+        data = data_int(data, "src",      "Src",          "0x%04X",     block1->block2.src);
+        data = data_int(data, "dst",      "Dst",          "0x%04X",     block1->block2.dst);
+        data = data_int(data, "l_npci",   "L/NPCI",       "0x%02X",     block1->block2.l_npci);
+        data = data_int(data, "tpci",     "TPCI",         "0x%02X",     block1->block2.tpci);
+        data = data_int(data, "apci",     "APCI",         "0x%02X",     block1->block2.apci);
+        data = data_int(data, "data_length","Data Length",NULL,         out->length);
+        data = data_str(data, "data",     "Data",         NULL,         str_buf);
+        data = data_str(data, "mic",      "Integrity",    NULL,         "CRC");
         /* clang-format on */
     } else {
         /* clang-format off */
-        data = data_make(
-                "model",    "",             DATA_STRING,    "Wireless-MBus",
-                "mode",     "Mode",         DATA_STRING,    mode,
-                "M",        "Manufacturer", DATA_STRING,    block1->M_str,
-                "id",       "ID",           DATA_INT,       block1->A_ID,
-                "version",  "Version",      DATA_INT,       block1->A_Version,
-                "type",     "Device Type",  DATA_FORMAT,    "0x%02X",   DATA_INT, block1->A_DevType,
-                "type_string",  "Device Type String",   DATA_STRING,        m_bus_device_type_str(block1->A_DevType),
-                "C",        "Control",      DATA_FORMAT,    "0x%02X",   DATA_INT, block1->C,
+        data = NULL;
+        data = data_str(data, "model",    "",             NULL,         "Wireless-MBus");
+        data = data_str(data, "mode",     "Mode",         NULL,         mode);
+        data = data_str(data, "M",        "Manufacturer", NULL,         block1->M_str);
+        data = data_int(data, "id",       "ID",           NULL,         block1->A_ID);
+        data = data_int(data, "version",  "Version",      NULL,         block1->A_Version);
+        data = data_int(data, "type",     "Device Type",  "0x%02X",     block1->A_DevType);
+        data = data_str(data, "type_string",  "Device Type String",   NULL,         m_bus_device_type_str(block1->A_DevType));
+        data = data_int(data, "C",        "Control",      "0x%02X",     block1->C);
 //                "L",        "Length",       DATA_INT,       block1->L,
-                "data_length",  "Data Length",          DATA_INT,           out->length,
-                "data",     "Data",         DATA_STRING,    str_buf,
-                "mic",      "Integrity",    DATA_STRING,    "CRC",
-                NULL);
+        data = data_int(data, "data_length",  "Data Length",          NULL,         out->length);
+        data = data_str(data, "data",     "Data",         NULL,         str_buf);
+        data = data_str(data, "mic",      "Integrity",    NULL,         "CRC");
         /* clang-format on */
     }
     if (block1->block2.CI) {

--- a/src/devices/markisol.c
+++ b/src/devices/markisol.c
@@ -96,14 +96,13 @@ static int markisol_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     };
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",          "Model",          DATA_STRING, "Markisol",
-            "id",             "",               DATA_FORMAT, "%04X", DATA_INT, address,
-            "control",        "Control",        DATA_STRING, control_strs[control],
-            "channel",        "Channel",        DATA_INT,    channel,
-            "zone",           "Zone",           DATA_INT,    zone,
-            "mic",            "Integrity",      DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",          "Model",          NULL,         "Markisol");
+    data = data_int(data, "id",             "",               "%04X",       address);
+    data = data_str(data, "control",        "Control",        NULL,         control_strs[control]);
+    data = data_int(data, "channel",        "Channel",        NULL,         channel);
+    data = data_int(data, "zone",           "Zone",           NULL,         zone);
+    data = data_str(data, "mic",            "Integrity",      NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/marlec_solar.c
+++ b/src/devices/marlec_solar.c
@@ -110,22 +110,43 @@ static int marlec_solar_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     int is_data = frame_type == 0x22;
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "Marlec-Solar",
-            "boost_time",       "",             DATA_COND, is_data, DATA_INT, boost_time,
-            "solar_off",        "",             DATA_COND, is_data, DATA_INT, solar_off,
-            "tank_hot",         "",             DATA_COND, is_data, DATA_INT, tank_hot,
-            "battery_low",      "",             DATA_COND, is_data, DATA_INT, battery_low,
-            "heating",          "",             DATA_COND, is_data, DATA_INT, heating,
-            "import_val",       "",             DATA_COND, is_data, DATA_INT, import_val,
-            "saved_today",      "",             DATA_COND, is_data && saved_type == SAVED_TODAY, DATA_INT, saved_val,
-            "saved_yesterday",  "",             DATA_COND, is_data && saved_type == SAVED_YESTERDAY, DATA_INT, saved_val,
-            "saved_last_7",     "",             DATA_COND, is_data && saved_type == SAVED_LAST_7, DATA_INT, saved_val,
-            "saved_last_28",    "",             DATA_COND, is_data && saved_type == SAVED_LAST_28, DATA_INT, saved_val,
-            "saved_total",      "",             DATA_COND, is_data && saved_type == SAVED_TOTAL, DATA_INT, saved_val,
-            "raw",              "Raw data",     DATA_STRING, frame_str,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Marlec-Solar");
+    if (is_data) {
+        data = data_int(data, "boost_time",       "",             NULL,         boost_time);
+    }
+    if (is_data) {
+        data = data_int(data, "solar_off",        "",             NULL,         solar_off);
+    }
+    if (is_data) {
+        data = data_int(data, "tank_hot",         "",             NULL,         tank_hot);
+    }
+    if (is_data) {
+        data = data_int(data, "battery_low",      "",             NULL,         battery_low);
+    }
+    if (is_data) {
+        data = data_int(data, "heating",          "",             NULL,         heating);
+    }
+    if (is_data) {
+        data = data_int(data, "import_val",       "",             NULL,         import_val);
+    }
+    if (is_data && saved_type == SAVED_TODAY) {
+        data = data_int(data, "saved_today",      "",             NULL,         saved_val);
+    }
+    if (is_data && saved_type == SAVED_YESTERDAY) {
+        data = data_int(data, "saved_yesterday",  "",             NULL,         saved_val);
+    }
+    if (is_data && saved_type == SAVED_LAST_7) {
+        data = data_int(data, "saved_last_7",     "",             NULL,         saved_val);
+    }
+    if (is_data && saved_type == SAVED_LAST_28) {
+        data = data_int(data, "saved_last_28",    "",             NULL,         saved_val);
+    }
+    if (is_data && saved_type == SAVED_TOTAL) {
+        data = data_int(data, "saved_total",      "",             NULL,         saved_val);
+    }
+    data = data_str(data, "raw",              "Raw data",     NULL,         frame_str);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
     decoder_output_data(decoder, data);
     return 1;

--- a/src/devices/maverick_et73.c
+++ b/src/devices/maverick_et73.c
@@ -78,12 +78,11 @@ static int maverick_et73_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     temp2_c   = (temp2_raw >> 4) * 0.1f;
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",                 DATA_STRING, "Maverick-ET73",
-            "id",               "Random Id",        DATA_INT, device,
-            "temperature_1_C",  "Temperature 1",    DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp1_c,
-            "temperature_2_C",  "Temperature 2",    DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp2_c,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "Maverick-ET73");
+    data = data_int(data, "id",               "Random Id",        NULL,         device);
+    data = data_dbl(data, "temperature_1_C",  "Temperature 1",    "%.1f C",     temp1_c);
+    data = data_dbl(data, "temperature_2_C",  "Temperature 2",    "%.1f C",     temp2_c);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/maverick_et73x.c
+++ b/src/devices/maverick_et73x.c
@@ -90,13 +90,12 @@ static int maverick_et73x_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                 pre, flags, temp1, temp2, digest, chk[0], chk[1], chk[2], id);
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",                     DATA_STRING, "Maverick-ET73x",
-            "id",               "Session_ID",           DATA_INT,    id,
-            "status",           "Status",               DATA_STRING, status,
-            "temperature_1_C",  "TemperatureSensor1",   DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp1_c,
-            "temperature_2_C",  "TemperatureSensor2",   DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp2_c,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",                     NULL,         "Maverick-ET73x");
+    data = data_int(data, "id",               "Session_ID",           NULL,         id);
+    data = data_str(data, "status",           "Status",               NULL,         status);
+    data = data_dbl(data, "temperature_1_C",  "TemperatureSensor1",   "%.2f C",     temp1_c);
+    data = data_dbl(data, "temperature_2_C",  "TemperatureSensor2",   "%.2f C",     temp2_c);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/maverick_xr30.c
+++ b/src/devices/maverick_xr30.c
@@ -80,13 +80,12 @@ static int maverick_xr30_callback(r_device *decoder, bitbuffer_t *bitbuffer)
                 sync, flags, temp1, temp2, digest, b[7], b[8], b[9], id);
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",                     DATA_STRING, "Maverick-XR30",
-            "id",               "Session_ID",           DATA_INT,    id,
-            "status",           "Status",               DATA_STRING, status,
-            "temperature_1_C",  "TemperatureSensor1",   DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp1_c,
-            "temperature_2_C",  "TemperatureSensor2",   DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp2_c,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",                     NULL,         "Maverick-XR30");
+    data = data_int(data, "id",               "Session_ID",           NULL,         id);
+    data = data_str(data, "status",           "Status",               NULL,         status);
+    data = data_dbl(data, "temperature_1_C",  "TemperatureSensor1",   "%.2f C",     temp1_c);
+    data = data_dbl(data, "temperature_2_C",  "TemperatureSensor2",   "%.2f C",     temp2_c);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/mebus.c
+++ b/src/devices/mebus.c
@@ -49,16 +49,15 @@ static int mebus433_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         unknown2 = (bb[1][3] & 0xf0) >> 4;
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",             DATA_STRING, "Mebus-433",
-                "id",               "Address",      DATA_INT,    address,
-                "channel",          "Channel",      DATA_INT,    channel,
-                "battery_ok",       "Battery",      DATA_INT,    !!battery,
-                "unknown1",         "Unknown 1",    DATA_INT,    unknown1,
-                "unknown2",         "Unknown 2",    DATA_INT,    unknown2,
-                "temperature_C",    "Temperature",  DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp * 0.1f,
-                "humidity",         "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, hum,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",             NULL,         "Mebus-433");
+        data = data_int(data, "id",               "Address",      NULL,         address);
+        data = data_int(data, "channel",          "Channel",      NULL,         channel);
+        data = data_int(data, "battery_ok",       "Battery",      NULL,         !!battery);
+        data = data_int(data, "unknown1",         "Unknown 1",    NULL,         unknown1);
+        data = data_int(data, "unknown2",         "Unknown 2",    NULL,         unknown2);
+        data = data_dbl(data, "temperature_C",    "Temperature",  "%.2f C",     temp * 0.1f);
+        data = data_int(data, "humidity",         "Humidity",     "%u %%",      hum);
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/megacode.c
+++ b/src/devices/megacode.c
@@ -68,13 +68,12 @@ static int megacode_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     int button   = raw & 0x7;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",    "",               DATA_STRING, "Megacode-Remote",
-            "id",       "Transmitter ID", DATA_INT,    id,
-            "raw",      "Raw",            DATA_FORMAT, "%06X", DATA_INT, raw,
-            "facility", "Facility Code",  DATA_INT,    facility,
-            "button",   "Button",         DATA_INT,    button,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",    "",               NULL,         "Megacode-Remote");
+    data = data_int(data, "id",       "Transmitter ID", NULL,         id);
+    data = data_int(data, "raw",      "Raw",            "%06X",       raw);
+    data = data_int(data, "facility", "Facility Code",  NULL,         facility);
+    data = data_int(data, "button",   "Button",         NULL,         button);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/missil_ml0757.c
+++ b/src/devices/missil_ml0757.c
@@ -106,23 +106,21 @@ static int missil_ml0757_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     if (flag_rwp) { // Rainwall and wind
         /* clang-format off */
-        data = data_make(
-                "model",            "",             DATA_STRING, "Missil-ML0757",
-                "id",               "ID",           DATA_INT,    id,
-                "battery_ok",       "Battery",      DATA_INT,    !flag_bat,
-                "rain_mm",          "Total rain",   DATA_FORMAT, "%.2f mm", DATA_DOUBLE, rainfall,
-                "wind_avg_km_h",    "Wind speed",   DATA_FORMAT, "%.2f km/h", DATA_DOUBLE, wind_kph,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",             NULL,         "Missil-ML0757");
+        data = data_int(data, "id",               "ID",           NULL,         id);
+        data = data_int(data, "battery_ok",       "Battery",      NULL,         !flag_bat);
+        data = data_dbl(data, "rain_mm",          "Total rain",   "%.2f mm",    rainfall);
+        data = data_dbl(data, "wind_avg_km_h",    "Wind speed",   "%.2f km/h",  wind_kph);
         /* clang-format on */
     }
     else { // Temperature
         /* clang-format off */
-        data = data_make(
-                "model",            "",             DATA_STRING, "Missil-ML0757",
-                "id",               "ID",           DATA_INT,    id,
-                "battery_ok",       "Battery",      DATA_INT,    !flag_bat,
-                "temperature_C",    "Temperature",  DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",             NULL,         "Missil-ML0757");
+        data = data_int(data, "id",               "ID",           NULL,         id);
+        data = data_int(data, "battery_ok",       "Battery",      NULL,         !flag_bat);
+        data = data_dbl(data, "temperature_C",    "Temperature",  "%.2f C",     temp_c);
         /* clang-format on */
     }
 

--- a/src/devices/mueller_hotrod.c
+++ b/src/devices/mueller_hotrod.c
@@ -89,13 +89,12 @@ static int mueller_hotrod_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int flag   = b[7] & 0x0f;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",       "",          DATA_STRING, "Mueller-HotRod",
-            "id",          "",          DATA_STRING, id_str,
-            "volume_gal",  "Volume",    DATA_FORMAT, "%u gal", DATA_INT, volume,
-            "flag",        "Flag",      DATA_FORMAT, "%x", DATA_INT, flag,
-            "mic",         "Integrity", DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",       "",          NULL,         "Mueller-HotRod");
+    data = data_str(data, "id",          "",          NULL,         id_str);
+    data = data_int(data, "volume_gal",  "Volume",    "%u gal",     volume);
+    data = data_int(data, "flag",        "Flag",      "%x",         flag);
+    data = data_str(data, "mic",         "Integrity", NULL,         "CRC");
     /* clang-format on */
     decoder_output_data(decoder, data);
     return 1;

--- a/src/devices/neptune_r900.c
+++ b/src/devices/neptune_r900.c
@@ -187,19 +187,18 @@ static int neptune_r900_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     snprintf(extra, sizeof(extra),"%02x%02x%02x", b[10], b[11], b[12]);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",       "",    DATA_STRING, "Neptune-R900",
-            "id",          "",    DATA_INT,    meter_id,
-            "unkn1",       "",    DATA_INT,    unkn1,
-            "unkn2",       "",    DATA_INT,    unkn2,
-            "nouse",       "",    DATA_INT,    nouse,
-            "backflow",    "",    DATA_INT,    backflow,
-            "consumption", "",    DATA_INT,    consumption,
-            "unkn3",       "",    DATA_INT,    unkn3,
-            "leak",        "",    DATA_INT,    leak,
-            "leaknow",     "",    DATA_INT,    leaknow,
-            "extra",       "",    DATA_STRING, extra,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",       "",    NULL,         "Neptune-R900");
+    data = data_int(data, "id",          "",    NULL,         meter_id);
+    data = data_int(data, "unkn1",       "",    NULL,         unkn1);
+    data = data_int(data, "unkn2",       "",    NULL,         unkn2);
+    data = data_int(data, "nouse",       "",    NULL,         nouse);
+    data = data_int(data, "backflow",    "",    NULL,         backflow);
+    data = data_int(data, "consumption", "",    NULL,         consumption);
+    data = data_int(data, "unkn3",       "",    NULL,         unkn3);
+    data = data_int(data, "leak",        "",    NULL,         leak);
+    data = data_int(data, "leaknow",     "",    NULL,         leaknow);
+    data = data_str(data, "extra",       "",    NULL,         extra);
     /* clang-format on */
     decoder_output_data(decoder, data);
 

--- a/src/devices/new_template.c
+++ b/src/devices/new_template.c
@@ -237,12 +237,11 @@ static int new_template_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data = data_make(
-            "model", "", DATA_STRING, "New-Template",
-            "id",    "", DATA_INT,    sensor_id,
-            "data",  "", DATA_INT,    value,
-            "mic",   "", DATA_STRING, "CHECKSUM", // CRC, CHECKSUM, or PARITY
-            NULL);
+    data = NULL;
+    data = data_str(data, "model", "", NULL,         "New-Template");
+    data = data_int(data, "id",    "", NULL,         sensor_id);
+    data = data_int(data, "data",  "", NULL,         value);
+    data = data_str(data, "mic",   "", NULL,         "CHECKSUM"); // CRC, CHECKSUM, or PARITY
     /* clang-format on */
     decoder_output_data(decoder, data);
 

--- a/src/devices/newkaku.c
+++ b/src/devices/newkaku.c
@@ -55,15 +55,14 @@ static int newkaku_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     uint32_t dv        = (b[4] >> 4);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",        "",             DATA_STRING, "KlikAanKlikUit-Switch",
-            "id",           "",             DATA_INT,    id,
-            "unit",         "Unit",         DATA_INT,    unit,
-            "group_call",   "Group Call",   DATA_STRING, group_cmd ? "Yes" : "No",
-            "command",      "Command",      DATA_STRING, on_bit ? "On" : "Off",
-            "dim",          "Dim",          DATA_STRING, dim_cmd ? "Yes" : "No",
-            "dim_value",    "Dim Value",    DATA_INT,    dv,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",        "",             NULL,         "KlikAanKlikUit-Switch");
+    data = data_int(data, "id",           "",             NULL,         id);
+    data = data_int(data, "unit",         "Unit",         NULL,         unit);
+    data = data_str(data, "group_call",   "Group Call",   NULL,         group_cmd ? "Yes" : "No");
+    data = data_str(data, "command",      "Command",      NULL,         on_bit ? "On" : "Off");
+    data = data_str(data, "dim",          "Dim",          NULL,         dim_cmd ? "Yes" : "No");
+    data = data_int(data, "dim_value",    "Dim Value",    NULL,         dv);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/nexa.c
+++ b/src/devices/nexa.c
@@ -55,14 +55,13 @@ static int nexa_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     uint32_t unit      = (b[3] & 0x03) ^ 0x03;        // inverted
 
     /* clang-format off */
-    data = data_make(
-            "model",         "",            DATA_STRING, "Nexa-Security",
-            "id",            "House Code",  DATA_INT,    id,
-            "channel",       "Channel",     DATA_INT,    channel,
-            "state",         "State",       DATA_STRING, on_bit ? "ON" : "OFF",
-            "unit",          "Unit",        DATA_INT,    unit,
-            "group",         "Group",       DATA_INT,    group_cmd,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",         "",            NULL,         "Nexa-Security");
+    data = data_int(data, "id",            "House Code",  NULL,         id);
+    data = data_int(data, "channel",       "Channel",     NULL,         channel);
+    data = data_str(data, "state",         "State",       NULL,         on_bit ? "ON" : "OFF");
+    data = data_int(data, "unit",          "Unit",        NULL,         unit);
+    data = data_int(data, "group",         "Group",       NULL,         group_cmd);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -77,25 +77,23 @@ static int nexus_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     if (humidity == 0x00) { // Thermo
         /* clang-format off */
-        data = data_make(
-                "model",         "",            DATA_STRING, "Nexus-T",
-                "id",            "House Code",  DATA_INT,    id,
-                "channel",       "Channel",     DATA_INT,    channel,
-                "battery_ok",    "Battery",     DATA_INT,    !!battery,
-                "temperature_C", "Temperature", DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",         "",            NULL,         "Nexus-T");
+        data = data_int(data, "id",            "House Code",  NULL,         id);
+        data = data_int(data, "channel",       "Channel",     NULL,         channel);
+        data = data_int(data, "battery_ok",    "Battery",     NULL,         !!battery);
+        data = data_dbl(data, "temperature_C", "Temperature", "%.2f C",     temp_c);
         /* clang-format on */
     }
     else { // Thermo/Hygro
         /* clang-format off */
-        data = data_make(
-                "model",         "",            DATA_STRING, "Nexus-TH",
-                "id",            "House Code",  DATA_INT,    id,
-                "channel",       "Channel",     DATA_INT,    channel,
-                "battery_ok",    "Battery",     DATA_INT,    !!battery,
-                "temperature_C", "Temperature", DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-                "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, humidity,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",         "",            NULL,         "Nexus-TH");
+        data = data_int(data, "id",            "House Code",  NULL,         id);
+        data = data_int(data, "channel",       "Channel",     NULL,         channel);
+        data = data_int(data, "battery_ok",    "Battery",     NULL,         !!battery);
+        data = data_dbl(data, "temperature_C", "Temperature", "%.2f C",     temp_c);
+        data = data_int(data, "humidity",      "Humidity",    "%u %%",      humidity);
         /* clang-format on */
     }
 

--- a/src/devices/nice_flor_s.c
+++ b/src/devices/nice_flor_s.c
@@ -50,13 +50,12 @@ static int nice_flor_s_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     uint16_t code = (b[1] << 12) | (b[2] << 4) | (b[3] >> 4);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",  "",              DATA_STRING, "Nice-FlorS",
-            "button", "Button ID",     DATA_INT,     button_id,
-            "serial", "Serial (enc.)", DATA_FORMAT, "%07x",        DATA_INT, serial,
-            "code",   "Code (enc.)",   DATA_FORMAT, "%04x",        DATA_INT, code,
-            "count",  "",              DATA_INT,     count,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",  "",              NULL,         "Nice-FlorS");
+    data = data_int(data, "button", "Button ID",     NULL,         button_id);
+    data = data_int(data, "serial", "Serial (enc.)", "%07x",       serial);
+    data = data_int(data, "code",   "Code (enc.)",   "%04x",       code);
+    data = data_int(data, "count",  "",              NULL,         count);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/norgo.c
+++ b/src/devices/norgo.c
@@ -164,13 +164,12 @@ static int norgo_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
         impulse_gap = (b[2] >> 4) | (b[3] << 4) | ((b[4] & 0x7F) << 12);
         /* clang-format off */
-        data = data_make(
-                "model",        "",             DATA_STRING, "Norgo-NGE101",
-                "id",           "Device ID",    DATA_INT,    device_id,
-                "channel",      "Channel",      DATA_INT,    channel,
-                "gap",          "Impulse gap",  DATA_INT,    impulse_gap,
-                "mic",          "Integrity",    DATA_STRING, "CRC",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",        "",             NULL,         "Norgo-NGE101");
+        data = data_int(data, "id",           "Device ID",    NULL,         device_id);
+        data = data_int(data, "channel",      "Channel",      NULL,         channel);
+        data = data_int(data, "gap",          "Impulse gap",  NULL,         impulse_gap);
+        data = data_str(data, "mic",          "Integrity",    NULL,         "CRC");
         /* clang-format on */
 
         decoder_output_data(decoder, data);
@@ -193,14 +192,13 @@ static int norgo_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         // should be enough for the duration of battery.
 
         /* clang-format off */
-        data = data_make(
-                "model",        "",             DATA_STRING, "Norgo-NGE101",
-                "id",           "Id",           DATA_INT,    device_id,
-                "channel",      "Channel",      DATA_INT,    channel,
-                "impulses",     "Impulses",     DATA_INT,    (uint32_t)impulses,
-                "battery_ok",   "Battery",      DATA_INT,    !low_battery,
-                "mic",          "Integrity",    DATA_STRING, "CRC",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",        "",             NULL,         "Norgo-NGE101");
+        data = data_int(data, "id",           "Id",           NULL,         device_id);
+        data = data_int(data, "channel",      "Channel",      NULL,         channel);
+        data = data_int(data, "impulses",     "Impulses",     NULL,         (uint32_t)impulses);
+        data = data_int(data, "battery_ok",   "Battery",      NULL,         !low_battery);
+        data = data_str(data, "mic",          "Integrity",    NULL,         "CRC");
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/oil_smart.c
+++ b/src/devices/oil_smart.c
@@ -89,14 +89,13 @@ static int oil_smart_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned 
     uint16_t depth = b[6];
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Oil-Ultrasonic",
-            "id",               "",             DATA_FORMAT, "%04x", DATA_INT, unit_id,
-            "depth_cm",         "Depth",        DATA_INT,    depth,
-            "unknown_1",        "Unknown 1",    DATA_FORMAT, "%02x", DATA_INT, unknown1,
-            "unknown_2",        "Unknown 2",    DATA_FORMAT, "%02x", DATA_INT, unknown2,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Oil-Ultrasonic");
+    data = data_int(data, "id",               "",             "%04x",       unit_id);
+    data = data_int(data, "depth_cm",         "Depth",        NULL,         depth);
+    data = data_int(data, "unknown_1",        "Unknown 1",    "%02x",       unknown1);
+    data = data_int(data, "unknown_2",        "Unknown 2",    "%02x",       unknown2);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/oil_standard.c
+++ b/src/devices/oil_standard.c
@@ -81,14 +81,13 @@ static int oil_standard_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     }
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",                "", DATA_STRING, "Oil-SonicStd",
-            "id",                   "", DATA_FORMAT, "%04x", DATA_INT, unit_id,
-            "flags",                "", DATA_FORMAT, "%02x", DATA_INT, flags,
-            "alarm",                "", DATA_INT,    alarm,
-            "binding_countdown",    "", DATA_INT,    binding_countdown,
-            "depth_cm",             "", DATA_INT,    depth,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",                "", NULL,         "Oil-SonicStd");
+    data = data_int(data, "id",                   "", "%04x",       unit_id);
+    data = data_int(data, "flags",                "", "%02x",       flags);
+    data = data_int(data, "alarm",                "", NULL,         alarm);
+    data = data_int(data, "binding_countdown",    "", NULL,         binding_countdown);
+    data = data_int(data, "depth_cm",             "", NULL,         depth);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/oil_watchman.c
+++ b/src/devices/oil_watchman.c
@@ -81,15 +81,14 @@ static int oil_watchman_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         }
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",                "", DATA_STRING, "Oil-SonicSmart",
-                "id",                   "", DATA_FORMAT, "%06x", DATA_INT, unit_id,
-                "flags",                "", DATA_FORMAT, "%02x", DATA_INT, flags,
-                "maybetemp",            "", DATA_INT,    maybetemp,
-                "temperature_C",        "", DATA_DOUBLE, temperature,
-                "binding_countdown",    "", DATA_INT,    binding_countdown,
-                "depth_cm",             "", DATA_INT,    depth,
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",                "", NULL,         "Oil-SonicSmart");
+        data = data_int(data, "id",                   "", "%06x",       unit_id);
+        data = data_int(data, "flags",                "", "%02x",       flags);
+        data = data_int(data, "maybetemp",            "", NULL,         maybetemp);
+        data = data_dbl(data, "temperature_C",        "", NULL,         temperature);
+        data = data_int(data, "binding_countdown",    "", NULL,         binding_countdown);
+        data = data_int(data, "depth_cm",             "", NULL,         depth);
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/oil_watchman_advanced.c
+++ b/src/devices/oil_watchman_advanced.c
@@ -84,14 +84,13 @@ static int oil_watchman_advanced_decode(r_device *decoder, bitbuffer_t *bitbuffe
         uint8_t depth     = b[10];
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",                "Model",        DATA_STRING, "Oil-SonicAdv",
-                "id",                   "ID",           DATA_FORMAT, "%08d", DATA_INT, serial,
-                "temperature_C",        "Temperature",  DATA_DOUBLE, temperature,
-                "depth_cm",             "Depth",        DATA_INT,    depth,
-                "status",               "Status",       DATA_FORMAT, "%02x", DATA_INT, status,
-                "mic",                  "Integrity",    DATA_STRING, "CRC",
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",                "Model",        NULL,         "Oil-SonicAdv");
+        data = data_int(data, "id",                   "ID",           "%08d",       serial);
+        data = data_dbl(data, "temperature_C",        "Temperature",  NULL,         temperature);
+        data = data_int(data, "depth_cm",             "Depth",        NULL,         depth);
+        data = data_int(data, "status",               "Status",       "%02x",       status);
+        data = data_str(data, "mic",                  "Integrity",    NULL,         "CRC");
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/opus_xt300.c
+++ b/src/devices/opus_xt300.c
@@ -80,13 +80,12 @@ static int opus_xt300_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         }
 
         /* clang-format off */
-        data = data_make(
-            "model",            "",             DATA_STRING, "Opus-XT300",
-            "channel",          "Channel",      DATA_INT,    channel,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.0f C", DATA_DOUBLE, (double)temp,
-            "moisture",         "Moisture",     DATA_FORMAT, "%d %%", DATA_INT, moisture,
-            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",             NULL,         "Opus-XT300");
+        data = data_int(data, "channel",          "Channel",      NULL,         channel);
+        data = data_dbl(data, "temperature_C",    "Temperature",  "%.0f C",     (double)temp);
+        data = data_int(data, "moisture",         "Moisture",     "%d %%",      moisture);
+        data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -248,14 +248,13 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         if (validate_os_v2_message(decoder, msg, 76, msg_bits, 15) != 0)
             return 0;
         /* clang-format off */
-        data = data_make(
-                "model",                 "",                        DATA_STRING, (sensor_id == ID_THGR122N) ? "Oregon-THGR122N" : "Oregon-THGR968",
-                "id",                        "House Code",    DATA_INT,        device_id,
-                "channel",             "Channel",         DATA_INT,        channel,
-                "battery_ok",          "Battery",         DATA_INT,    !battery_low,
-                "temperature_C", "Temperature", DATA_FORMAT, "%.2f C", DATA_DOUBLE, get_os_temperature(msg),
-                "humidity",            "Humidity",        DATA_FORMAT, "%u %%",     DATA_INT,        get_os_humidity(msg),
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",                 "",                        NULL,         (sensor_id == ID_THGR122N) ? "Oregon-THGR122N" : "Oregon-THGR968");
+        data = data_int(data, "id",                        "House Code",    NULL,         device_id);
+        data = data_int(data, "channel",             "Channel",         NULL,         channel);
+        data = data_int(data, "battery_ok",          "Battery",         NULL,         !battery_low);
+        data = data_dbl(data, "temperature_C", "Temperature", "%.2f C",     get_os_temperature(msg));
+        data = data_int(data, "humidity",            "Humidity",        "%u %%",      get_os_humidity(msg));
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -267,15 +266,14 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         float avgWindspeed  = ((msg[7] >> 4) & 0x0f) / 10.0F + (msg[7] & 0x0f) * 1.0F + ((msg[8] >> 4) & 0x0f) / 10.0F;
         float gustWindspeed = (msg[5] & 0x0f) / 10.0F + ((msg[6] >> 4) & 0x0f) * 1.0F + (msg[6] & 0x0f) / 10.0F;
         /* clang-format off */
-        data = data_make(
-                "model",            "",                     DATA_STRING, "Oregon-WGR968",
-                "id",                 "House Code", DATA_INT,        device_id,
-                "channel",        "Channel",        DATA_INT,        channel,
-                "battery_ok",          "Battery",         DATA_INT,    !battery_low,
-                "wind_max_m_s", "Gust",             DATA_FORMAT, "%.1f m/s",DATA_DOUBLE, gustWindspeed,
-                "wind_avg_m_s", "Average",        DATA_FORMAT, "%.1f m/s",DATA_DOUBLE, avgWindspeed,
-                "wind_dir_deg",    "Direction",    DATA_FORMAT, "%.1f degrees",DATA_DOUBLE, quadrant,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                     NULL,         "Oregon-WGR968");
+        data = data_int(data, "id",                 "House Code", NULL,         device_id);
+        data = data_int(data, "channel",        "Channel",        NULL,         channel);
+        data = data_int(data, "battery_ok",          "Battery",         NULL,         !battery_low);
+        data = data_dbl(data, "wind_max_m_s", "Gust",             "%.1f m/s",   gustWindspeed);
+        data = data_dbl(data, "wind_avg_m_s", "Average",        "%.1f m/s",   avgWindspeed);
+        data = data_dbl(data, "wind_dir_deg",    "Direction",    "%.1f degrees",quadrant);
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -298,15 +296,14 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         // decoder_logf(decoder, 0, __func__,"Weather Sensor BHTR968    Indoor        Temp: %.1fC    %.1fF     Humidity: %d%%", temp_c, ((temp_c*9)/5)+32, get_os_humidity(msg));
         // decoder_logf(decoder, 0, __func__, " (%s) Pressure: %dmbar (%s)", comfort_str, ((msg[7] & 0x0f) | (msg[8] & 0xf0))+856, forecast_str);
         /* clang-format off */
-        data = data_make(
-                "model",            "",                             DATA_STRING, "Oregon-BHTR968",
-                "id",                 "House Code",         DATA_INT,        device_id,
-                "channel",        "Channel",                DATA_INT,        channel,
-                "battery_ok",          "Battery",         DATA_INT,    !battery_low,
-                "temperature_C",    "Celsius",        DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-                "humidity",     "Humidity",             DATA_FORMAT, "%u %%",     DATA_INT,        get_os_humidity(msg),
-                "pressure_hPa",    "Pressure",        DATA_FORMAT, "%.0f hPa",     DATA_DOUBLE, pressure,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                             NULL,         "Oregon-BHTR968");
+        data = data_int(data, "id",                 "House Code",         NULL,         device_id);
+        data = data_int(data, "channel",        "Channel",                NULL,         channel);
+        data = data_int(data, "battery_ok",          "Battery",         NULL,         !battery_low);
+        data = data_dbl(data, "temperature_C",    "Celsius",        "%.2f C",     temp_c);
+        data = data_int(data, "humidity",     "Humidity",             "%u %%",      get_os_humidity(msg));
+        data = data_dbl(data, "pressure_hPa",    "Pressure",        "%.0f hPa",   pressure);
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -318,15 +315,14 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         float temp_c = get_os_temperature(msg);
         float pressure = ((msg[7] & 0x0f) | (msg[8] & 0xf0)) + 795;
         /* clang-format off */
-        data = data_make(
-                "model",            "",                 DATA_STRING,    "Oregon-BTHR918",
-                "id",               "House Code",       DATA_INT,       device_id,
-                "channel",          "Channel",          DATA_INT,       channel,
-                "battery_ok",       "Battery",          DATA_INT,       !battery_low,
-                "temperature_C",    "Celsius",          DATA_FORMAT,    "%.2f C", DATA_DOUBLE, temp_c,
-                "humidity",         "Humidity",         DATA_FORMAT,    "%u %%", DATA_INT, get_os_humidity(msg),
-                "pressure_hPa",     "Pressure",         DATA_FORMAT,    "%.0f hPa", DATA_DOUBLE, pressure,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                 NULL,         "Oregon-BTHR918");
+        data = data_int(data, "id",               "House Code",       NULL,         device_id);
+        data = data_int(data, "channel",          "Channel",          NULL,         channel);
+        data = data_int(data, "battery_ok",       "Battery",          NULL,         !battery_low);
+        data = data_dbl(data, "temperature_C",    "Celsius",          "%.2f C",     temp_c);
+        data = data_int(data, "humidity",         "Humidity",         "%u %%",      get_os_humidity(msg));
+        data = data_dbl(data, "pressure_hPa",     "Pressure",         "%.0f hPa",   pressure);
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -337,14 +333,13 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         float rain_rate  = ((msg[4] & 0x0f) * 100 + (msg[4] >> 4) * 10 + ((msg[5] >> 4) & 0x0f)) / 10.0F;
         float total_rain = ((msg[7] & 0xf) * 10000 + (msg[7] >> 4) * 1000 + (msg[6] & 0xf) * 100 + (msg[6] >> 4) * 10 + (msg[5] & 0xf)) / 10.0F;
         /* clang-format off */
-        data = data_make(
-                "model",            "",                     DATA_STRING, "Oregon-RGR968",
-                "id",                 "House Code", DATA_INT,        device_id,
-                "channel",        "Channel",        DATA_INT,        channel,
-                "battery_ok",          "Battery",         DATA_INT,    !battery_low,
-                "rain_rate_mm_h",    "Rain Rate",    DATA_FORMAT, "%.2f mm/h", DATA_DOUBLE, rain_rate,
-                "rain_mm", "Total Rain", DATA_FORMAT, "%.2f mm", DATA_DOUBLE, total_rain,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                     NULL,         "Oregon-RGR968");
+        data = data_int(data, "id",                 "House Code", NULL,         device_id);
+        data = data_int(data, "channel",        "Channel",        NULL,         channel);
+        data = data_int(data, "battery_ok",          "Battery",         NULL,         !battery_low);
+        data = data_dbl(data, "rain_rate_mm_h",    "Rain Rate",    "%.2f mm/h",  rain_rate);
+        data = data_dbl(data, "rain_mm", "Total Rain", "%.2f mm",    total_rain);
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -354,14 +349,17 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
             return 0;
         float temp_c = get_os_temperature(msg);
         /* clang-format off */
-        data = data_make(
-                "model", "", DATA_COND, sensor_id == ID_THR228N, DATA_STRING, "Oregon-THR228N",
-                "model", "", DATA_COND, sensor_id == ID_AWR129, DATA_STRING, "Oregon-AWR129",
-                "id",                        "House Code",    DATA_INT,        device_id,
-                "channel",             "Channel",         DATA_INT,        channel,
-                "battery_ok",          "Battery",         DATA_INT,    !battery_low,
-                "temperature_C",    "Celsius",        DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-                NULL);
+        data = NULL;
+        if (sensor_id == ID_THR228N) {
+            data = data_str(data, "model", "", NULL,         "Oregon-THR228N");
+        }
+        if (sensor_id == ID_AWR129) {
+            data = data_str(data, "model", "", NULL,         "Oregon-AWR129");
+        }
+        data = data_int(data, "id",                        "House Code",    NULL,         device_id);
+        data = data_int(data, "channel",             "Channel",         NULL,         channel);
+        data = data_int(data, "battery_ok",          "Battery",         NULL,         !battery_low);
+        data = data_dbl(data, "temperature_C",    "Celsius",        "%.2f C",     temp_c);
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -382,13 +380,12 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         }
 
         /* clang-format off */
-        data = data_make(
-                "model",                 "",                        DATA_STRING, "Oregon-THN132N",
-                "id",                        "House Code",    DATA_INT,        device_id,
-                "channel",             "Channel",         DATA_INT,        channel,
-                "battery_ok",          "Battery",         DATA_INT,    !battery_low,
-                "temperature_C",    "Celsius",        DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",                 "",                        NULL,         "Oregon-THN132N");
+        data = data_int(data, "id",                        "House Code",    NULL,         device_id);
+        data = data_int(data, "channel",             "Channel",         NULL,         channel);
+        data = data_int(data, "battery_ok",          "Battery",         NULL,         !battery_low);
+        data = data_dbl(data, "temperature_C",    "Celsius",        "%.2f C",     temp_c);
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -398,14 +395,13 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
             return 0;
         float temp_c = get_os_temperature(msg);
         /* clang-format off */
-        data = data_make(
-                "model",                 "",                        DATA_STRING, "Oregon-RTGN129",
-                "id",                        "House Code",    DATA_INT,        device_id,
-                "channel",             "Channel",         DATA_INT,        channel, // 1 to 5
-                "battery_ok",          "Battery",         DATA_INT,    !battery_low,
-                "temperature_C",    "Celsius",        DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-                "humidity",            "Humidity",        DATA_FORMAT, "%u %%",     DATA_INT,        get_os_humidity(msg),
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",                 "",                        NULL,         "Oregon-RTGN129");
+        data = data_int(data, "id",                        "House Code",    NULL,         device_id);
+        data = data_int(data, "channel",             "Channel",         NULL,         channel); // 1 to 5
+        data = data_int(data, "battery_ok",          "Battery",         NULL,         !battery_low);
+        data = data_dbl(data, "temperature_C",    "Celsius",        "%.2f C",     temp_c);
+        data = data_int(data, "humidity",            "Humidity",        "%u %%",      get_os_humidity(msg));
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -414,14 +410,13 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         if (validate_os_v2_message(decoder, msg, 173, msg_bits, 15) != 0)
              return 0;
         /* clang-format off */
-        data = data_make(
-                "model",            "",             DATA_STRING, "Oregon-RTGR328N",
-                "id",               "House Code",   DATA_INT,    device_id,
-                "channel",          "Channel",      DATA_INT,    channel, // 1 to 5
-                "battery_ok",          "Battery",         DATA_INT,    !battery_low,
-                "temperature_C",    "Temperature",  DATA_FORMAT, "%.2f C", DATA_DOUBLE, get_os_temperature(msg),
-                "humidity",         "Humidity",     DATA_FORMAT, "%u %%",   DATA_INT,    get_os_humidity(msg),
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",             NULL,         "Oregon-RTGR328N");
+        data = data_int(data, "id",               "House Code",   NULL,         device_id);
+        data = data_int(data, "channel",          "Channel",      NULL,         channel); // 1 to 5
+        data = data_int(data, "battery_ok",          "Battery",         NULL,         !battery_low);
+        data = data_dbl(data, "temperature_C",    "Temperature",  "%.2f C",     get_os_temperature(msg));
+        data = data_int(data, "humidity",         "Humidity",     "%u %%",      get_os_humidity(msg));
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -443,13 +438,12 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
                 year, month, day, hours, minutes, seconds);
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",             DATA_STRING, "Oregon-RTGR328N",
-                "id",               "House Code",   DATA_INT,    device_id,
-                "channel",          "Channel",      DATA_INT,    channel, // 1 to 5
-                "battery_ok",          "Battery",         DATA_INT,    !battery_low,
-                "radio_clock",      "Radio Clock",  DATA_STRING, clock_str,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",             NULL,         "Oregon-RTGR328N");
+        data = data_int(data, "id",               "House Code",   NULL,         device_id);
+        data = data_int(data, "channel",          "Channel",      NULL,         channel); // 1 to 5
+        data = data_int(data, "battery_ok",          "Battery",         NULL,         !battery_low);
+        data = data_str(data, "radio_clock",      "Radio Clock",  NULL,         clock_str);
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -458,14 +452,13 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         if (msg_bits == 76 && (validate_os_v2_message(decoder, msg, 76, msg_bits, 15) == 0)) {
             float temp_c = get_os_temperature(msg);
             /* clang-format off */
-            data = data_make(
-                    "model",                 "",                        DATA_STRING, "Oregon-RTGN318",
-                    "id",                        "House Code",    DATA_INT,        device_id,
-                    "channel",             "Channel",         DATA_INT,        channel, // 1 to 5
-                    "battery_ok",          "Battery",         DATA_INT,    !battery_low,
-                    "temperature_C",    "Celsius",        DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-                    "humidity",            "Humidity",        DATA_FORMAT, "%u %%",     DATA_INT,        get_os_humidity(msg),
-                    NULL);
+            data = NULL;
+            data = data_str(data, "model",                 "",                        NULL,         "Oregon-RTGN318");
+            data = data_int(data, "id",                        "House Code",    NULL,         device_id);
+            data = data_int(data, "channel",             "Channel",         NULL,         channel); // 1 to 5
+            data = data_int(data, "battery_ok",          "Battery",         NULL,         !battery_low);
+            data = data_dbl(data, "temperature_C",    "Celsius",        "%.2f C",     temp_c);
+            data = data_int(data, "humidity",            "Humidity",        "%u %%",      get_os_humidity(msg));
             /* clang-format on */
             decoder_output_data(decoder, data);
             return 1;
@@ -479,13 +472,12 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         if ((validate_os_v2_message(decoder, msg, 68, msg_bits, 12) == 0)) {
             float temp_c = get_os_temperature(msg);
             /* clang-format off */
-            data = data_make(
-                    "model",                 "",                        DATA_STRING, (sensor_id == ID_THN129) ? "Oregon-THN129" : "Oregon-RTHN129",
-                    "id",                        "House Code",    DATA_INT,        device_id,
-                    "channel",             "Channel",         DATA_INT,        channel, // 1 to 5
-                "battery_ok",          "Battery",         DATA_INT,    !battery_low,
-                    "temperature_C",    "Celsius",        DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-                    NULL);
+            data = NULL;
+            data = data_str(data, "model",                 "",                        NULL,         (sensor_id == ID_THN129) ? "Oregon-THN129" : "Oregon-RTHN129");
+            data = data_int(data, "id",                        "House Code",    NULL,         device_id);
+            data = data_int(data, "channel",             "Channel",         NULL,         channel); // 1 to 5
+            data = data_int(data, "battery_ok",          "Battery",         NULL,         !battery_low);
+            data = data_dbl(data, "temperature_C",    "Celsius",        "%.2f C",     temp_c);
             /* clang-format on */
             decoder_output_data(decoder, data);
             return 1;
@@ -513,15 +505,14 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         // according to your altitude level (600 is a good starting point)
         float pressure = ((msg[7] & 0x0f) | (msg[8] & 0xf0)) * 2 + (msg[8] & 0x01) + 600;
         /* clang-format off */
-        data = data_make(
-                "model",                 "",                        DATA_STRING, "Oregon-BTHGN129",
-                "id",                        "House Code",    DATA_INT,        device_id,
-                "channel",             "Channel",         DATA_INT,        channel, // 1 to 5
-                "battery_ok",          "Battery",         DATA_INT,    !battery_low,
-                "temperature_C",    "Celsius",        DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-                "humidity",             "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, get_os_humidity(msg),
-                "pressure_hPa",    "Pressure",        DATA_FORMAT, "%.2f hPa", DATA_DOUBLE, pressure,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",                 "",                        NULL,         "Oregon-BTHGN129");
+        data = data_int(data, "id",                        "House Code",    NULL,         device_id);
+        data = data_int(data, "channel",             "Channel",         NULL,         channel); // 1 to 5
+        data = data_int(data, "battery_ok",          "Battery",         NULL,         !battery_low);
+        data = data_dbl(data, "temperature_C",    "Celsius",        "%.2f C",     temp_c);
+        data = data_int(data, "humidity",             "Humidity",     "%u %%",      get_os_humidity(msg));
+        data = data_dbl(data, "pressure_hPa",    "Pressure",        "%.2f hPa",   pressure);
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -542,13 +533,12 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         }
 
         /* clang-format off */
-        data = data_make(
-                "model",                    "",                     DATA_STRING, "Oregon-UVR128",
-                "id",                         "House Code", DATA_INT,        device_id,
-                "uv",                         "UV Index",     DATA_FORMAT, "%u", DATA_INT, uvidx,
-                "battery_ok",          "Battery",         DATA_INT,    !battery_low,
+        data = NULL;
+        data = data_str(data, "model",                    "",                     NULL,         "Oregon-UVR128");
+        data = data_int(data, "id",                         "House Code", NULL,         device_id);
+        data = data_int(data, "uv",                         "UV Index",     "%u",         uvidx);
+        data = data_int(data, "battery_ok",          "Battery",         NULL,         !battery_low);
                 //"channel",                "Channel",        DATA_INT,        channel,
-                NULL);
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -557,14 +547,13 @@ static int oregon_scientific_v2_1_decode(r_device *decoder, bitbuffer_t *bitbuff
         if (validate_os_v2_message(decoder, msg, 173, msg_bits, 15) != 0)
             return 0;
         /* clang-format off */
-        data = data_make(
-                "model",            "",             DATA_STRING, "Oregon-THGR328N",
-                "id",               "House Code",   DATA_INT,    device_id,
-                "channel",          "Channel",      DATA_INT,    channel, // 1 to 5
-                "battery_ok",          "Battery",         DATA_INT,    !battery_low,
-                "temperature_C",    "Temperature",  DATA_FORMAT, "%.2f C", DATA_DOUBLE, get_os_temperature(msg),
-                "humidity",         "Humidity",     DATA_FORMAT, "%u %%",   DATA_INT,    get_os_humidity(msg),
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",             NULL,         "Oregon-THGR328N");
+        data = data_int(data, "id",               "House Code",   NULL,         device_id);
+        data = data_int(data, "channel",          "Channel",      NULL,         channel); // 1 to 5
+        data = data_int(data, "battery_ok",          "Battery",         NULL,         !battery_low);
+        data = data_dbl(data, "temperature_C",    "Temperature",  "%.2f C",     get_os_temperature(msg));
+        data = data_int(data, "humidity",         "Humidity",     "%u %%",      get_os_humidity(msg));
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -672,14 +661,13 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
             return DECODE_FAIL_SANITY;
         }
         /* clang-format off */
-        data = data_make(
-                "model",                    "",                     DATA_STRING, "Oregon-THGR810",
-                "id",                         "House Code", DATA_INT,        device_id,
-                "channel",                "Channel",        DATA_INT,        channel,
-                "battery_ok",          "Battery",         DATA_INT,    !battery_low,
-                "temperature_C",    "Celsius",        DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-                "humidity",             "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, humidity,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",                    "",                     NULL,         "Oregon-THGR810");
+        data = data_int(data, "id",                         "House Code", NULL,         device_id);
+        data = data_int(data, "channel",                "Channel",        NULL,         channel);
+        data = data_int(data, "battery_ok",          "Battery",         NULL,         !battery_low);
+        data = data_dbl(data, "temperature_C",    "Celsius",        "%.2f C",     temp_c);
+        data = data_int(data, "humidity",             "Humidity",     "%u %%",      humidity);
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;                                    //msg[k] = ((msg[k] & 0x0F) << 4) + ((msg[k] & 0xF0) >> 4);
@@ -689,13 +677,12 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
             return DECODE_FAIL_MIC;
         float temp_c = get_os_temperature(msg);
         /* clang-format off */
-        data = data_make(
-                "model",                    "",                     DATA_STRING, "Oregon-THN802",
-                "id",                         "House Code", DATA_INT,        device_id,
-                "channel",                "Channel",        DATA_INT,        channel,
-                "battery_ok",          "Battery",         DATA_INT,    !battery_low,
-                "temperature_C",    "Celsius",        DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",                    "",                     NULL,         "Oregon-THN802");
+        data = data_int(data, "id",                         "House Code", NULL,         device_id);
+        data = data_int(data, "channel",                "Channel",        NULL,         channel);
+        data = data_int(data, "battery_ok",          "Battery",         NULL,         !battery_low);
+        data = data_dbl(data, "temperature_C",    "Celsius",        "%.2f C",     temp_c);
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -705,13 +692,12 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
             return DECODE_FAIL_MIC;
         int uvidx = get_os_uv(msg);
         /* clang-format off */
-        data = data_make(
-                "model",                    "",                     DATA_STRING, "Oregon-UV800",
-                "id",                         "House Code", DATA_INT,        device_id,
-                "channel",                "Channel",        DATA_INT,        channel,
-                "battery_ok",          "Battery",         DATA_INT,    !battery_low,
-                "uv",                         "UV Index",     DATA_FORMAT, "%u", DATA_INT, uvidx,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",                    "",                     NULL,         "Oregon-UV800");
+        data = data_int(data, "id",                         "House Code", NULL,         device_id);
+        data = data_int(data, "channel",                "Channel",        NULL,         channel);
+        data = data_int(data, "battery_ok",          "Battery",         NULL,         !battery_low);
+        data = data_int(data, "uv",                         "UV Index",     "%u",         uvidx);
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -738,14 +724,13 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
         float total_rain = get_os_total_rain(msg);
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",                     DATA_STRING, "Oregon-PCR800",
-                "id",                 "House Code", DATA_INT,        device_id,
-                "channel",        "Channel",        DATA_INT,        channel,
-                "battery_ok",          "Battery",         DATA_INT,    !battery_low,
-                "rain_rate_in_h",    "Rain Rate",    DATA_FORMAT, "%5.1f in/h", DATA_DOUBLE, rain_rate,
-                "rain_in", "Total Rain", DATA_FORMAT, "%7.3f in", DATA_DOUBLE, total_rain,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                     NULL,         "Oregon-PCR800");
+        data = data_int(data, "id",                 "House Code", NULL,         device_id);
+        data = data_int(data, "channel",        "Channel",        NULL,         channel);
+        data = data_int(data, "battery_ok",          "Battery",         NULL,         !battery_low);
+        data = data_dbl(data, "rain_rate_in_h",    "Rain Rate",    "%5.1f in/h", rain_rate);
+        data = data_dbl(data, "rain_in", "Total Rain", "%7.3f in",   total_rain);
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -756,14 +741,13 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
         float rain_rate = get_os_rain_rate(msg);
         float total_rain = get_os_total_rain(msg);
         /* clang-format off */
-        data = data_make(
-                "model",            "",                     DATA_STRING, "Oregon-PCR800a",
-                "id",                 "House Code", DATA_INT,        device_id,
-                "channel",        "Channel",        DATA_INT,        channel,
-                "battery_ok",          "Battery",         DATA_INT,    !battery_low,
-                "rain_rate_in_h",    "Rain Rate",    DATA_FORMAT, "%.1f in/h", DATA_DOUBLE, rain_rate,
-                "rain_in", "Total Rain", DATA_FORMAT, "%.1f in", DATA_DOUBLE, total_rain,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                     NULL,         "Oregon-PCR800a");
+        data = data_int(data, "id",                 "House Code", NULL,         device_id);
+        data = data_int(data, "channel",        "Channel",        NULL,         channel);
+        data = data_int(data, "battery_ok",          "Battery",         NULL,         !battery_low);
+        data = data_dbl(data, "rain_rate_in_h",    "Rain Rate",    "%.1f in/h",  rain_rate);
+        data = data_dbl(data, "rain_in", "Total Rain", "%.1f in",    total_rain);
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -793,15 +777,14 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
         }
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",                     DATA_STRING,    "Oregon-WGR800",
-                "id",                 "House Code", DATA_INT,         device_id,
-                "channel",        "Channel",        DATA_INT,         channel,
-                "battery_ok",          "Battery",         DATA_INT,    !battery_low,
-                "wind_max_m_s",             "Gust",             DATA_FORMAT,    "%.1f m/s",DATA_DOUBLE, gustWindspeed,
-                "wind_avg_m_s",        "Average",        DATA_FORMAT,    "%.1f m/s",DATA_DOUBLE, avgWindspeed,
-                "wind_dir_deg",    "Direction",    DATA_FORMAT,    "%.1f degrees",DATA_DOUBLE, quadrant,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",                     NULL,         "Oregon-WGR800");
+        data = data_int(data, "id",                 "House Code", NULL,         device_id);
+        data = data_int(data, "channel",        "Channel",        NULL,         channel);
+        data = data_int(data, "battery_ok",          "Battery",         NULL,         !battery_low);
+        data = data_dbl(data, "wind_max_m_s",             "Gust",             "%.1f m/s",   gustWindspeed);
+        data = data_dbl(data, "wind_avg_m_s",        "Average",        "%.1f m/s",   avgWindspeed);
+        data = data_dbl(data, "wind_dir_deg",    "Direction",    "%.1f degrees",quadrant);
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -825,14 +808,13 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
         //result compares to the CM160 LCD display values when * 1.12 between readings
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",                     DATA_STRING,    "Oregon-CM160",
-                "id",               "House Code",           DATA_INT, id,
+        data = NULL;
+        data = data_str(data, "model",            "",                     NULL,         "Oregon-CM160");
+        data = data_int(data, "id",               "House Code",           NULL,         id);
  //               "current_A",        "Current Amps",         DATA_FORMAT,   "%d A", DATA_INT, current_amps,
  //               "total_As",         "Total Amps",           DATA_FORMAT,   "%d As", DATA_INT, (int)total_amps,
-                "power_W",          "Power",                DATA_FORMAT,   "%7.4f W", DATA_DOUBLE, current_watts,
-                "energy_kWh",       "Energy",               DATA_FORMAT, "%7.4f kWh",DATA_DOUBLE, total_kWh,
-                NULL);
+        data = data_dbl(data, "power_W",          "Power",                "%7.4f W",    current_watts);
+        data = data_dbl(data, "energy_kWh",       "Energy",               "%7.4f kWh",  total_kWh);
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -854,14 +836,15 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
         float total_energy        = itotal / 3600.0f / 1000.0f;
         if (valid == 0) {
             /* clang-format off */
-            data = data_make(
-                    "model",            "",                 DATA_STRING, "Oregon-CM180",
-                    "id",               "House Code",       DATA_INT,    id,
-                    "battery_ok",       "Battery",          DATA_INT,    !batt_low,
-                    "power_W",          "Power",            DATA_FORMAT, "%d W",DATA_INT, ipower,
-                    "energy_kWh",       "Energy",           DATA_COND,   itotal != 0, DATA_FORMAT, "%.2f kWh",DATA_DOUBLE, total_energy,
-                    "sequence",         "sequence number",  DATA_INT,    sequence,
-                    NULL);
+            data = NULL;
+            data = data_str(data, "model",            "",                 NULL,         "Oregon-CM180");
+            data = data_int(data, "id",               "House Code",       NULL,         id);
+            data = data_int(data, "battery_ok",       "Battery",          NULL,         !batt_low);
+            data = data_int(data, "power_W",          "Power",            "%d W",       ipower);
+            if (itotal != 0) {
+                data = data_dbl(data, "energy_kWh",       "Energy",           "%.2f kWh",   total_energy);
+            }
+            data = data_int(data, "sequence",         "sequence number",  NULL,         sequence);
             /* clang-format on */
             decoder_output_data(decoder, data);
             return 1;
@@ -892,16 +875,17 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
 
         if (valid == 0) {
             /* clang-format off */
-            data = data_make(
-                    "model",            "",                 DATA_STRING, "Oregon-CM180i",
-                    "id",               "House Code",       DATA_INT,    id,
-                    "battery_ok",       "Battery",          DATA_INT,    !batt_low,
-                    "power1_W",         "Power1",           DATA_FORMAT, "%d W",DATA_INT, ipower1,
-                    "power2_W",         "Power2",           DATA_FORMAT, "%d W",DATA_INT, ipower2,
-                    "power3_W",         "Power3",           DATA_FORMAT, "%d W",DATA_INT, ipower3,
-                    "energy_kWh",       "Energy",           DATA_COND,   itotal != 0, DATA_FORMAT, "%.2f kWh",DATA_DOUBLE, total_energy,
-                    "sequence",         "sequence number",  DATA_INT,    sequence,
-                    NULL);
+            data = NULL;
+            data = data_str(data, "model",            "",                 NULL,         "Oregon-CM180i");
+            data = data_int(data, "id",               "House Code",       NULL,         id);
+            data = data_int(data, "battery_ok",       "Battery",          NULL,         !batt_low);
+            data = data_int(data, "power1_W",         "Power1",           "%d W",       ipower1);
+            data = data_int(data, "power2_W",         "Power2",           "%d W",       ipower2);
+            data = data_int(data, "power3_W",         "Power3",           "%d W",       ipower3);
+            if (itotal != 0) {
+                data = data_dbl(data, "energy_kWh",       "Energy",           "%.2f kWh",   total_energy);
+            }
+            data = data_int(data, "sequence",         "sequence number",  NULL,         sequence);
             /* clang-format on */
             decoder_output_data(decoder, data);
             return 1;

--- a/src/devices/oregon_scientific_sl109h.c
+++ b/src/devices/oregon_scientific_sl109h.c
@@ -93,15 +93,14 @@ static int oregon_scientific_sl109h_callback(r_device *decoder, bitbuffer_t *bit
         id = ((b[3] & 0x0f) << 4) | (b[4] >> 4);
 
         /* clang-format off */
-        data = data_make(
-                "model",            "Model",                                DATA_STRING, "Oregon-SL109H",
-                "id",               "Id",                                   DATA_INT,    id,
-                "channel",          "Channel",                              DATA_INT,    channel,
-                "temperature_C",    "Celsius",      DATA_FORMAT, "%.1f C",  DATA_DOUBLE, temp_c,
-                "humidity",         "Humidity",     DATA_FORMAT, "%u %%",   DATA_INT,    humidity,
-                "status",           "Status",                               DATA_INT,    status,
-                "mic",              "Integrity",                            DATA_STRING, "CHECKSUM",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "Model",                                NULL,         "Oregon-SL109H");
+        data = data_int(data, "id",               "Id",                                   NULL,         id);
+        data = data_int(data, "channel",          "Channel",                              NULL,         channel);
+        data = data_dbl(data, "temperature_C",    "Celsius",      "%.1f C",     temp_c);
+        data = data_int(data, "humidity",         "Humidity",     "%u %%",      humidity);
+        data = data_int(data, "status",           "Status",                               NULL,         status);
+        data = data_str(data, "mic",              "Integrity",                            NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/oregon_scientific_v1.c
+++ b/src/devices/oregon_scientific_v1.c
@@ -69,14 +69,13 @@ static int oregon_scientific_v1_callback(r_device *decoder, bitbuffer_t *bitbuff
             temp_c = -temp_c;
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",            "",             DATA_STRING,    "Oregon-v1",
-                "id",               "SID",          DATA_INT,       sid,
-                "channel",          "Channel",      DATA_INT,       channel,
-                "battery_ok",       "Battery",      DATA_INT,       !battery,
-                "temperature_C",    "Temperature",  DATA_FORMAT,    "%.1f C",              DATA_DOUBLE,    temp_c,
-                "mic",              "Integrity",    DATA_STRING,    "CHECKSUM",
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",            "",             NULL,         "Oregon-v1");
+        data = data_int(data, "id",               "SID",          NULL,         sid);
+        data = data_int(data, "channel",          "Channel",      NULL,         channel);
+        data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery);
+        data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+        data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/philips_aj3650.c
+++ b/src/devices/philips_aj3650.c
@@ -122,12 +122,11 @@ static int philips_aj3650_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     battery_low = packet[PHILIPS_PACKETLEN - 1] & 0x40;
 
     /* clang-format off */
-    data = data_make(
-            "model",         "",            DATA_STRING, "Philips-Temperature",
-            "channel",       "Channel",     DATA_INT,    channel,
-            "battery_ok",    "Battery",     DATA_INT,    !battery_low,
-            "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",         "",            NULL,         "Philips-Temperature");
+    data = data_int(data, "channel",       "Channel",     NULL,         channel);
+    data = data_int(data, "battery_ok",    "Battery",     NULL,         !battery_low);
+    data = data_dbl(data, "temperature_C", "Temperature", "%.1f C",     temperature);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/philips_aj7010.c
+++ b/src/devices/philips_aj7010.c
@@ -100,12 +100,11 @@ static int philips_aj7010_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     decoder_logf(decoder, 1, __func__, "temperature: raw: %d %08X converted: %.2f", temp_raw, temp_raw, temp_c);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Philips-AJ7010",
-            "channel",          "Channel",      DATA_INT,    channel,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Philips-AJ7010");
+    data = data_int(data, "channel",          "Channel",      NULL,         channel);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/proflame2.c
+++ b/src/devices/proflame2.c
@@ -112,23 +112,22 @@ static int proflame2_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         int flame      = (b[4] & 0x07);
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",        "",             DATA_STRING, "Proflame2-Remote",
-                "id",           "Id",           DATA_FORMAT, "%06x", DATA_INT,    id,
-                "cmd1",         "Cmd1",         DATA_FORMAT, "%02x", DATA_INT,    cmd1, // add chk then remove this
-                "cmd2",         "Cmd2",         DATA_FORMAT, "%02x", DATA_INT,    cmd2, // add chk then remove this
-                "err1",         "Err1",         DATA_FORMAT, "%02x", DATA_INT,    err1, // add chk then remove this
-                "err2",         "Err2",         DATA_FORMAT, "%02x", DATA_INT,    err2, // add chk then remove this
-                "pilot",        "Pilot",        DATA_INT,    pilot,
-                "light",        "Light",        DATA_INT,    light,
-                "thermostat",   "Thermostat",   DATA_INT,    thermostat,
-                "power",        "Power",        DATA_INT,    power,
-                "front",        "Front",        DATA_INT,    front,
-                "fan",          "Fan",          DATA_INT,    fan,
-                "aux",          "Aux",          DATA_INT,    aux,
-                "flame",        "Flame",        DATA_INT,    flame,
-                "mic",          "Integrity",    DATA_STRING, "CHECKSUM",
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",        "",             NULL,         "Proflame2-Remote");
+        data = data_int(data, "id",           "Id",           "%06x",       id);
+        data = data_int(data, "cmd1",         "Cmd1",         "%02x",       cmd1); // add chk then remove this
+        data = data_int(data, "cmd2",         "Cmd2",         "%02x",       cmd2); // add chk then remove this
+        data = data_int(data, "err1",         "Err1",         "%02x",       err1); // add chk then remove this
+        data = data_int(data, "err2",         "Err2",         "%02x",       err2); // add chk then remove this
+        data = data_int(data, "pilot",        "Pilot",        NULL,         pilot);
+        data = data_int(data, "light",        "Light",        NULL,         light);
+        data = data_int(data, "thermostat",   "Thermostat",   NULL,         thermostat);
+        data = data_int(data, "power",        "Power",        NULL,         power);
+        data = data_int(data, "front",        "Front",        NULL,         front);
+        data = data_int(data, "fan",          "Fan",          NULL,         fan);
+        data = data_int(data, "aux",          "Aux",          NULL,         aux);
+        data = data_int(data, "flame",        "Flame",        NULL,         flame);
+        data = data_str(data, "mic",          "Integrity",    NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/prologue.c
+++ b/src/devices/prologue.c
@@ -71,16 +71,17 @@ static int prologue_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     humidity = ((b[3] & 0x0F) << 4) | (b[4] >> 4);
 
     /* clang-format off */
-    data = data_make(
-            "model",         "",            DATA_STRING, "Prologue-TH",
-            "subtype",       "",            DATA_INT,    type,
-            "id",            "",            DATA_INT,    id,
-            "channel",       "Channel",     DATA_INT,    channel,
-            "battery_ok",    "Battery",     DATA_INT,    !!battery,
-            "temperature_C", "Temperature", DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_raw * 0.1,
-            "humidity",      "Humidity",    DATA_COND,   humidity != 0xcc, DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "button",        "Button",      DATA_INT,    button,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",         "",            NULL,         "Prologue-TH");
+    data = data_int(data, "subtype",       "",            NULL,         type);
+    data = data_int(data, "id",            "",            NULL,         id);
+    data = data_int(data, "channel",       "Channel",     NULL,         channel);
+    data = data_int(data, "battery_ok",    "Battery",     NULL,         !!battery);
+    data = data_dbl(data, "temperature_C", "Temperature", "%.2f C",     temp_raw * 0.1);
+    if (humidity != 0xcc) {
+        data = data_int(data, "humidity",      "Humidity",    "%u %%",      humidity);
+    }
+    data = data_int(data, "button",        "Button",      NULL,         button);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/proove.c
+++ b/src/devices/proove.c
@@ -80,14 +80,13 @@ static int proove_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     uint32_t unit      = (b[3] & 0x03) ^ 0x03;        // inverted
 
     /* clang-format off */
-    data = data_make(
-            "model",         "",            DATA_STRING, "Proove-Security",
-            "id",            "House Code",  DATA_INT,    id,
-            "channel",       "Channel",     DATA_INT,    channel,
-            "state",         "State",       DATA_STRING, on_bit ? "ON" : "OFF",
-            "unit",          "Unit",        DATA_INT,    unit,
-            "group",         "Group",       DATA_INT,    group_cmd,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",         "",            NULL,         "Proove-Security");
+    data = data_int(data, "id",            "House Code",  NULL,         id);
+    data = data_int(data, "channel",       "Channel",     NULL,         channel);
+    data = data_str(data, "state",         "State",       NULL,         on_bit ? "ON" : "OFF");
+    data = data_int(data, "unit",          "Unit",        NULL,         unit);
+    data = data_int(data, "group",         "Group",       NULL,         group_cmd);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/quhwa.c
+++ b/src/devices/quhwa.c
@@ -44,10 +44,9 @@ static int quhwa_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     uint32_t id = (b[0] << 8) | b[1];
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",  "",    DATA_STRING, "Quhwa-Doorbell",
-            "id",     "ID",  DATA_INT, id,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",  "",    NULL,         "Quhwa-Doorbell");
+    data = data_int(data, "id",     "ID",  NULL,         id);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/quinetic.c
+++ b/src/devices/quinetic.c
@@ -89,12 +89,11 @@ static int quinetic_switch_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int id = (b[0] << 8) | (b[1]);
 
     /* clang-format off */
-    data_t *data = data_make(
-        "model",         "Model",           DATA_STRING, "Quinetic",
-        "id",            "ID",              DATA_FORMAT, "%04x", DATA_INT, id,
-        "channel",       "Channel",         DATA_INT,    switch_channel,
-        "mic",           "Integrity",       DATA_STRING, "CRC",
-        NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",         "Model",           NULL,         "Quinetic");
+    data = data_int(data, "id",            "ID",              "%04x",       id);
+    data = data_int(data, "channel",       "Channel",         NULL,         switch_channel);
+    data = data_str(data, "mic",           "Integrity",       NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/radiohead_ask.c
+++ b/src/devices/radiohead_ask.c
@@ -162,16 +162,15 @@ static int radiohead_ask_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         rh_data_payload[j] = (int)rh_payload[5 + j];
     }
     /* clang-format off */
-    data = data_make(
-            "model",        "",             DATA_STRING, "RadioHead-ASK",
-            "len",          "Data len",     DATA_INT, data_len,
-            "to",           "To",           DATA_INT, header_to,
-            "from",         "From",         DATA_INT, header_from,
-            "id",           "Id",           DATA_INT, header_id,
-            "flags",        "Flags",        DATA_INT, header_flags,
-            "payload",      "Payload",      DATA_ARRAY, data_array(data_len, DATA_INT, rh_data_payload),
-            "mic",          "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",        "",             NULL,         "RadioHead-ASK");
+    data = data_int(data, "len",          "Data len",     NULL,         data_len);
+    data = data_int(data, "to",           "To",           NULL,         header_to);
+    data = data_int(data, "from",         "From",         NULL,         header_from);
+    data = data_int(data, "id",           "Id",           NULL,         header_id);
+    data = data_int(data, "flags",        "Flags",        NULL,         header_flags);
+    data = data_ary(data, "payload",      "Payload",      NULL,         data_array(data_len, DATA_INT, rh_data_payload));
+    data = data_str(data, "mic",          "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -206,17 +205,16 @@ static int sensible_living_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     battery_voltage = (rh_payload[9] << 8) | rh_payload[10];
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",                 DATA_STRING,  "SensibleLiving-Moisture",
-            "house_id",         "House ID",         DATA_INT,     house_id,
-            "module_id",        "Module ID",        DATA_INT,     module_id,
-            "sensor_type",      "Sensor Type",      DATA_INT,     sensor_type,
-            "sensor_count",     "Sensor Count",     DATA_INT,     sensor_count,
-            "alarms",           "Alarms",           DATA_INT,     alarms,
-            "sensor_value",     "Sensor Value",     DATA_INT,     sensor_value,
-            "battery_mV",       "Battery Voltage",  DATA_INT,     battery_voltage * 10,
-            "mic",              "Integrity",        DATA_STRING,  "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "SensibleLiving-Moisture");
+    data = data_int(data, "house_id",         "House ID",         NULL,         house_id);
+    data = data_int(data, "module_id",        "Module ID",        NULL,         module_id);
+    data = data_int(data, "sensor_type",      "Sensor Type",      NULL,         sensor_type);
+    data = data_int(data, "sensor_count",     "Sensor Count",     NULL,         sensor_count);
+    data = data_int(data, "alarms",           "Alarms",           NULL,         alarms);
+    data = data_int(data, "sensor_value",     "Sensor Value",     NULL,         sensor_value);
+    data = data_int(data, "battery_mV",       "Battery Voltage",  NULL,         battery_voltage * 10);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/rainpoint.c
+++ b/src/devices/rainpoint.c
@@ -99,18 +99,17 @@ static int rainpoint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         chan = 3;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "RainPoint-Soil",
-            "id",               "",             DATA_FORMAT, "%04x", DATA_INT,    id,
-            "channel",          "",             DATA_INT,    chan,
-            "sync",             "Sync?",        DATA_FORMAT, "%04x", DATA_INT,    sync,
-            "flags",            "Flags?",       DATA_FORMAT, "%02x", DATA_INT,    flags,
-            "status",           "Status?",      DATA_FORMAT, "%04x", DATA_INT,    status,
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "RainPoint-Soil");
+    data = data_int(data, "id",               "",             "%04x",       id);
+    data = data_int(data, "channel",          "",             NULL,         chan);
+    data = data_int(data, "sync",             "Sync?",        "%04x",       sync);
+    data = data_int(data, "flags",            "Flags?",       "%02x",       flags);
+    data = data_int(data, "status",           "Status?",      "%04x",       status);
             //"battery_ok",       "Battery",      DATA_INT,    batt,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "moisture",         "Moisture",     DATA_FORMAT, "%d %%", DATA_INT, moisture,
-            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    data = data_int(data, "moisture",         "Moisture",     "%d %%",      moisture);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/regency_fan.c
+++ b/src/devices/regency_fan.c
@@ -144,13 +144,12 @@ static int regency_fan_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         }
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",            "",     DATA_STRING,    "Regency-Remote",
-                "channel",          "",     DATA_INT,       channel,
-                "command",          "",     DATA_STRING,    command_names[command],
-                "value",            "",     DATA_STRING,    value_string,
-                "mic",              "",     DATA_STRING,    "CHECKSUM",
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",            "",     NULL,         "Regency-Remote");
+        data = data_int(data, "channel",          "",     NULL,         channel);
+        data = data_str(data, "command",          "",     NULL,         command_names[command]);
+        data = data_str(data, "value",            "",     NULL,         value_string);
+        data = data_str(data, "mic",              "",     NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/revolt_nc5462.c
+++ b/src/devices/revolt_nc5462.c
@@ -83,18 +83,17 @@ static int revolt_nc5462_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int energy    = b[10] | b[9] << 8;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Revolt-NC5462",
-            "id",               "House Code",   DATA_INT,    id,
-            "voltage_V",        "Voltage",      DATA_FORMAT, "%d V",        DATA_INT,    voltage,
-            "current_A",        "Current",      DATA_FORMAT, "%.2f A",      DATA_DOUBLE, current * 0.01,
-            "frequency_Hz",     "Frequency",    DATA_FORMAT, "%d Hz",       DATA_INT,    frequency,
-            "power_W",          "Power",        DATA_FORMAT, "%.2f W",      DATA_DOUBLE, power * 0.1,
-            "power_factor_VA",  "Power factor", DATA_FORMAT, "%.2f VA",     DATA_DOUBLE, pf * 0.01,
-            "energy_kWh",       "Energy",       DATA_FORMAT, "%.2f kWh",    DATA_DOUBLE, energy * 0.01,
-            "button",           "Button",       DATA_INT, button,
-            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Revolt-NC5462");
+    data = data_int(data, "id",               "House Code",   NULL,         id);
+    data = data_int(data, "voltage_V",        "Voltage",      "%d V",       voltage);
+    data = data_dbl(data, "current_A",        "Current",      "%.2f A",     current * 0.01);
+    data = data_int(data, "frequency_Hz",     "Frequency",    "%d Hz",      frequency);
+    data = data_dbl(data, "power_W",          "Power",        "%.2f W",     power * 0.1);
+    data = data_dbl(data, "power_factor_VA",  "Power factor", "%.2f VA",    pf * 0.01);
+    data = data_dbl(data, "energy_kWh",       "Energy",       "%.2f kWh",   energy * 0.01);
+    data = data_int(data, "button",           "Button",       NULL,         button);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/revolt_zx7717.c
+++ b/src/devices/revolt_zx7717.c
@@ -137,19 +137,18 @@ static int revolt_zx7717_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     // double powerf = va > 1.0 ? power / va : 1.0; // computed value
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",                 DATA_STRING, "Revolt-ZX7717",
-            "id",               "Device ID",        DATA_FORMAT, "%04x", DATA_INT, id,
-            "channel",          "Channel",          DATA_INT,    channel,
-            "unknown_1",        "Unknown 1",        DATA_FORMAT, "%04x", DATA_INT, unknown1,
-            "unknown_2",        "Unknown 2",        DATA_FORMAT, "%04x", DATA_INT, unknown2,
-            "current_A",        "Current",          DATA_FORMAT, "%.3f A", DATA_DOUBLE, current * 0.001,
-            "voltage_V",        "Voltage",          DATA_FORMAT, "%.1f V", DATA_DOUBLE, voltage * 0.1,
-            "power_W",          "Power",            DATA_FORMAT, "%.1f W", DATA_DOUBLE, power * 0.1,
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "Revolt-ZX7717");
+    data = data_int(data, "id",               "Device ID",        "%04x",       id);
+    data = data_int(data, "channel",          "Channel",          NULL,         channel);
+    data = data_int(data, "unknown_1",        "Unknown 1",        "%04x",       unknown1);
+    data = data_int(data, "unknown_2",        "Unknown 2",        "%04x",       unknown2);
+    data = data_dbl(data, "current_A",        "Current",          "%.3f A",     current * 0.001);
+    data = data_dbl(data, "voltage_V",        "Voltage",          "%.1f V",     voltage * 0.1);
+    data = data_dbl(data, "power_W",          "Power",            "%.1f W",     power * 0.1);
             // "apparentpower_VA", "Apparent Power",   DATA_FORMAT, "%.1f VA", DATA_DOUBLE, va * 0.1, // computed value
             // "powerfactor",      "Power Factor",     DATA_DOUBLE, powerf, // computed value
-            "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
-            NULL);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/rftech.c
+++ b/src/devices/rftech.c
@@ -56,13 +56,12 @@ static int rftech_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     int button  = (b[2] & 0x60) != 0;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "RF-tech",
-            "id",               "Id",           DATA_INT,    sensor_id,
-            "battery_ok",       "Battery",      DATA_INT,    battery,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "button",           "Button",       DATA_INT,    button,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "RF-tech");
+    data = data_int(data, "id",               "Id",           NULL,         sensor_id);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         battery);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    data = data_int(data, "button",           "Button",       NULL,         button);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/risco_agility.c
+++ b/src/devices/risco_agility.c
@@ -156,15 +156,18 @@ static int risco_agility_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int counter   = gray_decode(counter_raw);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",       "",                 DATA_STRING, "Risco-RWX95P",
-            "id",          "",                 DATA_INT, id,
-            "counter",     "Counter",          DATA_INT, counter,
-            "tamper",      "Tamper",           DATA_COND,   tamper, DATA_INT, 1,
-            "motion",      "Motion",           DATA_COND,   motion, DATA_INT, 1,
-            "battery_ok",  "Battery_OK",       DATA_INT,    !low_batt,
-            "mic",         "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",       "",                 NULL,         "Risco-RWX95P");
+    data = data_int(data, "id",          "",                 NULL,         id);
+    data = data_int(data, "counter",     "Counter",          NULL,         counter);
+    if (tamper) {
+        data = data_int(data, "tamper",      "Tamper",           NULL,         1);
+    }
+    if (motion) {
+        data = data_int(data, "motion",      "Motion",           NULL,         1);
+    }
+    data = data_int(data, "battery_ok",  "Battery_OK",       NULL,         !low_batt);
+    data = data_str(data, "mic",         "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/rojaflex.c
+++ b/src/devices/rojaflex.c
@@ -186,19 +186,28 @@ static int rojaflex_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data = data_make(
-                "model",        "Model",        DATA_COND, device_type == DEVICE_TYPE_UNKNOWN, DATA_STRING, "RojaFlex-Other",
-                "model",        "Model",        DATA_COND, device_type == DEVICE_TYPE_SHUTTER, DATA_STRING, "RojaFlex-Shutter",
-                "model",        "Model",        DATA_COND, device_type == DEVICE_TYPE_REMOTE, DATA_STRING, "RojaFlex-Remote",
-                "model",        "Model",        DATA_COND, device_type == DEVICE_TYPE_BRIDGE, DATA_STRING, "RojaFlex-Bridge",
-                "id",           "ID",           DATA_FORMAT, "%07x", DATA_INT,    id,
-                "channel",      "Channel",      DATA_INT,    msg[CHANNEL_OFFSET] & 0xF,
-                "token",        "Msg Token",    DATA_FORMAT, "%04x", DATA_INT,    token,
-                "cmd_id",       "Value",        DATA_FORMAT, "%02x", DATA_INT,    msg[COMMAND_ID_OFFSET],
-                "cmd_name",     "Command",      DATA_STRING, cmd_str,
-                "cmd_value",    "Value",        DATA_INT,    msg[COMMAND_VALUE_OFFSET],
-                "mic",          "Integrity",    DATA_COND,   has_crc, DATA_STRING, "CRC",
-                NULL);
+    data = NULL;
+    if (device_type == DEVICE_TYPE_UNKNOWN) {
+        data = data_str(data, "model",        "Model",        NULL,         "RojaFlex-Other");
+    }
+    if (device_type == DEVICE_TYPE_SHUTTER) {
+        data = data_str(data, "model",        "Model",        NULL,         "RojaFlex-Shutter");
+    }
+    if (device_type == DEVICE_TYPE_REMOTE) {
+        data = data_str(data, "model",        "Model",        NULL,         "RojaFlex-Remote");
+    }
+    if (device_type == DEVICE_TYPE_BRIDGE) {
+        data = data_str(data, "model",        "Model",        NULL,         "RojaFlex-Bridge");
+    }
+    data = data_int(data, "id",           "ID",           "%07x",       id);
+    data = data_int(data, "channel",      "Channel",      NULL,         msg[CHANNEL_OFFSET] & 0xF);
+    data = data_int(data, "token",        "Msg Token",    "%04x",       token);
+    data = data_int(data, "cmd_id",       "Value",        "%02x",       msg[COMMAND_ID_OFFSET]);
+    data = data_str(data, "cmd_name",     "Command",      NULL,         cmd_str);
+    data = data_int(data, "cmd_value",    "Value",        NULL,         msg[COMMAND_VALUE_OFFSET]);
+    if (has_crc) {
+        data = data_str(data, "mic",          "Integrity",    NULL,         "CRC");
+    }
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/rosstech_dcu706.c
+++ b/src/devices/rosstech_dcu706.c
@@ -87,13 +87,12 @@ static int rosstech_dcu706_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data_t *data = data_make(
-        "model",            "Model",              DATA_STRING,   "Rosstech-Spa",
-        "id",               "ID",                 DATA_FORMAT,   "%04x",    DATA_INT,   id,
-        "msg_type",         "Transmission Type",  DATA_STRING,   msg_type == 0xba ? "Data" : "Bond",
-        "temperature_F",    "Temperature",        DATA_FORMAT,   "%d F",    DATA_INT,   temp_f,
-        "mic",              "Integrity",          DATA_STRING,   "CHECKSUM",
-        NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "Model",              NULL,         "Rosstech-Spa");
+    data = data_int(data, "id",               "ID",                 "%04x",       id);
+    data = data_str(data, "msg_type",         "Transmission Type",  NULL,         msg_type == 0xba ? "Data" : "Bond");
+    data = data_int(data, "temperature_F",    "Temperature",        "%d F",       temp_f);
+    data = data_str(data, "mic",              "Integrity",          NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/rubicson.c
+++ b/src/devices/rubicson.c
@@ -81,14 +81,13 @@ static int rubicson_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     temp_c   = (temp_raw >> 4) * 0.1f;
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "Rubicson-Temperature",
-            "id",               "House Code",   DATA_INT,    id,
-            "channel",          "Channel",      DATA_INT,    channel,
-            "battery_ok",       "Battery",      DATA_INT,    !!battery,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Rubicson-Temperature");
+    data = data_int(data, "id",               "House Code",   NULL,         id);
+    data = data_int(data, "channel",          "Channel",      NULL,         channel);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !!battery);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/rubicson_48659.c
+++ b/src/devices/rubicson_48659.c
@@ -170,12 +170,11 @@ static int rubicson_48659_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     float temp_f = ((b[1] & 0x04) >> 2) ? -1 : 1 * (((b[1] & 0x3) << 8) | b[2]);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",         "",            DATA_STRING, "Rubicson-48659",
-            "id",            "Id",          DATA_INT,    id,
-            "temperature_F", "Temperature", DATA_FORMAT, "%.1f F", DATA_DOUBLE, temp_f,
-            "mic",           "Integrity",   DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",         "",            NULL,         "Rubicson-48659");
+    data = data_int(data, "id",            "Id",          NULL,         id);
+    data = data_dbl(data, "temperature_F", "Temperature", "%.1f F",     temp_f);
+    data = data_str(data, "mic",           "Integrity",   NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/rubicson_pool_48942.c
+++ b/src/devices/rubicson_pool_48942.c
@@ -78,14 +78,13 @@ static int rubicson_pool_48942_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     decoder_log_bitbuffer(decoder, 1, __func__, bitbuffer, "");
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",          "",             DATA_STRING,  "Rubicson-48942",
-            "channel",        "Channel",      DATA_INT,     channel,
-            "id",             "Random ID",    DATA_INT,     random_id,
-            "battery_ok",     "Battery",      DATA_INT,     !battery_low,
-            "temperature_C",  "Temperature",  DATA_FORMAT,  "%.1f C", DATA_DOUBLE, temp_c,
-            "mic",            "Integrity",    DATA_STRING,  "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",          "",             NULL,         "Rubicson-48942");
+    data = data_int(data, "channel",        "Channel",      NULL,         channel);
+    data = data_int(data, "id",             "Random ID",    NULL,         random_id);
+    data = data_int(data, "battery_ok",     "Battery",      NULL,         !battery_low);
+    data = data_dbl(data, "temperature_C",  "Temperature",  "%.1f C",     temp_c);
+    data = data_str(data, "mic",            "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/s3318p.c
+++ b/src/devices/s3318p.c
@@ -98,16 +98,17 @@ static int s3318p_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     int battery_low = (b[4] & 0x40) >> 6;
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "Conrad-S3318P",
-            "id",               "ID",           DATA_INT,    id,
-            "channel",          "Channel",      DATA_INT,    channel,
-            "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-            "temperature_F",    "Temperature",  DATA_FORMAT, "%.2f F", DATA_DOUBLE, temp_f,
-            "humidity",         "Humidity",     DATA_COND,   humidity != 0, DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "button",           "Button",       DATA_INT,    button,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Conrad-S3318P");
+    data = data_int(data, "id",               "ID",           NULL,         id);
+    data = data_int(data, "channel",          "Channel",      NULL,         channel);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_dbl(data, "temperature_F",    "Temperature",  "%.2f F",     temp_f);
+    if (humidity != 0) {
+        data = data_int(data, "humidity",         "Humidity",     "%u %%",      humidity);
+    }
+    data = data_int(data, "button",           "Button",       NULL,         button);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/schou_72543_rain.c
+++ b/src/devices/schou_72543_rain.c
@@ -87,16 +87,15 @@ static int schou_72543_rain_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     float temperature_F = (((b[6] << 8) | b[5]) - 900) * 0.1f; // -40.0 to +158     degF
 
     /* clang-format off */
-    data_t   *data = data_make(
-            "model",            "",             DATA_STRING, "Schou-72543",
-            "id",               "ID",           DATA_INT,    device_id,
-            "temperature_F",    "Temperature",  DATA_FORMAT, "%.1f F",  DATA_DOUBLE, temperature_F,
-            "rain_mm",          "Rain",         DATA_FORMAT, "%.1f mm", DATA_DOUBLE, rain_mm,
-            "battery_ok",       "Battery_ok",   DATA_INT,    !battery_low,
-            "msg_counter",      "Counter",      DATA_INT,    message_counter,
-            "msg_repeat",       "Msg_repeat",   DATA_INT,    message_repeat,
-            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t   *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Schou-72543");
+    data = data_int(data, "id",               "ID",           NULL,         device_id);
+    data = data_dbl(data, "temperature_F",    "Temperature",  "%.1f F",     temperature_F);
+    data = data_dbl(data, "rain_mm",          "Rain",         "%.1f mm",    rain_mm);
+    data = data_int(data, "battery_ok",       "Battery_ok",   NULL,         !battery_low);
+    data = data_int(data, "msg_counter",      "Counter",      NULL,         message_counter);
+    data = data_int(data, "msg_repeat",       "Msg_repeat",   NULL,         message_repeat);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/schraeder.c
+++ b/src/devices/schraeder.c
@@ -64,15 +64,14 @@ static int schraeder_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     snprintf(flags_str, sizeof(flags_str), "%02x", flags);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Schrader",
-            "type",             "",             DATA_STRING, "TPMS",
-            "flags",            "",             DATA_STRING, flags_str,
-            "id",               "ID",           DATA_STRING, id_str,
-            "pressure_kPa",     "Pressure",     DATA_FORMAT, "%.1f kPa", DATA_DOUBLE, pressure * 0.1f,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.0f C", DATA_DOUBLE, (double)temperature,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Schrader");
+    data = data_str(data, "type",             "",             NULL,         "TPMS");
+    data = data_str(data, "flags",            "",             NULL,         flags_str);
+    data = data_str(data, "id",               "ID",           NULL,         id_str);
+    data = data_dbl(data, "pressure_kPa",     "Pressure",     "%.1f kPa",   pressure * 0.1f);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.0f C",     (double)temperature);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -137,15 +136,14 @@ static int schrader_EG53MA4_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     snprintf(flags_str, sizeof(flags_str), "%08x", flags);
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "Schrader-EG53MA4",
-            "type",             "",             DATA_STRING, "TPMS",
-            "flags",            "",             DATA_STRING, flags_str,
-            "id",               "ID",           DATA_STRING, id_str,
-            "pressure_kPa",     "Pressure",     DATA_FORMAT, "%.1f kPa", DATA_DOUBLE, pressure * 0.1f,
-            "temperature_F",    "Temperature",  DATA_FORMAT, "%.1f F", DATA_DOUBLE, (double)temperature,
-            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Schrader-EG53MA4");
+    data = data_str(data, "type",             "",             NULL,         "TPMS");
+    data = data_str(data, "flags",            "",             NULL,         flags_str);
+    data = data_str(data, "id",               "ID",           NULL,         id_str);
+    data = data_dbl(data, "pressure_kPa",     "Pressure",     "%.1f kPa",   pressure * 0.1f);
+    data = data_dbl(data, "temperature_F",    "Temperature",  "%.1f F",     (double)temperature);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -270,13 +268,12 @@ static int schrader_SMD3MA4_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     snprintf(id_str, sizeof(id_str), "%06X", serial_id);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Schrader-SMD3MA4",
-            "type",             "",             DATA_STRING, "TPMS",
-            "flags",            "",             DATA_INT,    flags,
-            "id",               "ID",           DATA_STRING, id_str,
-            "pressure_PSI",     "Pressure",     DATA_FORMAT, "%.1f PSI", DATA_DOUBLE, pressure * 0.2f,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Schrader-SMD3MA4");
+    data = data_str(data, "type",             "",             NULL,         "TPMS");
+    data = data_int(data, "flags",            "",             NULL,         flags);
+    data = data_str(data, "id",               "ID",           NULL,         id_str);
+    data = data_dbl(data, "pressure_PSI",     "Pressure",     "%.1f PSI",   pressure * 0.2f);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/scmplus.c
+++ b/src/devices/scmplus.c
@@ -138,18 +138,17 @@ static int scmplus_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     */
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",                 DATA_STRING, "SCMplus",
-            "id",               "",                 DATA_INT,    endpoint_id,
-            "ProtocolID",       "Protocol_ID",      DATA_STRING, protocol_id_str, // TODO: this should be int
-            "EndpointType",     "Endpoint_Type",    DATA_STRING, endpoint_type_str, // TODO: this should be int
-            "EndpointID",       "Endpoint_ID",      DATA_INT,    endpoint_id, // TODO: remove this (see "id")
-            "Consumption",      "",                 DATA_INT,    consumption_data,
-            "Tamper",           "",                 DATA_STRING, physical_tamper_str, // TODO: should be int
-            "PacketCRC",        "crc",              DATA_STRING, crc_str, // TODO: remove this
-            "MeterType",        "Meter_Type",       DATA_STRING, meter_type,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "SCMplus");
+    data = data_int(data, "id",               "",                 NULL,         endpoint_id);
+    data = data_str(data, "ProtocolID",       "Protocol_ID",      NULL,         protocol_id_str); // TODO: this should be int
+    data = data_str(data, "EndpointType",     "Endpoint_Type",    NULL,         endpoint_type_str); // TODO: this should be int
+    data = data_int(data, "EndpointID",       "Endpoint_ID",      NULL,         endpoint_id); // TODO: remove this (see "id")
+    data = data_int(data, "Consumption",      "",                 NULL,         consumption_data);
+    data = data_str(data, "Tamper",           "",                 NULL,         physical_tamper_str); // TODO: should be int
+    data = data_str(data, "PacketCRC",        "crc",              NULL,         crc_str); // TODO: remove this
+    data = data_str(data, "MeterType",        "Meter_Type",       NULL,         meter_type);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/secplus_v1.c
+++ b/src/devices/secplus_v1.c
@@ -361,21 +361,28 @@ static int secplus_v1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // decoder_logf(decoder, 0, __func__,  "# Security+:  rolling=2320615320  fixed=1846948897  (id1=2 id0=0 switch=1 remote_id=68405514 button=left)");
     /* clang-format off */
-    data_t *data = data_make(
-            "model",        "",             DATA_STRING, "Secplus-v1",
-            "id",           "",             DATA_INT,    id,
-            "id0",          "ID_0",         DATA_INT,    id0,
-            "id1",          "ID_1",         DATA_INT,    id1,
-            "switch_id",    "Switch-ID",    DATA_INT,    switch_id,
-            "pad_id",       "Pad-ID",       DATA_COND,   pad_id,    DATA_INT,    pad_id,
-            "pin",          "Pin",          DATA_COND,   pin,       DATA_STRING, pin_s,
-            "remote_id",    "Remote-ID",    DATA_COND,   remote_id, DATA_INT,    remote_id,
-            "button_id",    "Button-ID",    DATA_COND,   remote_id, DATA_STRING, button,
+    data_t *data = NULL;
+    data = data_str(data, "model",        "",             NULL,         "Secplus-v1");
+    data = data_int(data, "id",           "",             NULL,         id);
+    data = data_int(data, "id0",          "ID_0",         NULL,         id0);
+    data = data_int(data, "id1",          "ID_1",         NULL,         id1);
+    data = data_int(data, "switch_id",    "Switch-ID",    NULL,         switch_id);
+    if (pad_id) {
+        data = data_int(data, "pad_id",       "Pad-ID",       NULL,         pad_id);
+    }
+    if (pin) {
+        data = data_str(data, "pin",          "Pin",          NULL,         pin_s);
+    }
+    if (remote_id) {
+        data = data_int(data, "remote_id",    "Remote-ID",    NULL,         remote_id);
+    }
+    if (remote_id) {
+        data = data_str(data, "button_id",    "Button-ID",    NULL,         button);
+    }
             // "fixed",        "Fixed_Code",   DATA_INT,    fixed,
-            "fixed",        "Fixed_Code",   DATA_STRING, fixed_str,
+    data = data_str(data, "fixed",        "Fixed_Code",   NULL,         fixed_str);
             // "rolling",      "Rolling_Code", DATA_INT,    rolling,
-            "rolling",      "Rolling_Code", DATA_STRING, rolling_str,
-            NULL);
+    data = data_str(data, "rolling",      "Rolling_Code", NULL,         rolling_str);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/secplus_v2.c
+++ b/src/devices/secplus_v2.c
@@ -365,15 +365,14 @@ static int secplus_v2_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data_t *data;
-    data = data_make(
-            "model",       "Model",    DATA_STRING, "Secplus-v2",
-            "id",          "",       DATA_INT, (fixed_total & 0xffffffff),
-            "button_id",   "Button-ID",    DATA_INT,    (fixed_total >> 32),
-            "remote_id",   "Remote-ID",    DATA_INT,    (fixed_total & 0xffffffff),
+    data = NULL;
+    data = data_str(data, "model",       "Model",    NULL,         "Secplus-v2");
+    data = data_int(data, "id",          "",       NULL,         (fixed_total & 0xffffffff));
+    data = data_int(data, "button_id",   "Button-ID",    NULL,         (fixed_total >> 32));
+    data = data_int(data, "remote_id",   "Remote-ID",    NULL,         (fixed_total & 0xffffffff));
             // "fixed",       "",    DATA_INT,    fixed_total,
-            "fixed",       "Fixed_Code",    DATA_STRING,    fixed_str,
-            "rolling",     "Rolling_Code",    DATA_STRING,    rolling_str,
-            NULL);
+    data = data_str(data, "fixed",       "Fixed_Code",    NULL,         fixed_str);
+    data = data_str(data, "rolling",     "Rolling_Code",    NULL,         rolling_str);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/sharp_spc775.c
+++ b/src/devices/sharp_spc775.c
@@ -75,14 +75,13 @@ static int sharp_spc775_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_FAIL_MIC;
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",                 DATA_STRING, "Sharp-SPC775",
-            "id",               "",                 DATA_INT,    id,
-            "battery_ok",       "Battery",          DATA_INT,    !battery_low,
-            "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C",  DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",         DATA_FORMAT, "%u %%",    DATA_INT,    humidity,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "Sharp-SPC775");
+    data = data_int(data, "id",               "",                 NULL,         id);
+    data = data_int(data, "battery_ok",       "Battery",          NULL,         !battery_low);
+    data = data_dbl(data, "temperature_C",    "Temperature",      "%.1f C",     temp_c);
+    data = data_int(data, "humidity",         "Humidity",         "%u %%",      humidity);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/silvercrest.c
+++ b/src/devices/silvercrest.c
@@ -36,10 +36,9 @@ static int silvercrest_callback(r_device *decoder, bitbuffer_t *bitbuffer)
             return DECODE_ABORT_EARLY;
 
         /* clang-format off */
-        data = data_make(
-                "model",    "", DATA_STRING, "Silvercrest-Remote",
-                "button",   "", DATA_INT,    cmd,
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",    "", NULL,         "Silvercrest-Remote");
+        data = data_int(data, "button",   "", NULL,         cmd);
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/simplisafe.c
+++ b/src/devices/simplisafe.c
@@ -82,13 +82,12 @@ static int ss_sensor_parser(r_device *decoder, bitbuffer_t *bitbuffer, int row)
     }
 
     /* clang-format off */
-    data = data_make(
-            "model",        "",             DATA_STRING, "SimpliSafe-Sensor",
-            "id",           "Device ID",    DATA_STRING, id,
-            "seq",          "Sequence",     DATA_INT,    seq,
-            "state",        "State",        DATA_INT,    state,
-            "extradata",    "Extra Data",   DATA_STRING, extradata,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",        "",             NULL,         "SimpliSafe-Sensor");
+    data = data_str(data, "id",           "Device ID",    NULL,         id);
+    data = data_int(data, "seq",          "Sequence",     NULL,         seq);
+    data = data_int(data, "state",        "State",        NULL,         state);
+    data = data_str(data, "extradata",    "Extra Data",   NULL,         extradata);
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -120,12 +119,11 @@ static int ss_pinentry_parser(r_device *decoder, bitbuffer_t *bitbuffer, int row
     snprintf(extradata, sizeof(extradata), "Disarm Pin: %x%x%x%x", digits[0], digits[1], digits[2], digits[3]);
 
     /* clang-format off */
-    data = data_make(
-            "model",        "",             DATA_STRING, "SimpliSafe-Keypad",
-            "id",           "Device ID",    DATA_STRING, id,
-            "seq",          "Sequence",     DATA_INT,    b[9],
-            "extradata",    "Extra Data",   DATA_STRING, extradata,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",        "",             NULL,         "SimpliSafe-Keypad");
+    data = data_str(data, "id",           "Device ID",    NULL,         id);
+    data = data_int(data, "seq",          "Sequence",     NULL,         b[9]);
+    data = data_str(data, "extradata",    "Extra Data",   NULL,         extradata);
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -159,12 +157,11 @@ static int ss_keypad_commands(r_device *decoder, bitbuffer_t *bitbuffer, int row
     ss_get_id(id, b);
 
     /* clang-format off */
-    data = data_make(
-            "model",        "",             DATA_STRING, "SimpliSafe-Keypad",
-            "id",           "Device ID",    DATA_STRING, id,
-            "seq",          "Sequence",     DATA_INT,    b[9],
-            "extradata",    "Extra Data",   DATA_STRING, extradata,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",        "",             NULL,         "SimpliSafe-Keypad");
+    data = data_str(data, "id",           "Device ID",    NULL,         id);
+    data = data_int(data, "seq",          "Sequence",     NULL,         b[9]);
+    data = data_str(data, "extradata",    "Extra Data",   NULL,         extradata);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/simplisafe_gen3.c
+++ b/src/devices/simplisafe_gen3.c
@@ -71,15 +71,14 @@ static int simplisafe_gen3_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",                 DATA_STRING, "SimpliSafe-Gen3",
-            "id",               "ID",               DATA_FORMAT, "%08x", DATA_INT, id,
-            "msg_type",         "Type",             DATA_FORMAT, "%02x", DATA_INT, msg_type,
-            "ctr",              "Counter",          DATA_FORMAT, "%06x", DATA_INT, ctr,
-            "cmac",             "CMAC",             DATA_FORMAT, "%08x", DATA_INT, cmac,
-            "encr",             "Encrypted",        DATA_STRING, encr,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "SimpliSafe-Gen3");
+    data = data_int(data, "id",               "ID",               "%08x",       id);
+    data = data_int(data, "msg_type",         "Type",             "%02x",       msg_type);
+    data = data_int(data, "ctr",              "Counter",          "%06x",       ctr);
+    data = data_int(data, "cmac",             "CMAC",             "%08x",       cmac);
+    data = data_str(data, "encr",             "Encrypted",        NULL,         encr);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/smoke_gs558.c
+++ b/src/devices/smoke_gs558.c
@@ -103,13 +103,12 @@ static int smoke_gs558_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     snprintf(code_str, sizeof(code_str), "%02x%02x%02x", b[2], b[1], b[0]);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",        "",             DATA_STRING, "Smoke-GS558",
-            "id",           "",             DATA_INT, id,
-            "unit",         "",             DATA_INT, unit,
-            "learn",        "",             DATA_INT, learn > 1,
-            "code",         "Raw Code",     DATA_STRING, code_str,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",        "",             NULL,         "Smoke-GS558");
+    data = data_int(data, "id",           "",             NULL,         id);
+    data = data_int(data, "unit",         "",             NULL,         unit);
+    data = data_int(data, "learn",        "",             NULL,         learn > 1);
+    data = data_str(data, "code",         "Raw Code",     NULL,         code_str);
     /* clang-format on */
     decoder_output_data(decoder, data);
 

--- a/src/devices/solight_te44.c
+++ b/src/devices/solight_te44.c
@@ -69,14 +69,13 @@ static int solight_te44_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     temp_c   = (temp_raw >> 4) * 0.1f;
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "Solight-TE44",
-            "id",               "Id",           DATA_INT,    id,
-            "channel",          "Channel",      DATA_INT,    channel + 1,
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Solight-TE44");
+    data = data_int(data, "id",               "Id",           NULL,         id);
+    data = data_int(data, "channel",          "Channel",      NULL,         channel + 1);
 //            "battery_ok",       "Battery",      DATA_INT,    !!battery,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.2f C",     temp_c);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/somfy_iohc.c
+++ b/src/devices/somfy_iohc.c
@@ -173,24 +173,27 @@ static int somfy_iohc_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     decoder_logf_bitrow(decoder, 2, __func__, b, len * 8, "offset %u, num_bits %u, len %d, msg_len %d", offset, num_bits, len, msg_len);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",                 DATA_STRING, "Somfy-IOHC",
-            "id",               "Source",           DATA_FORMAT, "%06x", DATA_INT, msg_src_addr,
-            "dst_id",           "Target",           DATA_FORMAT, "%06x", DATA_INT, msg_dst_addr,
-            "msg_type",         "Command",          DATA_FORMAT, "%02x", DATA_INT, msg_cmd_id,
-            "msg",              "Message",          DATA_STRING, msg_data,
-            "mode",             "Mode",             DATA_STRING, msg_protocol_mode ? "One-way" : "Two-way",
-            "version",          "Version",          DATA_INT,    msg_protocol_version,
-            "counter",          "Counter",          DATA_COND, msg_protocol_mode == 1, DATA_INT,    msg_seq_nr,
-            "mac",              "MAC",              DATA_COND, msg_protocol_mode == 1, DATA_STRING, msg_mac,
-            "flag_end",         "End flag",         DATA_INT,    msg_end_flag,
-            "flag_start",       "Start flag",       DATA_INT,    msg_start_flag,
-            "flag_mode",        "Mode flag",        DATA_INT,    msg_protocol_mode,
-            "flag_beacon",      "Beacon flag",      DATA_INT,    msg_use_beacon,
-            "flag_routed",      "Routed flag",      DATA_INT,    msg_is_routed,
-            "flag_lpm",         "LPM flag",         DATA_INT,    msg_low_power_mode,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "Somfy-IOHC");
+    data = data_int(data, "id",               "Source",           "%06x",       msg_src_addr);
+    data = data_int(data, "dst_id",           "Target",           "%06x",       msg_dst_addr);
+    data = data_int(data, "msg_type",         "Command",          "%02x",       msg_cmd_id);
+    data = data_str(data, "msg",              "Message",          NULL,         msg_data);
+    data = data_str(data, "mode",             "Mode",             NULL,         msg_protocol_mode ? "One-way" : "Two-way");
+    data = data_int(data, "version",          "Version",          NULL,         msg_protocol_version);
+    if (msg_protocol_mode == 1) {
+        data = data_int(data, "counter",          "Counter",          NULL,         msg_seq_nr);
+    }
+    if (msg_protocol_mode == 1) {
+        data = data_str(data, "mac",              "MAC",              NULL,         msg_mac);
+    }
+    data = data_int(data, "flag_end",         "End flag",         NULL,         msg_end_flag);
+    data = data_int(data, "flag_start",       "Start flag",       NULL,         msg_start_flag);
+    data = data_int(data, "flag_mode",        "Mode flag",        NULL,         msg_protocol_mode);
+    data = data_int(data, "flag_beacon",      "Beacon flag",      NULL,         msg_use_beacon);
+    data = data_int(data, "flag_routed",      "Routed flag",      NULL,         msg_is_routed);
+    data = data_int(data, "flag_lpm",         "LPM flag",         NULL,         msg_low_power_mode);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/somfy_rts.c
+++ b/src/devices/somfy_rts.c
@@ -179,14 +179,13 @@ static int somfy_rts_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     decoder_logf(decoder, 2, __func__, "seed=0x%02x, chksum=0x%x", seed, chksum);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",          "",               DATA_STRING, "Somfy-RTS",
-            "id",             "",               DATA_FORMAT, "%06X", DATA_INT, address,
-            "control",        "Control",        DATA_STRING, control_str,
-            "counter",        "Counter",        DATA_INT,    counter,
-            "retransmission", "Retransmission", DATA_INT,    is_retransmission,
-            "mic",            "Integrity",      DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",          "",               NULL,         "Somfy-RTS");
+    data = data_int(data, "id",             "",               "%06X",       address);
+    data = data_str(data, "control",        "Control",        NULL,         control_str);
+    data = data_int(data, "counter",        "Counter",        NULL,         counter);
+    data = data_int(data, "retransmission", "Retransmission", NULL,         is_retransmission);
+    data = data_str(data, "mic",            "Integrity",      NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/springfield.c
+++ b/src/devices/springfield.c
@@ -69,18 +69,17 @@ static int springfield_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         }
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",            "",             DATA_STRING, "Springfield-Soil",
-                "id",               "SID",          DATA_INT,    sid,
-                "channel",          "Channel",      DATA_INT,    channel,
-                "battery_ok",       "Battery",      DATA_INT,    !battery,
-                "transmit",         "Transmit",     DATA_STRING, button ? "MANUAL" : "AUTO", // TODO: delete this
-                "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-                "moisture",         "Moisture",     DATA_FORMAT, "%d %%", DATA_INT, moisture,
-                "button",           "Button",       DATA_INT,    button,
+        data_t *data = NULL;
+        data = data_str(data, "model",            "",             NULL,         "Springfield-Soil");
+        data = data_int(data, "id",               "SID",          NULL,         sid);
+        data = data_int(data, "channel",          "Channel",      NULL,         channel);
+        data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery);
+        data = data_str(data, "transmit",         "Transmit",     NULL,         button ? "MANUAL" : "AUTO"); // TODO: delete this
+        data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+        data = data_int(data, "moisture",         "Moisture",     "%d %%",      moisture);
+        data = data_int(data, "button",           "Button",       NULL,         button);
 //                "uk1",            "uk1",          DATA_INT,    uk1,
-                "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-                NULL);
+        data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/srsmith_pool_srs_2c_tx.c
+++ b/src/devices/srsmith_pool_srs_2c_tx.c
@@ -134,14 +134,13 @@ static int srsmith_pool_srs_2c_tx_decode(r_device *decoder, bitbuffer_t *bitbuff
     }
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",                  "",                         DATA_STRING, "SRSmith-SRS2CTX",
-            "id",                     "Id",                       DATA_INT, reversed_pin, // technically peoples pins should be different on each remote
-            "button_press",           "Pushed Button ID",         DATA_FORMAT, "%02x", DATA_INT, button_id,
-            "button_press_name",      "Pushed Button String",     DATA_STRING, button_string,
-            "unknown",                "Unknown",                  DATA_FORMAT, "%08x", DATA_INT, unknown_field,
-            "mic",                    "Integrity",                DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",                  "",                         NULL,         "SRSmith-SRS2CTX");
+    data = data_int(data, "id",                     "Id",                       NULL,         reversed_pin); // technically peoples pins should be different on each remote
+    data = data_int(data, "button_press",           "Pushed Button ID",         "%02x",       button_id);
+    data = data_str(data, "button_press_name",      "Pushed Button String",     NULL,         button_string);
+    data = data_int(data, "unknown",                "Unknown",                  "%08x",       unknown_field);
+    data = data_str(data, "mic",                    "Integrity",                NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/steelmate.c
+++ b/src/devices/steelmate.c
@@ -79,15 +79,14 @@ static int steelmate_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         snprintf(sensor_idhex, sizeof(sensor_idhex), "0x%04x", sensor_id);
 
         /* clang-format off */
-        data_t *data = data_make(
-                "type",             "",             DATA_STRING, "TPMS",
-                "model",            "",             DATA_STRING, "Steelmate",
-                "id",               "",             DATA_STRING, sensor_idhex,
-                "pressure_PSI",     "",             DATA_DOUBLE, pressure_psi,
-                "temperature_F",    "",             DATA_DOUBLE, (float)tempFahrenheit,
-                "battery_mV",       "",             DATA_INT,    battery_mV,
-                "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "type",             "",             NULL,         "TPMS");
+        data = data_str(data, "model",            "",             NULL,         "Steelmate");
+        data = data_str(data, "id",               "",             NULL,         sensor_idhex);
+        data = data_dbl(data, "pressure_PSI",     "",             NULL,         pressure_psi);
+        data = data_dbl(data, "temperature_F",    "",             NULL,         (float)tempFahrenheit);
+        data = data_int(data, "battery_mV",       "",             NULL,         battery_mV);
+        data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/telldus_ft0385r.c
+++ b/src/devices/telldus_ft0385r.c
@@ -157,31 +157,29 @@ static int telldus_ft0385r_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     if (temp_raw != 0x7fb) {
-        data = data_make(
-            "model",            "",                 DATA_STRING, "Telldus-FT0385R",
+        data = NULL;
+        data = data_str(data, "model",            "",                 NULL,         "Telldus-FT0385R");
             //"battery_ok",       "Battery",          DATA_INT,    !batt_low,
-            "temperature_F",    "Temperature",      DATA_FORMAT, "%.1f F", DATA_DOUBLE, temp_f,
-            "humidity",         "Humidity",         DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "temperature_2_F",  "Temperature in",   DATA_FORMAT, "%.1f F", DATA_DOUBLE, temp2_f,
-            "humidity_2",       "Humidity in",      DATA_FORMAT, "%u %%", DATA_INT, humidity2,
-            "pressure_hPa",     "Pressure",         DATA_FORMAT, "%.1f hPa", DATA_DOUBLE, pressure * 0.1f,
+        data = data_dbl(data, "temperature_F",    "Temperature",      "%.1f F",     temp_f);
+        data = data_int(data, "humidity",         "Humidity",         "%u %%",      humidity);
+        data = data_dbl(data, "temperature_2_F",  "Temperature in",   "%.1f F",     temp2_f);
+        data = data_int(data, "humidity_2",       "Humidity in",      "%u %%",      humidity2);
+        data = data_dbl(data, "pressure_hPa",     "Pressure",         "%.1f hPa",   pressure * 0.1f);
             //"rain_rate_mm_h",   "Rain Rate",        DATA_FORMAT, "%.2f mm/h", DATA_DOUBLE, rain_rate * 0.1f,
-            "rain_mm",          "Rain",             DATA_FORMAT, "%.1f mm", DATA_DOUBLE, rain_tot * 0.1f,
-            "wind_dir_deg",     "Wind direction",   DATA_INT,    wind_dir,
-            "wind_avg_m_s",     "Wind",             DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wind * 0.1f,
-            "wind_max_m_s",     "Gust",             DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, gust * 0.1f,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+        data = data_dbl(data, "rain_mm",          "Rain",             "%.1f mm",    rain_tot * 0.1f);
+        data = data_int(data, "wind_dir_deg",     "Wind direction",   NULL,         wind_dir);
+        data = data_dbl(data, "wind_avg_m_s",     "Wind",             "%.1f m/s",   wind * 0.1f);
+        data = data_dbl(data, "wind_max_m_s",     "Gust",             "%.1f m/s",   gust * 0.1f);
+        data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     } else {
         // No outdoor data
-        data = data_make(
-            "model",            "",                 DATA_STRING, "Telldus-FT0385R",
+        data = NULL;
+        data = data_str(data, "model",            "",                 NULL,         "Telldus-FT0385R");
             //"battery_ok",       "Battery",          DATA_INT,    !batt_low,
-            "temperature_2_F",  "Temperature in",   DATA_FORMAT, "%.1f F", DATA_DOUBLE, temp2_f,
-            "humidity_2",       "Humidity in",      DATA_FORMAT, "%u %%", DATA_INT, humidity2,
-            "pressure_hPa",     "Pressure",         DATA_FORMAT, "%.1f hPa", DATA_DOUBLE, pressure * 0.1f,
-            "mic",              "Integrity",        DATA_STRING, "CRC",
-            NULL);
+        data = data_dbl(data, "temperature_2_F",  "Temperature in",   "%.1f F",     temp2_f);
+        data = data_int(data, "humidity_2",       "Humidity in",      "%u %%",      humidity2);
+        data = data_dbl(data, "pressure_hPa",     "Pressure",         "%.1f hPa",   pressure * 0.1f);
+        data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     }
     /* clang-format on */
 

--- a/src/devices/tfa_14_1504_v2.c
+++ b/src/devices/tfa_14_1504_v2.c
@@ -103,13 +103,14 @@ static int tfa_14_1504_v2_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     float temp_c                = ((int)raw_temp_c) - 532;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",                 DATA_STRING,    "TFA-141504v2",
-            "battery_ok",       "Battery",          DATA_INT,       battery_ok,
-            "probe_fail",       "Probe failure",    DATA_INT,       !is_probe_connected,
-            "temperature_C",    "Temperature",      DATA_COND,      is_probe_connected,     DATA_FORMAT,    "%.0f C",   DATA_DOUBLE,    temp_c,
-            "mic",              "Integrity",        DATA_STRING,    "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "TFA-141504v2");
+    data = data_int(data, "battery_ok",       "Battery",          NULL,         battery_ok);
+    data = data_int(data, "probe_fail",       "Probe failure",    NULL,         !is_probe_connected);
+    if (is_probe_connected) {
+        data = data_dbl(data, "temperature_C",    "Temperature",      "%.0f C",     temp_c);
+    }
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tfa_30_3196.c
+++ b/src/devices/tfa_30_3196.c
@@ -88,15 +88,14 @@ static int tfa_303196_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     int humidity    = b[3] & 0x7F;
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "TFA-303196",
-            "id",               "",             DATA_INT,    chk,
-            "channel",          "Channel",      DATA_INT,    channel,
-            "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "mic",              "Integrity",    DATA_STRING, "missing",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "TFA-303196");
+    data = data_int(data, "id",               "",             NULL,         chk);
+    data = data_int(data, "channel",          "Channel",      NULL,         channel);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    data = data_int(data, "humidity",         "Humidity",     "%u %%",      humidity);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "missing");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tfa_30_3221.c
+++ b/src/devices/tfa_30_3221.c
@@ -74,16 +74,15 @@ static int tfa_303221_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     sendmode    = (b[1] >> 6) & 1;
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "TFA-303221",
-            "id",               "Sensor ID",    DATA_INT,    device,
-            "channel",          "Channel",      DATA_INT,    channel,
-            "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "sendmode",         "Test mode",    DATA_INT,    sendmode,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "TFA-303221");
+    data = data_int(data, "id",               "Sensor ID",    NULL,         device);
+    data = data_int(data, "channel",          "Channel",      NULL,         channel);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.2f C",     temp_c);
+    data = data_int(data, "humidity",         "Humidity",     "%u %%",      humidity);
+    data = data_int(data, "sendmode",         "Test mode",    NULL,         sendmode);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tfa_drop_30.3233.c
+++ b/src/devices/tfa_drop_30.3233.c
@@ -162,13 +162,12 @@ static int tfa_drop_303233_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int battery_low = (row_data[3] & 0x80) >> 7;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",      "",           DATA_STRING, "TFA-Drop",
-            "id",         "",           DATA_FORMAT, "%5x", DATA_INT,  sensor_id,
-            "battery_ok", "Battery",    DATA_INT,    !battery_low,
-            "rain_mm",    "Rain in MM", DATA_DOUBLE, rain_mm,
-            "mic",        "Integrity",  DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",      "",           NULL,         "TFA-Drop");
+    data = data_int(data, "id",         "",           "%5x",        sensor_id);
+    data = data_int(data, "battery_ok", "Battery",    NULL,         !battery_low);
+    data = data_dbl(data, "rain_mm",    "Rain in MM", NULL,         rain_mm);
+    data = data_str(data, "mic",        "Integrity",  NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tfa_marbella.c
+++ b/src/devices/tfa_marbella.c
@@ -74,13 +74,12 @@ static int tfa_marbella_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     snprintf(serialnr_str, sizeof(serialnr_str), "%06x", serialnr);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "TFA-Marbella",
-            "id",               "",             DATA_STRING, serialnr_str,
-            "counter",          "",             DATA_INT,    counter,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "TFA-Marbella");
+    data = data_str(data, "id",               "",             NULL,         serialnr_str);
+    data = data_int(data, "counter",          "",             NULL,         counter);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tfa_pool_thermometer.c
+++ b/src/devices/tfa_pool_thermometer.c
@@ -64,14 +64,13 @@ static int tfa_pool_thermometer_decode(r_device *decoder, bitbuffer_t *bitbuffer
     battery     = ((b[3] & 0x20) >> 5);
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",                 DATA_STRING,    "TFA-Pool",
-            "id",               "Id",               DATA_INT,       device,
-            "channel",          "Channel",          DATA_INT,       channel,
-            "battery_ok",       "Battery",          DATA_INT,       battery,
-            "temperature_C",    "Temperature",      DATA_FORMAT,    "%.1f C",  DATA_DOUBLE,    temp_f,
-            "mic",              "Integrity",        DATA_STRING,    "CHECKSUM",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "TFA-Pool");
+    data = data_int(data, "id",               "Id",               NULL,         device);
+    data = data_int(data, "channel",          "Channel",          NULL,         channel);
+    data = data_int(data, "battery_ok",       "Battery",          NULL,         battery);
+    data = data_dbl(data, "temperature_C",    "Temperature",      "%.1f C",     temp_f);
+    data = data_str(data, "mic",              "Integrity",        NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tfa_twin_plus_30.3049.c
+++ b/src/devices/tfa_twin_plus_30.3049.c
@@ -92,15 +92,14 @@ static int tfa_twin_plus_303049_callback(r_device *decoder, bitbuffer_t *bitbuff
     float tempC = (negative_sign ? -((1 << 9) - temp) : temp) * 0.1F;
 
     /* clang-format off */
-    data = data_make(
-            "model",         "",            DATA_STRING, "TFA-TwinPlus",
-            "id",            "Id",          DATA_INT,    sensor_id,
-            "channel",       "Channel",     DATA_INT,    channel,
-            "battery_ok",    "Battery",     DATA_INT,    !battery_low,
-            "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, tempC,
-            "humidity",      "Humidity",    DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "mic",           "Integrity",   DATA_STRING, "CHECKSUM",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",         "",            NULL,         "TFA-TwinPlus");
+    data = data_int(data, "id",            "Id",          NULL,         sensor_id);
+    data = data_int(data, "channel",       "Channel",     NULL,         channel);
+    data = data_int(data, "battery_ok",    "Battery",     NULL,         !battery_low);
+    data = data_dbl(data, "temperature_C", "Temperature", "%.1f C",     tempC);
+    data = data_int(data, "humidity",      "Humidity",    "%u %%",      humidity);
+    data = data_str(data, "mic",           "Integrity",   NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/thermopro_tp11.c
+++ b/src/devices/thermopro_tp11.c
@@ -51,12 +51,11 @@ static int thermopro_tp11_sensor_callback(r_device *decoder, bitbuffer_t *bitbuf
     float temp_c = (temp_raw - 200) * 0.1f;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",         "",            DATA_STRING, "Thermopro-TP11",
-            "id",            "Id",          DATA_INT,    device,
-            "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "mic",           "Integrity",   DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",         "",            NULL,         "Thermopro-TP11");
+    data = data_int(data, "id",            "Id",          NULL,         device);
+    data = data_dbl(data, "temperature_C", "Temperature", "%.1f C",     temp_c);
+    data = data_str(data, "mic",           "Integrity",   NULL,         "CRC");
     /* clang-format on */
     decoder_output_data(decoder, data);
     return 1;

--- a/src/devices/thermopro_tp12.c
+++ b/src/devices/thermopro_tp12.c
@@ -90,13 +90,12 @@ static int thermopro_tp12_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     temp2_c = (temp2_raw - 200) * 0.1f;
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",            DATA_STRING, "Thermopro-TP12",
-            "id",               "Id",          DATA_INT,    device,
-            "temperature_1_C",  "Temperature 1 (Food)", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp1_c,
-            "temperature_2_C",  "Temperature 2 (Barbecue)", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp2_c,
-            "mic",              "Integrity",   DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",            NULL,         "Thermopro-TP12");
+    data = data_int(data, "id",               "Id",          NULL,         device);
+    data = data_dbl(data, "temperature_1_C",  "Temperature 1 (Food)", "%.1f C",     temp1_c);
+    data = data_dbl(data, "temperature_2_C",  "Temperature 2 (Barbecue)", "%.1f C",     temp2_c);
+    data = data_str(data, "mic",              "Integrity",   NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/thermopro_tp28b.c
+++ b/src/devices/thermopro_tp28b.c
@@ -122,18 +122,17 @@ static int thermopro_tp28b_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     float p2_set_lo = bcd2float(b[10], b[11]);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",                "",                             DATA_STRING,    "ThermoPro-TP28b",
-            "id",                   "",                             DATA_FORMAT,    "%04x",   DATA_INT,    id,
-            "temperature_1_C",      "Temperature 1",                DATA_FORMAT,    "%.1f C", DATA_DOUBLE, p1_temp,
-            "alarm_high_1_C",       "Temperature 1 alarm high",     DATA_FORMAT,    "%.1f C", DATA_DOUBLE, p1_set_hi,
-            "alarm_low_1_C",        "Temperature 1 alarm low",      DATA_FORMAT,    "%.1f C", DATA_DOUBLE, p1_set_lo,
-            "temperature_2_C",      "Temperature 2",                DATA_FORMAT,    "%.1f C", DATA_DOUBLE, p2_temp,
-            "alarm_high_2_C",       "Temperature 2 alarm high",     DATA_FORMAT,    "%.1f C", DATA_DOUBLE, p2_set_hi,
-            "alarm_low_2_C",        "Temperature 2 alarm low",      DATA_FORMAT,    "%.1f C", DATA_DOUBLE, p2_set_lo,
-            "flags",                "Status flags",                 DATA_FORMAT,    "%04x",   DATA_INT,    flags,
-            "mic",                  "Integrity",                    DATA_STRING,    "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",                "",                             NULL,         "ThermoPro-TP28b");
+    data = data_int(data, "id",                   "",                             "%04x",       id);
+    data = data_dbl(data, "temperature_1_C",      "Temperature 1",                "%.1f C",     p1_temp);
+    data = data_dbl(data, "alarm_high_1_C",       "Temperature 1 alarm high",     "%.1f C",     p1_set_hi);
+    data = data_dbl(data, "alarm_low_1_C",        "Temperature 1 alarm low",      "%.1f C",     p1_set_lo);
+    data = data_dbl(data, "temperature_2_C",      "Temperature 2",                "%.1f C",     p2_temp);
+    data = data_dbl(data, "alarm_high_2_C",       "Temperature 2 alarm high",     "%.1f C",     p2_set_hi);
+    data = data_dbl(data, "alarm_low_2_C",        "Temperature 2 alarm low",      "%.1f C",     p2_set_lo);
+    data = data_int(data, "flags",                "Status flags",                 "%04x",       flags);
+    data = data_str(data, "mic",                  "Integrity",                    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/thermopro_tp82xb.c
+++ b/src/devices/thermopro_tp82xb.c
@@ -116,20 +116,31 @@ static int thermopro_tp828b_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     float p2_t_hi = (p2_hi_raw - 500) * 0.1f;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",                "",                             DATA_STRING,    "ThermoPro-TP828b",
-            "id",                   "",                             DATA_FORMAT,    "%02x",         DATA_INT,    id,
-            "display_u",            "Display Unit",                 DATA_COND, display_u == 0x2,    DATA_STRING, "Fahrenheit",
-            "display_u",            "Display Unit",                 DATA_COND, display_u == 0x0,    DATA_STRING, "Celsius",
-            "temperature_1_C",      "Temperature 1",                DATA_COND, p1_raw != 0xedd ,    DATA_FORMAT, "%.1f C", DATA_DOUBLE, p1_temp, // if 0xedd then no probe
-            "temperature_1_LO_C",   "Temperature 1 LO",             DATA_COND, p1_lo_raw != 0xeaa , DATA_FORMAT, "%.1f C", DATA_DOUBLE, p1_t_lo, // if 0xeaa then no LO
-            "temperature_1_HI_C",   "Temperature 1 HI",                                             DATA_FORMAT, "%.1f C", DATA_DOUBLE, p1_t_hi,
-            "temperature_2_C",      "Temperature 2",                DATA_COND, p2_raw != 0xedd ,    DATA_FORMAT, "%.1f C", DATA_DOUBLE, p2_temp, // if 0xedd then no probe
-            "temperature_2_LO_C",   "Temperature 2 LO",             DATA_COND, p2_lo_raw != 0xeaa , DATA_FORMAT, "%.1f C", DATA_DOUBLE, p2_t_lo, // if 0xeaa then no LO
-            "temperature_2_HI_C",   "Temperature 2 HI",                                             DATA_FORMAT, "%.1f C", DATA_DOUBLE, p2_t_hi,
-            "flags",                "Flags",                        DATA_FORMAT,    "%01x",         DATA_INT,    flags,
-            "mic",                  "Integrity",                    DATA_STRING,    "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",                "",                             NULL,         "ThermoPro-TP828b");
+    data = data_int(data, "id",                   "",                             "%02x",       id);
+    if (display_u == 0x2) {
+        data = data_str(data, "display_u",            "Display Unit",                 NULL,         "Fahrenheit");
+    }
+    if (display_u == 0x0) {
+        data = data_str(data, "display_u",            "Display Unit",                 NULL,         "Celsius");
+    }
+    if (p1_raw != 0xedd ) {
+        data = data_dbl(data, "temperature_1_C",      "Temperature 1",                "%.1f C",     p1_temp); // if 0xedd then no probe
+    }
+    if (p1_lo_raw != 0xeaa ) {
+        data = data_dbl(data, "temperature_1_LO_C",   "Temperature 1 LO",             "%.1f C",     p1_t_lo); // if 0xeaa then no LO
+    }
+    data = data_dbl(data, "temperature_1_HI_C",   "Temperature 1 HI",                                             "%.1f C",     p1_t_hi);
+    if (p2_raw != 0xedd ) {
+        data = data_dbl(data, "temperature_2_C",      "Temperature 2",                "%.1f C",     p2_temp); // if 0xedd then no probe
+    }
+    if (p2_lo_raw != 0xeaa ) {
+        data = data_dbl(data, "temperature_2_LO_C",   "Temperature 2 LO",             "%.1f C",     p2_t_lo); // if 0xeaa then no LO
+    }
+    data = data_dbl(data, "temperature_2_HI_C",   "Temperature 2 HI",                                             "%.1f C",     p2_t_hi);
+    data = data_int(data, "flags",                "Flags",                        "%01x",       flags);
+    data = data_str(data, "mic",                  "Integrity",                    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);
@@ -224,18 +235,29 @@ static int thermopro_tp829b_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     float p4_temp = (p4_raw - 500) * 0.1f;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",                "",                             DATA_STRING,    "ThermoPro-TP829b",
-            "id",                   "",                             DATA_FORMAT,    "%02x",      DATA_INT,    id,
-            "display_u",            "Display Unit",                 DATA_COND, display_u == 0x2, DATA_STRING, "Fahrenheit",
-            "display_u",            "Display Unit",                 DATA_COND, display_u == 0x0, DATA_STRING, "Celsius",
-            "temperature_1_C",      "Temperature 1",                DATA_COND, p1_raw != 0xedd , DATA_FORMAT, "%.1f C", DATA_DOUBLE, p1_temp, // if 0xedd then no probe
-            "temperature_2_C",      "Temperature 2",                DATA_COND, p2_raw != 0xedd , DATA_FORMAT, "%.1f C", DATA_DOUBLE, p2_temp, // if 0xedd then no probe
-            "temperature_3_C",      "Temperature 3",                DATA_COND, p3_raw != 0xedd , DATA_FORMAT, "%.1f C", DATA_DOUBLE, p3_temp, // if 0xedd then no probe
-            "temperature_4_C",      "Temperature 4",                DATA_COND, p4_raw != 0xedd , DATA_FORMAT, "%.1f C", DATA_DOUBLE, p4_temp, // if 0xedd then no probe
-            "flags",                "Flags",                        DATA_FORMAT,    "%01x",      DATA_INT,    flags,
-            "mic",                  "Integrity",                    DATA_STRING,    "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",                "",                             NULL,         "ThermoPro-TP829b");
+    data = data_int(data, "id",                   "",                             "%02x",       id);
+    if (display_u == 0x2) {
+        data = data_str(data, "display_u",            "Display Unit",                 NULL,         "Fahrenheit");
+    }
+    if (display_u == 0x0) {
+        data = data_str(data, "display_u",            "Display Unit",                 NULL,         "Celsius");
+    }
+    if (p1_raw != 0xedd ) {
+        data = data_dbl(data, "temperature_1_C",      "Temperature 1",                "%.1f C",     p1_temp); // if 0xedd then no probe
+    }
+    if (p2_raw != 0xedd ) {
+        data = data_dbl(data, "temperature_2_C",      "Temperature 2",                "%.1f C",     p2_temp); // if 0xedd then no probe
+    }
+    if (p3_raw != 0xedd ) {
+        data = data_dbl(data, "temperature_3_C",      "Temperature 3",                "%.1f C",     p3_temp); // if 0xedd then no probe
+    }
+    if (p4_raw != 0xedd ) {
+        data = data_dbl(data, "temperature_4_C",      "Temperature 4",                "%.1f C",     p4_temp); // if 0xedd then no probe
+    }
+    data = data_int(data, "flags",                "Flags",                        "%01x",       flags);
+    data = data_str(data, "mic",                  "Integrity",                    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/thermopro_tx2.c
+++ b/src/devices/thermopro_tx2.c
@@ -77,16 +77,17 @@ static int thermopro_tx2_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     humidity = ((b[3] & 0x0F) << 4) | (b[4] >> 4);
 
     /* clang-format off */
-    data = data_make(
-            "model",         "",            DATA_STRING, "Thermopro-TX2",
-            "subtype",       "",            DATA_INT, type,
-            "id",            "",            DATA_INT, id,
-            "channel",       "Channel",     DATA_INT, channel,
-            "battery_ok",    "Battery",     DATA_INT, !battery,
-            "temperature_C", "Temperature", DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_raw * 0.1,
-            "humidity",      "Humidity",    DATA_COND, humidity != 0xcc, DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "button",        "Button",      DATA_INT, button,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",         "",            NULL,         "Thermopro-TX2");
+    data = data_int(data, "subtype",       "",            NULL,         type);
+    data = data_int(data, "id",            "",            NULL,         id);
+    data = data_int(data, "channel",       "Channel",     NULL,         channel);
+    data = data_int(data, "battery_ok",    "Battery",     NULL,         !battery);
+    data = data_dbl(data, "temperature_C", "Temperature", "%.2f C",     temp_raw * 0.1);
+    if (humidity != 0xcc) {
+        data = data_int(data, "humidity",      "Humidity",    "%u %%",      humidity);
+    }
+    data = data_int(data, "button",        "Button",      NULL,         button);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/thermopro_tx2c.c
+++ b/src/devices/thermopro_tx2c.c
@@ -75,16 +75,17 @@ static int thermopro_tx2c_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int humidity = (((b[3] & 0xF) << 4) | (b[4] >> 4));
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",         "",            DATA_STRING, "Thermopro-TX2C",
+    data_t *data = NULL;
+    data = data_str(data, "model",         "",            NULL,         "Thermopro-TX2C");
             // "subtype",       "",            DATA_INT, type,
-            "id",            "Id",          DATA_INT, id,
-            "channel",       "Channel",     DATA_INT, channel,
-            "battery_ok",    "Battery",     DATA_INT, !battery,
-            "temperature_C", "Temperature", DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "humidity",      "Humidity",    DATA_COND, humidity != 0x0a, DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "button",        "Button",      DATA_INT, button,
-            NULL);
+    data = data_int(data, "id",            "Id",          NULL,         id);
+    data = data_int(data, "channel",       "Channel",     NULL,         channel);
+    data = data_int(data, "battery_ok",    "Battery",     NULL,         !battery);
+    data = data_dbl(data, "temperature_C", "Temperature", "%.1f C",     temp_c);
+    if (humidity != 0x0a) {
+        data = data_int(data, "humidity",      "Humidity",    "%u %%",      humidity);
+    }
+    data = data_int(data, "button",        "Button",      NULL,         button);
     /* clang-format on */
     decoder_output_data(decoder, data);
     return 1;

--- a/src/devices/thermor.c
+++ b/src/devices/thermor.c
@@ -93,12 +93,11 @@ static int thermor_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     if (b[0] == 0xff && b[1] == b[2] && b[1] == b[4] && b[1] == b[5] && b[1] == b[6] && b[1] == b[7] && b[1] == b[8] && b[1] == b[10]  ) {
         int new_id = ~b[1] & 0xff;
         /* clang-format off */
-        data_t *data = data_make(
-                "model",          "",           DATA_STRING, "Thermor-DG950",
-                "id",         "",               DATA_FORMAT, "%d", DATA_INT, new_id,
-                "pairing",         "Pairing?",  DATA_INT, 1,
-                "mic",            "Integrity",  DATA_STRING, "CHECKSUM",
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",          "",           NULL,         "Thermor-DG950");
+        data = data_int(data, "id",         "",               "%d",         new_id);
+        data = data_int(data, "pairing",         "Pairing?",  NULL,         1);
+        data = data_str(data, "mic",            "Integrity",  NULL,         "CHECKSUM");
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;
@@ -177,18 +176,23 @@ static int thermor_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         }
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",          "",               DATA_STRING, "Thermor-DG950",
-                "id",             "",               DATA_FORMAT, "%d",    DATA_INT,    id,
-                "temperature_C",  "Temperature",    DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_C,
-                "rain_rate_mm_h", "Rain Rate",      DATA_COND, have_rain, DATA_FORMAT, "%.1f mm/h", DATA_DOUBLE, rain_rate1 * 0.1f,
-                "wind_dir_deg",   "Wind Direction", DATA_COND, have_wdir, DATA_INT,     wind_dir_d,
-                "wind_avg_km_h",  "Wind avg speed", DATA_COND, have_wspd, DATA_FORMAT, "%.1f km/h", DATA_DOUBLE, wind_speed_kmh,
+        data_t *data = NULL;
+        data = data_str(data, "model",          "",               NULL,         "Thermor-DG950");
+        data = data_int(data, "id",             "",               "%d",         id);
+        data = data_dbl(data, "temperature_C",  "Temperature",    "%.1f C",     temp_C);
+        if (have_rain) {
+            data = data_dbl(data, "rain_rate_mm_h", "Rain Rate",      "%.1f mm/h",  rain_rate1 * 0.1f);
+        }
+        if (have_wdir) {
+            data = data_int(data, "wind_dir_deg",   "Wind Direction", NULL,         wind_dir_d);
+        }
+        if (have_wspd) {
+            data = data_dbl(data, "wind_avg_km_h",  "Wind avg speed", "%.1f km/h",  wind_speed_kmh);
+        }
                 //"wind_coef",      "Wind Coef",      DATA_COND, have_wspd, DATA_INT,     wind_coef,
                 //"wind_ratio",     "Wind Ratio",     DATA_COND, have_wspd, DATA_DOUBLE,  wind_ratio,
-                "pairing",         "Pairing?",      DATA_INT, 0,
-                "mic",            "Integrity",      DATA_STRING, "CHECKSUM",
-                NULL);
+        data = data_int(data, "pairing",         "Pairing?",      NULL,         0);
+        data = data_str(data, "mic",            "Integrity",      NULL,         "CHECKSUM");
         /* clang-format on */
         decoder_output_data(decoder, data);
         return 1;

--- a/src/devices/tpms_abarth124.c
+++ b/src/devices/tpms_abarth124.c
@@ -66,16 +66,15 @@ static int tpms_abarth124_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsi
     snprintf(id_str, sizeof(id_str), "%02x%02x%02x%02x", b[0], b[1], b[2], b[3]);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Abarth-124Spider",
-            "type",             "",             DATA_STRING, "TPMS",
-            "id",               "",             DATA_STRING, id_str,
-            "flags",            "",             DATA_STRING, flags,
-            "pressure_kPa",     "Pressure",     DATA_FORMAT, "%.0f kPa", DATA_DOUBLE, (float)pressure * 1.38,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.0f C", DATA_DOUBLE, (float)temperature - 50.0,
-            "status",           "",             DATA_INT, status,
-            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Abarth-124Spider");
+    data = data_str(data, "type",             "",             NULL,         "TPMS");
+    data = data_str(data, "id",               "",             NULL,         id_str);
+    data = data_str(data, "flags",            "",             NULL,         flags);
+    data = data_dbl(data, "pressure_kPa",     "Pressure",     "%.0f kPa",   (float)pressure * 1.38);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.0f C",     (float)temperature - 50.0);
+    data = data_int(data, "status",           "",             NULL,         status);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tpms_ave.c
+++ b/src/devices/tpms_ave.c
@@ -91,19 +91,24 @@ static int tpms_ave_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned r
     snprintf(id_str, sizeof(id_str), "%08x", id);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "Model",         DATA_STRING, "AVE",
-            "type",             "Type",          DATA_STRING, "TPMS",
-            "id",               "Id",            DATA_STRING, id_str,
-            "mode",             "Mode",          DATA_FORMAT, "M%d", DATA_INT, mode,
-            "pressure_kPa",     "Pressure",      DATA_FORMAT, "%.1f kPa", DATA_DOUBLE, pressure,
-            "temperature_C",    "Temperature",   DATA_FORMAT, "%.0f C", DATA_DOUBLE, (double)temperature - 50.0,
-            "battery_ok",       "Battery level", DATA_COND, battery_level < 6, DATA_DOUBLE, 1.0,
-            "battery_ok",       "Battery level", DATA_COND, battery_level == 6, DATA_DOUBLE, 0.75,
-            "battery_ok",       "Battery level", DATA_COND, battery_level == 7, DATA_DOUBLE, 0.25,
-            "flags",            "Flags",         DATA_FORMAT, "0x%x", DATA_INT, flags,
-            "mic",              "Integrity",     DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "Model",         NULL,         "AVE");
+    data = data_str(data, "type",             "Type",          NULL,         "TPMS");
+    data = data_str(data, "id",               "Id",            NULL,         id_str);
+    data = data_int(data, "mode",             "Mode",          "M%d",        mode);
+    data = data_dbl(data, "pressure_kPa",     "Pressure",      "%.1f kPa",   pressure);
+    data = data_dbl(data, "temperature_C",    "Temperature",   "%.0f C",     (double)temperature - 50.0);
+    if (battery_level < 6) {
+        data = data_dbl(data, "battery_ok",       "Battery level", NULL,         1.0);
+    }
+    if (battery_level == 6) {
+        data = data_dbl(data, "battery_ok",       "Battery level", NULL,         0.75);
+    }
+    if (battery_level == 7) {
+        data = data_dbl(data, "battery_ok",       "Battery level", NULL,         0.25);
+    }
+    data = data_int(data, "flags",            "Flags",         "0x%x",       flags);
+    data = data_str(data, "mic",              "Integrity",     NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tpms_bmw.c
+++ b/src/devices/tpms_bmw.c
@@ -146,21 +146,32 @@ static int tpms_bmw_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",               "",                DATA_COND, len_msg == 11, DATA_STRING, "BMW-GEN5",
-            "model",               "",                DATA_COND, len_msg == 8, DATA_STRING, "Audi-PressureAlert",
-            "type",                "",                DATA_STRING, "TPMS",
-            "alert",               "Alert",           DATA_COND, len_msg == 8, DATA_STRING, "Alert Pressure increase/decrease !",
-            "brand",               "Brand",           DATA_INT,    brand_id,
-            "id",                  "",                DATA_STRING, id_str,
-            "pressure_kPa",        "Pressure",        DATA_FORMAT, "%.1f kPa", DATA_DOUBLE, (double)pressure_kPa,
-            "temperature_C",       "Temperature",     DATA_FORMAT, "%.1f C",   DATA_DOUBLE, (double)temperature_C,
-            "flags1",              "",                DATA_COND, len_msg == 11, DATA_INT,    flags1,
-            "flags2",              "",                DATA_COND, len_msg == 11, DATA_INT,    flags2,
-            "flags3",              "",                DATA_COND, len_msg == 11, DATA_INT,    flags3, // Nominal Pressure for brand HUF 0x03
-            "msg",                 "msg",             DATA_STRING, msg_str, // To remove after guess all tags
-            "mic",                 "Integrity",       DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    if (len_msg == 11) {
+        data = data_str(data, "model",               "",                NULL,         "BMW-GEN5");
+    }
+    if (len_msg == 8) {
+        data = data_str(data, "model",               "",                NULL,         "Audi-PressureAlert");
+    }
+    data = data_str(data, "type",                "",                NULL,         "TPMS");
+    if (len_msg == 8) {
+        data = data_str(data, "alert",               "Alert",           NULL,         "Alert Pressure increase/decrease !");
+    }
+    data = data_int(data, "brand",               "Brand",           NULL,         brand_id);
+    data = data_str(data, "id",                  "",                NULL,         id_str);
+    data = data_dbl(data, "pressure_kPa",        "Pressure",        "%.1f kPa",   (double)pressure_kPa);
+    data = data_dbl(data, "temperature_C",       "Temperature",     "%.1f C",     (double)temperature_C);
+    if (len_msg == 11) {
+        data = data_int(data, "flags1",              "",                NULL,         flags1);
+    }
+    if (len_msg == 11) {
+        data = data_int(data, "flags2",              "",                NULL,         flags2);
+    }
+    if (len_msg == 11) {
+        data = data_int(data, "flags3",              "",                NULL,         flags3); // Nominal Pressure for brand HUF 0x03
+    }
+    data = data_str(data, "msg",                 "msg",             NULL,         msg_str); // To remove after guess all tags
+    data = data_str(data, "mic",                 "Integrity",       NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tpms_bmw_g3.c
+++ b/src/devices/tpms_bmw_g3.c
@@ -88,19 +88,18 @@ static int tpms_bmwg3_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     snprintf(msg_str, sizeof(msg_str), "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x", b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7], b[8], b[9], b[10]);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",               "",                DATA_STRING, "BMW-GEN3",
-            "type",                "",                DATA_STRING, "TPMS",
+    data_t *data = NULL;
+    data = data_str(data, "model",               "",                NULL,         "BMW-GEN3");
+    data = data_str(data, "type",                "",                NULL,         "TPMS");
             //"id",                  "",                DATA_FORMAT, "%08x",     DATA_INT,    id,
-            "id",                  "",                DATA_INT,    id,
-            "pressure_kPa",        "Pressure",        DATA_FORMAT, "%.1f kPa", DATA_DOUBLE, (double)pressure_kPa,
-            "temperature_C",       "Temperature",     DATA_FORMAT, "%.1f C",   DATA_DOUBLE, temperature_C,
-            "flags1",              "",                DATA_FORMAT, "%08b",     DATA_INT,    flags1,
-            "flags2",              "",                DATA_FORMAT, "%08b",     DATA_INT,    flags2,
-            "flags3",              "",                DATA_FORMAT, "%08b",     DATA_INT,    flags3,
-            "msg",                 "msg",             DATA_STRING, msg_str, // To remove after guess all tags
-            "mic",                 "Integrity",       DATA_STRING, "CRC",
-            NULL);
+    data = data_int(data, "id",                  "",                NULL,         id);
+    data = data_dbl(data, "pressure_kPa",        "Pressure",        "%.1f kPa",   (double)pressure_kPa);
+    data = data_dbl(data, "temperature_C",       "Temperature",     "%.1f C",     temperature_C);
+    data = data_int(data, "flags1",              "",                "%08b",       flags1);
+    data = data_int(data, "flags2",              "",                "%08b",       flags2);
+    data = data_int(data, "flags3",              "",                "%08b",       flags3);
+    data = data_str(data, "msg",                 "msg",             NULL,         msg_str); // To remove after guess all tags
+    data = data_str(data, "mic",                 "Integrity",       NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tpms_citroen.c
+++ b/src/devices/tpms_citroen.c
@@ -74,18 +74,17 @@ static int tpms_citroen_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     snprintf(id_str, sizeof(id_str), "%08x", id);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Citroen",
-            "type",             "",             DATA_STRING, "TPMS",
-            "id",               "",             DATA_STRING, id_str,
-            "state",            "",             DATA_STRING, state_str,
-            "flags",            "",             DATA_INT,    flags,
-            "repeat",           "",             DATA_INT,    repeat,
-            "pressure_kPa",     "Pressure",     DATA_FORMAT, "%.0f kPa", DATA_DOUBLE, (double)pressure * 1.364,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.0f C", DATA_DOUBLE, (double)temperature - 50.0,
-            "maybe_battery",    "",             DATA_INT,    maybe_battery,
-            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Citroen");
+    data = data_str(data, "type",             "",             NULL,         "TPMS");
+    data = data_str(data, "id",               "",             NULL,         id_str);
+    data = data_str(data, "state",            "",             NULL,         state_str);
+    data = data_int(data, "flags",            "",             NULL,         flags);
+    data = data_int(data, "repeat",           "",             NULL,         repeat);
+    data = data_dbl(data, "pressure_kPa",     "Pressure",     "%.0f kPa",   (double)pressure * 1.364);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.0f C",     (double)temperature - 50.0);
+    data = data_int(data, "maybe_battery",    "",             NULL,         maybe_battery);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tpms_eezrv.c
+++ b/src/devices/tpms_eezrv.c
@@ -127,18 +127,17 @@ static int tpms_eezrv_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     snprintf(flags_str, sizeof(flags_str), "%02x%02x", flags1, flags2);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "EezTire-E618",
-            "type",             "",             DATA_STRING, "TPMS",
-            "id",               "",             DATA_STRING, id_str,
-            "battery_ok",       "Battery_OK",   DATA_INT,    !low_batt,
-            "pressure_kPa",     "Pressure",     DATA_FORMAT, "%.0f kPa", DATA_DOUBLE, (double)pressure_kPa,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, (double)temperature_C,
-            "flags",            "Flags",        DATA_STRING, flags_str,
-            "fast_leak",        "Fast Leak",    DATA_INT,    fast_leak,
-            "inflate",          "Inflate",      DATA_INT,    infl_detected,
-            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "EezTire-E618");
+    data = data_str(data, "type",             "",             NULL,         "TPMS");
+    data = data_str(data, "id",               "",             NULL,         id_str);
+    data = data_int(data, "battery_ok",       "Battery_OK",   NULL,         !low_batt);
+    data = data_dbl(data, "pressure_kPa",     "Pressure",     "%.0f kPa",   (double)pressure_kPa);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     (double)temperature_C);
+    data = data_str(data, "flags",            "Flags",        NULL,         flags_str);
+    data = data_int(data, "fast_leak",        "Fast Leak",    NULL,         fast_leak);
+    data = data_int(data, "inflate",          "Inflate",      NULL,         infl_detected);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tpms_elantra2012.c
+++ b/src/devices/tpms_elantra2012.c
@@ -78,18 +78,17 @@ static int tpms_elantra2012_decode(r_device *decoder, bitbuffer_t *bitbuffer, un
     snprintf(flags_str, sizeof(flags_str), "%x", flags);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Elantra2012",
-            "type",             "",             DATA_STRING, "TPMS",
-            "id",               "",             DATA_STRING, id_str,
-            "pressure_kPa",     "Pressure",     DATA_FORMAT, "%.1f kPa", DATA_DOUBLE, (float)pressure_kpa,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.0f C", DATA_DOUBLE, (float)temperature_c,
-            "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-            "triggered",        "LF Triggered", DATA_INT,    triggered,
-            "storage",          "Storage mode", DATA_INT,    storage,
-            "flags",            "All Flags",    DATA_STRING, flags_str,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Elantra2012");
+    data = data_str(data, "type",             "",             NULL,         "TPMS");
+    data = data_str(data, "id",               "",             NULL,         id_str);
+    data = data_dbl(data, "pressure_kPa",     "Pressure",     "%.1f kPa",   (float)pressure_kpa);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.0f C",     (float)temperature_c);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_int(data, "triggered",        "LF Triggered", NULL,         triggered);
+    data = data_int(data, "storage",          "Storage mode", NULL,         storage);
+    data = data_str(data, "flags",            "All Flags",    NULL,         flags_str);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tpms_ford.c
+++ b/src/devices/tpms_ford.c
@@ -162,19 +162,20 @@ static int tpms_ford_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned 
     snprintf(unknown_3_str, sizeof(unknown_3_str), "%01x", unknown_3);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Ford",
-            "type",             "",             DATA_STRING, "TPMS",
-            "id",               "",             DATA_STRING, id_str,
-            "pressure_PSI",     "Pressure",     DATA_FORMAT, "%.2f PSI", DATA_DOUBLE, pressure_psi,
-            "temperature_C",    "Temperature",  DATA_COND, temperature_valid, DATA_FORMAT, "%.1f C",   DATA_DOUBLE, (float)temperature_c,
-            "moving",           "Moving",       DATA_INT,    moving,
-            "learn",            "Learn",        DATA_INT,    learn,
-            "code",             "",             DATA_STRING, code_str,
-            "unknown",          "",             DATA_STRING, unknown_str,
-            "unknown_3",        "",             DATA_STRING, unknown_3_str,
-            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Ford");
+    data = data_str(data, "type",             "",             NULL,         "TPMS");
+    data = data_str(data, "id",               "",             NULL,         id_str);
+    data = data_dbl(data, "pressure_PSI",     "Pressure",     "%.2f PSI",   pressure_psi);
+    if (temperature_valid) {
+        data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     (float)temperature_c);
+    }
+    data = data_int(data, "moving",           "Moving",       NULL,         moving);
+    data = data_int(data, "learn",            "Learn",        NULL,         learn);
+    data = data_str(data, "code",             "",             NULL,         code_str);
+    data = data_str(data, "unknown",          "",             NULL,         unknown_str);
+    data = data_str(data, "unknown_3",        "",             NULL,         unknown_3_str);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tpms_hyundai_vdo.c
+++ b/src/devices/tpms_hyundai_vdo.c
@@ -82,18 +82,17 @@ static int tpms_hyundai_vdo_decode(r_device *decoder, bitbuffer_t *bitbuffer, un
     snprintf(id_str, sizeof(id_str), "%08x", id);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Hyundai-VDO",
-            "type",             "",             DATA_STRING, "TPMS",
-            "id",               "",             DATA_STRING, id_str,
-            "state",            "",             DATA_INT,    state,
-            "flags",            "",             DATA_INT,    flags,
-            "repeat",           "repetition",   DATA_INT,    repeat,
-            "pressure_kPa",     "pressure",     DATA_FORMAT, "%.0f kPa", DATA_DOUBLE, (double)pressure * 1.375,
-            "temperature_C",    "temp",         DATA_FORMAT, "%.0f C", DATA_DOUBLE, (double)temperature - 50.0,
-            "maybe_battery",    "",             DATA_INT,    maybe_battery,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Hyundai-VDO");
+    data = data_str(data, "type",             "",             NULL,         "TPMS");
+    data = data_str(data, "id",               "",             NULL,         id_str);
+    data = data_int(data, "state",            "",             NULL,         state);
+    data = data_int(data, "flags",            "",             NULL,         flags);
+    data = data_int(data, "repeat",           "repetition",   NULL,         repeat);
+    data = data_dbl(data, "pressure_kPa",     "pressure",     "%.0f kPa",   (double)pressure * 1.375);
+    data = data_dbl(data, "temperature_C",    "temp",         "%.0f C",     (double)temperature - 50.0);
+    data = data_int(data, "maybe_battery",    "",             NULL,         maybe_battery);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tpms_jansite.c
+++ b/src/devices/tpms_jansite.c
@@ -60,16 +60,15 @@ static int tpms_jansite_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     snprintf(code_str, sizeof(code_str), "%02x%02x%02x%02x%02x%02x%02x", b[0], b[1], b[2], b[3], b[4], b[5], b[6]); // figure out the checksum
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Jansite",
-            "type",             "",             DATA_STRING, "TPMS",
-            "id",               "",             DATA_STRING, id_str,
-            "flags",            "",             DATA_INT, flags,
-            "pressure_kPa",     "Pressure",     DATA_FORMAT, "%.0f kPa", DATA_DOUBLE, (double)pressure * 1.7,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.0f C", DATA_DOUBLE, (double)temperature - 50.0,
-            "code",             "",             DATA_STRING, code_str,
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Jansite");
+    data = data_str(data, "type",             "",             NULL,         "TPMS");
+    data = data_str(data, "id",               "",             NULL,         id_str);
+    data = data_int(data, "flags",            "",             NULL,         flags);
+    data = data_dbl(data, "pressure_kPa",     "Pressure",     "%.0f kPa",   (double)pressure * 1.7);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.0f C",     (double)temperature - 50.0);
+    data = data_str(data, "code",             "",             NULL,         code_str);
             //"mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tpms_jansite_solar.c
+++ b/src/devices/tpms_jansite_solar.c
@@ -81,16 +81,15 @@ static int tpms_jansite_solar_decode(r_device *decoder, bitbuffer_t *bitbuffer, 
     snprintf(code_str, sizeof(code_str), "%02x%02x%02x%02x%02x%02x%02x%02x%02x", b[2], b[3], b[4], b[5], b[6], b[7], b[8], b[9], b[10]);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Jansite-Solar",
-            "type",             "",             DATA_STRING, "TPMS",
-            "id",               "",             DATA_STRING, id_str,
-            "flags",            "",             DATA_INT, flags,
-            "pressure_kPa",     "Pressure",     DATA_FORMAT, "%.0f kPa", DATA_DOUBLE, (float)pressure * 1.6,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.0f C", DATA_DOUBLE, (float)temperature - 55.0,
-            "code",             "",             DATA_STRING, code_str,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Jansite-Solar");
+    data = data_str(data, "type",             "",             NULL,         "TPMS");
+    data = data_str(data, "id",               "",             NULL,         id_str);
+    data = data_int(data, "flags",            "",             NULL,         flags);
+    data = data_dbl(data, "pressure_kPa",     "Pressure",     "%.0f kPa",   (float)pressure * 1.6);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.0f C",     (float)temperature - 55.0);
+    data = data_str(data, "code",             "",             NULL,         code_str);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tpms_kia.c
+++ b/src/devices/tpms_kia.c
@@ -88,17 +88,16 @@ static int tpms_kia_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned r
     float temperature_float = temperature - 50.0f;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Kia",
-            "type",             "",             DATA_STRING, "TPMS",
-            "id",               "",             DATA_STRING, id_str,
-            "unknown1",         "",             DATA_STRING, unknown1_str,
-            "unknown2",         "",             DATA_STRING, unknown2_str,
-            "pressure_PSI",     "pressure",     DATA_FORMAT, "%.1f PSI", DATA_DOUBLE, pressure_float,
-            "temperature_C",    "temperature",  DATA_FORMAT, "%.0f C", DATA_DOUBLE, temperature_float,
-            "raw",              "",             DATA_STRING, raw,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Kia");
+    data = data_str(data, "type",             "",             NULL,         "TPMS");
+    data = data_str(data, "id",               "",             NULL,         id_str);
+    data = data_str(data, "unknown1",         "",             NULL,         unknown1_str);
+    data = data_str(data, "unknown2",         "",             NULL,         unknown2_str);
+    data = data_dbl(data, "pressure_PSI",     "pressure",     "%.1f PSI",   pressure_float);
+    data = data_dbl(data, "temperature_C",    "temperature",  "%.0f C",     temperature_float);
+    data = data_str(data, "raw",              "",             NULL,         raw);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tpms_nissan.c
+++ b/src/devices/tpms_nissan.c
@@ -57,14 +57,13 @@ static int tpms_nissan_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigne
     snprintf(id_str, sizeof(id_str), "%06x", id);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Nissan",
-            "type",             "",             DATA_STRING, "TPMS",
-            "id",               "",             DATA_STRING, id_str,
-            "mode",             "",             DATA_INT,    mode,
-            "pressure_PSI",     "Pressure",     DATA_FORMAT, "%.1f PSI", DATA_DOUBLE, pressure_psi,
-            "unknown",          "",             DATA_INT,    unknown,
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Nissan");
+    data = data_str(data, "type",             "",             NULL,         "TPMS");
+    data = data_str(data, "id",               "",             NULL,         id_str);
+    data = data_int(data, "mode",             "",             NULL,         mode);
+    data = data_dbl(data, "pressure_PSI",     "Pressure",     "%.1f PSI",   pressure_psi);
+    data = data_int(data, "unknown",          "",             NULL,         unknown);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tpms_pmv107j.c
+++ b/src/devices/tpms_pmv107j.c
@@ -68,18 +68,17 @@ static int tpms_pmv107j_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     snprintf(id_str, sizeof(id_str), "%08x", id);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING,    "PMV-107J",
-            "type",             "",             DATA_STRING,    "TPMS",
-            "id",               "",             DATA_STRING,    id_str,
-            "status",           "",             DATA_INT,       status,
-            "battery_ok",       "",             DATA_INT,       !battery_low,
-            "counter",          "",             DATA_INT,       counter,
-            "failed",           "",             DATA_STRING,    failed ? "FAIL" : "OK",
-            "pressure_kPa",     "",             DATA_DOUBLE,    pressure_kpa,
-            "temperature_C",    "",             DATA_DOUBLE,    temperature_c,
-            "mic",              "Integrity",    DATA_STRING,    "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "PMV-107J");
+    data = data_str(data, "type",             "",             NULL,         "TPMS");
+    data = data_str(data, "id",               "",             NULL,         id_str);
+    data = data_int(data, "status",           "",             NULL,         status);
+    data = data_int(data, "battery_ok",       "",             NULL,         !battery_low);
+    data = data_int(data, "counter",          "",             NULL,         counter);
+    data = data_str(data, "failed",           "",             NULL,         failed ? "FAIL" : "OK");
+    data = data_dbl(data, "pressure_kPa",     "",             NULL,         pressure_kpa);
+    data = data_dbl(data, "temperature_C",    "",             NULL,         temperature_c);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tpms_porsche.c
+++ b/src/devices/tpms_porsche.c
@@ -68,15 +68,14 @@ static int tpms_porsche_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     snprintf(id_str, sizeof(id_str), "%08x", id);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Porsche",
-            "type",             "",             DATA_STRING, "TPMS",
-            "id",               "",             DATA_STRING, id_str,
-            "pressure_kPa",     "Pressure",     DATA_FORMAT, "%.1f kPa",    DATA_DOUBLE, (float)pressure_kpa,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.0f C",      DATA_DOUBLE, (float)temperature_c,
-            "flags",            "",             DATA_FORMAT, "%04x",        DATA_INT,    flags,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Porsche");
+    data = data_str(data, "type",             "",             NULL,         "TPMS");
+    data = data_str(data, "id",               "",             NULL,         id_str);
+    data = data_dbl(data, "pressure_kPa",     "Pressure",     "%.1f kPa",   (float)pressure_kpa);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.0f C",     (float)temperature_c);
+    data = data_int(data, "flags",            "",             "%04x",       flags);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tpms_renault.c
+++ b/src/devices/tpms_renault.c
@@ -62,15 +62,14 @@ static int tpms_renault_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsign
     snprintf(code_str, sizeof(code_str), "%04x", unknown);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Renault",
-            "type",             "",             DATA_STRING, "TPMS",
-            "id",               "",             DATA_STRING, id_str,
-            "flags",            "",             DATA_STRING, flags_str,
-            "pressure_kPa",     "",             DATA_FORMAT, "%.1f kPa", DATA_DOUBLE, (double)pressure_kpa,
-            "temperature_C",    "",             DATA_FORMAT, "%.0f C", DATA_DOUBLE, (double)temp_c,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Renault");
+    data = data_str(data, "type",             "",             NULL,         "TPMS");
+    data = data_str(data, "id",               "",             NULL,         id_str);
+    data = data_str(data, "flags",            "",             NULL,         flags_str);
+    data = data_dbl(data, "pressure_kPa",     "",             "%.1f kPa",   (double)pressure_kpa);
+    data = data_dbl(data, "temperature_C",    "",             "%.0f C",     (double)temp_c);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tpms_renault_0435r.c
+++ b/src/devices/tpms_renault_0435r.c
@@ -114,18 +114,17 @@ static int tpms_renault_0435r_decode(r_device *decoder, bitbuffer_t *bitbuffer, 
     snprintf(flags_str, sizeof(flags_str), "%02x", flags);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",           "",                         DATA_STRING, "Renault-0435R",
-            "type",            "",                         DATA_STRING, "TPMS",
-            "id",              "",                         DATA_STRING, id_str,
-            "flags",           "",                         DATA_STRING, flags_str,
-            "pressure_kPa",    "Pressure",                 DATA_FORMAT, "%.1f kPa",  DATA_DOUBLE, (double)pressure_kpa,
-            "temperature_C",   "Temperature",              DATA_FORMAT, "%.0f C",    DATA_DOUBLE, (double)temp_c,
-            "centrifugal_acc", "Centrifugal Acceleration", DATA_FORMAT, "%.0f m/s2", DATA_DOUBLE, (double)rad_acc,
-            "mic",             "",                         DATA_STRING, "CRC",
-            "has_tick",        "",                         DATA_INT,    has_tick,
-            "tick",            "",                         DATA_INT,    tick - 0x80*(1-has_tick), //set to negative value when has_tick == 0 (invert bit 7)
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",           "",                         NULL,         "Renault-0435R");
+    data = data_str(data, "type",            "",                         NULL,         "TPMS");
+    data = data_str(data, "id",              "",                         NULL,         id_str);
+    data = data_str(data, "flags",           "",                         NULL,         flags_str);
+    data = data_dbl(data, "pressure_kPa",    "Pressure",                 "%.1f kPa",   (double)pressure_kpa);
+    data = data_dbl(data, "temperature_C",   "Temperature",              "%.0f C",     (double)temp_c);
+    data = data_dbl(data, "centrifugal_acc", "Centrifugal Acceleration", "%.0f m/s2",  (double)rad_acc);
+    data = data_str(data, "mic",             "",                         NULL,         "CRC");
+    data = data_int(data, "has_tick",        "",                         NULL,         has_tick);
+    data = data_int(data, "tick",            "",                         NULL,         tick - 0x80*(1-has_tick)); //set to negative value when has_tick == 0 (invert bit 7)
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tpms_toyota.c
+++ b/src/devices/tpms_toyota.c
@@ -64,15 +64,14 @@ static int tpms_toyota_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigne
     snprintf(id_str, sizeof(id_str), "%08x", id);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING,    "Toyota",
-            "type",             "",             DATA_STRING,    "TPMS",
-            "id",               "",             DATA_STRING,    id_str,
-            "status",           "",             DATA_INT,       status,
-            "pressure_PSI",     "",             DATA_DOUBLE,    pressure1*0.25-7.0,
-            "temperature_C",    "",             DATA_DOUBLE,    temp-40.0,
-            "mic",              "Integrity",    DATA_STRING,    "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Toyota");
+    data = data_str(data, "type",             "",             NULL,         "TPMS");
+    data = data_str(data, "id",               "",             NULL,         id_str);
+    data = data_int(data, "status",           "",             NULL,         status);
+    data = data_dbl(data, "pressure_PSI",     "",             NULL,         pressure1*0.25-7.0);
+    data = data_dbl(data, "temperature_C",    "",             NULL,         temp-40.0);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tpms_truck.c
+++ b/src/devices/tpms_truck.c
@@ -77,17 +77,16 @@ static int tpms_truck_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned
     snprintf(id_str, sizeof(id_str), "%08x", id);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Truck",
-            "type",             "",             DATA_STRING, "TPMS",
-            "id",               "",             DATA_STRING, id_str,
-            "wheel",            "",             DATA_INT,    wheel,
-            "pressure_kPa",     "Pressure",     DATA_FORMAT, "%.0f kPa",    DATA_DOUBLE, (float)pressure,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.0f C",      DATA_DOUBLE, (float)temperature,
-            "state",            "State?",       DATA_FORMAT, "%x",          DATA_INT,    state,
-            "flags",            "Flags?",       DATA_FORMAT, "%x",          DATA_INT,    flags,
-            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Truck");
+    data = data_str(data, "type",             "",             NULL,         "TPMS");
+    data = data_str(data, "id",               "",             NULL,         id_str);
+    data = data_int(data, "wheel",            "",             NULL,         wheel);
+    data = data_dbl(data, "pressure_kPa",     "Pressure",     "%.0f kPa",   (float)pressure);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.0f C",     (float)temperature);
+    data = data_int(data, "state",            "State?",       "%x",         state);
+    data = data_int(data, "flags",            "Flags?",       "%x",         flags);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/tpms_tyreguard400.c
+++ b/src/devices/tpms_tyreguard400.c
@@ -104,22 +104,21 @@ static int tpms_tyreguard400_decode(r_device *decoder, bitbuffer_t *bitbuffer, u
     int temp_c = b[8] - 40;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",           "Model",                 DATA_STRING, "TyreGuard400",
-            "type",            "Type",                  DATA_STRING, "TPMS",
-            "id",              "ID",                    DATA_STRING, id_str,
+    data_t *data = NULL;
+    data = data_str(data, "model",           "Model",                 NULL,         "TyreGuard400");
+    data = data_str(data, "type",            "Type",                  NULL,         "TPMS");
+    data = data_str(data, "id",              "ID",                    NULL,         id_str);
 //            "flags",           "Flags",                 DATA_STRING, flags_str,
-            "pressure_kPa",    "Pressure",              DATA_FORMAT, "%.1f kPa",  DATA_DOUBLE, (double)pressure_kpa,
-            "temperature_C",   "Temperature",           DATA_FORMAT, "%.0f C",    DATA_DOUBLE, (double)temp_c,
-            "peering_request", "Peering req",           DATA_INT,    peering_request,
-            "leaking",         "Leaking detected",      DATA_INT,    leaking,
-            "ack_leaking",     "Ack leaking",           DATA_INT,    ack_leaking,
+    data = data_dbl(data, "pressure_kPa",    "Pressure",              "%.1f kPa",   (double)pressure_kpa);
+    data = data_dbl(data, "temperature_C",   "Temperature",           "%.0f C",     (double)temp_c);
+    data = data_int(data, "peering_request", "Peering req",           NULL,         peering_request);
+    data = data_int(data, "leaking",         "Leaking detected",      NULL,         leaking);
+    data = data_int(data, "ack_leaking",     "Ack leaking",           NULL,         ack_leaking);
 //            "add256",          "",                      DATA_INT,    add256,
 //            "add512",          "",                      DATA_INT,    add512,
 //            "add1024",          "",                     DATA_INT,    add1024,
 //            "battery_ok",    "Batt OK",                 DATA_INT,    !bat_low,
-            "mic",             "Integrity",             DATA_STRING, "CRC",
-            NULL);
+    data = data_str(data, "mic",             "Integrity",             NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/ts_ft002.c
+++ b/src/devices/ts_ft002.c
@@ -87,16 +87,15 @@ static int ts_ft002_decoder(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_FAIL_SANITY;
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",                     DATA_STRING, "TS-FT002",
-            "id",               "Id",                   DATA_INT,    id,
-            "depth_cm",         "Depth",                DATA_INT,    depth,
-            "temperature_C",    "Temperature",          DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "transmit_s",       "Transmit Interval",    DATA_INT,    transmit,
+    data = NULL;
+    data = data_str(data, "model",            "",                     NULL,         "TS-FT002");
+    data = data_int(data, "id",               "Id",                   NULL,         id);
+    data = data_int(data, "depth_cm",         "Depth",                NULL,         depth);
+    data = data_dbl(data, "temperature_C",    "Temperature",          "%.1f C",     temp_c);
+    data = data_int(data, "transmit_s",       "Transmit Interval",    NULL,         transmit);
             //"battery_ok",       "Battery",              DATA_INT,    batt_low,
-            "flags",            "Battery Flag?",        DATA_INT,    batt_low,
-            "mic",              "Integrity",            DATA_STRING, "CHECKSUM",
-            NULL);
+    data = data_int(data, "flags",            "Battery Flag?",        NULL,         batt_low);
+    data = data_str(data, "mic",              "Integrity",            NULL,         "CHECKSUM");
     decoder_output_data(decoder, data);
     /* clang-format on */
 

--- a/src/devices/ttx201.c
+++ b/src/devices/ttx201.c
@@ -172,11 +172,10 @@ static int ttx201_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row
         snprintf(clock_str, sizeof(clock_str), "%04d-%02d-%02dT%02d:%02d:%02d %s", year + 2000, month, day, hour, minute, second, cest ? "CEST" : "CET");
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",             DATA_STRING, "Emos-TTX201",
-                "radio_clock",      "Radio Clock",  DATA_STRING, clock_str,
-                "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",             NULL,         "Emos-TTX201");
+        data = data_str(data, "radio_clock",      "Radio Clock",  NULL,         clock_str);
+        data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
         /* clang-format on */
     } else { // temperature
         int device_id       = b[1];
@@ -186,14 +185,13 @@ static int ttx201_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row
         float temperature_c = (temperature >> 4) * 0.1f;
 
         /* clang-format off */
-        data = data_make(
-                "model",            "",             DATA_STRING, "Emos-TTX201",
-                "id",               "House Code",   DATA_INT,    device_id,
-                "channel",          "Channel",      DATA_INT,    channel,
-                "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-                "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature_c,
-                "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-                NULL);
+        data = NULL;
+        data = data_str(data, "model",            "",             NULL,         "Emos-TTX201");
+        data = data_int(data, "id",               "House Code",   NULL,         device_id);
+        data = data_int(data, "channel",          "Channel",      NULL,         channel);
+        data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+        data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temperature_c);
+        data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
         /* clang-format on */
     }
 

--- a/src/devices/vaillant_vrt340f.c
+++ b/src/devices/vaillant_vrt340f.c
@@ -99,14 +99,13 @@ static int vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         int battery_low        = b[11] != 0;      // if not zero, battery is low
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",        "",                     DATA_STRING, "Vaillant-VRT340f",
-                "id",           "Device ID",            DATA_FORMAT, "0x%04X", DATA_INT, device_id,
-                "heating",      "Heating Mode",         DATA_STRING, (heating_mode == 0 && target_temperature == 0) ? "OFF" : heating_mode ? "ON (2-point)" : "ON (analogue)",
-                "heating_temp", "Heating Water Temp.",  DATA_FORMAT, "%d", DATA_INT, target_temperature,
-                "water",        "Pre-heated Water",     DATA_STRING, water_preheated ? "ON" : "off",
-                "battery_ok",   "Battery",              DATA_INT,    !battery_low,
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",        "",                     NULL,         "Vaillant-VRT340f");
+        data = data_int(data, "id",           "Device ID",            "0x%04X",     device_id);
+        data = data_str(data, "heating",      "Heating Mode",         NULL,         (heating_mode == 0 && target_temperature == 0) ? "OFF" : heating_mode ? "ON (2-point)" : "ON (analogue)");
+        data = data_int(data, "heating_temp", "Heating Water Temp.",  "%d",         target_temperature);
+        data = data_str(data, "water",        "Pre-heated Water",     NULL,         water_preheated ? "ON" : "off");
+        data = data_int(data, "battery_ok",   "Battery",              NULL,         !battery_low);
         /* clang-format on */
         decoder_output_data(decoder, data);
 
@@ -124,10 +123,9 @@ static int vaillant_vrt340_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         int device_id = (b[11] << 8) | b[12];
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",        "",                     DATA_STRING, "Vaillant-VRT340f",
-                "id",           "Device ID",            DATA_INT,    device_id,
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",        "",                     NULL,         "Vaillant-VRT340f");
+        data = data_int(data, "id",           "Device ID",            NULL,         device_id);
         /* clang-format on */
         decoder_output_data(decoder, data);
 

--- a/src/devices/vauno_en8822c.c
+++ b/src/devices/vauno_en8822c.c
@@ -73,15 +73,14 @@ static int vauno_en8822c_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int humidity  = (b[3] >> 1);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Vauno-EN8822C",
-            "id",               "ID",           DATA_INT, device_id,
-            "channel",          "Channel",      DATA_INT, channel,
-            "battery_ok",       "Battery",      DATA_INT, !battery_low,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "humidity",         "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "Vauno-EN8822C");
+    data = data_int(data, "id",               "ID",           NULL,         device_id);
+    data = data_int(data, "channel",          "Channel",      NULL,         channel);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    data = data_int(data, "humidity",         "Humidity",     "%u %%",      humidity);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/vevor_7in1.c
+++ b/src/devices/vevor_7in1.c
@@ -119,21 +119,20 @@ static int vevor_7in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             }
 
             /* clang-format off */
-            data_t *data = data_make(
-                    "model",            "",                 DATA_STRING, "Vevor-7in1",
-                    "id",               "",                 DATA_FORMAT, "%04x", DATA_INT,    id,
-                    "channel",          "Channel",          DATA_INT,    channel,
-                    "battery_ok",       "Battery_OK",       DATA_INT,    !battery_low,
-                    "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-                    "humidity",         "Humidity",         DATA_FORMAT, "%u %%", DATA_INT, humidity,
-                    "wind_avg_km_h",    "Wind avg speed",   DATA_FORMAT, "%.1f km/h",  DATA_DOUBLE, speed_kmh,
-                    "wind_max_km_h",    "Wind max speed",   DATA_FORMAT, "%.1f km/h",  DATA_DOUBLE, gust_kmh,
-                    "wind_dir_deg",     "Wind Direction",   DATA_INT,    direction_deg,
-                    "rain_mm",          "Total rainfall",   DATA_FORMAT, "%.1f mm",  DATA_DOUBLE, rain_mm,
-                    "uv",               "UV Index",         DATA_FORMAT, "%u", DATA_INT, uv_index,
-                    "light_lux",        "Lux",              DATA_FORMAT, "%u", DATA_INT, light_lux,
-                    "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
-                    NULL);
+            data_t *data = NULL;
+            data = data_str(data, "model",            "",                 NULL,         "Vevor-7in1");
+            data = data_int(data, "id",               "",                 "%04x",       id);
+            data = data_int(data, "channel",          "Channel",          NULL,         channel);
+            data = data_int(data, "battery_ok",       "Battery_OK",       NULL,         !battery_low);
+            data = data_dbl(data, "temperature_C",    "Temperature",      "%.1f C",     temp_c);
+            data = data_int(data, "humidity",         "Humidity",         "%u %%",      humidity);
+            data = data_dbl(data, "wind_avg_km_h",    "Wind avg speed",   "%.1f km/h",  speed_kmh);
+            data = data_dbl(data, "wind_max_km_h",    "Wind max speed",   "%.1f km/h",  gust_kmh);
+            data = data_int(data, "wind_dir_deg",     "Wind Direction",   NULL,         direction_deg);
+            data = data_dbl(data, "rain_mm",          "Total rainfall",   "%.1f mm",    rain_mm);
+            data = data_int(data, "uv",               "UV Index",         "%u",         uv_index);
+            data = data_int(data, "light_lux",        "Lux",              "%u",         light_lux);
+            data = data_str(data, "mic",              "Integrity",        NULL,         "CHECKSUM");
             /* clang-format on */
 
             decoder_output_data(decoder, data);

--- a/src/devices/visonic_powercode.c
+++ b/src/devices/visonic_powercode.c
@@ -83,19 +83,18 @@ static int visonic_powercode_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     snprintf(id_str, sizeof(id_str), "%02x%02x%02x", msg[0], msg[1], msg[2]);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",        "Model",        DATA_STRING, "Visonic-Powercode",
-            "id",           "ID",           DATA_STRING, id_str,
-            "tamper",       "Tamper",       DATA_INT,    ((0x80 & msg[3]) == 0x80) ? 1 : 0,
-            "alarm",        "Alarm",        DATA_INT,    ((0x40 & msg[3]) == 0x40) ? 1 : 0,
-            "battery_ok",   "Battery",      DATA_INT,    ((0x20 & msg[3]) == 0x20) ? 0 : 1,
-            "else",         "Else",         DATA_INT,    ((0x10 & msg[3]) == 0x10) ? 1 : 0,
-            "restore",      "Restore",      DATA_INT,    ((0x08 & msg[3]) == 0x08) ? 1 : 0,
-            "supervised",   "Supervised",   DATA_INT,    ((0x04 & msg[3]) == 0x04) ? 1 : 0,
-            "spidernet",    "Spidernet",    DATA_INT,    ((0x02 & msg[3]) == 0x02) ? 1 : 0,
-            "repeater",     "Repeater",     DATA_INT,    ((0x01 & msg[3]) == 0x01) ? 1 : 0,
-            "mic",          "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",        "Model",        NULL,         "Visonic-Powercode");
+    data = data_str(data, "id",           "ID",           NULL,         id_str);
+    data = data_int(data, "tamper",       "Tamper",       NULL,         ((0x80 & msg[3]) == 0x80) ? 1 : 0);
+    data = data_int(data, "alarm",        "Alarm",        NULL,         ((0x40 & msg[3]) == 0x40) ? 1 : 0);
+    data = data_int(data, "battery_ok",   "Battery",      NULL,         ((0x20 & msg[3]) == 0x20) ? 0 : 1);
+    data = data_int(data, "else",         "Else",         NULL,         ((0x10 & msg[3]) == 0x10) ? 1 : 0);
+    data = data_int(data, "restore",      "Restore",      NULL,         ((0x08 & msg[3]) == 0x08) ? 1 : 0);
+    data = data_int(data, "supervised",   "Supervised",   NULL,         ((0x04 & msg[3]) == 0x04) ? 1 : 0);
+    data = data_int(data, "spidernet",    "Spidernet",    NULL,         ((0x02 & msg[3]) == 0x02) ? 1 : 0);
+    data = data_int(data, "repeater",     "Repeater",     NULL,         ((0x01 & msg[3]) == 0x01) ? 1 : 0);
+    data = data_str(data, "mic",          "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     // return data

--- a/src/devices/watts_thermostat.c
+++ b/src/devices/watts_thermostat.c
@@ -153,15 +153,14 @@ static int watts_thermostat_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         }
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",            "Model",            DATA_STRING, "Watts-WFHTRF",
-                "id",               "ID",               DATA_INT,    id,
-                "pairing",          "Pairing",          DATA_INT,    pairing,
-                "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C",      DATA_DOUBLE,  temp * 0.1f,
-                "setpoint_C",       "Setpoint",         DATA_FORMAT, "%.1f C",      DATA_DOUBLE,  setp * 0.1f,
-                "flags",            "Flags",            DATA_INT,    flags[0],
-                "mic",              "Integrity",        DATA_STRING, "CHECKSUM",
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",            "Model",            NULL,         "Watts-WFHTRF");
+        data = data_int(data, "id",               "ID",               NULL,         id);
+        data = data_int(data, "pairing",          "Pairing",          NULL,         pairing);
+        data = data_dbl(data, "temperature_C",    "Temperature",      "%.1f C",     temp * 0.1f);
+        data = data_dbl(data, "setpoint_C",       "Setpoint",         "%.1f C",     setp * 0.1f);
+        data = data_int(data, "flags",            "Flags",            NULL,         flags[0]);
+        data = data_str(data, "mic",              "Integrity",        NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);

--- a/src/devices/waveman.c
+++ b/src/devices/waveman.c
@@ -66,13 +66,12 @@ static int waveman_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     id_str[1] = '\0';
 
     /* clang-format off */
-    data = data_make(
-            "model",    "",     DATA_STRING,    "Waveman-Switch",
-            "id",       "",     DATA_STRING,    id_str,
-            "channel",  "",     DATA_INT,       (nb[1] >> 2) + 1,
-            "button",   "",     DATA_INT,       (nb[1] & 3) + 1,
-            "state",    "",     DATA_STRING,    (nb[2] == 0xe) ? "ON" : "OFF",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",    "",     NULL,         "Waveman-Switch");
+    data = data_str(data, "id",       "",     NULL,         id_str);
+    data = data_int(data, "channel",  "",     NULL,         (nb[1] >> 2) + 1);
+    data = data_int(data, "button",   "",     NULL,         (nb[1] & 3) + 1);
+    data = data_str(data, "state",    "",     NULL,         (nb[2] == 0xe) ? "ON" : "OFF");
     /* clang-format on */
     decoder_output_data(decoder, data);
 

--- a/src/devices/wec2103.c
+++ b/src/devices/wec2103.c
@@ -68,17 +68,16 @@ static int wec2103_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int battery_low = (b[1] & 0x04) >> 3;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "WEC-2103",
-            "id",               "ID",           DATA_INT,    device_id,
-            "channel",          "Channel",      DATA_INT,    channel,
-            "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-            "button",           "Button",       DATA_INT,    button,
-            "temperature_F",    "Temperature",  DATA_FORMAT, "%.2f F", DATA_DOUBLE, temp_f,
-            "humidity",         "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "flags",            "Flags",        DATA_INT,    flags,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "WEC-2103");
+    data = data_int(data, "id",               "ID",           NULL,         device_id);
+    data = data_int(data, "channel",          "Channel",      NULL,         channel);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_int(data, "button",           "Button",       NULL,         button);
+    data = data_dbl(data, "temperature_F",    "Temperature",  "%.2f F",     temp_f);
+    data = data_int(data, "humidity",         "Humidity",     "%u %%",      humidity);
+    data = data_int(data, "flags",            "Flags",        NULL,         flags);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/wg_pb12v1.c
+++ b/src/devices/wg_pb12v1.c
@@ -72,12 +72,11 @@ static int wg_pb12v1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     float temp_c = (temp_raw - 400) * 0.1f;
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",            "",             DATA_STRING, "WG-PB12V1",
-            "id",               "ID",           DATA_INT,    id,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "mic",              "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "WG-PB12V1");
+    data = data_int(data, "id",               "ID",           NULL,         id);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CRC");
     /* clang-format on */
     decoder_output_data(decoder, data);
     return 1;

--- a/src/devices/ws2032.c
+++ b/src/devices/ws2032.c
@@ -81,19 +81,18 @@ static int fineoffset_ws2032_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int rain_raw      = (b[9] << 16) | (b[10] << 8) | b[11]; // raw tip count
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",                 DATA_STRING, "WS2032",
-            "id",               "Station ID",        DATA_FORMAT, "%04X",    DATA_INT,    device_id,
-            "battery_ok",       "Battery",                                  DATA_INT,    !battery_low,
-            "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C",  DATA_DOUBLE, temperature,
-            "humidity",         "Humidity",         DATA_FORMAT, "%u %%",   DATA_INT,    humidity,
-            "wind_dir_deg",     "Wind Direction",   DATA_FORMAT, "%.1f",    DATA_DOUBLE, dir,
-            "wind_avg_km_h",    "Wind avg speed",   DATA_FORMAT, "%.1f",    DATA_DOUBLE, speed,
-            "wind_max_km_h",    "Wind gust",        DATA_FORMAT, "%.1f",    DATA_DOUBLE, gust,
-            "rain",             "Rain tips",                                DATA_INT,    rain_raw,
-            "flags",            "Flags",            DATA_FORMAT, "%02x",    DATA_INT,    flags,
-            "mic",              "Integrity",                                DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",                 NULL,         "WS2032");
+    data = data_int(data, "id",               "Station ID",        "%04X",       device_id);
+    data = data_int(data, "battery_ok",       "Battery",                                  NULL,         !battery_low);
+    data = data_dbl(data, "temperature_C",    "Temperature",      "%.1f C",     temperature);
+    data = data_int(data, "humidity",         "Humidity",         "%u %%",      humidity);
+    data = data_dbl(data, "wind_dir_deg",     "Wind Direction",   "%.1f",       dir);
+    data = data_dbl(data, "wind_avg_km_h",    "Wind avg speed",   "%.1f",       speed);
+    data = data_dbl(data, "wind_max_km_h",    "Wind gust",        "%.1f",       gust);
+    data = data_int(data, "rain",             "Rain tips",                                NULL,         rain_raw);
+    data = data_int(data, "flags",            "Flags",            "%02x",       flags);
+    data = data_str(data, "mic",              "Integrity",                                NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/wssensor.c
+++ b/src/devices/wssensor.c
@@ -68,14 +68,13 @@ static int wssensor_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     temperature_c = (temperature >> 4) * 0.1f;
 
     /* clang-format off */
-    data = data_make(
-            "model",         "",            DATA_STRING, "Hyundai-WS",
-            "id",            "House Code",  DATA_INT, sensor_id,
-            "channel",       "Channel",     DATA_INT, channel,
-            "battery_ok",    "Battery",     DATA_INT,    !!battery_status,
-            "temperature_C", "Temperature", DATA_FORMAT, "%.2f C", DATA_DOUBLE, temperature_c,
-            "button",           "Button",       DATA_INT, startup,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",         "",            NULL,         "Hyundai-WS");
+    data = data_int(data, "id",            "House Code",  NULL,         sensor_id);
+    data = data_int(data, "channel",       "Channel",     NULL,         channel);
+    data = data_int(data, "battery_ok",    "Battery",     NULL,         !!battery_status);
+    data = data_dbl(data, "temperature_C", "Temperature", "%.2f C",     temperature_c);
+    data = data_int(data, "button",           "Button",       NULL,         startup);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/wt0124.c
+++ b/src/devices/wt0124.c
@@ -75,13 +75,12 @@ static int wt1024_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     decoder_log_bitbuffer(decoder, 1, __func__, bitbuffer, "");
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "WT0124-Pool",
-            "id",               "Random ID",    DATA_INT,    sensor_rid,
-            "channel",          "Channel",      DATA_INT,    channel,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "WT0124-Pool");
+    data = data_int(data, "id",               "Random ID",    NULL,         sensor_rid);
+    data = data_int(data, "channel",          "Channel",      NULL,         channel);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.1f C",     temp_c);
+    data = data_str(data, "mic",              "Integrity",    NULL,         "CHECKSUM");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/wt450.c
+++ b/src/devices/wt450.c
@@ -100,15 +100,14 @@ static int wt450_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     seq           = (b[4] >> 6);
 
     /* clang-format off */
-    data = data_make(
-            "model",            "",             DATA_STRING, "WT450-TH",
-            "id",               "House Code",   DATA_INT,    house_code,
-            "channel",          "Channel",      DATA_INT,    channel,
-            "battery_ok",       "Battery",      DATA_INT,    !battery_low,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp,
-            "humidity",         "Humidity",     DATA_FORMAT, "%u %%", DATA_INT, humidity,
-            "seq",              "Sequence",     DATA_INT,    seq,
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",            "",             NULL,         "WT450-TH");
+    data = data_int(data, "id",               "House Code",   NULL,         house_code);
+    data = data_int(data, "channel",          "Channel",      NULL,         channel);
+    data = data_int(data, "battery_ok",       "Battery",      NULL,         !battery_low);
+    data = data_dbl(data, "temperature_C",    "Temperature",  "%.2f C",     temp);
+    data = data_int(data, "humidity",         "Humidity",     "%u %%",      humidity);
+    data = data_int(data, "seq",              "Sequence",     NULL,         seq);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/x10_rf.c
+++ b/src/devices/x10_rf.c
@@ -133,14 +133,13 @@ static int x10_rf_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     decoder_logf_bitbuffer(decoder, 1, __func__, bitbuffer, "id=%s%d event_str=%s", housecode, bDeviceCode, event_str);
 
     /* clang-format off */
-    data_t *data = data_make(
-            "model",        "",             DATA_STRING, "X10-RF",
-            "id",           "",             DATA_INT,    bDeviceCode,
-            "channel",      "",             DATA_STRING, housecode,
-            "state",        "State",        DATA_STRING, event_str,
-            "data",         "Data",         DATA_FORMAT, "%08x", DATA_INT, code,
-            "mic",          "Integrity",    DATA_STRING, "PARITY",
-            NULL);
+    data_t *data = NULL;
+    data = data_str(data, "model",        "",             NULL,         "X10-RF");
+    data = data_int(data, "id",           "",             NULL,         bDeviceCode);
+    data = data_str(data, "channel",      "",             NULL,         housecode);
+    data = data_str(data, "state",        "State",        NULL,         event_str);
+    data = data_int(data, "data",         "Data",         "%08x",       code);
+    data = data_str(data, "mic",          "Integrity",    NULL,         "PARITY");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -170,16 +170,21 @@ static int x10_sec_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* build and handle data set for normal output */
     /* clang-format off */
-    data = data_make(
-            "model",        "",             DATA_STRING, "X10-Security",
-            "id",           "Device ID",    DATA_STRING, x10_id_str,
-            "code",         "Code",         DATA_STRING, x10_code_str,
-            "event",        "Event",        DATA_STRING, event_str,
-            "delay",        "Delay",        DATA_COND,   delay,         DATA_INT, delay,
-            "battery_ok",   "Battery",      DATA_COND,   battery_low,   DATA_INT, !battery_low,
-            "tamper",       "Tamper",       DATA_COND,   tamper,        DATA_INT, tamper,
-            "mic",          "Integrity",    DATA_STRING, "CRC",
-            NULL);
+    data = NULL;
+    data = data_str(data, "model",        "",             NULL,         "X10-Security");
+    data = data_str(data, "id",           "Device ID",    NULL,         x10_id_str);
+    data = data_str(data, "code",         "Code",         NULL,         x10_code_str);
+    data = data_str(data, "event",        "Event",        NULL,         event_str);
+    if (delay) {
+        data = data_int(data, "delay",        "Delay",        NULL,         delay);
+    }
+    if (battery_low) {
+        data = data_int(data, "battery_ok",   "Battery",      NULL,         !battery_low);
+    }
+    if (tamper) {
+        data = data_int(data, "tamper",       "Tamper",       NULL,         tamper);
+    }
+    data = data_str(data, "mic",          "Integrity",    NULL,         "CRC");
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/yale_hsa.c
+++ b/src/devices/yale_hsa.c
@@ -105,14 +105,13 @@ static int yale_hsa_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         int event = (msg[4]);
 
         /* clang-format off */
-        data_t *data = data_make(
-                "model",        "",             DATA_STRING, "Yale-HSA",
-                "id",           "",             DATA_FORMAT, "%04x", DATA_INT, id,
-                "stype",        "Sensor type",  DATA_FORMAT, "%02x", DATA_INT, stype,
-                "state",        "State",        DATA_FORMAT, "%02x", DATA_INT, state,
-                "event",        "Event",        DATA_FORMAT, "%02x", DATA_INT, event,
-                "mic",          "Integrity",    DATA_STRING, "CHECKSUM",
-                NULL);
+        data_t *data = NULL;
+        data = data_str(data, "model",        "",             NULL,         "Yale-HSA");
+        data = data_int(data, "id",           "",             "%04x",       id);
+        data = data_int(data, "stype",        "Sensor type",  "%02x",       stype);
+        data = data_int(data, "state",        "State",        "%02x",       state);
+        data = data_int(data, "event",        "Event",        "%02x",       event);
+        data = data_str(data, "mic",          "Integrity",    NULL,         "CHECKSUM");
         /* clang-format on */
 
         decoder_output_data(decoder, data);


### PR DESCRIPTION
A preview for the (scripted) change from the `data_make()` varargs convention to the new type-safe and compact data api.

This can later be shortened from e.g.
```
data_t *data = NULL;
data = data_str(data, "model", ...);
data = data_int(data, "id", ...);
```
to
```
data_t *data = data_new();
data_str(data, "model", ...);
data_int(data, "id", ...);
```
if we use introduce a fixed header for data_t lists.
