### PR TITLE
Add demod state reset between input files

### DIFF
--- a/include/baseband.h
+++ b/include/baseband.h
@@ -106,6 +106,9 @@ typedef struct demodfm_state {
     int64_t blp_32[2]; ///< Current low pass filter B coeffs, 32 bit
 } demodfm_state_t;
 
+/** Reset the lowpass filter to an initial state. */
+void baseband_low_pass_filter_reset(filter_state_t *lowpass_filter);
+
 /** Lowpass filter.
 
     Function is stateful.
@@ -114,22 +117,25 @@ typedef struct demodfm_state {
     @param len number of samples to process
     @param[in,out] state State to store between chunk processing
 */
-void baseband_low_pass_filter(uint16_t const *x_buf, int16_t *y_buf, uint32_t len, filter_state_t *state);
+void baseband_low_pass_filter(filter_state_t *state, uint16_t const *x_buf, int16_t *y_buf, uint32_t len);
+
+/** Reset the FM demodulator to an initial state. */
+void baseband_demod_FM_reset(demodfm_state_t *demod_fm);
 
 /** FM demodulator.
 
     Function is stateful.
+    @param[in,out] state State to store between chunk processing
     @param x_buf input samples (I/Q samples in interleaved uint8)
     @param[out] y_buf output from FM demodulator
     @param num_samples number of samples to process
     @param samp_rate sample rate of samples to process
     @param low_pass Low-pass filter frequency or ratio
-    @param[in,out] state State to store between chunk processing
 */
-void baseband_demod_FM(uint8_t const *x_buf, int16_t *y_buf, unsigned long num_samples, uint32_t samp_rate, float low_pass, demodfm_state_t *state);
+void baseband_demod_FM(demodfm_state_t *state, uint8_t const *x_buf, int16_t *y_buf, unsigned long num_samples, uint32_t samp_rate, float low_pass);
 
 /// For evaluation.
-void baseband_demod_FM_cs16(int16_t const *x_buf, int16_t *y_buf, unsigned long num_samples, uint32_t samp_rate, float low_pass, demodfm_state_t *state);
+void baseband_demod_FM_cs16(demodfm_state_t *state, int16_t const *x_buf, int16_t *y_buf, unsigned long num_samples, uint32_t samp_rate, float low_pass);
 
 /** Initialize tables and constants.
     Should be called once at startup.

--- a/include/pulse_detect.h
+++ b/include/pulse_detect.h
@@ -38,6 +38,9 @@ pulse_detect_t *pulse_detect_create(void);
 
 void pulse_detect_free(pulse_detect_t *pulse_detect);
 
+/// Reset pulse detector to initial values.
+void pulse_detect_reset(pulse_detect_t *pulse_detect);
+
 /// Set pulse detector level values.
 ///
 /// @param pulse_detect The pulse_detect instance

--- a/src/baseband.c
+++ b/src/baseband.c
@@ -123,6 +123,10 @@ float magnitude_true_cs16(int16_t const *iq_buf, uint16_t *y_buf, uint32_t len)
     return len > 0 && sum >= len ? MAG_TO_DB((float)sum / len) : MAG_TO_DB(1);
 }
 
+void baseband_low_pass_filter_reset(filter_state_t *lowpass_filter)
+{
+    *lowpass_filter = (filter_state_t){0};
+}
 
 // Fixed-point arithmetic on Q0.15
 #define F_SCALE 15
@@ -138,7 +142,7 @@ float magnitude_true_cs16(int16_t const *iq_buf, uint16_t *y_buf, uint32_t len)
     - but the b coeffs are small so it won't happen
     - Q15.14>>14 = Q15.0
 */
-void baseband_low_pass_filter(uint16_t const *x_buf, int16_t *y_buf, uint32_t len, filter_state_t *state)
+void baseband_low_pass_filter(filter_state_t *state, uint16_t const *x_buf, int16_t *y_buf, uint32_t len)
 {
     ///  [b,a] = butter(1, 0.01) -> 3x tau (95%) ~100 samples
     //static int const a[FILTER_ORDER + 1] = {FIX(1.00000) >> 1, FIX(0.96907) >> 1};
@@ -197,8 +201,13 @@ static int16_t atan2_int16(int32_t y, int32_t x)
     return angle;
 }
 
+void baseband_demod_FM_reset(demodfm_state_t *demod_fm)
+{
+    *demod_fm = (demodfm_state_t){0};
+}
+
 /// Fast Instantaneous frequency and Low Pass filter, CU8 samples
-void baseband_demod_FM(uint8_t const *x_buf, int16_t *y_buf, unsigned long num_samples, uint32_t samp_rate, float low_pass, demodfm_state_t *state)
+void baseband_demod_FM(demodfm_state_t *state, uint8_t const *x_buf, int16_t *y_buf, unsigned long num_samples, uint32_t samp_rate, float low_pass)
 {
     // Select filter coeffs, [b,a] = butter(1, cutoff)
     // e.g [b,a] = butter(1, 0.1) -> 3x tau (95%) ~10 samples, 250k -> 40us, 1024k -> 10us
@@ -291,7 +300,7 @@ static int32_t atan2_int32(int32_t y, int32_t x)
 }
 
 /// Fast Instantaneous frequency and Low Pass filter, CS16 samples.
-void baseband_demod_FM_cs16(int16_t const *x_buf, int16_t *y_buf, unsigned long num_samples, uint32_t samp_rate, float low_pass, demodfm_state_t *state)
+void baseband_demod_FM_cs16(demodfm_state_t *state, int16_t const *x_buf, int16_t *y_buf, unsigned long num_samples, uint32_t samp_rate, float low_pass)
 {
     // Select filter coeffs, [b,a] = butter(1, cutoff)
     // e.g [b,a] = butter(1, 0.1) -> 3x tau (95%) ~10 samples, 250k -> 40us, 1024k -> 10us

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -71,6 +71,18 @@ void pulse_detect_free(pulse_detect_t *pulse_detect)
     free(pulse_detect);
 }
 
