### PR TITLE
Add nexus_sauna device

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [276]  RainPoint HCS012ARF Rain Gauge sensor
     [277]  Apator Metra E-RM 30
     [278]  ThermoPro TX-7B Outdoor Thermometer Hygrometer
+    [279]  Nexus, CRX, Prego sauna temperature sensor
 
 * Disabled by default, use -R n or a conf file to enable
 

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -517,6 +517,7 @@ convert si
   protocol 276 # RainPoint HCS012ARF Rain Gauge sensor
   protocol 277 # Apator Metra E-RM 30
   protocol 278 # ThermoPro TX-7B Outdoor Thermometer Hygrometer
+  protocol 279 # Nexus, CRX, Prego sauna temperature sensor
 
 ## Flex devices (command line option "-X")
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -286,6 +286,7 @@
     DECL(rainpoint_hcs012arf) \
     DECL(apator_metra_erm30) \
     DECL(thermopro_tx7b) \
+    DECL(nexus_sauna) \
 
     /* Add new decoders here. */
 

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -101,25 +101,26 @@ static int nexus_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 /**
- * Nexus Sauna sensor with ID, temperature, battery and test flag.
- * The "Sauna sensor", sends 36 bits 6 times, the nibbles are:
- *
- * [id0] [id1] [flags] [const] [temp0] [temp1] [temp2] [temp2] [const2]
- *
- * - The 8-bit id changes when the battery is changed in the sensor.
- * - flags are 4 bits B T C C, where:
- * B is the battery status: 1=OK, 0=LOW
- * T is Test mode, 0=Normal, 1=Test.
- * To enter test mode, press and hold Tx/Send button while putting the last battery in, it will send values at ~2sec intreval.
- * CC is the channel: It is always 11 (0x3) for CH4
- * - temp is 16 bit signed scaled by 10
- * - const is always 1111 (0x0F)
- * - const2 is always 0001 (0x1)
- * To be exact, the "Sauna sensor" seems to send niblets 6 times with const2=0x1, and then seventh time sends just 35 bits, so last nibble is 0b000.
- * Maybe this is "data-end" mark. I don't know. Anyway, it can be ignored here, cause data has been parsed already.
- *
- * Sauna sensor kit is sold by IKH (CRX) and Motonet (Prego).
- */
+ Nexus Sauna sensor with ID, temperature, battery and test flag.
+
+ The "Sauna sensor", sends 36 bits 6 times, the nibbles are:
+
+ [id0] [id1] [flags] [const] [temp0] [temp1] [temp2] [temp2] [const2]
+
+ - The 8-bit id changes when the battery is changed in the sensor.
+ - flags are 4 bits B T C C, where:
+ B is the battery status: 1=OK, 0=LOW
+ T is Test mode, 0=Normal, 1=Test.
+ To enter test mode, press and hold Tx/Send button while putting the last battery in, it will send values at ~2sec intreval.
+ CC is the channel: It is always 11 (0x3) for CH4
+ - temp is 16 bit signed scaled by 10
+ - const is always 1111 (0x0F)
+ - const2 is always 0001 (0x1)
+ To be exact, the "Sauna sensor" seems to send niblets 6 times with const2=0x1, and then seventh time sends just 35 bits, so last nibble is 0b000.
+ Maybe this is "data-end" mark. I don't know. Anyway, it can be ignored here, cause data has been parsed already.
+
+ Sauna sensor kit is sold by IKH (CRX) and Motonet (Prego).
+*/
 static int nexus_sauna_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     int r = bitbuffer_find_repeated_row(bitbuffer, 3, 36);

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -101,6 +101,7 @@ static int nexus_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 /**
+ * Nexus Sauna sensor with ID, temperature, battery and test flag.
  * The "Sauna sensor", sends 36 bits 6 times, the nibbles are:
  *
  * [id0] [id1] [flags] [const] [temp0] [temp1] [temp2] [temp2] [const2]

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -176,15 +176,15 @@ static char const *const output_fields[] = {
 };
 
 r_device const nexus = {
-    .name        = "Nexus, FreeTec NC-7345, NX-3980, Solight TE82S, TFA 30.3209 temperature/humidity sensor",
-    .modulation  = OOK_PULSE_PPM,
-    .short_width = 1000,
-    .long_width  = 2000,
-    .gap_limit   = 3000,
-    .reset_limit = 5000,
-    .decode_fn   = &nexus_decode,
-    .priority    = 10, // Eliminate false positives by letting Rubicson-Temperature go earlier
-    .fields      = output_fields,
+        .name        = "Nexus, FreeTec NC-7345, NX-3980, Solight TE82S, TFA 30.3209 temperature/humidity sensor",
+        .modulation  = OOK_PULSE_PPM,
+        .short_width = 1000,
+        .long_width  = 2000,
+        .gap_limit   = 3000,
+        .reset_limit = 5000,
+        .decode_fn   = &nexus_decode,
+        .priority    = 10, // Eliminate false positives by letting Rubicson-Temperature go earlier
+        .fields      = output_fields,
 };
 
 static char const *const sauna_output_fields[] = {
@@ -198,13 +198,13 @@ static char const *const sauna_output_fields[] = {
 };
 
 r_device const nexus_sauna = {
-    .name        = "Nexus, CRX, Prego sauna temperature sensor",
-    .modulation  = OOK_PULSE_PPM,
-    .short_width = 1000,
-    .long_width  = 2000,
-    .gap_limit   = 3000,
-    .reset_limit = 5000,
-    .decode_fn   = &nexus_sauna_decode,
-    .priority    = 10, // Eliminate false positives by letting Rubicson-Temperature go earlier
-    .fields      = sauna_output_fields,
+        .name        = "Nexus, CRX, Prego sauna temperature sensor",
+        .modulation  = OOK_PULSE_PPM,
+        .short_width = 1000,
+        .long_width  = 2000,
+        .gap_limit   = 3000,
+        .reset_limit = 5000,
+        .decode_fn   = &nexus_sauna_decode,
+        .priority    = 10, // Eliminate false positives by letting Rubicson-Temperature go earlier
+        .fields      = sauna_output_fields,
 };

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -165,13 +165,13 @@ static int nexus_sauna_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 static char const *const output_fields[] = {
-    "model",
-    "id",
-    "channel",
-    "battery_ok",
-    "temperature_C",
-    "humidity",
-    NULL,
+        "model",
+        "id",
+        "channel",
+        "battery_ok",
+        "temperature_C",
+        "humidity",
+        NULL,
 };
 
 r_device const nexus = {
@@ -187,13 +187,13 @@ r_device const nexus = {
 };
 
 static char const *const sauna_output_fields[] = {
-    "model",
-    "id",
-    "channel",
-    "battery_ok",
-    "temperature_C",
-    "test",
-    NULL,
+        "model",
+        "id",
+        "channel",
+        "battery_ok",
+        "temperature_C",
+        "test",
+        NULL,
 };
 
 r_device const nexus_sauna = {

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -100,7 +100,7 @@ static int nexus_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
-/*
+/**
  * The "Sauna sensor", sends 36 bits 6 times, the nibbles are:
  *
  * [id0] [id1] [flags] [const] [temp0] [temp1] [temp2] [temp2] [const2]
@@ -151,13 +151,13 @@ static int nexus_sauna_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     data_t *data;
     /* clang-format off */
     data = data_make(
-        "model",         "",            DATA_STRING, "Nexus-Sauna",
-        "id",            "House Code",  DATA_INT,    id,
-        "channel",       "Channel",     DATA_INT,    4,
-        "battery_ok",    "Battery",     DATA_INT,    !!battery,
-        "temperature_C", "Temperature", DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
-        "test",          "Test?",       DATA_STRING, test ? "Yes" : "No",
-        NULL);
+            "model",         "",            DATA_STRING, "Nexus-Sauna",
+            "id",            "House Code",  DATA_INT,    id,
+            "channel",       "Channel",     DATA_INT,    4,
+            "battery_ok",    "Battery",     DATA_INT,    !!battery,
+            "temperature_C", "Temperature", DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
+            "test",          "Test?",       DATA_STRING, test ? "Yes" : "No",
+            NULL);
     /* clang-format on */
 
     decoder_output_data(decoder, data);

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -150,9 +150,8 @@ static int nexus_sauna_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int battery  = b[1] & 0x80;
     int temp_raw = (int16_t)((b[2] << 8) | (b[3])); // sign-extend
     float temp_c = temp_raw * 0.1f;
