### PR TITLE
Change Rubicson, Nexus, Solight-TE44, Baldr-Rain priority

### DIFF
--- a/src/devices/rubicson.c
+++ b/src/devices/rubicson.c
@@ -7,7 +7,10 @@
     (at your option) any later version.
 
 */
-/** @fn int rubicson_callback(r_device *decoder, bitbuffer_t *bitbuffer)
+
+#include "decoder.h"
+
+/**
 Rubicson temperature sensor.
 
 Also older TFA 30.3197 sensors.
@@ -33,14 +36,25 @@ data is grouped into 9 nibbles
 
 The sensor can be bought at Kjell&Co. The Infactory pool sensor can be bought at Pearl.
 */
-
-#include "decoder.h"
-
-// NOTE: this is used in nexus.c and solight_te44.c
-int rubicson_crc_check(uint8_t *b);
-
-int rubicson_crc_check(uint8_t *b)
+static int rubicson_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
+    int r = bitbuffer_find_repeated_row(bitbuffer, 3, 36);
+    if (r < 0) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    uint8_t *b = bitbuffer->bb[r];
+
+    // Infactory devices report 38 (or for last repetition) 37 bits
+    if (bitbuffer->bits_per_row[r] < 36 || bitbuffer->bits_per_row[r] > 38) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    if ((b[3] & 0xf0) != 0xf0) {
+        return DECODE_ABORT_EARLY; // const not 1111
+    }
+
+    // CRC check
     uint8_t tmp[5];
     tmp[0] = b[0];                // Byte 0 is nibble 0 and 1
     tmp[1] = b[1];                // Byte 1 is nibble 2 and 3
@@ -49,40 +63,19 @@ int rubicson_crc_check(uint8_t *b)
     tmp[4] = (b[3] & 0x0f) << 4 | // CRC is nibble 7 and 8
              (b[4] & 0xf0) >> 4;
 
