### PR TITLE
Fix unit_of_measurement for windspeed to mph in examples/rtl_433_mqtt_hass.py

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -350,7 +350,7 @@ mappings = {
         "config": {
             "device_class": "wind_speed",
             "name": "Wind Speed",
-            "unit_of_measurement": "mi/h",
+            "unit_of_measurement": "mph",
             "value_template": "{{ value|float }}",
             "state_class": "measurement"
         }


### PR DESCRIPTION
This PR updates the `unit_of_measurement` for wind_avg_mi_h from `mi/h` to `mph` in examples/rtl_433_mqtt_hass.py.

Fixes https://github.com/merbanan/rtl_433/issues/3336.

The latest release for Home Assistant 2025.7 began enforcing configuration validation to ensure MQTT sensors use a valid unit of measurement via this PR https://github.com/home-assistant/core/pull/146722.