### PR TITLE
Add protocol 281 'omni.c' device driver for microcontroller multisensor protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,8 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [274]  Revolt ZX-7717 power meter
     [275]  GM-Aftermarket TPMS
     [276]  RainPoint HCS012ARF Rain Gauge sensor
-    [277]  Apator Metra E-RM 30
+    [277]  Omni Multisensor
+    [278]  Apator Metra E-RM 30
 
 * Disabled by default, use -R n or a conf file to enable
 
@@ -372,7 +373,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
   [-d <RTL-SDR USB device index>] (default: 0)
   [-d :<RTL-SDR USB device serial (can be set with rtl_eeprom -s)>]
 	To set gain for RTL-SDR use -g <gain> to set an overall gain in dB.
-	SoapySDR device driver is available.
+	SoapySDR device driver is not available.
   [-d ""] Open default SoapySDR device
   [-d driver=rtlsdr] Open e.g. specific SoapySDR device
 	To set gain for SoapySDR use -g ELEM=val,ELEM=val,... e.g. -g LNA=20,TIA=8,PGA=2 (for LimeSDR).

--- a/README.md
+++ b/README.md
@@ -362,8 +362,8 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [274]  Revolt ZX-7717 power meter
     [275]  GM-Aftermarket TPMS
     [276]  RainPoint HCS012ARF Rain Gauge sensor
-    [277]  Omni Multisensor
-    [278]  Apator Metra E-RM 30
+    [277]  Apator Metra E-RM 30
+    [278]  Omni Multisensor
 
 * Disabled by default, use -R n or a conf file to enable
 

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -515,7 +515,7 @@ convert si
   protocol 274 # Revolt ZX-7717 power meter
   protocol 275 # GM-Aftermarket TPMS
   protocol 276 # RainPoint HCS012ARF Rain Gauge sensor
-  protocol 277 # omni
+  protocol 277 # Omni Multisensor
   
 ## Flex devices (command line option "-X")
 

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -517,6 +517,7 @@ convert si
   protocol 276 # RainPoint HCS012ARF Rain Gauge sensor
   protocol 277 # Apator Metra E-RM 30
   protocol 278 # Omni Multisensor
+
 ## Flex devices (command line option "-X")
 
 # Some general decoder definitions for various devices, enable as needed.

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -515,7 +515,8 @@ convert si
   protocol 274 # Revolt ZX-7717 power meter
   protocol 275 # GM-Aftermarket TPMS
   protocol 276 # RainPoint HCS012ARF Rain Gauge sensor
-
+  protocol 277 # Omni
+  
 ## Flex devices (command line option "-X")
 
 # Some general decoder definitions for various devices, enable as needed.

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -516,7 +516,6 @@ convert si
   protocol 275 # GM-Aftermarket TPMS
   protocol 276 # RainPoint HCS012ARF Rain Gauge sensor
   protocol 277 # Omni Multisensor
-  
 ## Flex devices (command line option "-X")
 
 # Some general decoder definitions for various devices, enable as needed.

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -515,7 +515,7 @@ convert si
   protocol 274 # Revolt ZX-7717 power meter
   protocol 275 # GM-Aftermarket TPMS
   protocol 276 # RainPoint HCS012ARF Rain Gauge sensor
-  protocol 277 # Omni
+  protocol 277 # omni
   
 ## Flex devices (command line option "-X")
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -285,7 +285,6 @@
     DECL(tpms_gm) \
     DECL(rainpoint_hcs012arf) \
     DECL(omni) \
-
     /* Add new decoders here. */
 
 #define DECL(name) extern r_device name;

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -284,7 +284,8 @@
     DECL(revolt_zx7717) \
     DECL(tpms_gm) \
     DECL(rainpoint_hcs012arf) \
-
+    DECL(omni) \
+  
     /* Add new decoders here. */
 
 #define DECL(name) extern r_device name;

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -285,7 +285,7 @@
     DECL(tpms_gm) \
     DECL(rainpoint_hcs012arf) \
     DECL(omni) \
-  
+
     /* Add new decoders here. */
 
 #define DECL(name) extern r_device name;

--- a/man/man1/rtl_433.1
+++ b/man/man1/rtl_433.1
@@ -168,7 +168,7 @@ RTL\-SDR device driver is available.
 To set gain for RTL\-SDR use \-g <gain> to set an overall gain in dB.
 .RE
 .RS
