### PR TITLE
Add Support for BMW GEN2 TPMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [254]  Thermor DG950 weather station
     [255]  Mueller Hot Rod water meter
     [256]  ThermoPro TP28b Super Long Range Wireless Meat Thermometer for Smoker BBQ Grill
-    [257]  BMW Gen3 TPMS
+    [257]  BMW Gen2 and Gen3 TPMS
     [258]  Chamberlain CWPIRC PIR Sensor
     [259]  ThermoPro Meat Thermometers, TP829B 4 probes with temp only
     [260]* Arad/Master Meter Dialog3G water utility meter

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -495,7 +495,7 @@ convert si
   protocol 254 # Thermor DG950 weather station
   protocol 255 # Mueller Hot Rod water meter
   protocol 256 # ThermoPro TP28b Super Long Range Wireless Meat Thermometer for Smoker BBQ Grill
-  protocol 257 # BMW Gen3 TPMS
+  protocol 257 # BMW Gen2 and Gen3 TPMS
   protocol 258 # Chamberlain CWPIRC PIR Sensor
   protocol 259 # ThermoPro Meat Thermometers, TP829B 4 probes with temp only
 # protocol 260 # Arad/Master Meter Dialog3G water utility meter

--- a/src/devices/tpms_bmw_g3.c
+++ b/src/devices/tpms_bmw_g3.c
@@ -93,12 +93,11 @@ static int tpms_bmwg3_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_FAIL_MIC; // crc mismatch
     }
 
