### PR TITLE
Add output file reopen on sighup

### DIFF
--- a/include/data.h
+++ b/include/data.h
@@ -186,6 +186,7 @@ typedef struct data_output {
     void (R_API_CALLCONV *print_int)(struct data_output *output, int data, char const *format);
     void (R_API_CALLCONV *output_start)(struct data_output *output, char const *const *fields, int num_fields);
     void (R_API_CALLCONV *output_print)(struct data_output *output, data_t *data);
+    void (R_API_CALLCONV *output_reload)(struct data_output *output);
     void (R_API_CALLCONV *output_free)(struct data_output *output);
     int log_level; ///< the maximum log level (verbosity) allowed, more verbose messages must be ignored.
 } data_output_t;
@@ -201,6 +202,9 @@ R_API void data_output_start(struct data_output *output, char const *const *fiel
 
 /** Prints a structured data object, flushes the output if applicable. */
 R_API void data_output_print(struct data_output *output, data_t *data);
+
+/** Reload this output by reopening file descriptors if needed. */
+R_API void data_output_reload(struct data_output *output);
 
 R_API void data_output_free(struct data_output *output);
 

--- a/include/data.h
+++ b/include/data.h
@@ -186,7 +186,7 @@ typedef struct data_output {
     void (R_API_CALLCONV *print_int)(struct data_output *output, int data, char const *format);
     void (R_API_CALLCONV *output_start)(struct data_output *output, char const *const *fields, int num_fields);
     void (R_API_CALLCONV *output_print)(struct data_output *output, data_t *data);
-    void (R_API_CALLCONV *output_reload)(struct data_output *output);
+    void (R_API_CALLCONV *output_reopen)(struct data_output *output);
     void (R_API_CALLCONV *output_free)(struct data_output *output);
     int log_level; ///< the maximum log level (verbosity) allowed, more verbose messages must be ignored.
 } data_output_t;
@@ -203,8 +203,8 @@ R_API void data_output_start(struct data_output *output, char const *const *fiel
 /** Prints a structured data object, flushes the output if applicable. */
 R_API void data_output_print(struct data_output *output, data_t *data);
 
-/** Reload this output by reopening file descriptors if needed. */
-R_API void data_output_reload(struct data_output *output);
+/** Reopen this output by closing and opening file descriptors as needed. */
+R_API void data_output_reopen(struct data_output *output);
 
 R_API void data_output_free(struct data_output *output);
 

--- a/include/output_file.h
+++ b/include/output_file.h
@@ -18,14 +18,14 @@
 /** Construct data output for CSV printer.
 
     @param log_level the highest log level to process
-    @param file the output stream
+    @param path the output stream path, defaults to stdout if NULL
     @return The auxiliary data to pass along with data_csv_printer to data_print.
             You must release this object with data_output_free once you're done with it.
 */
-struct data_output *data_output_csv_create(int log_level, FILE *file);
+struct data_output *data_output_csv_create(int log_level, char const *path);
 
-struct data_output *data_output_json_create(int log_level, FILE *file);
+struct data_output *data_output_json_create(int log_level, char const *path);
 
-struct data_output *data_output_kv_create(int log_level, FILE *file);
+struct data_output *data_output_kv_create(int log_level, char const *path);
 
 #endif /* INCLUDE_OUTPUT_FILE_H_ */

--- a/include/output_log.h
+++ b/include/output_log.h
@@ -18,10 +18,10 @@
 /** Construct data output for LOG printer.
 
     @param log_level the highest log level to process
-    @param file the optional output stream, defaults to stderr
+    @param path the optional output stream path, defaults to stderr if NULL
     @return The auxiliary data to pass along with data_log_printer to data_print.
             You must release this object with data_output_free once you're done with it.
 */
-struct data_output *data_output_log_create(int log_level, FILE *file);
+struct data_output *data_output_log_create(int log_level, char const *path);
 
 #endif /* INCLUDE_OUTPUT_LOG_H_ */

--- a/include/output_trigger.h
+++ b/include/output_trigger.h
@@ -25,9 +25,9 @@
 ///     $ echo oneshot | sudo tee /sys/class/leds/led0/trigger
 ///     $ rtl_433 ... -F trigger:/sys/class/leds/led0/shot
 ///
-/// @param file a trigger output stream
+/// @param path a trigger output stream path
 /// @return The initialized data output.
 ///         You must release this object with data_output_free once you're done with it.
-struct data_output *data_output_trigger_create(FILE *file);
+struct data_output *data_output_trigger_create(char const *path);
 
 #endif /* INCLUDE_OUTPUT_TRIGGER_H_ */

--- a/include/r_api.h
+++ b/include/r_api.h
@@ -95,6 +95,8 @@ void add_rtltcp_output(struct r_cfg *cfg, char *param);
 
 void start_outputs(struct r_cfg *cfg, char const *const *well_known);
 
+void reopen_outputs(struct r_cfg *cfg);
+
 void add_sr_dumper(struct r_cfg *cfg, char const *spec, int overwrite);
 
 void reopen_dumpers(struct r_cfg *cfg);

--- a/src/data.c
+++ b/src/data.c
@@ -411,6 +411,13 @@ R_API void data_output_start(struct data_output *output, char const *const *fiel
     output->output_start(output, fields, num_fields);
 }
 
+R_API void data_output_reload(struct data_output *output)
+{
+    if (!output || !output->output_reload)
+        return;
+    output->output_reload(output);
+}
+
 R_API void data_output_free(data_output_t *output)
 {
     if (!output)

--- a/src/data.c
+++ b/src/data.c
@@ -411,11 +411,11 @@ R_API void data_output_start(struct data_output *output, char const *const *fiel
     output->output_start(output, fields, num_fields);
 }
 
-R_API void data_output_reload(struct data_output *output)
+R_API void data_output_reopen(struct data_output *output)
 {
-    if (!output || !output->output_reload)
+    if (!output || !output->output_reopen)
         return;
-    output->output_reload(output);
+    output->output_reopen(output);
 }
 
 R_API void data_output_free(data_output_t *output)

--- a/src/output_file.c
+++ b/src/output_file.c
@@ -123,7 +123,7 @@ static void R_API_CALLCONV data_output_json_print(data_output_t *output, data_t 
     }
 }
 
-static void R_API_CALLCONV data_output_json_reload(data_output_t *output)
+static void R_API_CALLCONV data_output_json_reopen(data_output_t *output)
 {
     data_output_json_t *json = (data_output_json_t *)output;
 
@@ -170,11 +170,11 @@ struct data_output *data_output_json_create(int log_level, char const *path)
     json->output.print_double  = print_json_double;
     json->output.print_int     = print_json_int;
     json->output.output_print  = data_output_json_print;
-    json->output.output_reload = data_output_json_reload;
+    json->output.output_reopen = data_output_json_reopen;
     json->output.output_free   = data_output_json_free;
     json->path                 = path;
 
-    data_output_json_reload(&json->output);
+    data_output_json_reopen(&json->output);
 
     return (struct data_output *)json;
 }
@@ -418,7 +418,7 @@ static void R_API_CALLCONV data_output_kv_print(data_output_t *output, data_t *d
     }
 }
 
-static void R_API_CALLCONV data_output_kv_reload(data_output_t *output)
+static void R_API_CALLCONV data_output_kv_reopen(data_output_t *output)
 {
     data_output_kv_t *kv = (data_output_kv_t *)output;
 
@@ -470,11 +470,11 @@ struct data_output *data_output_kv_create(int log_level, char const *path)
     kv->output.print_double  = print_kv_double;
     kv->output.print_int     = print_kv_int;
     kv->output.output_print  = data_output_kv_print;
-    kv->output.output_reload = data_output_kv_reload;
+    kv->output.output_reopen = data_output_kv_reopen;
     kv->output.output_free   = data_output_kv_free;
     kv->path                 = path;
 
-    data_output_kv_reload(&kv->output);
+    data_output_kv_reopen(&kv->output);
 
     kv->term  = term_init(kv->file);
     kv->color = term_has_color(kv->term);
@@ -669,7 +669,7 @@ static void R_API_CALLCONV data_output_csv_print(data_output_t *output, data_t *
     fflush(csv->file);
 }
 
-static void R_API_CALLCONV data_output_csv_reload(data_output_t *output)
+static void R_API_CALLCONV data_output_csv_reopen(data_output_t *output)
 {
     data_output_csv_t *csv = (data_output_csv_t *)output;
 
@@ -720,11 +720,11 @@ struct data_output *data_output_csv_create(int log_level, char const *path)
     csv->output.print_int     = print_csv_int;
     csv->output.output_start  = data_output_csv_start;
     csv->output.output_print  = data_output_csv_print;
-    csv->output.output_reload = data_output_csv_reload;
+    csv->output.output_reopen = data_output_csv_reopen;
     csv->output.output_free   = data_output_csv_free;
     csv->path                 = path;
 
-    data_output_csv_reload(&csv->output);
+    data_output_csv_reopen(&csv->output);
 
     return (struct data_output *)csv;
 }

--- a/src/output_log.c
+++ b/src/output_log.c
@@ -135,7 +135,7 @@ static void R_API_CALLCONV data_output_log_print(data_output_t *output, data_t *
     fflush(log->file);
 }
 
-static void R_API_CALLCONV data_output_log_reload(data_output_t *output)
+static void R_API_CALLCONV data_output_log_reopen(data_output_t *output)
 {
     data_output_log_t *log = (data_output_log_t *)output;
 
@@ -144,10 +144,10 @@ static void R_API_CALLCONV data_output_log_reload(data_output_t *output)
     }
 
     if (!log->path || !*log->path) {
-        log->file = stderr; // No path given
+        log->file = stderr; // No path given, note that we default to STDERR
     }
     else if (*log->path == '-' && log->path[1] == '\0') {
-        log->file = stderr; // STDERR requested
+        log->file = stdout; // STDOUT requested
     }
     else {
         log->file = fopen(log->path, "a");
@@ -182,11 +182,11 @@ struct data_output *data_output_log_create(int log_level, char const *path)
     log->output.print_double  = print_log_double;
     log->output.print_int     = print_log_int;
     log->output.output_print  = data_output_log_print;
-    log->output.output_reload = data_output_log_reload;
+    log->output.output_reopen = data_output_log_reopen;
     log->output.output_free   = data_output_log_free;
     log->path                 = path;
 
-    data_output_log_reload(&log->output); // Note: print to stderr by default
+    data_output_log_reopen(&log->output); // Note: print to stderr by default
 
     return (struct data_output *)log;
 }

--- a/src/output_trigger.c
+++ b/src/output_trigger.c
@@ -35,7 +35,7 @@ static void R_API_CALLCONV data_output_trigger_print(data_output_t *output, data
     fflush(trigger->file);
 }
 
-static void R_API_CALLCONV data_output_trigger_reload(data_output_t *output)
+static void R_API_CALLCONV data_output_trigger_reopen(data_output_t *output)
 {
     data_output_trigger_t *trigger = (data_output_trigger_t *)output;
 
@@ -76,11 +76,11 @@ struct data_output *data_output_trigger_create(char const *path)
     }
 
     trigger->output.output_print  = data_output_trigger_print;
-    trigger->output.output_reload = data_output_trigger_reload;
+    trigger->output.output_reopen = data_output_trigger_reopen;
     trigger->output.output_free   = data_output_trigger_free;
     trigger->path                 = path;
 
-    data_output_trigger_reload(&trigger->output);
+    data_output_trigger_reopen(&trigger->output);
 
     return (struct data_output *)trigger;
 }

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -1126,7 +1126,7 @@ void reopen_outputs(struct r_cfg *cfg)
 {
     for (size_t i = 0; i < cfg->output_handler.len; ++i) { // list might contain NULLs
         data_output_t *output = cfg->output_handler.elems[i];
-        data_output_reload(output);
+        data_output_reopen(output);
     }
 }
 

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -1004,11 +1004,11 @@ static int lvlarg_param(char **param, int default_verb)
     return val;
 }
 