-SoapySDR device driver is available.
+SoapySDR device driver is not available.
 .RE
 .TP
 [ \fB\-d\fI ""\fP ]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -191,6 +191,7 @@ add_library(r_433 STATIC
     devices/oil_standard.c
     devices/oil_watchman.c
     devices/oil_watchman_advanced.c
+    devices/omni.c
     devices/opus_xt300.c
     devices/oregon_scientific.c
     devices/oregon_scientific_sl109h.c

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -161,7 +161,7 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     */
     default:
     case OMNI_MSGFMT_00:
-	ptr = &hexstring[0];
+        ptr = &hexstring[0];
         for (int ij = 1; ij < 9; ij++)
             ptr += sprintf(ptr, "0x%02x ", b[ij]);
         itemp_c     = ((double)((int32_t)(((((uint32_t)b[1]) << 24) | ((uint32_t)(b[2]) & 0xF0) << 16)) >> 20)) / 10.0;
@@ -230,7 +230,7 @@ static char const *const output_fields[] = {
 };
 
 /* clang-format off */
-r_device omni = {
+const r_device omni = {
         .name        = "Omni multisensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 200,  // short pulse is ~200 us

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -202,7 +202,7 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "mic",     "Integrity", DATA_STRING,  "CRC",
             NULL);
         /* clang-format on */
-	break;
+        break;
 
         /* New decoders follow here */
         break;

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -1,4 +1,3 @@
-/* -*- mode: c++ ; indent-tabs-mode: nil; tab-width: 4; c-basic-offset: 4; -*- */
 /** @file
     Omni Multisensor.
 
@@ -136,7 +135,7 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     char hexstring[50];
     char *ptr;
     data_t *data;
-    
+
     // Decode that format, if we know it
     switch (message_fmt) {
 

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -14,15 +14,18 @@
 /**
 Omni Multisensor
 
+The 'sensor' is actually a programmed microcontroller (e.g.,
+Raspberry Pi Pico 2 or similar) with multiple possible data-sensor
+attachments.  A message 'format' field indicates the format of the data
+packet being sent.  The protocol, and this decoder, support up to
+16 different message formats
+*/
+
+/* 
 The protocol is for the extensible wireless sensor 'omni'
 -  Single transmission protocol
 -  Flexible 64-bit data payload field structure
 -  Extensible to a total of 16 possible multi-sensor data formats
-
-The 'sensor' is actually a programmed microcontroller (e.g.,
-Raspberry Pi Pico 2 or similar) with multiple possible data-sensor
-attachments.  A message 'format' field indicates the format of the data
-packet being sent.
 
 NOTE: the rtl_433 decoder, omni.c, uses the "fmt" or "Format" field
 here, as transmitted by omni.c, to decode the incoming message.
@@ -120,8 +123,8 @@ For format=1 messages, the message nibbles are to be read as:
 
 static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    data_t *data;
     uint8_t *b;
+    data_t *data;
     char hexstring[50];
     char *ptr;
     int message_fmt, id;
@@ -161,8 +164,8 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         volts       = ((double)(b[8])) / 100.0 + 3.00;
         // Make the data descriptor
         /* clang-format off */
-       data = data_make(
-            "model",           "",                                               DATA_STRING, "omni",
+           data = data_make(
+            "model",           "",                                               DATA_STRING, "Omni Multisensor",
             "id",              "Id",                                             DATA_INT,     id,
             "channel",         "Format",                                         DATA_INT,     message_fmt,
             "temperature_C"  , "Core Temperature",   DATA_FORMAT, "%.2f ˚C",     DATA_DOUBLE,  itemp_c,

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -127,7 +127,7 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     };
 
     // OK, that's our message buffer for decoding
-    uint8_t b = bitbuffer->bb[r];
+    uint8_t *b = bitbuffer->bb[r];
 
     // Validate the packet against the CRC8 checksum
     if (crc8(b, 9, 0x97, initCRC) != b[9]) {
@@ -145,7 +145,7 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     // Default to fmt=00 so unformatted message data are reported in hex
     default:
     case OMNI_MSGFMT_00:
-        ptr = &char hexstring[50];
+        char *ptr = &char hexstring[50];
         // print just the 8 data bytes as payload data
         for (int ij = 1; ij < 9; ij++)
             ptr += sprintf(ptr, "%02x", b[ij]);

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -146,7 +146,7 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         // print just the 8 data bytes as payload data
         for (int ij = 1; ij < 9; ij++)
             ptr += sprintf(ptr, "%02x", b[ij]);
-        double itemp_c = (double)(((int16_t)( b[1]<<8  | b[2]<<4 )) >> 4) * 0.10;
+        double itemp_c = (double)(((int16_t)( b[1]<<8  | b[2] )) >> 4) * 0.10;
         double volts   = ((double)(b[8])) * 0.01 + 3.00;
         // Make the data descriptor
         /* clang-format off */
@@ -163,7 +163,7 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         break;
 
     case OMNI_MSGFMT_01:
-        itemp_c = (double)(((int16_t)( b[1]<<8  | b[2]<<4 )) >> 4) * 0.10;
+        itemp_c = (double)(((int16_t)( b[1]<<8  | b[2] )) >> 4) * 0.10;
         double otemp_c = (double) (((int16_t)(b[2]<<12 | b[3]<<4 )) >> 4) * 0.10;
         double ihum    = (double)b[4];
         double light   = (double)b[5];

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -148,7 +148,7 @@ static char const *const output_fields_01[] = {
 /* New format output_field_nn declaration goes here */
 
 /* clang-format off */
-r_device const omni = {
+r_device omni = {
         .name        = "Omni multisensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 200,  // short pulse is ~200 us
@@ -213,14 +213,14 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         // Make the data descriptor
         /* clang-format off */
        data = data_make(
-	    "model",           "",                                               DATA_STRING, "Omni",
-	    "id",              "Id",                                             DATA_INT,     id,
-	    "channel",         "Format",                                         DATA_INT,     message_fmt,
-	    "temperature_C"  , "Core Temperature",   DATA_FORMAT, "%.2f ˚C",     DATA_DOUBLE,  itemp_c, 
-	    "voltage_V",       "VCC voltage",        DATA_FORMAT, "%.2f V",      DATA_DOUBLE,  volts,
+            "model",           "",                                               DATA_STRING, "Omni",
+            "id",              "Id",                                             DATA_INT,     id,
+            "channel",         "Format",                                         DATA_INT,     message_fmt,
+            "temperature_C"  , "Core Temperature",   DATA_FORMAT, "%.2f ˚C",     DATA_DOUBLE,  itemp_c,
+            "voltage_V",       "VCC voltage",        DATA_FORMAT, "%.2f V",      DATA_DOUBLE,  volts,
             "payload",         "Payload",                                        DATA_STRING,  hexstring,
-	    "mic",             "Integrity",                                      DATA_STRING,  "CRC",
-	    NULL);
+            "mic",             "Integrity",                                      DATA_STRING,  "CRC",
+            NULL);
         /* clang-format on */
         break;
 
@@ -231,26 +231,26 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         ihum        = (double)b[4];
         ohum        = (double)b[5];
         press       = (double)(((uint16_t)(b[6] << 8)) | b[7]) / 10.0;
-	volts       = ((double)(b[8])) / 100.0 + 3.00;
+        volts       = ((double)(b[8])) / 100.0 + 3.00;
         // Make the data descriptor
         /* clang-format off */
-	data = data_make(
-	    "model",           "",                                               DATA_STRING, "Omni",
-	    "id",              "Id",                                             DATA_INT,     id,
-	    "channel",         "Format",                                         DATA_INT,     message_fmt,
-	    "temperature_C"  , "Indoor Temperature", DATA_FORMAT, "%.2f ˚C",     DATA_DOUBLE,  itemp_c, 
-	    "temperature_2_C", "Outdoor Temperature",DATA_FORMAT, "%.2f ˚C",     DATA_DOUBLE,  otemp_c, 
-	    "humidity",        "Indoor Humidity",    DATA_FORMAT, "%.0f %%",     DATA_DOUBLE,  ihum,
-	    "Light %",         "Light",              DATA_FORMAT, "%.0f%%",      DATA_DOUBLE,  ohum,
-	    "pressure_hPa",    "BarometricPressure", DATA_FORMAT, "%.1f hPa",    DATA_DOUBLE,  press,
-	    "voltage_V",       "VCC voltage",        DATA_FORMAT, "%.2f V",      DATA_DOUBLE,  volts,
-	    "mic",             "Integrity",                                      DATA_STRING,  "CRC",
-	    NULL);
+        data = data_make(
+            "model",           "",                                               DATA_STRING, "Omni",
+            "id",              "Id",                                             DATA_INT,     id,
+            "channel",         "Format",                                         DATA_INT,     message_fmt,
+            "temperature_C"  , "Indoor Temperature", DATA_FORMAT, "%.2f ˚C",     DATA_DOUBLE,  itemp_c,
+            "temperature_2_C", "Outdoor Temperature",DATA_FORMAT, "%.2f ˚C",     DATA_DOUBLE,  otemp_c,
+            "humidity",        "Indoor Humidity",    DATA_FORMAT, "%.0f %%",     DATA_DOUBLE,  ihum,
+            "Light %",         "Light",              DATA_FORMAT, "%.0f%%",      DATA_DOUBLE,  ohum,
+            "pressure_hPa",    "BarometricPressure", DATA_FORMAT, "%.1f hPa",    DATA_DOUBLE,  press,
+            "voltage_V",       "VCC voltage",        DATA_FORMAT, "%.2f V",      DATA_DOUBLE,  volts,
+            "mic",             "Integrity",                                      DATA_STRING,  "CRC",
+            NULL);
         /* clang-format on */
         break;
 
-	/* New decoders follow here */
-	
+        /* New decoders follow here */
+
     };
 
     // And output the field values

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -1,5 +1,6 @@
 /** @file
-    omni multi-sensor protocol, v1.2
+`   Omni Multisensor Protocol
+    v1.2
 
     Copyright (C) 2025 H. David Todd <hdtodd@gmail.com>
 
@@ -11,7 +12,7 @@
 
 /* clang-format off */
 /**
-omni multisensor protocol.
+Omni Multisensor Protocol
 
 The protocol is for the extensible wireless sensor 'omni'
 -  Single transmission protocol
@@ -123,11 +124,7 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     uint8_t *b;
     char hexstring[50];
     char *ptr;
-
-    // Fields common to all message types
     int message_fmt, id;
-
-    // Fields needed depending upon the message type
     double itemp_c, volts;
 
     // Find a row that's a candidate for decoding
@@ -154,7 +151,7 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     // Decode that format, if we know it
     switch (message_fmt) {
 
-    //  Default to fmt=00 so message data are reported in hex
+    // Default to fmt=00 so unformatted message data are reported in hex
     default:
     case OMNI_MSGFMT_00:
         ptr = &hexstring[0];
@@ -176,15 +173,14 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         /* clang-format on */
         break;
 
-        break;
-
         /* New decoders follow here */
+        break;
 
     };
 
     // And output the field values
     decoder_output_data(decoder, data);
-    return 1;
+    return 1; // if we got here, one valid message was returned
 }
 
 // List the output fields for various message types
@@ -205,7 +201,7 @@ static char const *const output_fields[] = {
 
 /* clang-format off */
 r_device const omni = {
-        .name        = "Omni Multisensor",
+        .name        = "Omni Multisensor Protocol",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 200,  // short pulse is ~200 us
         .long_width  = 400,  // long pulse is ~400 us

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -21,7 +21,7 @@ packet being sent.  The protocol, and this decoder, support up to
 16 different message formats
 */
 
-/* 
+/*
 The protocol is for the extensible wireless sensor 'omni'
 -  Single transmission protocol
 -  Flexible 64-bit data payload field structure

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -200,7 +200,7 @@ static char const *const output_fields[] = {
 };
 
 /* clang-format off */
-const r_device omni = {
+r_device const omni = {
         .name        = "Omni Multisensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 200,  // short pulse is ~200 us

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -7,9 +7,10 @@
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-
-The 'sensor' is actually a programmed microcontroller (e.g.,
-Raspberry Pi Pico 2 or similar) with multiple possible data-sensor
+/*
+/**
+The 'sensor' is actually a programmed microcontroller, such as
+Raspberry Pi Pico 2 or similar, with multiple possible data-sensor
 attachments.  A message 'format' field indicates the format of the data
 packet being sent.  The protocol, and this decoder, support up to
 16 different message formats:

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -118,7 +118,11 @@ For format=1 messages, the message nibbles are to be read as:
 
 static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-  // Find a row that's a candidate for decoding
+    char hexstring[50];
+    char *ptr;
+    data_t *data;
+    
+    // Find a row that's a candidate for decoding
     int r = bitbuffer_find_repeated_row(bitbuffer, 2, 80);
 
     if (r < 0 || bitbuffer->bits_per_row[r] > 82) {
@@ -145,15 +149,15 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     // Default to fmt=00 so unformatted message data are reported in hex
     default:
     case OMNI_MSGFMT_00:
-        char *ptr = &char hexstring[50];
+        ptr = &hexstring[0];
         // print just the 8 data bytes as payload data
         for (int ij = 1; ij < 9; ij++)
             ptr += sprintf(ptr, "%02x", b[ij]);
-        double itemp_c     = ((double)((int32_t)(((((uint32_t)b[1]) << 24) | ((uint32_t)(b[2]) & 0xF0) << 16)) >> 20)) * 0.10;
-        double volts       = ((double)(b[8])) * 0.01 + 3.00;
+        double itemp_c = ((double)((int32_t)(((((uint32_t)b[1]) << 24) | ((uint32_t)(b[2]) & 0xF0) << 16)) >> 20)) * 0.10;
+        double volts   = ((double)(b[8])) * 0.01 + 3.00;
         // Make the data descriptor
         /* clang-format off */
-        data_t *data = data_make(
+        data = data_make(
             "model",           "",                                               DATA_STRING, "Omni Multisensor",
             "id",              "Id",                                             DATA_INT,     id,
             "channel",         "Format",                                         DATA_INT,     message_fmt,
@@ -166,12 +170,12 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         break;
 
     case OMNI_MSGFMT_01:
-        itemp_c     = ((double)((int32_t)(((((uint32_t)b[1]) << 24) | ((uint32_t)(b[2]) & 0xF0) << 16)) >> 20)) * 0.10;
-        double otemp_c     = ((double)((int32_t)(((((uint32_t)b[2]) << 28) | ((uint32_t)b[3]) << 20)) >> 20)) * 0.10;
-        double ihum        = (double)b[4];
-        double light       = (double)b[5];
-        double press       = (double)(((uint16_t)(b[6] << 8)) | b[7]) * 0.10;
-        volts       = ((double)(b[8])) * 0.01 + 3.00;
+        itemp_c        = ((double)((int32_t)(((((uint32_t)b[1]) << 24) | ((uint32_t)(b[2]) & 0xF0) << 16)) >> 20)) * 0.10;
+        double otemp_c = ((double)((int32_t)(((((uint32_t)b[2]) << 28) | ((uint32_t)b[3]) << 20)) >> 20)) * 0.10;
+        double ihum    = (double)b[4];
+        double light   = (double)b[5];
+        double press   = (double)(((uint16_t)(b[6] << 8)) | b[7]) * 0.10;
+        volts          = ((double)(b[8])) * 0.01 + 3.00;
         // Make the data descriptor
         /* clang-format off */
         data = data_make(

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -200,7 +200,7 @@ static char const *const output_fields[] = {
 };
 
 /* clang-format off */
-r_device const omni = {
+const r_device omni = {
         .name        = "Omni Multisensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 200,  // short pulse is ~200 us

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -231,7 +231,7 @@ static char const *const output_fields[] = {
 
 /* clang-format off */
 const r_device omni = {
-        .name        = "Omni multisensor",
+        .name        = "omni",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 200,  // short pulse is ~200 us
         .long_width  = 400,  // long pulse is ~400 us

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -148,7 +148,7 @@ static char const *const output_fields_01[] = {
 /* New format output_field_nn declaration goes here */
 
 /* clang-format off */
-r_device omni = {
+r_device const omni = {
         .name        = "Omni multisensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 200,  // short pulse is ~200 us

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -23,12 +23,12 @@ Raspberry Pi Pico 2 or similar) with multiple possible data-sensor
 attachments.  A message 'format' field indicates the format of the data
 packet being sent.
 
-NOTE: the rtl_433 decoder, omni.c, uses the "fmt" or "Format" field 
-here, as transmitted by omni.c, to decode the incoming message.  
+NOTE: the rtl_433 decoder, omni.c, uses the "fmt" or "Format" field
+here, as transmitted by omni.c, to decode the incoming message.
 But, through omni.c, rtl_433 reports the packet format-field value
-as "channel" in its published reporting (JSON, for example), 
+as "channel" in its published reporting (JSON, for example),
 in keeping with the standard nomenclature and order of field-name
-precedence used within rtl_433 for data fields.  
+precedence used within rtl_433 for data fields.
 
 The omni protocol is OOK modulated PWM with fixed period of 600μs
 for data bits, preambled by four long startbit pulses of fixed period equal
@@ -59,7 +59,7 @@ total of 336 bits requiring ~212μs.
 The last packet in a burst is followed by a postamble low
 of at least 1250μs.
 
-These 4-packet bursts repeat every 30 seconds. 
+These 4-packet bursts repeat every 30 seconds.
 
 The message in each packet is 10 bytes / 20 nibbles:
 
@@ -124,8 +124,8 @@ static char const *const output_fields_00[] = {
         "model",
         "fmt",
         "id",
-	"temperature_C",
-	"voltage_V",
+        "temperature_C",
+        "voltage_V",
         "payload",
         "mic",
         NULL,
@@ -140,7 +140,7 @@ static char const *const output_fields_01[] = {
         "humidity",
         "light_level",
         "pressure_hPa",
-	"voltage_V",
+        "voltage_V",
         "mic",
         NULL,
 };
@@ -212,7 +212,7 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         volts       = ((double)(b[8])) / 100.0 + 3.00;
         // Make the data descriptor
         /* clang-format off */
-	data = data_make(
+       data = data_make(
 	    "model",           "",                                               DATA_STRING, "Omni",
 	    "id",              "Id",                                             DATA_INT,     id,
 	    "channel",         "Format",                                         DATA_INT,     message_fmt,

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -121,7 +121,7 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     char hexstring[50];
     char *ptr;
     data_t *data;
-    
+
     // Find a row that's a candidate for decoding
     int r = bitbuffer_find_repeated_row(bitbuffer, 2, 80);
 

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -178,7 +178,7 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "temperature_C"  , "Indoor Temperature", DATA_FORMAT, "%.2f ˚C",     DATA_DOUBLE,  itemp_c,
             "temperature_2_C", "Outdoor Temperature",DATA_FORMAT, "%.2f ˚C",     DATA_DOUBLE,  otemp_c,
             "humidity",        "Indoor Humidity",    DATA_FORMAT, "%.0f %%",     DATA_DOUBLE,  ihum,
-            "light %",         "Light",              DATA_FORMAT, "%.0f%%",      DATA_DOUBLE,  light,
+            "light_pct",       "Light",              DATA_FORMAT, "%.0f %%",      DATA_DOUBLE,  light,
             "pressure_hPa",    "BarometricPressure", DATA_FORMAT, "%.1f hPa",    DATA_DOUBLE,  press,
             "voltage_V",       "VCC voltage",        DATA_FORMAT, "%.2f V",      DATA_DOUBLE,  volts,
             "mic",             "Integrity",                                      DATA_STRING,  "CRC",
@@ -193,15 +193,13 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         for (int ij = 1; ij < 9; ij++)
             ptr += sprintf(ptr, "%02x", b[ij]);
         // Make the data descriptor
-        /* clang-format off */
         data = data_make(
             "model",   "",          DATA_STRING, "Omni-Multisensor",
             "id",      "Id",        DATA_INT,     id,
-            "channel",         "Format",                                         DATA_INT,     message_fmt,
+            "channel", "Format",    DATA_INT,     message_fmt,
             "payload", "Payload",   DATA_STRING,  hexstring,
             "mic",     "Integrity", DATA_STRING,  "CRC",
             NULL);
-        /* clang-format on */
         break;
 
         /* New decoders follow here */
@@ -223,7 +221,7 @@ static char const *const output_fields[] = {
         "temperature_2_C",
         "humidity",
         "pressure_hPa",
-        "light_level",
+        "light_pct",
         "voltage_V",
         "payload",
         "mic",

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -1,5 +1,5 @@
 /** @file
-    Omni multi-sensor protocol, v1.0
+    Omni multi-sensor protocol, v1.1
 
     Copyright (C) 2025 H. David Todd <hdtodd@gmail.com>
 
@@ -20,7 +20,7 @@ The protocol is for the extensible wireless sensor 'omni'
 
 The 'sensor' is actually a programmed microcontroller (e.g.,
 Raspberry Pi Pico 2 or similar) with multiple possible data-sensor
-attachments.  A packet 'format' field indicates the format of the data
+attachments.  A message 'format' field indicates the format of the data
 packet being sent.
 
 NOTE: the rtl_433 decoder, omni.c, uses the "fmt" or "Format" field 

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -205,7 +205,7 @@ static char const *const output_fields[] = {
 
 /* clang-format off */
 const r_device omni = {
-        .name        = "omni multisensor",
+        .name        = "omni",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 200,  // short pulse is ~200 us
         .long_width  = 400,  // long pulse is ~400 us

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -1,5 +1,5 @@
 /** @file
-`   Omni Multisensor Protocol
+`   Omni Multisensor
     v1.2
 
     Copyright (C) 2025 H. David Todd <hdtodd@gmail.com>
@@ -12,7 +12,7 @@
 
 /* clang-format off */
 /**
-Omni Multisensor Protocol
+Omni Multisensor
 
 The protocol is for the extensible wireless sensor 'omni'
 -  Single transmission protocol
@@ -201,7 +201,7 @@ static char const *const output_fields[] = {
 
 /* clang-format off */
 r_device const omni = {
-        .name        = "Omni Multisensor Protocol",
+        .name        = "Omni Multisensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 200,  // short pulse is ~200 us
         .long_width  = 400,  // long pulse is ~400 us

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -1,0 +1,260 @@
+/** @file
+    Omni multi-sensor protocol, v1.0
+
+    Copyright (C) 2025 H. David Todd <hdtodd@gmail.com>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+/* clang-format off */
+/**
+Omni multisensor protocol.
+
+The protocol is for the extensible wireless sensor 'omni'
+-  Single transmission protocol
+-  Flexible 64-bit data payload field structure
+-  Extensible to a total of 16 possible multi-sensor data formats
+
+The 'sensor' is actually a programmed microcontroller (e.g.,
+Raspberry Pi Pico 2 or similar) with multiple possible data-sensor
+attachments.  A packet 'format' field indicates the format of the data
+packet being sent.
+
+NOTE: the rtl_433 decoder, omni.c, uses the "fmt" or "Format" field 
+here, as transmitted by omni.c, to decode the incoming message.  
+But, through omni.c, rtl_433 reports the packet format-field value
+as "channel" in its published reporting (JSON, for example), 
+in keeping with the standard nomenclature and order of field-name
+precedence used within rtl_433 for data fields.  
+
+The omni protocol is OOK modulated PWM with fixed period of 600μs
+for data bits, preambled by four long startbit pulses of fixed period equal
+to 1200μs. It is similar to the Lacrosse TX141TH-BV2.
+
+A single data packet looks as follows:
+1) preamble - 600μs high followed by 600μs low, repeated 4 times:
+
+     ----      ----      ----      ----
+    |    |    |    |    |    |    |    |
+          ----      ----      ----      ----
+
+2) a train of 80 data pulses with fixed 600μs period follows immediately:
+
+     ---    --     --     ---    ---    --     ---
+    |   |  |  |   |  |   |   |  |   |  |  |   |   |
+         --    ---    ---     --     --    ---     -- ....
+
+A logical 0 is 400μs of high followed by 200μs of low.
+A logical 1 is 200μs of high followed by 400μs of low.
+
+Thus, in the example pictured above the bits are 0 1 1 0 0 1 0 ...
+
+The omni microcontroller sends 4 of identical packets of
+4-pulse preamble followed by 80 data bits in a single burst, for a
+total of 336 bits requiring ~212μs.
+
+The last packet in a burst is followed by a postamble low
+of at least 1250μs.
+
+These 4-packet bursts repeat every 30 seconds. 
+
+The message in each packet is 10 bytes / 20 nibbles:
+
+    [fmt] [id] 16*[data] [crc8] [crc8]
+
+- fmt is a 4-bit message data format identifier
+- id is a 4-bit device identifier
+- data are 16 nibbles = 8 bytes of data payload fields,
+      interpreted according to 'fmt'
+- crc8 is 2 nibbles = 1 byte of CRC8 checksum of the first 9 bytes:
+      polynomial 0x97, init 0xaa
+
+A format=0 message simply transmits the core temperature and input power
+voltage of the microcontroller and is the format used if no data
+sensor is present.  For format=0 messages, the message
+nibbles are to be read as:
+
+     fi tt t0 00 00 00 00 00 vv cc
+
+     f: format of datagram, 0-15
+     i: id of device, 0-15
+     t: Pico 2 core temperature: °C *10, 12-bit, 2's complement integer
+     0: bytes should be 0
+     v: (VCC-3.00)*100, as 8-bit integer, in volts: 3V00..5V55 volts
+     c: CRC8 checksum of bytes 1..9, initial remainder 0xaa,
+        divisor polynomial 0x97, no reflections or inversions
+
+A format=1 message format is provided as a more complete example.
+It uses the Bosch BME688 environmental sensor as a data source.
+It is an indoor-outdoor temperature/humidity/pressure sensor, and the
+message packet has the following fields:
+    indoor temp, outdoor temp, indoor humidity, outdoor humidity,
+    barometric pressure, sensor power VCC.
+The data fields are binary values, 2's complement for temperatures.
+For format=1 messages, the message nibbles are to be read as:
+
+     fi 11 12 22 hh gg pp pp vv cc
+
+     f: format of datagram, 0-15
+     i: id of device, 0-15
+     1: sensor 1 temp reading (e.g, indoor),  °C *10, 12-bit, 2's complement integer
+     2: sensor 2 temp reading (e.g, outdoor), °C *10, 12-bit, 2's complement integer
+     h: sensor 1 humidity reading (e.g., indoor),  %RH as 8-bit integer
+     g: sensor 2 humidity reading (e.g., outdoor), %RH as 8-bit integer
+     p: barometric pressure * 10, in hPa, as 16-bit integer, 0..6553.5 hPa
+     v: (VCC-3.00)*100, as 8-bit integer, in volts: 3V00..5V55 volts
+     c: CRC8 checksum of bytes 1..9, initial remainder 0xaa,
+            divisor polynomial 0x97, no reflections or inversions
+*/
+/* clang-format on */
+
+#include "decoder.h"
+
+#define initCRC 0xaa
+#define OMNI_MSGFMT_00 0x00
+#define OMNI_MSGFMT_01 0x01
+
+static int omni_decode(r_device *, bitbuffer_t *);
+
+// List the output fields for various message types
+static char const *const output_fields_00[] = {
+        "model",
+        "fmt",
+        "id",
+	"temperature_C",
+	"voltage_V",
+        "payload",
+        "mic",
+        NULL,
+};
+
+static char const *const output_fields_01[] = {
+        "model",
+        "fmt",
+        "id",
+        "temperature_C",
+        "temperature_2_C",
+        "humidity",
+        "light_level",
+        "pressure_hPa",
+	"voltage_V",
+        "mic",
+        NULL,
+};
+
+/* New format output_field_nn declaration goes here */
+
+/* clang-format off */
+r_device omni = {
+        .name        = "Omni multisensor",
+        .modulation  = OOK_PULSE_PWM,
+        .short_width = 200,  // short pulse is ~200 us
+        .long_width  = 400,  // long pulse is ~400 us
+        .sync_width  = 600,  // sync pulse is ~600 us
+        .gap_limit   = 500,  // long gap (with short pulse) is ~400 us, sync gap is ~600 us
+        .reset_limit = 1250, // maximum gap is 1250 us (long gap + longer sync gap on last repeat)
+        .decode_fn   = &omni_decode,
+        .fields      = output_fields_00,
+};
+/* clang-format on */
+
+static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    data_t *data;
+    uint8_t *b;
+
+    // Fields common to all message types
+    int message_fmt, id;
+
+    // Fields needed depending upon the message type
+    double itemp_c, otemp_c, ihum, ohum, press, volts;
+
+    // Find a row that's a candidate for decoding
+    int r = bitbuffer_find_repeated_row(bitbuffer, 2, 80);
+
+    if (r < 0 || bitbuffer->bits_per_row[r] > 82) {
+        decoder_log(decoder, 1, __func__, "Omni: Invalid message");
+        return DECODE_ABORT_LENGTH;
+    };
+
+    // OK, that's our message buffer for decoding
+    b = bitbuffer->bb[r];
+
+    // Validate the packet against the CRC8 checksum
+    if (crc8(b, 9, 0x97, initCRC) != b[9]) {
+        decoder_log(decoder, 1, __func__, "Omni: CRC8 checksum error");
+        return DECODE_FAIL_MIC;
+    }
+
+    // OK looks like we have a valid packet.  What format?
+    message_fmt = b[0] >> 4;
+    id          = b[0] & 0x0F;
+
+    // Decode that format, if we know it
+    switch (message_fmt) {
+
+    /*  Default to fmt=00 so message data are reported in hex
+    default:
+        decoder_log(decoder, 1, __func__, "Unknown message type");
+        return DECODE_FAIL_SANITY;
+    */
+    default:
+    case OMNI_MSGFMT_00:
+        omni.fields = output_fields_00;
+        char hexstring[50];
+        char *ptr = &hexstring[0];
+        for (int ij = 1; ij < 9; ij++)
+            ptr += sprintf(ptr, "0x%02x ", b[ij]);
+        itemp_c     = ((double)((int32_t)(((((uint32_t)b[1]) << 24) | ((uint32_t)(b[2]) & 0xF0) << 16)) >> 20)) / 10.0;
+        volts       = ((double)(b[8])) / 100.0 + 3.00;
+        // Make the data descriptor
+        /* clang-format off */
+	data = data_make(
+	    "model",           "",                                               DATA_STRING, "Omni",
+	    "id",              "Id",                                             DATA_INT,     id,
+	    "channel",         "Format",                                         DATA_INT,     message_fmt,
+	    "temperature_C"  , "Core Temperature",   DATA_FORMAT, "%.2f ˚C",     DATA_DOUBLE,  itemp_c, 
+	    "voltage_V",       "VCC voltage",        DATA_FORMAT, "%.2f V",      DATA_DOUBLE,  volts,
+            "payload",         "Payload",                                        DATA_STRING,  hexstring,
+	    "mic",             "Integrity",                                      DATA_STRING,  "CRC",
+	    NULL);
+        /* clang-format on */
+        break;
+
+    case OMNI_MSGFMT_01:
+        omni.fields = output_fields_01;
+        itemp_c     = ((double)((int32_t)(((((uint32_t)b[1]) << 24) | ((uint32_t)(b[2]) & 0xF0) << 16)) >> 20)) / 10.0;
+        otemp_c     = ((double)((int32_t)(((((uint32_t)b[2]) << 28) | ((uint32_t)b[3]) << 20)) >> 20)) / 10.0;
+        ihum        = (double)b[4];
+        ohum        = (double)b[5];
+        press       = (double)(((uint16_t)(b[6] << 8)) | b[7]) / 10.0;
+	volts       = ((double)(b[8])) / 100.0 + 3.00;
+        // Make the data descriptor
+        /* clang-format off */
+	data = data_make(
+	    "model",           "",                                               DATA_STRING, "Omni",
+	    "id",              "Id",                                             DATA_INT,     id,
+	    "channel",         "Format",                                         DATA_INT,     message_fmt,
+	    "temperature_C"  , "Indoor Temperature", DATA_FORMAT, "%.2f ˚C",     DATA_DOUBLE,  itemp_c, 
+	    "temperature_2_C", "Outdoor Temperature",DATA_FORMAT, "%.2f ˚C",     DATA_DOUBLE,  otemp_c, 
+	    "humidity",        "Indoor Humidity",    DATA_FORMAT, "%.0f %%",     DATA_DOUBLE,  ihum,
+	    "Light %",         "Light",              DATA_FORMAT, "%.0f%%",      DATA_DOUBLE,  ohum,
+	    //	    "humidity_2",      "Outdoor Humidity",   DATA_FORMAT, "%.0f %%",     DATA_DOUBLE,  ohum,
+	    "pressure_hPa",    "BarometricPressure", DATA_FORMAT, "%.1f hPa",    DATA_DOUBLE,  press,
+	    "voltage_V",       "VCC voltage",        DATA_FORMAT, "%.2f V",      DATA_DOUBLE,  volts,
+	    "mic",             "Integrity",                                      DATA_STRING,  "CRC",
+	    NULL);
+        /* clang-format on */
+        break;
+
+	/* New decoders follow here */
+	
+    };
+
+    // And output the field values
+    decoder_output_data(decoder, data);
+    return 1;
+}

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -205,7 +205,7 @@ static char const *const output_fields[] = {
 
 /* clang-format off */
 r_device const omni = {
-        .name        = "omni",
+        .name        = "Omni Multisensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 200,  // short pulse is ~200 us
         .long_width  = 400,  // long pulse is ~400 us

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -1,5 +1,5 @@
 /** @file
-    Omni multi-sensor protocol, v1.1
+    Omni multi-sensor protocol, v1.2
 
     Copyright (C) 2025 H. David Todd <hdtodd@gmail.com>
 
@@ -242,7 +242,6 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 	    "temperature_2_C", "Outdoor Temperature",DATA_FORMAT, "%.2f ˚C",     DATA_DOUBLE,  otemp_c, 
 	    "humidity",        "Indoor Humidity",    DATA_FORMAT, "%.0f %%",     DATA_DOUBLE,  ihum,
 	    "Light %",         "Light",              DATA_FORMAT, "%.0f%%",      DATA_DOUBLE,  ohum,
-	    //	    "humidity_2",      "Outdoor Humidity",   DATA_FORMAT, "%.0f %%",     DATA_DOUBLE,  ohum,
 	    "pressure_hPa",    "BarometricPressure", DATA_FORMAT, "%.1f hPa",    DATA_DOUBLE,  press,
 	    "voltage_V",       "VCC voltage",        DATA_FORMAT, "%.2f V",      DATA_DOUBLE,  volts,
 	    "mic",             "Integrity",                                      DATA_STRING,  "CRC",

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -7,7 +7,7 @@
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-/*
+*/
 /**
 The 'sensor' is actually a programmed microcontroller, such as
 Raspberry Pi Pico 2 or similar, with multiple possible data-sensor
@@ -218,7 +218,7 @@ static char const *const output_fields[] = {
 
 /* clang-format off */
 r_device const omni = {
-        .name        = "Omni-Multisensor",
+        .name        = "Omni Multisensor",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 200,  // short pulse is ~200 us
         .long_width  = 400,  // long pulse is ~400 us

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -158,7 +158,7 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     default:
     case OMNI_MSGFMT_00:
         ptr = &hexstring[0];
-	// print just the 8 data bytes as payload data
+        // print just the 8 data bytes as payload data
         for (int ij = 1; ij < 9; ij++)
             ptr += sprintf(ptr, "%02x", b[ij]);
         itemp_c     = ((double)((int32_t)(((((uint32_t)b[1]) << 24) | ((uint32_t)(b[2]) & 0xF0) << 16)) >> 20)) / 10.0;

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -204,7 +204,7 @@ static char const *const output_fields[] = {
 };
 
 /* clang-format off */
-const r_device omni = {
+r_device const omni = {
         .name        = "omni",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 200,  // short pulse is ~200 us

--- a/src/devices/omni.c
+++ b/src/devices/omni.c
@@ -178,7 +178,7 @@ static int omni_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "temperature_C"  , "Indoor Temperature", DATA_FORMAT, "%.2f ˚C",     DATA_DOUBLE,  itemp_c,
             "temperature_2_C", "Outdoor Temperature",DATA_FORMAT, "%.2f ˚C",     DATA_DOUBLE,  otemp_c,
             "humidity",        "Indoor Humidity",    DATA_FORMAT, "%.0f %%",     DATA_DOUBLE,  ihum,
-            "Light %",         "Light",              DATA_FORMAT, "%.0f%%",      DATA_DOUBLE,  light,
+            "light %",         "Light",              DATA_FORMAT, "%.0f%%",      DATA_DOUBLE,  light,
             "pressure_hPa",    "BarometricPressure", DATA_FORMAT, "%.1f hPa",    DATA_DOUBLE,  press,
             "voltage_V",       "VCC voltage",        DATA_FORMAT, "%.2f V",      DATA_DOUBLE,  volts,
             "mic",             "Integrity",                                      DATA_STRING,  "CRC",


### PR DESCRIPTION
The 'omni.c' driver decodes programmable microcontroller (Arduino, Pico2, etc.) transmissions to rtl_433.  The protocol offers 16 possible sensor-data formats in an 8-byte payload.

Example microcontroller programs to generate omni-compatible transmissions for rtl_433 are available for [Pico2](http://github.com/hdtodd/omnisensor_433) and [Arduino](http://github.com/hdtodd/WP_433).

Decoder output and signal data are available in `rtl_433_tests/test/omni`.