-    data_t *data;
     /* clang-format off */
-    data = data_make(
+    data_t *data = data_make(
             "model",         "",            DATA_STRING, "Nexus-Sauna",
             "id",            "House Code",  DATA_INT,    id,
             "channel",       "Channel",     DATA_INT,    4,

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -101,25 +101,25 @@ static int nexus_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 }
 
 /**
- Nexus Sauna sensor with ID, temperature, battery and test flag.
+Nexus Sauna sensor with ID, temperature, battery and test flag.
 
- The "Sauna sensor", sends 36 bits 6 times, the nibbles are:
+The "Sauna sensor", sends 36 bits 6 times, the nibbles are:
 
  [id0] [id1] [flags] [const] [temp0] [temp1] [temp2] [temp2] [const2]
 
- - The 8-bit id changes when the battery is changed in the sensor.
- - flags are 4 bits B T C C, where:
- B is the battery status: 1=OK, 0=LOW
- T is Test mode, 0=Normal, 1=Test.
- To enter test mode, press and hold Tx/Send button while putting the last battery in, it will send values at ~2sec intreval.
- CC is the channel: It is always 11 (0x3) for CH4
- - temp is 16 bit signed scaled by 10
- - const is always 1111 (0x0F)
- - const2 is always 0001 (0x1)
- To be exact, the "Sauna sensor" seems to send niblets 6 times with const2=0x1, and then seventh time sends just 35 bits, so last nibble is 0b000.
- Maybe this is "data-end" mark. I don't know. Anyway, it can be ignored here, cause data has been parsed already.
+- The 8-bit id changes when the battery is changed in the sensor.
+- flags are 4 bits B T C C, where:
+  B is the battery status: 1=OK, 0=LOW
+  T is Test mode, 0=Normal, 1=Test.
+  To enter test mode, press and hold Tx/Send button while putting the last battery in, it will send values at ~2sec intreval.
+  CC is the channel: It is always 11 (0x3) for CH4
+- temp is 16 bit signed scaled by 10
+- const is always 1111 (0x0F)
+- const2 is always 0001 (0x1)
+  To be exact, the "Sauna sensor" seems to send niblets 6 times with const2=0x1, and then seventh time sends just 35 bits, so last nibble is 0b000.
+  Maybe this is "data-end" mark. I don't know. Anyway, it can be ignored here, cause data has been parsed already.
 
- Sauna sensor kit is sold by IKH (CRX) and Motonet (Prego).
+Sauna sensor kit is sold by IKH (CRX) and Motonet (Prego).
 */
 static int nexus_sauna_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {

--- a/src/devices/nexus.c
+++ b/src/devices/nexus.c
@@ -61,6 +61,9 @@ static int nexus_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_ABORT_EARLY;
     }
 
+    if ((b[1] & 0x30) == 0x30) {
+        return DECODE_ABORT_EARLY; // channel not 1-3
+    }
     int id       = b[0];
     int battery  = b[1] & 0x80;
     int channel  = ((b[1] & 0x30) >> 4) + 1;
@@ -97,24 +100,109 @@ static int nexus_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     return 1;
 }
 