-/// Opens the path @p param (or STDOUT if empty or `-`) for append writing, removes leading `,` and `:` from path name.
-static FILE *fopen_output(char const *param)
+/// Returns the path @p param by removing leading `,` and `:` from path name.
+static char const *param_output_path(char const *param)
 {
     if (!param || !*param) {
-        return stdout; // No path given
+        return NULL; // No path given
     }
     while (*param == ',') {
         param++; // Skip all leading `,`
@@ -1017,26 +1017,21 @@ static FILE *fopen_output(char const *param)
         param++; // Skip one leading `:`
     }
     if (*param == '-' && param[1] == '\0') {
-        return stdout; // STDOUT requested
+        return NULL; // STDOUT requested
     }
-    FILE *file = fopen(param, "a");
-    if (!file) {
-        fprintf(stderr, "rtl_433: failed to open output file\n");
-        exit(1);
-    }
-    return file;
+    return param;
 }
 
 void add_json_output(r_cfg_t *cfg, char *param)
 {
     int log_level = lvlarg_param(&param, 0);
-    list_push(&cfg->output_handler, data_output_json_create(log_level, fopen_output(param)));
+    list_push(&cfg->output_handler, data_output_json_create(log_level, param_output_path(param)));
 }
 
 void add_csv_output(r_cfg_t *cfg, char *param)
 {
     int log_level = lvlarg_param(&param, 0);
-    list_push(&cfg->output_handler, data_output_csv_create(log_level, fopen_output(param)));
+    list_push(&cfg->output_handler, data_output_csv_create(log_level, param_output_path(param)));
 }
 
 void start_outputs(r_cfg_t *cfg, char const *const *well_known)
