### PR TITLE
Change dB estimate display to true RSSI

### DIFF
--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -206,7 +206,7 @@ int pulse_detect_package(pulse_detect_t *pulse_detect, int16_t const *envelope_d
             int att = pulse_detect->use_mag_est ? mag_to_att(am_n) : amp_to_att(am_n);
             att_hist[att] += 1;
         }
-        int16_t ook_threshold = (s->ook_low_estimate + s->ook_high_estimate) / 2;
+        int16_t ook_threshold = (s->ook_low_estimate + MIN(s->ook_high_estimate, OOK_MAX_HIGH_LEVEL)) / 2;
         if (pulse_detect->ook_fixed_high_level != 0) {
             ook_threshold = pulse_detect->ook_fixed_high_level; // Manual override
         }
@@ -239,7 +239,6 @@ int pulse_detect_package(pulse_detect_t *pulse_detect, int16_t const *envelope_d
                     // Calculate default OOK high level estimate
                     s->ook_high_estimate = pulse_detect->ook_high_low_ratio * s->ook_low_estimate; // Default is a ratio of low level
                     s->ook_high_estimate = MAX(s->ook_high_estimate, pulse_detect->ook_min_high_level);
-                    s->ook_high_estimate = MIN(s->ook_high_estimate, OOK_MAX_HIGH_LEVEL);
                     if (s->lead_in_counter <= OOK_EST_LOW_RATIO) s->lead_in_counter += 1;        // Allow initial estimate to settle
                 }
                 break;
@@ -271,7 +270,6 @@ int pulse_detect_package(pulse_detect_t *pulse_detect, int16_t const *envelope_d
                     // Calculate OOK high level estimate
                     s->ook_high_estimate += am_n / OOK_EST_HIGH_RATIO - s->ook_high_estimate / OOK_EST_HIGH_RATIO;
                     s->ook_high_estimate = MAX(s->ook_high_estimate, pulse_detect->ook_min_high_level);
-                    s->ook_high_estimate = MIN(s->ook_high_estimate, OOK_MAX_HIGH_LEVEL);
                     // Estimate pulse carrier frequency
                     pulses->fsk_f1_est += fm_data[s->data_counter] / OOK_EST_HIGH_RATIO - pulses->fsk_f1_est / OOK_EST_HIGH_RATIO;
                 }

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -338,7 +338,9 @@ void calc_rssi_snr(r_cfg_t *cfg, pulse_data_t *pulse_data)
 {
     float ook_high_estimate = pulse_data->ook_high_estimate > 0 ? pulse_data->ook_high_estimate : 1;
     float ook_low_estimate = pulse_data->ook_low_estimate > 0 ? pulse_data->ook_low_estimate : 1;
-    float asnr   = ook_high_estimate / ook_low_estimate;
+    int const OOK_MAX_HIGH_LEVEL = DB_TO_AMP(0); // Maximum estimate for high level (-0 dB)
+    float ook_max_estimate = ook_high_estimate < OOK_MAX_HIGH_LEVEL ? ook_high_estimate : OOK_MAX_HIGH_LEVEL;
+    float asnr   = ook_max_estimate / ook_low_estimate;
     float foffs1 = (float)pulse_data->fsk_f1_est / INT16_MAX * cfg->samp_rate / 2.0f;
     float foffs2 = (float)pulse_data->fsk_f2_est / INT16_MAX * cfg->samp_rate / 2.0f;
     pulse_data->freq1_hz = (foffs1 + cfg->center_frequency);


### PR DESCRIPTION
This change removes the upper bound of 0 dB from the RSSI reading to show when signals are clipping.
The SNR is still limited to 0 dB, i.e. `snr = min(rssi, 0 dB) - noise`.

The OOK pulse detect is slightly changed as the high estimate tracks a little higher now but that should have no impact.

We still need a dedicated clipping warning for FSK signals as the RSSI is only shown on successful decodes. (OOK can handle a clipping signal very well, FSK can't.)