### PR TITLE
minor: watchman advanced depth is 12 bits

### DIFF
--- a/src/devices/oil_watchman_advanced.c
+++ b/src/devices/oil_watchman_advanced.c
@@ -38,8 +38,9 @@ Data Layout:
   - 0x80 - the first one or two transmissions after the sync period when the device seems to be calibrating itself
   - 0x98 - normal, live value that you'll see on every transmission when the device is up and running
 - 1 byte temperature, in intervals of 0.5 degrees, offset by 0x48
-- 2 byte - varying bytes which could be the raw sensor reading
-- 1 byte integer depth (i.e. the distance between the sensor and the oil in the tank)
+- 1 byte - varying bytes which could be the raw sensor reading
+- 4 bits - varying bytes which could be the raw sensor reading
+- 12 bits - integer depth (i.e. the distance between the sensor and the oil in the tank)
 - 4 byte of 0x01050300 - constant values which could be a version number? (1.5.3.0)
 - 2 byte CRC-16 poly 0x8005 init 0
 */
@@ -81,7 +82,7 @@ static int oil_watchman_advanced_decode(r_device *decoder, bitbuffer_t *bitbuffe
         uint32_t serial   = (b[3] << 16) | (b[4] << 8) | b[5];
         uint8_t status    = b[6];
         float temperature = (b[7] - 0x48) / 2; // truncate to whole number
-        uint8_t depth     = b[10];
+        uint16_t depth     = ((b[9] & 0x0f) << 8) | b[10];
 
         /* clang-format off */
         data_t *data = data_make(


### PR DESCRIPTION
GH-2306

Observed with an 0x0106 device with 8-bit depth overflowing from 0xf4 to
0x(1)07:

    2dd40e 0106 00011a 80 4b a6 30 f4 01170000c9020
    2dd40e 0106 00011a 80 51 a6 41 07 01170000bb240
