### PR TITLE
Add support for Altronics X7064A temperature, humidity sensor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [212]  Renault 0435R TPMS
     [213]  Fine Offset Electronics WS80 weather station
     [214]  EMOS E6016 weatherstation with DCF77
-    [215]  Emax W6, rebrand Altronics x7063/4, Optex 990040/50/51, Orium 13093/13123, Infactory FWS-1200, Newentor Q9, Otio 810025, Protmex PT3390A, Jula Marquant 014331/32, TechniSat IMETEO X6 76-4924-00, Weather Station or temperature/humidity sensor
+    [215]  Emax W6, rebrand Altronics x7063/4/x7064A, Optex 990040/50/51, Orium 13093/13123, Infactory FWS-1200, Newentor Q9, Otio 810025, Protmex PT3390A, Jula Marquant 014331/32, TechniSat IMETEO X6 76-4924-00, Weather Station or temperature/humidity sensor
     [216]* ANT and ANT+ devices
     [217]  EMOS E6016 rain gauge
     [218]  Microchip HCS200/HCS300 KeeLoq Hopping Encoder based remotes (FSK)

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -453,7 +453,7 @@ convert si
   protocol 212 # Renault 0435R TPMS
   protocol 213 # Fine Offset Electronics WS80 weather station
   protocol 214 # EMOS E6016 weatherstation with DCF77
-  protocol 215 # Emax W6, rebrand Altronics x7063/4, Optex 990040/50/51, Orium 13093/13123, Infactory FWS-1200, Newentor Q9, Otio 810025, Protmex PT3390A, Jula Marquant 014331/32, TechniSat IMETEO X6 76-4924-00, Weather Station or temperature/humidity sensor
+  protocol 215 # Emax W6, rebrand Altronics x7063/4/x7064A, Optex 990040/50/51, Orium 13093/13123, Infactory FWS-1200, Newentor Q9, Otio 810025, Protmex PT3390A, Jula Marquant 014331/32, TechniSat IMETEO X6 76-4924-00, Weather Station or temperature/humidity sensor
 # protocol 216 # ANT and ANT+ devices
   protocol 217 # EMOS E6016 rain gauge
   protocol 218 # Microchip HCS200/HCS300 KeeLoq Hopping Encoder based remotes (FSK)


### PR DESCRIPTION
This is related to the issue #3463 

This PR to enrich existing models already decoded by the emax decoder.

- Altronics X7064A is sending temperature in °C, offset 500, scale 10, while other models are sending temperature in °F, offset 900 and scale 10.
- The checksum formula is the same but offset by 0x9A for this model.