### PR TITLE
New device Raddy WF-100C Lite

### DIFF
--- a/src/devices/new_template.c
+++ b/src/devices/new_template.c
@@ -1,7 +1,7 @@
 /** @file
-    Template decoder for DEVICE, tested with BRAND, BRAND.
-
-    Copyright (C) 2016 Benjamin Larsson
+    Template decoder for Raddy WF-100C Lite
+    
+    Copyright (C) 2025 Chad Matsalla
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This is the Raddy WF-100C Lite Weather Station 13-in-1 Wireless Indoor Outdoor with Temperature, Barometric, Humidity, Wind Gauge, Rain Gauge, Weather Forecast, Moon Phrase, Alarm Clock.
[Raddy's Site](https://iraddy.com/products/wf-100c-lite)

![Raddy WF-100C](https://iraddy.com/cdn/shop/products/WF-100C_Lite_Professional_Weather_Station_01_590x.jpg)

It currently appears as `Cotech-367959` so I'll be basing my work on that.