+void pulse_detect_reset(pulse_detect_t *pulse_detect)
+{
+    pulse_detect->ook_state         = PD_OOK_STATE_IDLE;
+    pulse_detect->pulse_length      = 0;
+    pulse_detect->max_pulse         = 0;
+    pulse_detect->data_counter      = 0;
+    pulse_detect->lead_in_counter   = 0;
+    pulse_detect->ook_low_estimate  = 0;
+    pulse_detect->ook_high_estimate = 0;
+    pulse_detect_fsk_init(&pulse_detect->pulse_detect_fsk);
+}
+
 void pulse_detect_set_levels(pulse_detect_t *pulse_detect, int use_mag_est, float fixed_high_level, float min_high_level, float high_low_ratio, int verbosity)
 {
     pulse_detect->use_mag_est = use_mag_est;

--- a/tests/baseband-test.c
+++ b/tests/baseband-test.c
@@ -156,18 +156,18 @@ int main(int argc, char *argv[])
     );
     write_buf("bb.am.s16", y16_buf, sizeof(uint16_t) * n_samples);
     MEASURE("baseband_low_pass_filter",
-        baseband_low_pass_filter(y16_buf, (int16_t *)u16_buf, n_samples, &state);
+        baseband_low_pass_filter(&state, y16_buf, (int16_t *)u16_buf, n_samples);
     );
     write_buf("bb.lp.am.s16", u16_buf, sizeof(int16_t) * n_samples);
     MEASURE("baseband_demod_FM",
-        baseband_demod_FM(cu8_buf, s16_buf, n_samples, 250000, 0.1f, &fm_state);
+        baseband_demod_FM(&fm_state, cu8_buf, s16_buf, n_samples, 250000, 0.1f);
     );
     write_buf("bb.fm.s16", s16_buf, sizeof(int16_t) * n_samples);
 
     write_buf("bb.cs16", cs16_buf, sizeof(int16_t) * 2 * n_samples);
     //envelope_detect_cs16(cs16_buf, y32_buf, n_samples);
     //write_buf("bb.am.u32", y32_buf, sizeof(uint32_t) * n_samples);
-    //baseband_low_pass_filter_u32(y32_buf, u32_buf, n_samples, &state);
+    //baseband_low_pass_filter_u32(&state, y32_buf, u32_buf, n_samples);
     //write_buf("bb.lp.am.u32", u32_buf, sizeof(uint32_t) * n_samples);
 
     MEASURE("magnitude_est_cs16",
@@ -178,15 +178,15 @@ int main(int argc, char *argv[])
     );
     write_buf("bb.mag.s16", y16_buf, sizeof(uint16_t) * n_samples);
     MEASURE("baseband_low_pass_filter",
-        baseband_low_pass_filter(y16_buf, (int16_t *)u16_buf, n_samples, &state);
+        baseband_low_pass_filter(&state, y16_buf, (int16_t *)u16_buf, n_samples);
     );
     write_buf("bb.mag.lp.s16", u16_buf, sizeof(int16_t) * n_samples);
 
-    //baseband_demod_FM_cs16(cs16_buf, s32_buf, n_samples, &fm_state);
+    //baseband_demod_FM_cs16(&fm_state, cs16_buf, s32_buf, n_samples);
     //write_buf("bb.fm.s32", s32_buf, sizeof(int32_t) * n_samples);
 
     MEASURE("baseband_demod_FM_cs16",
-        baseband_demod_FM_cs16(cs16_buf, s16_buf, n_samples, 250000, 0.1f, &fm_state);
+        baseband_demod_FM_cs16(&fm_state, cs16_buf, s16_buf, n_samples, 250000, 0.1f);
     );
     write_buf("bb.cs16.fm.s16", s16_buf, sizeof(int16_t) * n_samples);
 

--- a/tests/pulse-eval.c
+++ b/tests/pulse-eval.c
@@ -229,7 +229,6 @@ int main(int argc, char *argv[])
 
     n_read = read_buf(filename, cu8_buf, sizeof(uint8_t) * 2 * block_size);
     if (n_read < 1) {
-        ret = 1;
         goto out;
     }
     n_samples = n_read / (sizeof(uint8_t) * 2);
@@ -241,11 +240,11 @@ int main(int argc, char *argv[])
     magnitude_est_cu8(cu8_buf, y16_buf, n_samples);
     envelope_detect_nolut(cu8_buf, am16_buf, n_samples);
     demodfm_state_t fm_state;
-    baseband_demod_FM(cu8_buf, fm16_buf, n_samples, &fm_state, 0);
+    baseband_demod_FM(&fm_state, cu8_buf, fm16_buf, n_samples, 250000, 0.1f);
     // envelope_detect(cu8_buf, y16_buf, n_samples);
     // magnitude_est_cu8(cu8_buf, y16_buf, n_samples);
-    // baseband_low_pass_filter(y16_buf, (int16_t *)u16_buf, n_samples, &state);
-    // baseband_demod_FM(cu8_buf, s16_buf, n_samples, &fm_state);
+    // baseband_low_pass_filter(&state, y16_buf, (int16_t *)u16_buf, n_samples);
+    // baseband_demod_FM(&fm_state, cu8_buf, s16_buf, n_samples, 250000, 0.1f);
 
     // moving avgs (AM)
     mavg_t ml = {0};


### PR DESCRIPTION
This fully resets the demod between input files. Reading multiple files behaves the same as reading each file on it's own now.