### PR TITLE
Steelmate tpms improvements

### DIFF
--- a/src/devices/steelmate.c
+++ b/src/devices/steelmate.c
@@ -57,10 +57,9 @@ static int steelmate_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     uint8_t const preamble_pattern[] = {0x00, 0x00, 0x7f}; // inverted, raw value is 0x5a
     //Loop through each row of data
-    for (int row = 0; row < bitbuffer->num_rows; row++)
-    {
+    for (int row = 0; row < bitbuffer->num_rows; row++) {
         //Payload is inverted Manchester encoded, and reversed MSB/LSB order
-        uint8_t *b = bitbuffer->bb[row];
+        uint8_t *b       = bitbuffer->bb[row];
         unsigned row_len = bitbuffer->bits_per_row[row];
 
         //Length must be 72, 73, 208 or 209 bits to be considered a valid packet
@@ -69,9 +68,9 @@ static int steelmate_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         //Valid preamble? (Note, the data is still wrong order at this point. Correct pre-amble: 0x00 0x00 0x01)
         unsigned bitpos = bitbuffer_search(bitbuffer, row, 0, preamble_pattern, 24);
-        if (bitpos >= row_len-64)
+        if (bitpos >= row_len - 64)
             continue; // DECODE_ABORT_EARLY
-        b = &b[bitpos/8];
+        b = &b[bitpos / 8];
 
         //Preamble
         uint8_t preamble = ~reverse8(b[2]);
@@ -84,21 +83,21 @@ static int steelmate_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         uint8_t p1 = ~reverse8(b[5]);
 
         //Temperature is sent as degrees Celcius + 50.
-        uint8_t v1 = ~reverse8(b[6]);
+        uint8_t v1          = ~reverse8(b[6]);
         uint8_t tempCelcius = v1 - 50;
 
         //Battery voltage is stored as 100*(3.9v-<volt>).
-        uint8_t b1 = ~reverse8(b[7]);
-        int battery_mV = (int)3900-((double)b1*10.0f);
+        uint8_t b1     = ~reverse8(b[7]);
+        int battery_mV = (int)3900 - ((double)b1 * 10.0f);
 
         //Checksum is a sum of all the other values
-        uint8_t payload_checksum = ~reverse8(b[8]);
+        uint8_t payload_checksum    = ~reverse8(b[8]);
         uint8_t calculated_checksum = preamble + id1 + id2 + p1 + v1 + b1;
         if (payload_checksum != calculated_checksum)
             continue; // DECODE_FAIL_MIC
 
         int sensor_id      = (id1 << 8) | id2;
-        float pressure_kpa = p1 * 3.125f; // as guessed in #3200
+        float pressure_kpa = p1 * 3.125f;                         // as guessed in #3200
         float pressure_psi = pressure_kpa * (1.0f / 6.89475729f); // Keep the PSI value to not Break the decoder after new formula, #3200.
 
         char sensor_idhex[7];

--- a/src/devices/steelmate.c
+++ b/src/devices/steelmate.c
@@ -142,9 +142,9 @@ static char const *const output_fields[] = {
 r_device const steelmate = {
         .name        = "Steelmate TPMS",
         .modulation  = FSK_PULSE_MANCHESTER_ZEROBIT,
-        .short_width = 12 * 4,
-        .long_width  = 0,
-        .reset_limit = 27 * 4,
+        .short_width = 50,
+        .long_width  = 50,
+        .reset_limit = 120,
         .decode_fn   = &steelmate_callback,
         .fields      = output_fields,
 };

--- a/src/devices/steelmate.c
+++ b/src/devices/steelmate.c
@@ -69,7 +69,7 @@ static int steelmate_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         //Valid preamble? (Note, the data is still wrong order at this point. Correct pre-amble: 0x00 0x00 0x01)
         unsigned bitpos = bitbuffer_search(bitbuffer, row, 0, preamble_pattern, 24);
-        if (bitpos >= row_len)
+        if (bitpos >= row_len-64)
             continue; // DECODE_ABORT_EARLY
         b = &b[bitpos/8];
 

--- a/src/devices/steelmate.c
+++ b/src/devices/steelmate.c
@@ -91,7 +91,7 @@ static int steelmate_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
         //Battery voltage is stored as 100*(3.9v-<volt>).
         uint8_t b1     = b[7];
-        int battery_mv = (int)3900 - ((double)b1 * 10.0f);
+        int battery_mv = 3900 - b1 * 10;
 
         int sensor_id      = (id1 << 8) | id2;
         float pressure_kpa = p1 * 3.125f;                         // as guessed in #3200

--- a/src/devices/steelmate.c
+++ b/src/devices/steelmate.c
@@ -43,7 +43,7 @@ Bytes 2 to 9 are inverted Manchester with swapped MSB/LSB:
 - I = id, 0xc3f0
 - P = Pressure in Bar, scale 32, 0xA0 / 32 = 5 Bar, or 0xA0 * 3.125 = 500 kPA, see issue #3200
 - T = Temperature in Celcius + 50, 0x4a = 24 'C
-- B = Battery, where mV = 4000-(value*10). E.g 0x8e becomes 4000-(1420) = 2580mV.
+- B = Battery, where mV = 3900-(value*10). E.g 0x8e becomes 3900-(1420) = 2480mV.
 -     This calculation is approximate fit from sample data, any improvements are welcome.
 -   > If this field is set to 0xFF, a "fast leak" alarm is triggered.
 -   > If this field is set to 0xFE, a "slow leak" alarm is triggered.
@@ -63,7 +63,6 @@ static int steelmate_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         uint8_t *b = bitbuffer->bb[row];
         uint16_t row_len = bitbuffer->bits_per_row[row];
 
-        //Length must be 72 or 209 bits to be considered a valid packet
         //Length must be 72, 73, 208 or 209 bits to be considered a valid packet
         if (row_len != 72 && row_len != 73 && row_len != 209 && row_len != 208)
             continue; // DECODE_ABORT_LENGTH
@@ -85,11 +84,11 @@ static int steelmate_callback(r_device *decoder, bitbuffer_t *bitbuffer)
         uint8_t p1 = ~reverse8(b[5]);
 
         //Temperature is sent as degrees Celcius + 50.
-        uint8_t tempCelcius = ~reverse8(b[6]);
+        uint8_t tempCelcius = ~reverse8(b[6]) - 50;
 
-        //Battery voltage is stored as 100*(4v-<volt>).
+        //Battery voltage is stored as 100*(3.9v-<volt>).
         uint8_t v1 = ~reverse8(b[7]);
-        int battery_mV = (int)4000-((double)v1*10.0f);
+        int battery_mV = (int)3900-((double)v1*10.0f);
 
         //Checksum is a sum of all the other values
         uint8_t payload_checksum = ~reverse8(b[8]);


### PR DESCRIPTION
Improvements to this protocol per discussions in #3200. I'm adding this to the existing pending branch.

I did some fairly thorough analysis on the bench involving a bike pump, power supply, fridge, 3d printer heated bed and a transmitter. The following changes are made:

- Temperature is degrees C + 50, it's much more accurate than degrees F. I left the unit as F though for backwards compatibility. My display hasn't got temperature, I just heated it and read the values. @e100 also figured this out.
- Based on analysis from @e100 and my own PSU tests, i updated the voltage formula to something that is very close to the real value. Incremented voltages on a PSU by 0.1v and read the transmitted value, and compared with two graph lines. This new formula almost exactly matches the line.
- When the voltage byte is 0xFF or 0xFE, the display shows alerts. Added these.
- Both short and long packets are sent. Same data, different preamble size. Now accounts for both including demodulation artifacts.
- Better preamble detection.
- Tweaked signal timings for more reliable detection.

I also have ensured rtl_433_tests are updated/passing and will send a PR for this.

