### PR TITLE
minor: Fix flex device memory leak during destruction (#3350)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,3 +1,5 @@
+# https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax
+# https://docs.github.com/en/actions/reference/runners/github-hosted-runners
 name: Build Analyze Check
 on: [push, pull_request]
 jobs:
@@ -16,25 +18,47 @@ jobs:
         run: cmake -B build
       - name: Build
         run: cmake --build build
+      - name: Test
+        run: |
+          cmake --build build --target test || \
+          { cat build/Testing/Temporary/LastTest.log && false; }
 
   build_check_job:
     runs-on: ubuntu-latest
-    name: Build with CMake
+    strategy:
+      fail-fast: false
+      matrix:
+        cmake-generator: [Unix Makefiles, Ninja]
+        cmake-build-type: [Debug, Release]
+    name: Build ${{ matrix.cmake-build-type }} ${{ matrix.cmake-generator }}
     steps:
       - uses: actions/checkout@v5
-      - name: Setup
+      - name: Apt Update
+        run: sudo apt-get update -q -y --no-install-recommends
+      - name: Install Build Tools
+        run: sudo apt-get install -q -y --no-install-recommends cmake ninja-build
+      - name: Install Libraries
+        run: sudo apt-get install -q -y --no-install-recommends libsoapysdr-dev librtlsdr-dev
+      - name: Versions
         run: |
-          sudo apt-get update -q -y
-          sudo apt-get install -q -y --no-install-recommends cmake ninja-build
-          sudo apt-get install -q -y libsoapysdr-dev librtlsdr-dev
-      - name: Configure CMake+Ninja
-        run: cmake -GNinja -B ${{ runner.workspace }}/b/ninja -DENABLE_RTLSDR=OFF -DENABLE_SOAPYSDR=OFF
-      - name: Build CMake+Ninja
-        run: cmake --build ${{ runner.workspace }}/b/ninja
-      - name: Configure CMake+UnixMakefiles
-        run: cmake -G"Unix Makefiles" -B ${{ runner.workspace }}/b/unixmakefiles -DENABLE_RTLSDR=OFF -DENABLE_SOAPYSDR=OFF
-      - name: Build CMake+UnixMakefiles
-        run: cmake --build ${{ runner.workspace }}/b/unixmakefiles
+          cmake --version
+          lsb_release -a
+          make --version
+          echo Ninja Version: $(ninja --version)
+          uname -a
+      - name: Configure
+        run: |
+          cmake \
+            -B build \
+            -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} \
+            -DENABLE_RTLSDR=OFF -DENABLE_SOAPYSDR=OFF \
+            -G "${{ matrix.cmake-generator }}"
+      - name: Build
+        run: cmake --build build
+      - name: Test
+        run: |
+          cmake --build build --target test || \
+          { cat build/Testing/Temporary/LastTest.log && false; }
 
   doc_check_job:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ cmake-build-debug/
 
 # Precompiled headers
 *.h.pch
+
+# Dynamically generated files
+include/version.h

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ cmake-build-debug/
 # File manager files
 .DS_Store
 .history
+
+# Precompiled headers
+*.h.pch

--- a/include/r_api.h
+++ b/include/r_api.h
@@ -31,7 +31,7 @@ void r_free_cfg(struct r_cfg *cfg);
 
 /* device decoder protocols */
 
-void register_protocol(struct r_cfg *cfg, struct r_device *r_dev, char *arg);
+void register_protocol(struct r_cfg *cfg, struct r_device const *r_dev, char *arg);
 
 void free_protocol(struct r_device *r_dev);
 

