### PR TITLE
Fix argument handling in sigrok file generation

### DIFF
--- a/src/write_sigrok.c
+++ b/src/write_sigrok.c
@@ -167,8 +167,8 @@ void write_sigrok(char const *filename, unsigned samplerate, unsigned probes, un
         if (!dup) {
             FATAL_STRDUP("write_sigrok()");
         }
+        argv_dups[arg] = dup;
         argv[arg++] = dup;
-        argv_dups[arg++] = dup;
     }
 
     int status = 0;


### PR DESCRIPTION
Since 96226b5a7 (October 2023), when building the arguments for `zip` for creating a sigrok file, the arg count is incremented multiple times for each analog file, leaving extra `NULL`s, causing only the first analog file to be included. Any other analog files are not included in the zip file and are not cleaned up afterwards.

This PR removes the extra increment, allowing all files to be included in the sigrok file and cleaned up afterwards.

Before:
```
$ rtl_433 -r g2678_433.92M_250k.cs16 -w test.sr
rtl_433 version 24.10-41-ge215c2dc branch master at 202501251130 inputs file rtl_tcp SoapySDR with TLS
[Input] Test mode active. Reading samples from file: g2678_433.92M_250k.cs16
  adding: version (stored 0%)
  adding: metadata (deflated 24%)
  adding: logic-1-1 (deflated 100%)
  adding: analog-1-4-1 (deflated 82%)
```

After:
```
$ rtl_433 -r g2678_433.92M_250k.cs16 -w test.sr
rtl_433 version 24.10-42-g4af625d5 branch sigrok-fixes at 202501251246 inputs file rtl_tcp SoapySDR with TLS
[Input] Test mode active. Reading samples from file: g2678_433.92M_250k.cs16
  adding: version (stored 0%)
  adding: metadata (deflated 24%)
  adding: logic-1-1 (deflated 100%)
  adding: analog-1-4-1 (deflated 82%)
  adding: analog-1-5-1 (deflated 82%)
  adding: analog-1-6-1 (deflated 87%)
  adding: analog-1-7-1 (deflated 78%)
```