### PR TITLE
Add support for Ecowitt WH43 AQI device to fineoffset.c

### DIFF
--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -482,28 +482,6 @@ packet_found:
     return 1;
 }
 
-static char const *const output_fields_WH0290[] = {
-        "model",
-        "id",
-        "battery_ok",
-        "ext_power",
-        "pm2_5_ug_m3",
-        "estimated_pm10_0_ug_m3",
-        "family",
-        "mic",
-        NULL,
-};
-
-r_device const fineoffset_WH0290 = {
-        .name        = "Fine Offset/EcoWitt WH0290/WH41/WH43 Wireless Air Quality Monitor",
-        .modulation  = FSK_PULSE_PCM,
-        .short_width = 58,
-        .long_width  = 58,
-        .reset_limit = 5000,
-        .decode_fn   = &fineoffset_WH0290_callback,
-        .fields      = output_fields_WH0290,
-};
-
 /**
 Fine Offset Electronics WH25 / WH32 / WH32B / WN32B Temperature/Humidity/Pressure sensor protocol.
 


### PR DESCRIPTION
The code for the Fine Offset/Ecowitt WH0290/WH41/PM25 devices in fineoffset.c is _this close_ to supporting the similar Ecowitt WH43.  The WH43 uses a longer packet, due in part to the 24-bit ID (vs 8-bit for the 41), which then offsets the location of the battery, PM2.5/10, CRC, and Checksum bits. Both device classes use the same `aa2dd4` preamble, and identify themselves in the first byte b[0], allowing logic to parse and determine what and where the data resides in the packet. 
I changed the code to allow the WH41 or WH43 to be decoded, as well as adding some output that is present in the WH45 and WH46 decoders, namely the power source, via `ext_power`.  Battery status logic also was changed, as the existing code allowed for `battery_ok` to be 1.2, instead of capped at 1.0.