### PR TITLE
Change to exit on SIGPIPE

### DIFF
--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1383,8 +1383,7 @@ static void sighandler(int signum)
     if (signum == SIGPIPE) {
         // NOTE: we already ignore most network SIGPIPE's, this might be a STDOUT/STDERR problem.
         // Printing is likely not the correct way to handle this.
-        write_err("Ignoring received signal SIGPIPE, Broken pipe.\n");
-        return;
+        write_err("Signal SIGPIPE caught, broken pipe, exiting!\n");
     }
     else if (signum == SIGHUP) {
         sig_hup = 1;


### PR DESCRIPTION
Since #2705 and #2729 added proper network sigpipe handling we can now exit on any other SIGPIPE.
The first SIGPIPE will still write a error message and begin a shutdown. Any subsequent SIGPIPE will exit immediately.