-    if (is_gen2){
+    if (is_gen2) {
         decoder_log(decoder, 1, __func__, "BMW Gen 2 found");
-    }else{
+    } else {
     decoder_log(decoder, 1, __func__, "BMW Gen 3 found");
     }
-
 
     float pressure_kPa      = (b[4] - 43) * 2.5f;
     float temperature_C     = (b[5] - 40);

--- a/src/devices/tpms_bmw_g3.c
+++ b/src/devices/tpms_bmw_g3.c
@@ -1,5 +1,5 @@
 /** @file
-    BMW Gen3 TPMS sensor.
+    BMW Gen2 Gen3 TPMS sensor.
 
     Copyright (C) 2024 Bruno OCTAU (ProfBoc75), \@Billymazze
 
@@ -9,9 +9,11 @@
     (at your option) any later version.
 */
 /**
-BMW Gen3 TPMS sensor.
+BMW Gen2 Gen3 TPMS sensor.
 
 issue #2893 BMW Gen3 TPMS support open by \@Billymazze
+
+issue #3300 BMW gen 2/3 TPMS
 
 Last progress based on this:
 
@@ -22,18 +24,26 @@ RF signal:
 
     FSK, PCM, s=l=52 µs, Differential Manchester
 
-Data layout{89} 11 x 8:
+Data layout{89} 11 x 8 (Gen3):
 
     Byte Position  0  1  2  3  4  5  6  7  8  9 10 11
     Data Layout  [II II II II PP TT F1 F2 F3]CC CC 8
     Sample        1c 50 f1 75 85 45 f8 02 03 73 42 8
 
+Data layout {81} 10 x 8 (Gen2):
+
+                   0  1  2  3  4  5  6  7  8  9 10
+                 [78 34 a9 7e 90 3c 80 51]6a 6e 0 [CRC 16 0x1021 0x0000 OK]
+                 [1e 2a e7 fe 89 3a f8 51]71 0d 0 [CRC OK]
+                 [78 34 a9 7e 93 40 80 51]5c db 0 [CRC OK]
+
 - II:{32} ID, hexa 0x1c50f175 or decimal value 475066741
 - PP:{8}: Tire pressure, PSI = (PP - 43) * 0.363 or kPa = ( PP - 43 ) * 2.5
 - TT:{8}: Temperature in C offset 40
-- F1, F2, F3: Flags that could contain battery information, flat tire, lost of pressure ...
-- CC: CRC-16 bits, poly 0x1021, init 0x0000 [from previous 9 bytes].
-- 8: useless trailing bit
+- F1, F2 Flags that could contain battery information, flat tire, lost of pressure ...
+- F3, Flags only on Gen3 model.
+- CC: CRC-16 bits, poly 0x1021, init 0x0000 [from previous bytes].
+- 8 or 0: useless trailing bit after CRC.
 
 */
 
@@ -64,32 +74,50 @@ static int tpms_bmwg3_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     decoder_log_bitrow(decoder, 2, __func__, decoded.bb[0], decoded.bits_per_row[0], "DMC");
 
-    if (decoded.bits_per_row[0] < 88) {
+    // Based on the lenght define if Gen2 10 bytes, 81 bits or Gen3, 11 bytes, 89 bits.
+    int msg_len = decoded.bits_per_row[0];
+    int is_gen2 = 0;
+
+    if (80 <= msg_len && msg_len < 88 ) { // could be Gen2
+        is_gen2 = 1;
+    }
+    if (msg_len < 80) {
         decoder_logf(decoder, 2, __func__, "Too short");
         return DECODE_ABORT_LENGTH;
     }
 
     b = decoded.bb[0];
 
-    if (crc16(b, 11, 0x1021, 0x0000)) {
-        decoder_logf(decoder, 1, __func__, "crc error, expected %02x%02x, calculated %04x", b[9], b[10], crc16(b, 11, 0x1021, 0x0000));
+    if (crc16(b, 11 - is_gen2, 0x1021, 0x0000)) {
+        decoder_logf(decoder, 1, __func__, "crc error, expected %02x%02x, calculated %04x", b[9 - is_gen2], b[10 - is_gen2], crc16(b, 11 - is_gen2, 0x1021, 0x0000));
         return DECODE_FAIL_MIC; // crc mismatch
     }
-    decoder_log(decoder, 1, __func__, "BMW G3 found");
+
+    if (is_gen2){
+        decoder_log(decoder, 1, __func__, "BMW Gen 2 found");
+    }else{
+    decoder_log(decoder, 1, __func__, "BMW Gen 3 found");
+    }
+
+
     float pressure_kPa      = (b[4] - 43) * 2.5f;
     float temperature_C     = (b[5] - 40);
     int flags1              = b[6]; // fixed value to 0xf8 could be Brand ID ?
     int flags2              = b[7]; // Battery , pressure warning ?
-    int flags3              = b[8]; // fixed value to 0x03 could be Brand ID ?
+    int flags3              = b[8]; // fixed value to 0x03 could be Brand ID ?, useless with Gen2
 
     uint32_t id             = ((uint32_t)b[0] << 24) | (b[1] << 16) | (b[2] << 8) | (b[3]);
 
-    char msg_str[23];
-    snprintf(msg_str, sizeof(msg_str), "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x", b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7], b[8], b[9], b[10]);
+    char msg_str[23 - (2 * is_gen2) ];
+    if (is_gen2) {
+        snprintf(msg_str, sizeof(msg_str), "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x", b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7], b[8], b[9]);
+    }else{
+        snprintf(msg_str, sizeof(msg_str), "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x", b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7], b[8], b[9], b[10]);
+    }
 
     /* clang-format off */
     data_t *data = data_make(
-            "model",               "",                DATA_STRING, "BMW-GEN3",
+            "model",               "",                DATA_STRING, is_gen2 ? "BMW-GEN2" : "BMW-GEN3",
             "type",                "",                DATA_STRING, "TPMS",
             //"id",                  "",                DATA_FORMAT, "%08x",     DATA_INT,    id,
             "id",                  "",                DATA_INT,    id,
@@ -97,7 +125,7 @@ static int tpms_bmwg3_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "temperature_C",       "Temperature",     DATA_FORMAT, "%.1f C",   DATA_DOUBLE, temperature_C,
             "flags1",              "",                DATA_FORMAT, "%08b",     DATA_INT,    flags1,
             "flags2",              "",                DATA_FORMAT, "%08b",     DATA_INT,    flags2,
-            "flags3",              "",                DATA_FORMAT, "%08b",     DATA_INT,    flags3,
+            "flags3",              "",                DATA_COND, !is_gen2,     DATA_FORMAT, "%08b",     DATA_INT,    flags3,
             "msg",                 "msg",             DATA_STRING, msg_str, // To remove after guess all tags
             "mic",                 "Integrity",       DATA_STRING, "CRC",
             NULL);
@@ -122,7 +150,7 @@ static char const *const output_fields[] = {
 };
 
 r_device const tpms_bmwg3 = {
-        .name        = "BMW Gen3 TPMS",
+        .name        = "BMW Gen2 and Gen3 TPMS",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 52,
         .long_width  = 52,


### PR DESCRIPTION
Related to issue #3300  

This PR add support of BMW Gen 2 TPMS with existing Gen 3 decoder.