### PR TITLE
Add support for WS69 pressure sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [75]  LaCrosse TX35DTH-IT, TFA Dostmann 30.3155 Temperature/Humidity sensor
     [76]  LaCrosse TX29IT, TFA Dostmann 30.3159.IT Temperature sensor
     [77]  Vaillant calorMatic VRT340f Central Heating Control
-    [78]  Fine Offset Electronics, WH25, WH32, WH32B, WN32B, WH24, WH65B, HP1000, Misol WS2320 Temperature/Humidity/Pressure Sensor
+    [78]  Fine Offset Electronics, WH25, WH32, WH32B, WN32B, WH24, WH65, WS69, HP1000, Misol WS2320 Temperature/Humidity/Pressure Sensor
     [79]  Fine Offset Electronics, WH0530 Temperature/Rain Sensor
     [80]  IBIS beacon
     [81]  Oil Ultrasonic STANDARD FSK

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -316,7 +316,7 @@ convert si
   protocol 75  # LaCrosse TX35DTH-IT, TFA Dostmann 30.3155 Temperature/Humidity sensor
   protocol 76  # LaCrosse TX29IT, TFA Dostmann 30.3159.IT Temperature sensor
   protocol 77  # Vaillant calorMatic VRT340f Central Heating Control
-  protocol 78  # Fine Offset Electronics, WH25, WH32, WH32B, WN32B, WH24, WH65B, HP1000, Misol WS2320 Temperature/Humidity/Pressure Sensor
+  protocol 78  # Fine Offset Electronics, WH25, WH32, WH32B, WN32B, WH24, WH65, WS69, HP1000, Misol WS2320 Temperature/Humidity/Pressure Sensor
   protocol 79  # Fine Offset Electronics, WH0530 Temperature/Rain Sensor
   protocol 80  # IBIS beacon
   protocol 81  # Oil Ultrasonic STANDARD FSK


### PR DESCRIPTION
Adds support for the extra pressure sensor found on newer WS69.

See also #3059 and #3426