### PR TITLE
Add support for La Crosse View LTV-WSDR1 Cyclone Wind and Rain Sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [287]  Fine Offset Electronics WS85 weather station
     [288]  Oria WA150KM freezer and fridge thermometer
     [289]  Voltcraft EnergyCount 3000 (ec3k)
+    [290]  LaCrosse Technology View LTV-WSDR1 Cyclone Wind and Rain Sensor
 
 * Disabled by default, use -R n or a conf file to enable
 

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -528,6 +528,7 @@ convert si
   protocol 287 # Fine Offset Electronics WS85 weather station
   protocol 288 # Oria WA150KM freezer and fridge thermometer
   protocol 289 # Voltcraft EnergyCount 3000 (ec3k)
+  protocol 290 # LaCrosse Technology View LTV-WSDR1 Cyclone Wind and Rain Sensor
 
 ## Flex devices (command line option "-X")
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -297,6 +297,7 @@
     DECL(fineoffset_ws85) \
     DECL(oria_wa150km) \
     DECL(ec3k) \
+    DECL(lacrosse_wsdr1) \
 
     /* Add new decoders here. */
 

--- a/src/devices/lacrosse_wr1.c
+++ b/src/devices/lacrosse_wr1.c
@@ -9,14 +9,20 @@
     (at your option) any later version.
 */
 /**
-LaCrosse Technology View LTV-WR1 Multi Sensor.
+LaCrosse Technology View LTV-WR1 Multi Sensor,
+LTV-WSDR1 Cyclone Wind and Rain Sensor.
 
 LaCrosse Color Forecast Station (model S84060?) utilizes the remote
 Thermo/Hygro LTV-TH3 and LTV-WR1 multi sensor (wind spd/dir and rain).
 
+Both models of sensor have the same specifications and transmit the same data
+format. The only apparent differences are in the bit width and the number of
+padding bits surrounding the packet.
+
 Product pages:
 https://www.lacrossetechnology.com/products/S84060
 https://www.lacrossetechnology.com/products/ltv-wr1
+https://www.lacrossetechnology.com/products/ltv-wsdr1
 
 Specifications:
 - Wind Speed Range: 0 to 188 kmh
@@ -39,9 +45,10 @@ capabilities of the CMT2119A and CMT2219A.
 
 Protocol Specification:
 
-Data bits are NRZ encoded with logical 1 and 0 bits 104us in length.
+Data bits are NRZ encoded with logical 1 and 0 bits 104us in length for LTV-WR1
+and 107us for LTV-WSDR1.
 
-LTV-WR1
+LTV-WR1, LTV-WSDR1
     SYN:32h ID:24h ?:4b SEQ:3d ?:1b WSPD:12d WDIR:12d RAIN1:12d RAIN2:12d CHK:8h
 
     CHK is CRC-8 poly 0x31 init 0x00 over 10 bytes following SYN
@@ -50,7 +57,12 @@ LTV-WR1
 
 #include "decoder.h"
 
-static int lacrosse_wr1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+struct model {
+    const char *name;
+    uint16_t min_bits_per_row, max_bits_per_row;
+};
+
+static int _lacrosse_wr1_decode(r_device *decoder, bitbuffer_t *bitbuffer, const struct model *model)
 {
     uint8_t const preamble_pattern[] = {0xd2, 0xaa, 0x2d, 0xd4};
 
@@ -62,13 +74,15 @@ static int lacrosse_wr1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     float speed_kmh;
     // float rain_mm;
 
-    if (bitbuffer->bits_per_row[0] < 120) {
+    if (bitbuffer->bits_per_row[0] < model->min_bits_per_row) {
         decoder_logf(decoder, 1, __func__, "Packet too short: %d bits", bitbuffer->bits_per_row[0]);
         return DECODE_ABORT_LENGTH;
-    } else if (bitbuffer->bits_per_row[0] > 156) {
+    }
+    else if (bitbuffer->bits_per_row[0] > model->max_bits_per_row) {
         decoder_logf(decoder, 1, __func__, "Packet too long: %d bits", bitbuffer->bits_per_row[0]);
         return DECODE_ABORT_LENGTH;
-    } else {
+    }
+    else {
         decoder_logf(decoder, 1, __func__, "packet length: %d", bitbuffer->bits_per_row[0]);
     }
 
@@ -106,7 +120,7 @@ static int lacrosse_wr1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",            "",                 DATA_STRING, "LaCrosse-WR1",
+            "model",            "",                 DATA_STRING, model->name,
             "id",               "Sensor ID",        DATA_FORMAT, "%06x", DATA_INT, id,
             "seq",              "Sequence",         DATA_INT,     seq,
             "flags",            "unknown",          DATA_INT,     flags,
@@ -135,6 +149,17 @@ static char const *const output_fields[] = {
         NULL,
 };
 
+static const struct model lacrosse_wr1_model = {
+        .name             = "LaCrosse-WR1",
+        .min_bits_per_row = 120,
+        .max_bits_per_row = 156,
+};
+
+static int lacrosse_wr1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    return _lacrosse_wr1_decode(decoder, bitbuffer, &lacrosse_wr1_model);
+}
+
 // flex decoder m=FSK_PCM, s=104, l=104, r=9600
 r_device const lacrosse_wr1 = {
         .name        = "LaCrosse Technology View LTV-WR1 Multi Sensor",
@@ -143,5 +168,27 @@ r_device const lacrosse_wr1 = {
         .long_width  = 104,
         .reset_limit = 9600,
         .decode_fn   = &lacrosse_wr1_decode,
+        .fields      = output_fields,
+};
+
+static const struct model lacrosse_wsdr1_model = {
+        .name             = "LaCrosse-WSDR1",
+        .min_bits_per_row = 200,
+        .max_bits_per_row = 224,
+};
+
+static int lacrosse_wsdr1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    return _lacrosse_wr1_decode(decoder, bitbuffer, &lacrosse_wsdr1_model);
+}
+
+// flex decoder m=FSK_PCM, s=107, l=107, r=9600
+r_device const lacrosse_wsdr1 = {
+        .name        = "LaCrosse Technology View LTV-WSDR1 Cyclone Wind and Rain Sensor",
+        .modulation  = FSK_PULSE_PCM,
+        .short_width = 107,
+        .long_width  = 107,
+        .reset_limit = 9600,
+        .decode_fn   = &lacrosse_wsdr1_decode,
         .fields      = output_fields,
 };


### PR DESCRIPTION
The signal is just different enough to not be picked up by the existing LTV-WR1 decoder. (Though tragically lacrosse_r1_decode incorrectly matches on the LTV-WSDR1 signals, with garbage output.)

The La Crosse View V41CA weather station display shows precipitation on a bar graph with axis labels at halfway and top. At the smallest scale, the labels are 1.27 mm and 2.54 mm for measurements from an LTV-WSDR1. One tip of the bucket causes the raw_rain1 value to increment by one, and the displayed precipitation to increment by ~0.25 mm. (The raw_rain2 value takes on the previous sequence number's raw_rain1 value, presumably to afford measuring the instantaneous precipitation rate from a single packet.) The LTV-WSDR1 therefore most likely measures rainfall in units of 0.254 mm, or 0.01 inches. And it is a pretty safe bet that the LTV-WR1 also measures 0.01 inch per bucket tip since it has identical specifications to the LTV-WSDR1 and transmits in the same format, and other rain La Crosse rain gauges in the same product family (LTV-R1, LTV-R3) are also known to measure ~0.01 inch per bucket tip. Change the rain outputs for the LTV-WR1 and LTV-WSDR1 decoder to be scaled to physical units.

Make the flags output field conditional so it is only output if any of the flags are set.