+/*
+ * The "Sauna sensor", sends 36 bits 6 times, the nibbles are:
+ *
+ * [id0] [id1] [flags] [const] [temp0] [temp1] [temp2] [temp2] [const2]
+ *
+ * - The 8-bit id changes when the battery is changed in the sensor.
+ * - flags are 4 bits B T C C, where:
+ * B is the battery status: 1=OK, 0=LOW
+ * T is Test mode, 0=Normal, 1=Test.
+ * To enter test mode, press and hold Tx/Send button while putting the last battery in, it will send values at ~2sec intreval.
+ * CC is the channel: It is always 11 (0x3) for CH4
+ * - temp is 16 bit signed scaled by 10
+ * - const is always 1111 (0x0F)
+ * - const2 is always 0001 (0x1)
+ * To be exact, the "Sauna sensor" seems to send niblets 6 times with const2=0x1, and then seventh time sends just 35 bits, so last nibble is 0b000.
+ * Maybe this is "data-end" mark. I don't know. Anyway, it can be ignored here, cause data has been parsed already.
+ *
+ * Sauna sensor kit is sold by IKH (CRX) and Motonet (Prego).
+ */
+static int nexus_sauna_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    int r = bitbuffer_find_repeated_row(bitbuffer, 3, 36);
+    if (r < 0) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    uint8_t *b = bitbuffer->bb[r];
+
+    // we expect 36 bits but there might be a trailing 0 bit
+    if (bitbuffer->bits_per_row[r] > 37) {
+        return DECODE_ABORT_LENGTH;
+    }
+    if ((b[1] & 0xf) != 0xf) {
+        return DECODE_ABORT_EARLY; // const not 1111
+    }
+    // Reduce false positives.
+    if ((b[0] == 0) || ((b[4] & 0x10) != 0x10)) {
+        return DECODE_ABORT_EARLY;
+    }
+    if ((b[1] & 0x30) != 0x30) {
+        return DECODE_ABORT_EARLY; // channel not 4
+    }
+
+    int id       = b[0];
+    int test     = b[1] & 0x40;
+    int battery  = b[1] & 0x80;
+    int temp_raw = (int16_t)((b[2] << 8) | (b[3])); // sign-extend
+    float temp_c = temp_raw * 0.1f;
+    data_t *data;
+    /* clang-format off */
+    data = data_make(
+        "model",         "",            DATA_STRING, "Nexus-Sauna",
+        "id",            "House Code",  DATA_INT,    id,
+        "channel",       "Channel",     DATA_INT,    4,
+        "battery_ok",    "Battery",     DATA_INT,    !!battery,
+        "temperature_C", "Temperature", DATA_FORMAT, "%.2f C", DATA_DOUBLE, temp_c,
+        "test",          "Test?",       DATA_STRING, test ? "Yes" : "No",
+        NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
 static char const *const output_fields[] = {
-        "model",
-        "id",
-        "channel",
-        "battery_ok",
-        "temperature_C",
-        "humidity",
-        NULL,
+    "model",
+    "id",
+    "channel",
+    "battery_ok",
+    "temperature_C",
+    "humidity",
+    NULL,
 };
 
 r_device const nexus = {
-        .name        = "Nexus, FreeTec NC-7345, NX-3980, Solight TE82S, TFA 30.3209 temperature/humidity sensor",
-        .modulation  = OOK_PULSE_PPM,
-        .short_width = 1000,
-        .long_width  = 2000,
-        .gap_limit   = 3000,
-        .reset_limit = 5000,
-        .decode_fn   = &nexus_decode,
-        .priority    = 10, // Eliminate false positives by letting Rubicson-Temperature go earlier
-        .fields      = output_fields,
+    .name        = "Nexus, FreeTec NC-7345, NX-3980, Solight TE82S, TFA 30.3209 temperature/humidity sensor",
+    .modulation  = OOK_PULSE_PPM,
+    .short_width = 1000,
+    .long_width  = 2000,
+    .gap_limit   = 3000,
+    .reset_limit = 5000,
+    .decode_fn   = &nexus_decode,
+    .priority    = 10, // Eliminate false positives by letting Rubicson-Temperature go earlier
+    .fields      = output_fields,
+};
+
+static char const *const sauna_output_fields[] = {
+    "model",
+    "id",
+    "channel",
+    "battery_ok",
+    "temperature_C",
+    "test",
+    NULL,
+};
+
+r_device const nexus_sauna = {
+    .name        = "Nexus, CRX, Prego sauna temperature sensor",
+    .modulation  = OOK_PULSE_PPM,
+    .short_width = 1000,
+    .long_width  = 2000,
+    .gap_limit   = 3000,
+    .reset_limit = 5000,
+    .decode_fn   = &nexus_sauna_decode,
+    .priority    = 10, // Eliminate false positives by letting Rubicson-Temperature go earlier
+    .fields      = sauna_output_fields,
 };


### PR DESCRIPTION
PR for Nexus Sauna sensor, as instructed in issue #3324.

Tested with normal Nexus-sensor and two Sauna sensors:
```
$ ./build/src/rtl_433 -R 19 -R 279
rtl_433 version -128-NOTFOUND branch feat-nexus_sauna at 202507091953 inputs file rtl_tcp RTL-SDR SoapySDR with TLS
Detached kernel driver
Found Rafael Micro R820T tuner
[SDR] Using device 0: Realtek, RTL2838UHIDIR, SN: 00000001, "Generic RTL2832U OEM"
Exact sample rate is: 250000.000414 Hz
Allocating 15 zero-copy buffers
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
time      : 2025-07-09 20:40:38
model     : Nexus-Sauna  House Code: 69
Channel   : 4            Battery   : 1             Temperature: 31.60 C      Test?     : No
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
time      : 2025-07-09 20:41:04
model     : Nexus-TH     House Code: 59
Channel   : 2            Battery   : 1             Temperature: 27.00 C      Humidity  : 9 %
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
time      : 2025-07-09 20:41:12
model     : Nexus-Sauna  House Code: 161
Channel   : 4            Battery   : 1             Temperature: 24.20 C      Test?     : Yes
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
time      : 2025-07-09 20:41:14
model     : Nexus-Sauna  House Code: 161
Channel   : 4            Battery   : 1             Temperature: 24.30 C      Test?     : Yes
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
time      : 2025-07-09 20:41:17
model     : Nexus-Sauna  House Code: 161
Channel   : 4            Battery   : 1             Temperature: 24.30 C      Test?     : Yes

```