@@ -1055,13 +1050,13 @@ void start_outputs(r_cfg_t *cfg, char const *const *well_known)
 void add_log_output(r_cfg_t *cfg, char *param)
 {
     int log_level = lvlarg_param(&param, LOG_TRACE);
-    list_push(&cfg->output_handler, data_output_log_create(log_level, fopen_output(param)));
+    list_push(&cfg->output_handler, data_output_log_create(log_level, param_output_path(param)));
 }
 
 void add_kv_output(r_cfg_t *cfg, char *param)
 {
     int log_level = lvlarg_param(&param, LOG_TRACE);
-    list_push(&cfg->output_handler, data_output_kv_create(log_level, fopen_output(param)));
+    list_push(&cfg->output_handler, data_output_kv_create(log_level, param_output_path(param)));
 }
 
 void add_mqtt_output(r_cfg_t *cfg, char *param)
@@ -1105,7 +1100,7 @@ void add_http_output(r_cfg_t *cfg, char *param)
 void add_trigger_output(r_cfg_t *cfg, char *param)
 {
     // Note: no log_level, we never trigger on logs.
-    list_push(&cfg->output_handler, data_output_trigger_create(fopen_output(param)));
+    list_push(&cfg->output_handler, data_output_trigger_create(param_output_path(param)));
 }
 
 void add_null_output(r_cfg_t *cfg, char *param)