--- a/include/r_device.h
+++ b/include/r_device.h
@@ -68,7 +68,7 @@ typedef struct r_device {
     float sync_width;
     float tolerance;
     int (*decode_fn)(struct r_device *decoder, struct bitbuffer *bitbuffer);
-    struct r_device *(*create_fn)(char *args);
+    struct r_device *(*create_fn)(char const *args);
     unsigned priority; ///< Run later and only if no previous events were produced
     unsigned disabled; ///< 0: default enabled, 1: default disabled, 2: disabled, 3: disabled and hidden
     char const *const *fields; ///< List of fields this decoder produces; required for CSV output. NULL-terminated.

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -331,7 +331,8 @@
     DECL(tpms_schrader_motorcycle) \
     /* Add new decoders here. */
 
-#define DECL(name) extern r_device name;
+#define DECL(name) extern r_device const name;
+DECL(flex_decoder)
 DEVICES
 #undef DECL
 

--- a/src/devices/blueline.c
+++ b/src/devices/blueline.c
@@ -397,7 +397,7 @@ static char const *const output_fields[] = {
 
 r_device const blueline;
 
-static r_device *blueline_create(char *arg)
+static r_device *blueline_create(char const *arg)
 {
     r_device *r_dev = decoder_create(&blueline, sizeof(struct blueline_stateful_context));
     if (!r_dev) {

--- a/src/devices/fineoffset.c
+++ b/src/devices/fineoffset.c
@@ -15,7 +15,7 @@
 
 r_device const fineoffset_WH2;
 
-static r_device *fineoffset_WH2_create(char *arg)
+static r_device *fineoffset_WH2_create(char const *arg)
 {
     if (arg && !strcmp(arg, "no-wh5")) {
         r_device *r_dev = decoder_create(&fineoffset_WH2, sizeof(int));

--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -12,6 +12,7 @@
 #include "decoder.h"
 #include "optparse.h"
 #include "fatal.h"
+#include "rtl_433_devices.h"
 #include <stdlib.h>
 
 enum uart_mode {
@@ -657,10 +658,7 @@ static unsigned parse_uart_mode(char const *str)
     return 0;
 }
 
-// NOTE: this is declared in rtl_433.c also.
-r_device *flex_create_device(char *spec);
-
-r_device *flex_create_device(char *spec)
+static r_device *flex_create_device(char const *spec)
 {
     if (!spec || !*spec || *spec == '?' || !strncasecmp(spec, "help", strlen(spec))) {
         help();
@@ -673,15 +671,18 @@ r_device *flex_create_device(char *spec)
     struct flex_params *params = decoder_user_data(dev);
     int get_count = 0;
 
-    spec = strdup(spec);
-    if (!spec)
+    char * mutable_spec = strdup(spec); // spec will be mutated by getkwargs()
+    if (!mutable_spec)
         FATAL_STRDUP("flex_create_device()");
+    spec = mutable_spec;
 
+    // Copy const fields from static global struct
+    dev->create_fn = flex_create_device;
     dev->decode_fn = flex_callback;
     dev->fields = output_fields;
 
     char *key, *val;
-    while (getkwargs(&spec, &key, &val)) {
+    while (getkwargs(&mutable_spec, &key, &val)) {
         key = remove_ws(key);
         val = trim_ws(val);
 
@@ -858,6 +859,13 @@ r_device *flex_create_device(char *spec)
                 params->min_rows, params->min_bits, params->min_repeats, params->invert, params->reflect, params->match_len, params->preamble_len);
     */
 
-    free(spec);
+    free((void*)spec);
     return dev;
 }
+
+r_device const flex_decoder = {
+        .name        = "General purpose decoder",
+        .create_fn   = &flex_create_device,
+        .decode_fn   = &flex_callback,
+        .fields      = output_fields,
+};

--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -65,9 +65,12 @@ static unsigned long extract_number(uint8_t *data, unsigned bit_offset, unsigned
     return val;
 }
 
+#define FLEX_GET_STR_LEN 32
+#define FLEX_DEV_NAME_LEN 64
+
 struct flex_map {
     unsigned key;
-    const char *val;
+    char val[FLEX_GET_STR_LEN];
 };
 
 #define GETTER_MAP_SLOTS 16
@@ -76,15 +79,16 @@ struct flex_get {
     unsigned bit_offset;
     unsigned bit_count;
     unsigned long mask;
-    const char *name;
+    char name[FLEX_GET_STR_LEN];
     struct flex_map map[GETTER_MAP_SLOTS];
-    const char *format;
+    char format[FLEX_GET_STR_LEN];
 };
 
 #define GETTER_SLOTS 12
 
 struct flex_params {
-    char *name;
+    char name[FLEX_GET_STR_LEN];
+    char dev_name[FLEX_DEV_NAME_LEN];
     unsigned min_rows;
     unsigned max_rows;
     unsigned min_bits;
@@ -131,13 +135,13 @@ static void render_getters(data_t *data, uint8_t *bits, struct flex_params *para
         else
             val = extract_number(bits, getter->bit_offset, getter->bit_count);
         int m;
-        for (m = 0; getter->map[m].val; m++) {
+        for (m = 0; getter->map[m].val[0]; m++) {
             if (getter->map[m].key == val) {
                 data_str(data, getter->name, "", NULL, getter->map[m].val);
                 break;
             }
         }
-        if (!getter->map[m].val) {
+        if (!getter->map[m].val[0]) {
             data_int(data, getter->name, "", getter->format, val);
         }
     }
@@ -572,7 +576,6 @@ static const char *parse_map(const char *arg, struct flex_get *getter)
 
     while (*c) {
         unsigned long key;
-        char *val;
 
         while (*c == ' ') c++;
         if (*c == ']') return c + 1;
@@ -587,18 +590,15 @@ static const char *parse_map(const char *arg, struct flex_get *getter)
         // then parse a string
         const char *e = c;
         while (*e && *e != ' ' && *e != ']') e++;
-        val = malloc(e - c + 1);
-        if (!val)
-            WARN_MALLOC("parse_map()");
-        else { // NOTE: skipped on alloc failure.
-            memcpy(val, c, e - c);
-            val[e - c] = '\0';
-        }
+        size_t map_len = (size_t)(e - c);
+        strncpy(getter->map[i].val, c, FLEX_GET_STR_LEN - 1);
+        getter->map[i].val[FLEX_GET_STR_LEN - 1] = '\0';
+        if (map_len >= FLEX_GET_STR_LEN)
+            fprintf(stderr, "Warning: flex map value truncated at %d chars.\n", FLEX_GET_STR_LEN - 1);
         c = e;
 
         // store result
         getter->map[i].key = key;
-        getter->map[i].val = val;
         i++;
     }
     return c;
@@ -622,18 +622,20 @@ static void parse_getter(const char *arg, struct flex_get *getter)
             getter->mask = extract_number(bitrow, 0, getter->bit_count);
         }
         else if (*arg == '%') {
-            getter->format = strdup(arg);
-            if (!getter->format)
-                FATAL_STRDUP("parse_getter()");
+            strncpy(getter->format, arg, FLEX_GET_STR_LEN - 1);
+            getter->format[FLEX_GET_STR_LEN - 1] = '\0';
+            if (strlen(arg) >= FLEX_GET_STR_LEN)
+                fprintf(stderr, "Warning: flex format truncated at %d chars.\n", FLEX_GET_STR_LEN - 1);
         }
         else {
-            getter->name = strdup(arg);
-            if (!getter->name)
-                FATAL_STRDUP("parse_getter()");
+            strncpy(getter->name, arg, FLEX_GET_STR_LEN - 1);
+            getter->name[FLEX_GET_STR_LEN - 1] = '\0';
+            if (strlen(arg) >= FLEX_GET_STR_LEN)
+                fprintf(stderr, "Warning: flex getter name truncated at %d chars.\n", FLEX_GET_STR_LEN - 1);
         }
         arg = p;
     }
-    if (!getter->name) {
+    if (!getter->name[0]) {
         fprintf(stderr, "Bad flex spec, \"get\" missing name!\n");
         usage();
     }
@@ -689,15 +691,14 @@ static r_device *flex_create_device(char const *spec)
         if (!key || !*key)
             continue;
         else if (!strcasecmp(key, "n") || !strcasecmp(key, "name")) {
-            params->name = strdup(val);
-            if (!params->name)
-                FATAL_STRDUP("flex_create_device()");
-            int name_size = strlen(val) + 27;
-            char* flex_name = malloc(name_size);
-            if (!flex_name)
-                FATAL_MALLOC("flex_create_device()");
-            snprintf(flex_name, name_size, "General purpose decoder '%s'", val);
-            dev->name = flex_name;
+            strncpy(params->name, val, FLEX_GET_STR_LEN - 1);
+            params->name[FLEX_GET_STR_LEN - 1] = '\0';
+            if (strlen(val) >= FLEX_GET_STR_LEN)
+                fprintf(stderr, "Warning: flex name truncated at %d chars.\n", FLEX_GET_STR_LEN - 1);
+            snprintf(params->dev_name, FLEX_DEV_NAME_LEN, "General purpose decoder '%s'", val);
+            if (snprintf(NULL, 0, "General purpose decoder '%s'", val) - 1 >= FLEX_DEV_NAME_LEN)
+                fprintf(stderr, "Warning: flex device name truncated at %d chars.\n", FLEX_DEV_NAME_LEN - 1);
+            dev->name = params->dev_name;
         }
 
         else if (!strcasecmp(key, "m") || !strcasecmp(key, "modulation"))
@@ -797,7 +798,7 @@ static r_device *flex_create_device(char const *spec)
         }
         params->fields[i++] = "len";
         params->fields[i++] = "data";
-        for (int g = 0; g < GETTER_SLOTS && params->getter[g].name; ++g) {
+        for (int g = 0; g < GETTER_SLOTS && params->getter[g].name[0]; ++g) {
             params->fields[i++] = params->getter[g].name;
         }
         dev->fields = params->fields;
@@ -805,7 +806,7 @@ static r_device *flex_create_device(char const *spec)
 
     // sanity checks
 
-    if (!params->name || !*params->name) {
+    if (!params->name[0]) {
         fprintf(stderr, "Bad flex spec, missing name!\n");
         usage();
     }

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -232,7 +232,7 @@ void r_free_cfg(r_cfg_t *cfg)
 
 /* device decoder protocols */
 
-void register_protocol(r_cfg_t *cfg, r_device *r_dev, char *arg)
+void register_protocol(r_cfg_t *cfg, r_device const *r_dev, char *arg)
 {
     // use arg of 'v', 'vv', 'vvv' as device verbosity
     int dev_verbose = 0;
@@ -276,7 +276,6 @@ void register_protocol(r_cfg_t *cfg, r_device *r_dev, char *arg)
 
 void free_protocol(r_device *r_dev)
 {
-    // free(r_dev->name);
     free(r_dev->decode_ctx);
     free(r_dev);
 }

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -58,6 +58,7 @@
 #include "sigmf.h"
 #include "mongoose.h"
 #include "delay_timer.h"
+#include "rtl_433_devices.h"
 
 #ifdef _WIN32
 #include <io.h>
@@ -92,8 +93,6 @@
 #ifndef STDERR_FILENO
 #define STDERR_FILENO 2
 #endif
-
-r_device *flex_create_device(char *spec); // maybe put this in some header file?
 
 static void print_version(void)
 {
@@ -481,7 +480,6 @@ static void parse_conf_args(r_cfg_t *cfg, int argc, char *argv[])
 static void parse_conf_option(r_cfg_t *cfg, int opt, char *arg)
 {
     int n;
-    r_device *flex_device;
 
     if (arg && (!strcmp(arg, "help") || !strcmp(arg, "?"))) {
         arg = NULL; // remove the arg if it's a request for the usage help
@@ -832,12 +830,7 @@ static void parse_conf_option(r_cfg_t *cfg, int opt, char *arg)
         }
         break;
     case 'X':
-        if (!arg) {
-            flex_create_device(NULL);
-        }
-
-        flex_device = flex_create_device(arg);
-        register_protocol(cfg, flex_device, "");
+        register_protocol(cfg, &flex_decoder, arg);
         break;
     case 'q':
         fprintf(stderr, "quiet option (-q) is default and deprecated. See -v to increase verbosity\n");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,24 @@ endforeach(testSrc)
 # Define integration tests
 ########################################################################
 add_test(rtl_433_help ../src/rtl_433 -h)
+add_test(flex_decoder_help ../src/rtl_433 -X)
+add_test(flex_decoder bash -c
+    "touch empty_file.cu8 && \
+    ../src/rtl_433 \
+        -X n=name,m=FSK_PCM,s=10,l=10,r=10240 \
+        -r empty_file.cu8")
+# Borrowed from: https://github.com/merbanan/rtl_433/pull/786#issuecomment-410513334
+add_test(flex_decoder_w_getter bash -c
+    "touch empty_file.cu8 && \
+    ../src/rtl_433 \
+        -X 'n=name,m=FSK_PCM,s=10,l=10,r=10240,get=@20:{12}0x7f:status:[10:pir 14:open 7:close 11:tamper 0xf:battery_low]' \
+        -r empty_file.cu8")
+# Borrowed from: https://github.com/merbanan/rtl_433/pull/1532#issue-728103584
+add_test(flex_decoder_w_getter_and_format_specifier bash -c
+    "touch empty_file.cu8 && \
+    ../src/rtl_433 \
+        -X 'n=name,m=FSK_PCM,s=10,l=10,r=10240,get=@2:{32}:code:%x' \
+        -r empty_file.cu8")
 
 # Black-box test of the HTTP/WS API server. Starts rtl_433 in manual device
 # mode (no SDR), exercises each endpoint, and shuts it down cleanly. Skipped


### PR DESCRIPTION
This PR is meant to address: https://github.com/merbanan/rtl_433/issues/3350

1. `build: Add memory leak detection in "Build Analyze Check" GitHub Action` highlights the issue as can be seen by the workflow in my forked repo: https://github.com/dandwyer/rtl_433/actions/runs/17200738585/job/48790690802#step:9:387
2. `minor: Fix flex device memory leak during destruction` addresses the issue as can be seen here: https://github.com/dandwyer/rtl_433/actions/runs/17200928948