-    return crc8(tmp, 5, 0x31, 0x6c) == 0;
-}
-
-static int rubicson_callback(r_device *decoder, bitbuffer_t *bitbuffer)
-{
-    data_t *data;
-    uint8_t *b;
-    int id, battery, channel, temp_raw;
-    float temp_c;
-
-    int r = bitbuffer_find_repeated_row(bitbuffer, 3, 36);
-    if (r < 0)
-        return DECODE_ABORT_EARLY;
-
-    b = bitbuffer->bb[r];
-
-    // Infactory devices report 38 (or for last repetition) 37 bits
-    if (bitbuffer->bits_per_row[r] < 36 || bitbuffer->bits_per_row[r] > 38)
-        return DECODE_ABORT_LENGTH;
-
-    if ((b[3] & 0xf0) != 0xf0)
-        return DECODE_ABORT_EARLY; // const not 1111
-
-    if (!rubicson_crc_check(b))
+    int chk = crc8(tmp, 5, 0x31, 0x6c);
+    if (chk) {
         return DECODE_FAIL_MIC;
+    }
 
-    id       = b[0];
-    battery  = (b[1] & 0x80);
-    channel  = ((b[1] & 0x30) >> 4) + 1;
-    temp_raw = (int16_t)((b[1] << 12) | (b[2] << 4)); // sign-extend
-    temp_c   = (temp_raw >> 4) * 0.1f;
+    int id       = b[0];
+    int battery  = (b[1] & 0x80);
+    int channel  = ((b[1] & 0x30) >> 4) + 1;
+    int temp_raw = (int16_t)((b[1] << 12) | (b[2] << 4)); // sign-extend
+    float temp_c = (temp_raw >> 4) * 0.1f;
 
     /* clang-format off */
-    data = data_make(
+    data_t *data = data_make(
             "model",            "",             DATA_STRING, "Rubicson-Temperature",
             "id",               "House Code",   DATA_INT,    id,
             "channel",          "Channel",      DATA_INT,    channel,

--- a/src/devices/solight_te44.c
+++ b/src/devices/solight_te44.c
@@ -8,8 +8,13 @@
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
 */
-/** @fn int solight_te44_callback(r_device *decoder, bitbuffer_t *bitbuffer)
+
+#include "decoder.h"
+
+/**
 Solight TE44 -- Generic wireless thermometer, which might be sold as part of different kits.
+
+Note: this is identical with Rubicson and is only active when Rubicson is disabled.
 
 So far these were identified (mostly sold in central/eastern europe)
 - Solight TE44
@@ -24,7 +29,7 @@ Data structure:
 
 12 repetitions of the same 36 bit payload, 1bit zero as a separator between each repetition.
 
-    36 bit payload format: iiiiiiii b0ccmmmm tttttttt 1111xxxx xxxx
+    36 bit payload format: iiiiiiii b0cctttt tttttttt 1111xxxx xxxx
 
 - i: 8 bit random key (changes after device reset)
 - b 1 bit battery flag: 1 if battery is ok, 0 if battery is low
@@ -33,43 +38,45 @@ Data structure:
 - x: 8 bit checksum
 
 */
-
-#include "decoder.h"
-
-// NOTE: this should really not be here
-int rubicson_crc_check(uint8_t *b);
-
-static int solight_te44_callback(r_device *decoder, bitbuffer_t *bitbuffer)
+static int solight_te44_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    data_t *data;
-    uint8_t *b;
-    int id, channel, temp_raw;
-    // int battery;
-    float temp_c;
-
     int r = bitbuffer_find_repeated_row(bitbuffer, 3, 36);
-    if (r < 0)
+    if (r < 0) {
         return DECODE_ABORT_EARLY;
+    }
 
-    b = bitbuffer->bb[r];
+    uint8_t *b = bitbuffer->bb[r];
 
-    if (bitbuffer->bits_per_row[r] != 37)
+    if (bitbuffer->bits_per_row[r] != 37) {
         return DECODE_ABORT_LENGTH;
+    }
 
-    if ((b[3] & 0xf0) != 0xf0)
+    if ((b[3] & 0xf0) != 0xf0) {
         return DECODE_ABORT_EARLY; // const not 1111
+    }
 
-    if (!rubicson_crc_check(b))
-        return DECODE_ABORT_EARLY;
+    // CRC check
+    uint8_t tmp[5];
+    tmp[0] = b[0];                // Byte 0 is nibble 0 and 1
+    tmp[1] = b[1];                // Byte 1 is nibble 2 and 3
+    tmp[2] = b[2];                // Byte 2 is nibble 4 and 5
+    tmp[3] = b[3] & 0xf0;         // Byte 3 is nibble 6 and 0-padding
+    tmp[4] = (b[3] & 0x0f) << 4 | // CRC is nibble 7 and 8
+             (b[4] & 0xf0) >> 4;
 
-    id       = b[0];
-    //battery  = (b[1] & 0x80);
-    channel  = ((b[1] & 0x30) >> 4);
-    temp_raw = (int16_t)((b[1] << 12) | (b[2] << 4)); // sign-extend
-    temp_c   = (temp_raw >> 4) * 0.1f;
+    int chk = crc8(tmp, 5, 0x31, 0x6c);
+    if (chk) {
+        return DECODE_FAIL_MIC;
+    }
+
+    int id       = b[0];
+    // int battery  = (b[1] & 0x80);
+    int channel  = ((b[1] & 0x30) >> 4);
+    int temp_raw = (int16_t)((b[1] << 12) | (b[2] << 4)); // sign-extend
+    float temp_c = (temp_raw >> 4) * 0.1f;
 
     /* clang-format off */
-    data = data_make(
+    data_t *data = data_make(
             "model",            "",             DATA_STRING, "Solight-TE44",
             "id",               "Id",           DATA_INT,    id,
             "channel",          "Channel",      DATA_INT,    channel + 1,
@@ -100,6 +107,7 @@ r_device const solight_te44 = {
         .long_width  = 1932, // long gap = 1932 us
         .gap_limit   = 3000, // packet gap = 3880 us
         .reset_limit = 6000,
-        .decode_fn   = &solight_te44_callback,
+        .decode_fn   = &solight_te44_decode,
+        .priority    = 10, // Eliminate false positives by letting Rubicson-Temperature go earlier
         .fields      = output_fields,
 };


### PR DESCRIPTION
This removes the `rubicson_crc_check()` hack and changes the decoder priority order instead.
- Rubicson has priority (if enabled)
- Nexus and Baldr-Rain (if enabled) only decode if decoding in Rubicson failed
- Solight-TE44 also has lowerd priority as it is identical to Rubicson (how did we miss this?)

**Note to users of Solight-TE44:** the decoder model changes from `Solight-TE44` to `Rubicson-Temperature`.
Disable Rubicson with `-R -2` if you don't want this to happen.