@@ -1125,6 +1120,14 @@ void add_rtltcp_output(r_cfg_t *cfg, char *param)
     print_logf(LOG_CRITICAL, "rtl_tcp server", "Starting rtl_tcp server at %s port %s", host, port);
 
     list_push(&cfg->raw_handler, raw_output_rtltcp_create(host, port, extra, cfg));
+}
+
+void reopen_outputs(struct r_cfg *cfg)
+{
+    for (size_t i = 0; i < cfg->output_handler.len; ++i) { // list might contain NULLs
+        data_output_t *output = cfg->output_handler.elems[i];
+        data_output_reload(output);
+    }
 }
 
 void add_sr_dumper(r_cfg_t *cfg, char const *spec, int overwrite)

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1532,6 +1532,7 @@ static void timer_handler(struct mg_connection *nc, int ev, void *ev_data)
     //fprintf(stderr, "%s: %d, %d, %p, %p\n", __func__, nc->sock, ev, nc->user_data, ev_data);
     r_cfg_t *cfg = (r_cfg_t *)nc->user_data;
     if (sig_hup) {
+        reopen_outputs(cfg);
         reopen_dumpers(cfg);
         sig_hup = 0;
     }

--- a/tests/data-test.c
+++ b/tests/data-test.c
@@ -40,9 +40,9 @@ int main(void)
     /* clang-format on */
     const char *fields[] = { "label", "house_code", "temp", "array", "array2", "array3", "data", "house_code" };
 
-    void *json_output = data_output_json_create(0, stdout);
-    void *kv_output = data_output_kv_create(0, stdout);
-    void *csv_output = data_output_csv_create(0, stdout);
+    void *json_output = data_output_json_create(0, NULL/* stdout */);
+    void *kv_output = data_output_kv_create(0, NULL/* stdout */);
+    void *csv_output = data_output_csv_create(0, NULL/* stdout */);
     data_output_start(csv_output, fields, sizeof fields / sizeof *fields);
 
     data_output_print(json_output, data); fprintf(stdout, "\n");


### PR DESCRIPTION
This addresses #3281

On receiving the SIGHUP signal rtl_433 will reopen all configured outputs. This way you can rotate log files.

Unfinished because:
- [ ] the CSV output needs to write a new column header line, but only if the file is truely new
- [ ] the output reopen function should be using a DRY helper