### PR TITLE
Fix visonic decode even if good package is not the first in buffer

### DIFF
--- a/src/devices/visonic_powercode.c
+++ b/src/devices/visonic_powercode.c
@@ -51,11 +51,11 @@ static int visonic_powercode_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     uint8_t msg[32];
     uint8_t lrc;
 
-    // 37 bits expected, 6 packet repetitions, accept 4
-    int row = bitbuffer_find_repeated_row(bitbuffer, 4, 37);
+    // 37 bits expected, 6 packet repetitions, accept 2
+    int row = bitbuffer_find_repeated_row(bitbuffer, 2, 37);
 
     // exit if anything other than one row returned (-1 if failed)
-    if (row != 0)
+    if (row == -1)
         return DECODE_ABORT_LENGTH;
 
     // exit if incorrect number of bits in row or none


### PR DESCRIPTION
I often receive data where the first package is corrupted/too short, but the following 2 to 5 are correct. Therefore make the code work when the first good packet is not the very first in the buffer. Also allow to decode when only 2 repeated packets are received. Since there is a checksum in the packet, it might also be enough to use the first good packet, but let's stick to 2 for now.