### PR TITLE
Add support for La Crosse View LTV-TH2i Thermo/Hygro Sensor

### DIFF
--- a/src/devices/lacrosse_th3.c
+++ b/src/devices/lacrosse_th3.c
@@ -60,12 +60,15 @@ Sequence# 0,1,3,4,5 & 7
     CHK is CRC-8 poly 0x31 init 0xac over 7 bytes following SYN
 
 LTV-TH2i
-    SYNC:32h ID:24h ?:4b SEQ:3b ?:1b TEMP:12d HUM:12d CHK:8h TRAILER:96h
+    SYNC:32h ID:24h BATTLOW:1b RETRANS:1b ?:2b SEQ:3b ?:1b TEMP:12d HUM:12d CHK:8h TRAILER:96h
 
     CHK is CRC-8 poly 0x31 init (0x00 or 0xb2) over 7 bytes following SYN
     The CRC init value for a given packet is seemingly arbitrary, though it
     appears that the same init value is used for at most three packets in a row
     before switching.
+
+    Pressing the TX button under the battery cover causes the sensor to
+    immediately retransmit the most recent packet with the RETRANS flag set.
 
     TRAILER is 0xd2d2d2d2d200000000000000...
 
@@ -81,7 +84,7 @@ static int lacrosse_th_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     uint8_t b[11];
     uint32_t id;
     int flags, seq, offset, chk3, chk2, chk2i, model_num;
-    int raw_temp, humidity;
+    int raw_temp, humidity, batt_low, retrans;
     float temp_c;
 
     // bit length is specified as 104us for the TH3 (~256 bits per packet)
@@ -121,7 +124,9 @@ static int lacrosse_th_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     }
 
     id       = (b[0] << 16) | (b[1] << 8) | b[2];
-    flags    = (b[3] & 0xf1); // masks off seq bits
+    flags    = (b[3] & 0x31); // masks off seq bits and known flag bits
+    batt_low = (b[3] & 0x80) >> 7;
+    retrans  = (b[3] & 0x40) >> 6;
     seq      = (b[3] & 0x0e) >> 1;
     raw_temp = b[4] << 4 | ((b[5] & 0xf0) >> 4);
     humidity = ((b[5] & 0x0f) << 8) | b[6];
@@ -135,11 +140,13 @@ static int lacrosse_th_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     /* clang-format off */
     data = data_make(
          "model",            "",                 DATA_STRING, model_num == 3 ? "LaCrosse-TH3" : "LaCrosse-TH2",
-         "id",               "Sensor ID",        DATA_FORMAT, "%06x", DATA_INT, id,
-         "seq",              "Sequence",         DATA_INT,     seq,
-         "flags",            "unknown",          DATA_INT,     flags,
+         "id",               "Sensor ID",        DATA_FORMAT, "%06x",    DATA_INT, id,
+         "battery_ok",       "Battery",          DATA_INT,    !batt_low,
+         "retransmit",       "Retransmit",       DATA_COND,   retrans,   DATA_INT,    retrans,
+         "seq",              "Sequence",         DATA_INT,    seq,
+         "flags",            "unknown",          DATA_COND,   flags,     DATA_INT,    flags,
          "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C",  DATA_DOUBLE, temp_c,
-         "humidity",         "Humidity",         DATA_FORMAT, "%u %%", DATA_INT, humidity,
+         "humidity",         "Humidity",         DATA_FORMAT, "%u %%",   DATA_INT,    humidity,
          "mic",              "Integrity",        DATA_STRING, "CRC",
          NULL);
     /* clang-format on */
@@ -151,6 +158,8 @@ static int lacrosse_th_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 static char const *const output_fields[] = {
         "model",
         "id",
+        "battery_ok",
+        "retransmit",
         "seq",
         "flags",
         "temperature_C",


### PR DESCRIPTION
Much like its predecessor the LTV-TH2, the CRC on some of the packets transmitted by the LTV-TH2i will be calculated with a fixed nonzero initial value. Unlike the LTV-TH2, the TH2i uses init=0xb2. The lacrosse_th3 decoder is still able to decode the TH2i packets with init=0x00 CRC values, but it discards the majority of the reports as corrupt. Add a check for init=0x2b CRC to the decoder to improve its support for decoding packets from LTV-TH2i sensors.

### Change LaCrosse LTV-TH decoder to output battery_ok, retransmit

Experimentation with a La Crosse View LTV-TH2i sensor has revealed the semantics of two of the flags. One signals a low battery, and the other signals that the packet is a repeat broadcast triggered by a button press. (The La Crosse V41CA display audibly beeps upon reception of a packet with this flag set.) Break these flags out into their own output fields and squelch the display of the remaining unknown flags unless one of them is set.