### PR TITLE
Prevent s_long from being zero

### DIFF
--- a/src/pulse_slicer.c
+++ b/src/pulse_slicer.c
@@ -90,6 +90,11 @@ int pulse_slicer_pcm(pulse_data_t const *pulses, r_device *device)
     int events = 0;
     bitbuffer_t bits = {0};
 
+    // Prevent divide-by-zero
+    if (s_long <= 0) {
+        return 0;
+    }
+
     int const gap_limit = s_gap ? s_gap : s_reset;
     int const max_zeros = gap_limit / s_long;
     if (s_tolerance <= 0)


### PR DESCRIPTION
In function `pulse_analyzer`, `device->long_width` can be initialized as 0. 
```c
else if (hist_pulses.bins_count == 2 && hist_gaps.bins_count == 2 && hist_periods_pg.bins_count == 3) {
        fprintf(stderr, "Manchester coding\n");
        device->modulation  = (package_type == PULSE_DATA_FSK) ? FSK_PULSE_MANCHESTER_ZEROBIT : OOK_PULSE_MANCHESTER_ZEROBIT;
        device->short_width = to_us * MIN(hist_pulses.bins[0].mean, hist_pulses.bins[1].mean);
        device->long_width  = 0;                                                               
        device->reset_limit = to_us * (hist_gaps.bins[hist_gaps.bins_count - 1].max + 1);     
    }
``` 

When `device->long_width = 0`, `s_long = 0` and can pass the check for rouding to zero.
```c
int s_long  = device->long_width * samples_per_us;
...
int const max_zeros = gap_limit / s_long;
``` 
