### PR TITLE
Improve Truck TPMS decoder

### DIFF
--- a/src/devices/tpms_truck.c
+++ b/src/devices/tpms_truck.c
@@ -66,10 +66,10 @@ static int tpms_truck_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned
         return 0; // DECODE_FAIL_MIC;
     }
 
-    unsigned id        = (unsigned)b[0] << 24 | b[1] << 16 | b[2] << 8 | b[3];
+    unsigned id        = (unsigned)(b[0] << 24) | (b[1] << 16) | (b[2] << 8) | b[3];
     int wheel          = b[4];
-    int flags          = b[5] >> 4;
-    int pressure       = (b[5] & 0x0f) << 8 | b[6];
+    int flags          = (b[5] >> 4);
+    int pressure       = ((b[5] & 0x0f) << 8) | b[6];
     int temperature    = b[7];
     int pressure_alert = (flags & 0x4) == 0x4;
     int battery_ok     = (flags & 0x3) == 0x3; // 0x3 = battery ok, 0x0 = battery low, else unknown.

--- a/src/devices/tpms_truck.c
+++ b/src/devices/tpms_truck.c
@@ -83,11 +83,11 @@ static int tpms_truck_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned
             "type",           "",               DATA_STRING, "TPMS",
             "id",             "",               DATA_STRING, id_str,
             "wheel",          "",               DATA_INT,    wheel,
-            "pressure_kPa",   "Pressure",       DATA_FORMAT, "%.0f kPa",    DATA_DOUBLE, (float)pressure,
-            "temperature_C",  "Temperature",    DATA_FORMAT, "%.0f C",      DATA_DOUBLE, (float)temperature,
-            "pressure_alert", "Pressure Alert", DATA_INT, pressure_alert,
-            "battery_ok",     "Battery Ok",     DATA_INT, battery_ok,
-            "flags",          "Flag?",          DATA_FORMAT, "%x",          DATA_INT,    flags,
+            "pressure_kPa",   "Pressure",       DATA_FORMAT, "%.0f kPa",     DATA_DOUBLE, (float)pressure,
+            "temperature_C",  "Temperature",    DATA_FORMAT, "%.0f C",       DATA_DOUBLE, (float)temperature,
+            "pressure_alert", "Pressure Alert", DATA_COND,   pressure_alert, DATA_INT,    pressure_alert,
+            "battery_ok",     "Battery Ok",     DATA_INT,    battery_ok,
+            "flags",          "Flag?",          DATA_FORMAT, "%x",           DATA_INT,    flags,
             "mic",            "Integrity",      DATA_STRING, "CHECKSUM",
             NULL);
     /* clang-format on */

--- a/src/devices/tpms_truck.c
+++ b/src/devices/tpms_truck.c
@@ -18,7 +18,7 @@ The preamble is 232 bit 0x55..5556.
 The data packet is Manchester coded.
 
 Specification:
-- Monitoring temperature range: -40 C to 130 C
+- Monitoring temperature range: -127 C to 127 C
 - Monitoring air pressure range: 0.1 bar to 12.0 bar
 - 433 MHz FSK
 
@@ -29,11 +29,11 @@ Data layout (nibbles):
 - U: 4 bit state, decoding unknown, not included in checksum, could be sync
 - I: 32 bit ID
 - W: 8 bit wheel position
-- F: 4 bit unknown flags (seen: 0x3)
+- F: 4 bit status flags: 0xf = unknown. 0x8 = pressure alert. 0x2|0x1 = battery status (where 00 = low battery).
 - P: 12 bit Pressure (kPa)
-- T: 8 bit Temperature (deg. C, possibly signed?)
+- T: 8 bit Temperature (deg. C, signed)
 - C: 8 bit Checksum (XOR on bytes 0 to 7)
-- ?: 4 bit unknown (seems static)
+- ?: 4 bit unknown (seems static, probably a decoding artifact)
 
 Example data:
 
@@ -66,7 +66,6 @@ static int tpms_truck_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned
         return 0; // DECODE_FAIL_MIC;
     }
 
-    int state       = packet_bits.bb[0][0] >> 4; // fixed 0xa? could be sync
     unsigned id     = (unsigned)b[0] << 24 | b[1] << 16 | b[2] << 8 | b[3];
     int wheel       = b[4];
     int flags       = b[5] >> 4;
@@ -78,15 +77,17 @@ static int tpms_truck_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned
 
     /* clang-format off */
     data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Truck",
-            "type",             "",             DATA_STRING, "TPMS",
-            "id",               "",             DATA_STRING, id_str,
-            "wheel",            "",             DATA_INT,    wheel,
-            "pressure_kPa",     "Pressure",     DATA_FORMAT, "%.0f kPa",    DATA_DOUBLE, (float)pressure,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.0f C",      DATA_DOUBLE, (float)temperature,
-            "state",            "State?",       DATA_FORMAT, "%x",          DATA_INT,    state,
-            "flags",            "Flags?",       DATA_FORMAT, "%x",          DATA_INT,    flags,
-            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
+            "model",          "",               DATA_STRING, "Truck",
+            "type",           "",               DATA_STRING, "TPMS",
+            "id",             "",               DATA_STRING, id_str,
+            "wheel",          "",               DATA_INT,    wheel,
+            "pressure_kPa",   "Pressure",       DATA_FORMAT, "%.0f kPa",    DATA_DOUBLE, (float)pressure,
+            "temperature_C",  "Temperature",    DATA_FORMAT, "%.0f C",      DATA_DOUBLE, (float)temperature,
+            "pressure_alert", "Pressure Alert", DATA_COND, flags & 0x4, DATA_STRING, "pressure alert",
+            "battery",        "Battery Status", DATA_COND, (flags & 0x3) == 0, DATA_STRING, "low",
+            "battery",        "Battery Status", DATA_COND, flags & 0x3, DATA_STRING, "ok",
+            "flag",           "Flag?",          DATA_FORMAT, "%x",          DATA_INT,    flags,
+            "mic",            "Integrity",      DATA_STRING, "CHECKSUM",
             NULL);
     /* clang-format on */
 


### PR DESCRIPTION
(I have one of these TPMS sets as well as a Steelmate, hence two PRs).

This is named "Truck tpms" but it seems to be a common protocol for numerous solar powered aftermarket sensors. Mine is a generic unbranded one.

Did some investigation on the bench on this TPMS with a PSU and transmitter in order to clarify some fields in the decoder. I discovered the following:

- Confirm temperature is signed deg C. I fuzzed all values to the display and it matches all the way from -127 to 127. The actual supported range of the sensor itself is likely less.
- For the 4 bits documented as always 0x3, I found one bit sets a pressure alarm on the display, the other two trigger low battery on the display. Fuzzing the voltage on the sensor, it sent 11 for all values above ~2.1v and 00 for below 2.1v. The display alerts low voltage for 00, no alert for anything else. The fourth bit didn't have any effect on the display and remains unknown.
- The first byte is always 0x1a and the display ignores packets with any other value here, so is probably a sync byte.
- My display ignores the 'wheel' field, even though my sensors send unique values 0 through 3.

I'll also have a PR updating rtl_433_tests.
