### PR TITLE
Fix: fix a memory leak bug in function sdr_open_soapy.

### DIFF
--- a/src/sdr.c
+++ b/src/sdr.c
@@ -947,6 +947,7 @@ static int sdr_open_soapy(sdr_dev_t **out_dev, char const *dev_query, int verbos
     if (r != 0) {
         if (verbose)
             print_log(LOG_ERROR, __func__, "Failed to setup sdr device");
+        free(dev->dev_info);
         free(dev);
         return -3;
     }


### PR DESCRIPTION
`dev->dev_info` points to a memory object allocated at line 927.

When `r!=0`, the field `dev_info` is not freed before freeing pointer `dev`. Thus we add a free operation.