### PR TITLE
Add Inkbird IBS-P04R pool water quality sensor decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,103 +280,104 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [192]  Govee Water Leak Detector H5054, Door Contact Sensor B5023
     [193]  Clipsal CMR113 Cent-a-meter power meter
     [194]  Inkbird ITH-20R temperature humidity sensor
-    [195]  RainPoint soil temperature and moisture sensor
-    [196]  Atech-WS308 temperature sensor
-    [197]  Acurite Grill/Meat Thermometer 01185M
-    [198]* EnOcean ERP1
-    [199]  Linear Megacode Garage/Gate Remotes
-    [200]* Auriol 4-LD5661/4-LD5972/4-LD6313 temperature/rain sensors
-    [201]  Unbranded SolarTPMS for trucks
-    [202]  Funkbus / Instafunk (Berker, Gira, Jung)
-    [203]  Porsche Boxster/Cayman TPMS
-    [204]  Jasco/GE Choice Alert Security Devices
-    [205]  Telldus weather station FT0385R sensors
-    [206]  LaCrosse TX34-IT rain gauge
-    [207]  SmartFire Proflame 2 remote control
-    [208]  AVE TPMS
-    [209]  SimpliSafe Gen 3 Home Security System
-    [210]  Yale HSA (Home Security Alarm), YES-Alarmkit
-    [211]  Regency Ceiling Fan Remote (-f 303.75M to 303.96M)
-    [212]  Renault 0435R TPMS
-    [213]  Fine Offset Electronics WS80 weather station
-    [214]  EMOS E6016 weatherstation with DCF77
-    [215]  Emax W6, rebrand Altronics x7063/4, Optex 990040/50/51, Orium 13093/13123, Infactory FWS-1200, Newentor Q9, Otio 810025, Protmex PT3390A, Jula Marquant 014331/32, TechniSat IMETEO X6 76-4924-00, Weather Station or temperature/humidity sensor
-    [216]* ANT and ANT+ devices
-    [217]  EMOS E6016 rain gauge
-    [218]  Microchip HCS200/HCS300 KeeLoq Hopping Encoder based remotes (FSK)
-    [219]  Fine Offset Electronics WH45 air quality sensor
-    [220]  Maverick XR-30 BBQ Sensor
-    [221]  Fine Offset Electronics WN34S/L/D and Froggit DP150/D35 temperature sensor
-    [222]  Rubicson Pool Thermometer 48942
-    [223]  Badger ORION water meter, 100kbps (-f 916.45M -s 1200k)
-    [224]  GEO minim+ energy monitor
-    [225]  TyreGuard 400 TPMS
-    [226]  Kia TPMS (-s 1000k)
-    [227]  SRSmith Pool Light Remote Control SRS-2C-TX (-f 915M)
-    [228]  Neptune R900 flow meters
-    [229]  WEC-2103 temperature/humidity sensor
-    [230]  Vauno EN8822C
-    [231]  Govee Water Leak Detector H5054
-    [232]  TFA Dostmann 14.1504.V2 Radio-controlled grill and meat thermometer
-    [233]* CED7000 Shot Timer
-    [234]  Watchman Sonic Advanced / Plus, Tekelek
-    [235]  Oil Ultrasonic SMART FSK
-    [236]  Gasmate BA1008 meat thermometer
-    [237]  Flowis flow meters
-    [238]  Wireless M-Bus, Mode T, 32.768kbps (-f 868.3M -s 1000k)
-    [239]  Revolt NC-5642 Energy Meter
-    [240]  LaCrosse TX31U-IT, The Weather Channel WS-1910TWC-IT
-    [241]  EezTire E618, Carchet TPMS, TST-507 TPMS
-    [242]* Baldr / RainPoint rain gauge.
-    [243]  Celsia CZC1 Thermostat
-    [244]  Fine Offset Electronics WS90 weather station
-    [245]* ThermoPro TX-2C Thermometer and Humidity sensor
-    [246]  TFA 30.3151 Weather Station
-    [247]  Bresser water leakage
-    [248]* Nissan TPMS
-    [249]  Bresser lightning
-    [250]  Schou 72543 Day Rain Gauge, Motonet MTX Rain, MarQuant Rain Gauge, TFA Dostmann 30.3252.01/47.3006.01 Rain Gauge and Thermometer, ADE WS1907
-    [251]  Fine Offset / Ecowitt WH55 water leak sensor
-    [252]  BMW Gen4-Gen5 TPMS and Audi TPMS Pressure Alert, multi-brand HUF/Beru, Continental, Schrader/Sensata, Audi
-    [253]  Watts WFHT-RF Thermostat
-    [254]  Thermor DG950 weather station
-    [255]  Mueller Hot Rod water meter
-    [256]  ThermoPro TP28b Super Long Range Wireless Meat Thermometer for Smoker BBQ Grill
-    [257]  BMW Gen2 and Gen3 TPMS
-    [258]  Chamberlain CWPIRC PIR Sensor
-    [259]  ThermoPro Meat Thermometers, TP829B 4 probes with temp only
-    [260]* Arad/Master Meter Dialog3G water utility meter
-    [261]  Geevon TX16-3 outdoor sensor
-    [262]  Fine Offset Electronics WH46 air quality sensor
-    [263]  Vevor Wireless Weather Station 7-in-1
-    [264]  Arexx Multilogger IP-HA90, IP-TH78EXT, TSN-70E
-    [265]  Rosstech Digital Control Unit DCU-706/Sundance/Jacuzzi
-    [266]  Risco 2 Way Agility protocol, Risco PIR/PET Sensor RWX95P
-    [267]  ThermoPro Meat Thermometers, TP828B 2 probes with Temp, BBQ Target LO and HI
-    [268]  Bresser Thermo-/Hygro-Sensor Explore Scientific ST1005H
-    [269]  DeltaDore X3D devices
-    [270]* Quinetic
-    [271]  Landis & Gyr Gridstream Power Meters 9.6k
-    [272]  Landis & Gyr Gridstream Power Meters 19.2k
-    [273]  Landis & Gyr Gridstream Power Meters 38.4k
-    [274]  Revolt ZX-7717 power meter
-    [275]  GM-Aftermarket TPMS
-    [276]  RainPoint HCS012ARF Rain Gauge sensor
-    [277]  Apator Metra E-RM 30
-    [278]  ThermoPro TX-7B Outdoor Thermometer Hygrometer
-    [279]  Nexus, CRX, Prego sauna temperature sensor
-    [280]  Homelead HG9901 (Geevon, Dr.Meter, Royal Gardineer) soil moisture/temp/light level sensor
-    [281]  Maverick XR-50 BBQ Sensor
-    [282]  Orion Endpoint from Badger Meter, GIF2014W-OSE, water meter, hopping from 904.4 Mhz to 924.6Mhz (-s 1600k)
-    [283]  Fine Offset Electronics WH43 air quality sensor
-    [284]  Baldr E0666TH Thermo-Hygrometer
-    [285]  bm5-v2 12V Battery Monitor
-    [286]  Universal (Reverseable) 24V Fan Controller
-    [287]  Fine Offset Electronics WS85 weather station
-    [288]  Oria WA150KM freezer and fridge thermometer
-    [289]  Voltcraft EnergyCount 3000 (ec3k)
-    [290]  Orion Endpoint from Badger Meter, GIF2020OCECNA, water meter, hopping from 904.4 Mhz to 924.6Mhz (-s 1600k)
-    [291]  Geevon TX19-1 outdoor sensor
+    [195]  Inkbird IBS-P04R pool sensor
+    [196]  RainPoint soil temperature and moisture sensor
+    [197]  Atech-WS308 temperature sensor
+    [198]  Acurite Grill/Meat Thermometer 01185M
+    [199]* EnOcean ERP1
+    [200]  Linear Megacode Garage/Gate Remotes
+    [201]* Auriol 4-LD5661/4-LD5972/4-LD6313 temperature/rain sensors
+    [202]  Unbranded SolarTPMS for trucks
+    [203]  Funkbus / Instafunk (Berker, Gira, Jung)
+    [204]  Porsche Boxster/Cayman TPMS
+    [205]  Jasco/GE Choice Alert Security Devices
+    [206]  Telldus weather station FT0385R sensors
+    [207]  LaCrosse TX34-IT rain gauge
+    [208]  SmartFire Proflame 2 remote control
+    [209]  AVE TPMS
+    [210]  SimpliSafe Gen 3 Home Security System
+    [211]  Yale HSA (Home Security Alarm), YES-Alarmkit
+    [212]  Regency Ceiling Fan Remote (-f 303.75M to 303.96M)
+    [213]  Renault 0435R TPMS
+    [214]  Fine Offset Electronics WS80 weather station
+    [215]  EMOS E6016 weatherstation with DCF77
+    [216]  Emax W6, rebrand Altronics x7063/4, Optex 990040/50/51, Orium 13093/13123, Infactory FWS-1200, Newentor Q9, Otio 810025, Protmex PT3390A, Jula Marquant 014331/32, TechniSat IMETEO X6 76-4924-00, Weather Station or temperature/humidity sensor
+    [217]* ANT and ANT+ devices
+    [218]  EMOS E6016 rain gauge
+    [219]  Microchip HCS200/HCS300 KeeLoq Hopping Encoder based remotes (FSK)
+    [220]  Fine Offset Electronics WH45 air quality sensor
+    [221]  Maverick XR-30 BBQ Sensor
+    [222]  Fine Offset Electronics WN34S/L/D and Froggit DP150/D35 temperature sensor
+    [223]  Rubicson Pool Thermometer 48942
+    [224]  Badger ORION water meter, 100kbps (-f 916.45M -s 1200k)
+    [225]  GEO minim+ energy monitor
+    [226]  TyreGuard 400 TPMS
+    [227]  Kia TPMS (-s 1000k)
+    [228]  SRSmith Pool Light Remote Control SRS-2C-TX (-f 915M)
+    [229]  Neptune R900 flow meters
+    [230]  WEC-2103 temperature/humidity sensor
+    [231]  Vauno EN8822C
+    [232]  Govee Water Leak Detector H5054
+    [233]  TFA Dostmann 14.1504.V2 Radio-controlled grill and meat thermometer
+    [234]* CED7000 Shot Timer
+    [235]  Watchman Sonic Advanced / Plus, Tekelek
+    [236]  Oil Ultrasonic SMART FSK
+    [237]  Gasmate BA1008 meat thermometer
+    [238]  Flowis flow meters
+    [239]  Wireless M-Bus, Mode T, 32.768kbps (-f 868.3M -s 1000k)
+    [240]  Revolt NC-5642 Energy Meter
+    [241]  LaCrosse TX31U-IT, The Weather Channel WS-1910TWC-IT
+    [242]  EezTire E618, Carchet TPMS, TST-507 TPMS
+    [243]* Baldr / RainPoint rain gauge.
+    [244]  Celsia CZC1 Thermostat
+    [245]  Fine Offset Electronics WS90 weather station
+    [246]* ThermoPro TX-2C Thermometer and Humidity sensor
+    [247]  TFA 30.3151 Weather Station
+    [248]  Bresser water leakage
+    [249]* Nissan TPMS
+    [250]  Bresser lightning
+    [251]  Schou 72543 Day Rain Gauge, Motonet MTX Rain, MarQuant Rain Gauge, TFA Dostmann 30.3252.01/47.3006.01 Rain Gauge and Thermometer, ADE WS1907
+    [252]  Fine Offset / Ecowitt WH55 water leak sensor
+    [253]  BMW Gen4-Gen5 TPMS and Audi TPMS Pressure Alert, multi-brand HUF/Beru, Continental, Schrader/Sensata, Audi
+    [254]  Watts WFHT-RF Thermostat
+    [255]  Thermor DG950 weather station
+    [256]  Mueller Hot Rod water meter
+    [257]  ThermoPro TP28b Super Long Range Wireless Meat Thermometer for Smoker BBQ Grill
+    [258]  BMW Gen2 and Gen3 TPMS
+    [259]  Chamberlain CWPIRC PIR Sensor
+    [260]  ThermoPro Meat Thermometers, TP829B 4 probes with temp only
+    [261]* Arad/Master Meter Dialog3G water utility meter
+    [262]  Geevon TX16-3 outdoor sensor
+    [263]  Fine Offset Electronics WH46 air quality sensor
+    [264]  Vevor Wireless Weather Station 7-in-1
+    [265]  Arexx Multilogger IP-HA90, IP-TH78EXT, TSN-70E
+    [266]  Rosstech Digital Control Unit DCU-706/Sundance/Jacuzzi
+    [267]  Risco 2 Way Agility protocol, Risco PIR/PET Sensor RWX95P
+    [268]  ThermoPro Meat Thermometers, TP828B 2 probes with Temp, BBQ Target LO and HI
+    [269]  Bresser Thermo-/Hygro-Sensor Explore Scientific ST1005H
+    [270]  DeltaDore X3D devices
+    [271]* Quinetic
+    [272]  Landis & Gyr Gridstream Power Meters 9.6k
+    [273]  Landis & Gyr Gridstream Power Meters 19.2k
+    [274]  Landis & Gyr Gridstream Power Meters 38.4k
+    [275]  Revolt ZX-7717 power meter
+    [276]  GM-Aftermarket TPMS
+    [277]  RainPoint HCS012ARF Rain Gauge sensor
+    [278]  Apator Metra E-RM 30
+    [279]  ThermoPro TX-7B Outdoor Thermometer Hygrometer
+    [280]  Nexus, CRX, Prego sauna temperature sensor
+    [281]  Homelead HG9901 (Geevon, Dr.Meter, Royal Gardineer) soil moisture/temp/light level sensor
+    [282]  Maverick XR-50 BBQ Sensor
+    [283]  Orion Endpoint from Badger Meter, GIF2014W-OSE, water meter, hopping from 904.4 Mhz to 924.6Mhz (-s 1600k)
+    [284]  Fine Offset Electronics WH43 air quality sensor
+    [285]  Baldr E0666TH Thermo-Hygrometer
+    [286]  bm5-v2 12V Battery Monitor
+    [287]  Universal (Reverseable) 24V Fan Controller
+    [288]  Fine Offset Electronics WS85 weather station
+    [289]  Oria WA150KM freezer and fridge thermometer
+    [290]  Voltcraft EnergyCount 3000 (ec3k)
+    [291]  Orion Endpoint from Badger Meter, GIF2020OCECNA, water meter, hopping from 904.4 Mhz to 924.6Mhz (-s 1600k)
+    [292]  Geevon TX19-1 outdoor sensor
 
 * Disabled by default, use -R n or a conf file to enable
 

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -433,103 +433,104 @@ convert si
   protocol 192 # Govee Water Leak Detector H5054, Door Contact Sensor B5023
   protocol 193 # Clipsal CMR113 Cent-a-meter power meter
   protocol 194 # Inkbird ITH-20R temperature humidity sensor
-  protocol 195 # RainPoint soil temperature and moisture sensor
-  protocol 196 # Atech-WS308 temperature sensor
-  protocol 197 # Acurite Grill/Meat Thermometer 01185M
-# protocol 198 # EnOcean ERP1
-  protocol 199 # Linear Megacode Garage/Gate Remotes
-# protocol 200 # Auriol 4-LD5661/4-LD5972/4-LD6313 temperature/rain sensors
-  protocol 201 # Unbranded SolarTPMS for trucks
-  protocol 202 # Funkbus / Instafunk (Berker, Gira, Jung)
-  protocol 203 # Porsche Boxster/Cayman TPMS
-  protocol 204 # Jasco/GE Choice Alert Security Devices
-  protocol 205 # Telldus weather station FT0385R sensors
-  protocol 206 # LaCrosse TX34-IT rain gauge
-  protocol 207 # SmartFire Proflame 2 remote control
-  protocol 208 # AVE TPMS
-  protocol 209 # SimpliSafe Gen 3 Home Security System
-  protocol 210 # Yale HSA (Home Security Alarm), YES-Alarmkit
-  protocol 211 # Regency Ceiling Fan Remote (-f 303.75M to 303.96M)
-  protocol 212 # Renault 0435R TPMS
-  protocol 213 # Fine Offset Electronics WS80 weather station
-  protocol 214 # EMOS E6016 weatherstation with DCF77
-  protocol 215 # Emax W6, rebrand Altronics x7063/4, Optex 990040/50/51, Orium 13093/13123, Infactory FWS-1200, Newentor Q9, Otio 810025, Protmex PT3390A, Jula Marquant 014331/32, TechniSat IMETEO X6 76-4924-00, Weather Station or temperature/humidity sensor
-# protocol 216 # ANT and ANT+ devices
-  protocol 217 # EMOS E6016 rain gauge
-  protocol 218 # Microchip HCS200/HCS300 KeeLoq Hopping Encoder based remotes (FSK)
-  protocol 219 # Fine Offset Electronics WH45 air quality sensor
-  protocol 220 # Maverick XR-30 BBQ Sensor
-  protocol 221 # Fine Offset Electronics WN34S/L/D and Froggit DP150/D35 temperature sensor
-  protocol 222 # Rubicson Pool Thermometer 48942
-  protocol 223 # Badger ORION water meter, 100kbps (-f 916.45M -s 1200k)
-  protocol 224 # GEO minim+ energy monitor
-  protocol 225 # TyreGuard 400 TPMS
-  protocol 226 # Kia TPMS (-s 1000k)
-  protocol 227 # SRSmith Pool Light Remote Control SRS-2C-TX (-f 915M)
-  protocol 228 # Neptune R900 flow meters
-  protocol 229 # WEC-2103 temperature/humidity sensor
-  protocol 230 # Vauno EN8822C
-  protocol 231 # Govee Water Leak Detector H5054
-  protocol 232 # TFA Dostmann 14.1504.V2 Radio-controlled grill and meat thermometer
-# protocol 233 # CED7000 Shot Timer
-  protocol 234 # Watchman Sonic Advanced / Plus, Tekelek
-  protocol 235 # Oil Ultrasonic SMART FSK
-  protocol 236 # Gasmate BA1008 meat thermometer
-  protocol 237 # Flowis flow meters
-  protocol 238 # Wireless M-Bus, Mode T, 32.768kbps (-f 868.3M -s 1000k)
-  protocol 239 # Revolt NC-5642 Energy Meter
-  protocol 240 # LaCrosse TX31U-IT, The Weather Channel WS-1910TWC-IT
-  protocol 241 # EezTire E618, Carchet TPMS, TST-507 TPMS
-# protocol 242 # Baldr / RainPoint rain gauge.
-  protocol 243 # Celsia CZC1 Thermostat
-  protocol 244 # Fine Offset Electronics WS90 weather station
-# protocol 245 # ThermoPro TX-2C Thermometer and Humidity sensor
-  protocol 246 # TFA 30.3151 Weather Station
-  protocol 247 # Bresser water leakage
-# protocol 248 # Nissan TPMS
-  protocol 249 # Bresser lightning
-  protocol 250 # Schou 72543 Day Rain Gauge, Motonet MTX Rain, MarQuant Rain Gauge, TFA Dostmann 30.3252.01/47.3006.01 Rain Gauge and Thermometer, ADE WS1907
-  protocol 251 # Fine Offset / Ecowitt WH55 water leak sensor
-  protocol 252 # BMW Gen4-Gen5 TPMS and Audi TPMS Pressure Alert, multi-brand HUF/Beru, Continental, Schrader/Sensata, Audi
-  protocol 253 # Watts WFHT-RF Thermostat
-  protocol 254 # Thermor DG950 weather station
-  protocol 255 # Mueller Hot Rod water meter
-  protocol 256 # ThermoPro TP28b Super Long Range Wireless Meat Thermometer for Smoker BBQ Grill
-  protocol 257 # BMW Gen2 and Gen3 TPMS
-  protocol 258 # Chamberlain CWPIRC PIR Sensor
-  protocol 259 # ThermoPro Meat Thermometers, TP829B 4 probes with temp only
-# protocol 260 # Arad/Master Meter Dialog3G water utility meter
-  protocol 261 # Geevon TX16-3 outdoor sensor
-  protocol 262 # Fine Offset Electronics WH46 air quality sensor
-  protocol 263 # Vevor Wireless Weather Station 7-in-1
-  protocol 264 # Arexx Multilogger IP-HA90, IP-TH78EXT, TSN-70E
-  protocol 265 # Rosstech Digital Control Unit DCU-706/Sundance/Jacuzzi
-  protocol 266 # Risco 2 Way Agility protocol, Risco PIR/PET Sensor RWX95P
-  protocol 267 # ThermoPro Meat Thermometers, TP828B 2 probes with Temp, BBQ Target LO and HI
-  protocol 268 # Bresser Thermo-/Hygro-Sensor Explore Scientific ST1005H
-  protocol 269 # DeltaDore X3D devices
-# protocol 270 # Quinetic
-  protocol 271 # Landis & Gyr Gridstream Power Meters 9.6k
-  protocol 272 # Landis & Gyr Gridstream Power Meters 19.2k
-  protocol 273 # Landis & Gyr Gridstream Power Meters 38.4k
-  protocol 274 # Revolt ZX-7717 power meter
-  protocol 275 # GM-Aftermarket TPMS
-  protocol 276 # RainPoint HCS012ARF Rain Gauge sensor
-  protocol 277 # Apator Metra E-RM 30
-  protocol 278 # ThermoPro TX-7B Outdoor Thermometer Hygrometer
-  protocol 279 # Nexus, CRX, Prego sauna temperature sensor
-  protocol 280 # Homelead HG9901 (Geevon, Dr.Meter, Royal Gardineer) soil moisture/temp/light level sensor
-  protocol 281 # Maverick XR-50 BBQ Sensor
-  protocol 282 # Orion Endpoint from Badger Meter, GIF2014W-OSE, water meter, hopping from 904.4 Mhz to 924.6Mhz (-s 1600k)
-  protocol 283 # Fine Offset Electronics WH43 air quality sensor
-  protocol 284 # Baldr E0666TH Thermo-Hygrometer
-  protocol 285 # bm5-v2 12V Battery Monitor
-  protocol 286 # Universal (Reverseable) 24V Fan Controller
-  protocol 287 # Fine Offset Electronics WS85 weather station
-  protocol 288 # Oria WA150KM freezer and fridge thermometer
-  protocol 289 # Voltcraft EnergyCount 3000 (ec3k)
-  protocol 290 # Orion Endpoint from Badger Meter, GIF2020OCECNA, water meter, hopping from 904.4 Mhz to 924.6Mhz (-s 1600k)
-  protocol 291 # Geevon TX19-1 outdoor sensor
+  protocol 195 # Inkbird IBS-P04R pool sensor
+  protocol 196 # RainPoint soil temperature and moisture sensor
+  protocol 197 # Atech-WS308 temperature sensor
+  protocol 198 # Acurite Grill/Meat Thermometer 01185M
+# protocol 199 # EnOcean ERP1
+  protocol 200 # Linear Megacode Garage/Gate Remotes
+# protocol 201 # Auriol 4-LD5661/4-LD5972/4-LD6313 temperature/rain sensors
+  protocol 202 # Unbranded SolarTPMS for trucks
+  protocol 203 # Funkbus / Instafunk (Berker, Gira, Jung)
+  protocol 204 # Porsche Boxster/Cayman TPMS
+  protocol 205 # Jasco/GE Choice Alert Security Devices
+  protocol 206 # Telldus weather station FT0385R sensors
+  protocol 207 # LaCrosse TX34-IT rain gauge
+  protocol 208 # SmartFire Proflame 2 remote control
+  protocol 209 # AVE TPMS
+  protocol 210 # SimpliSafe Gen 3 Home Security System
+  protocol 211 # Yale HSA (Home Security Alarm), YES-Alarmkit
+  protocol 212 # Regency Ceiling Fan Remote (-f 303.75M to 303.96M)
+  protocol 213 # Renault 0435R TPMS
+  protocol 214 # Fine Offset Electronics WS80 weather station
+  protocol 215 # EMOS E6016 weatherstation with DCF77
+  protocol 216 # Emax W6, rebrand Altronics x7063/4, Optex 990040/50/51, Orium 13093/13123, Infactory FWS-1200, Newentor Q9, Otio 810025, Protmex PT3390A, Jula Marquant 014331/32, TechniSat IMETEO X6 76-4924-00, Weather Station or temperature/humidity sensor
+# protocol 217 # ANT and ANT+ devices
+  protocol 218 # EMOS E6016 rain gauge
+  protocol 219 # Microchip HCS200/HCS300 KeeLoq Hopping Encoder based remotes (FSK)
+  protocol 220 # Fine Offset Electronics WH45 air quality sensor
+  protocol 221 # Maverick XR-30 BBQ Sensor
+  protocol 222 # Fine Offset Electronics WN34S/L/D and Froggit DP150/D35 temperature sensor
+  protocol 223 # Rubicson Pool Thermometer 48942
+  protocol 224 # Badger ORION water meter, 100kbps (-f 916.45M -s 1200k)
+  protocol 225 # GEO minim+ energy monitor
+  protocol 226 # TyreGuard 400 TPMS
+  protocol 227 # Kia TPMS (-s 1000k)
+  protocol 228 # SRSmith Pool Light Remote Control SRS-2C-TX (-f 915M)
+  protocol 229 # Neptune R900 flow meters
+  protocol 230 # WEC-2103 temperature/humidity sensor
+  protocol 231 # Vauno EN8822C
+  protocol 232 # Govee Water Leak Detector H5054
+  protocol 233 # TFA Dostmann 14.1504.V2 Radio-controlled grill and meat thermometer
+# protocol 234 # CED7000 Shot Timer
+  protocol 235 # Watchman Sonic Advanced / Plus, Tekelek
+  protocol 236 # Oil Ultrasonic SMART FSK
+  protocol 237 # Gasmate BA1008 meat thermometer
+  protocol 238 # Flowis flow meters
+  protocol 239 # Wireless M-Bus, Mode T, 32.768kbps (-f 868.3M -s 1000k)
+  protocol 240 # Revolt NC-5642 Energy Meter
+  protocol 241 # LaCrosse TX31U-IT, The Weather Channel WS-1910TWC-IT
+  protocol 242 # EezTire E618, Carchet TPMS, TST-507 TPMS
+# protocol 243 # Baldr / RainPoint rain gauge.
+  protocol 244 # Celsia CZC1 Thermostat
+  protocol 245 # Fine Offset Electronics WS90 weather station
+# protocol 246 # ThermoPro TX-2C Thermometer and Humidity sensor
+  protocol 247 # TFA 30.3151 Weather Station
+  protocol 248 # Bresser water leakage
+# protocol 249 # Nissan TPMS
+  protocol 250 # Bresser lightning
+  protocol 251 # Schou 72543 Day Rain Gauge, Motonet MTX Rain, MarQuant Rain Gauge, TFA Dostmann 30.3252.01/47.3006.01 Rain Gauge and Thermometer, ADE WS1907
+  protocol 252 # Fine Offset / Ecowitt WH55 water leak sensor
+  protocol 253 # BMW Gen4-Gen5 TPMS and Audi TPMS Pressure Alert, multi-brand HUF/Beru, Continental, Schrader/Sensata, Audi
+  protocol 254 # Watts WFHT-RF Thermostat
+  protocol 255 # Thermor DG950 weather station
+  protocol 256 # Mueller Hot Rod water meter
+  protocol 257 # ThermoPro TP28b Super Long Range Wireless Meat Thermometer for Smoker BBQ Grill
+  protocol 258 # BMW Gen2 and Gen3 TPMS
+  protocol 259 # Chamberlain CWPIRC PIR Sensor
+  protocol 260 # ThermoPro Meat Thermometers, TP829B 4 probes with temp only
+# protocol 261 # Arad/Master Meter Dialog3G water utility meter
+  protocol 262 # Geevon TX16-3 outdoor sensor
+  protocol 263 # Fine Offset Electronics WH46 air quality sensor
+  protocol 264 # Vevor Wireless Weather Station 7-in-1
+  protocol 265 # Arexx Multilogger IP-HA90, IP-TH78EXT, TSN-70E
+  protocol 266 # Rosstech Digital Control Unit DCU-706/Sundance/Jacuzzi
+  protocol 267 # Risco 2 Way Agility protocol, Risco PIR/PET Sensor RWX95P
+  protocol 268 # ThermoPro Meat Thermometers, TP828B 2 probes with Temp, BBQ Target LO and HI
+  protocol 269 # Bresser Thermo-/Hygro-Sensor Explore Scientific ST1005H
+  protocol 270 # DeltaDore X3D devices
+# protocol 271 # Quinetic
+  protocol 272 # Landis & Gyr Gridstream Power Meters 9.6k
+  protocol 273 # Landis & Gyr Gridstream Power Meters 19.2k
+  protocol 274 # Landis & Gyr Gridstream Power Meters 38.4k
+  protocol 275 # Revolt ZX-7717 power meter
+  protocol 276 # GM-Aftermarket TPMS
+  protocol 277 # RainPoint HCS012ARF Rain Gauge sensor
+  protocol 278 # Apator Metra E-RM 30
+  protocol 279 # ThermoPro TX-7B Outdoor Thermometer Hygrometer
+  protocol 280 # Nexus, CRX, Prego sauna temperature sensor
+  protocol 281 # Homelead HG9901 (Geevon, Dr.Meter, Royal Gardineer) soil moisture/temp/light level sensor
+  protocol 282 # Maverick XR-50 BBQ Sensor
+  protocol 283 # Orion Endpoint from Badger Meter, GIF2014W-OSE, water meter, hopping from 904.4 Mhz to 924.6Mhz (-s 1600k)
+  protocol 284 # Fine Offset Electronics WH43 air quality sensor
+  protocol 285 # Baldr E0666TH Thermo-Hygrometer
+  protocol 286 # bm5-v2 12V Battery Monitor
+  protocol 287 # Universal (Reverseable) 24V Fan Controller
+  protocol 288 # Fine Offset Electronics WS85 weather station
+  protocol 289 # Oria WA150KM freezer and fridge thermometer
+  protocol 290 # Voltcraft EnergyCount 3000 (ec3k)
+  protocol 291 # Orion Endpoint from Badger Meter, GIF2020OCECNA, water meter, hopping from 904.4 Mhz to 924.6Mhz (-s 1600k)
+  protocol 292 # Geevon TX19-1 outdoor sensor
 
 ## Flex devices (command line option "-X")
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -202,6 +202,7 @@
     DECL(govee) \
     DECL(cmr113) \
     DECL(inkbird_ith20r) \
+    DECL(inkbird_p04r) \
     DECL(rainpoint) \
     DECL(atech_ws308) \
     DECL(acurite_01185m) \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -159,6 +159,7 @@ add_library(r_433 STATIC
     devices/ikea_sparsnas.c
     devices/infactory.c
     devices/inkbird_ith20r.c
+    devices/inkbird_p04r.c
     devices/inovalley-kw9015b.c
     devices/insteon.c
     devices/interlogix.c

--- a/src/devices/inkbird_p04r.c
+++ b/src/devices/inkbird_p04r.c
@@ -1,0 +1,147 @@
+/** @file
+    Decoder for Inkbird IBS-P04R Pool Sensor.
+
+    Copyright (C) 2026 Anthony Grieco
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+/**
+Decoder for Inkbird IBS-P04R pool water quality sensor.
+
+The sensor transmits temperature and TDS (total dissolved solids) on 433.92 MHz.
+The device uses FSK-PCM encoding.
+The device sends a transmission every ~80 sec.
+
+Related to the Inkbird ITH-20R (protocol 194) but uses a different subtype,
+CRC parameters, payload length, and field layout.
+
+- Preamble: aa aa aa ... aa aa (1200+ bits of alternating 10101010)
+- Sync Word (16 bits): 2DD4
+
+Data layout:
+
+    SS SS LL FF CC VV VV BB II II XX XX XX XX TT TT DD RR RR UU UU KK KK
+
+- S: 16 bit Inkbird device family header (0xD391)
+- L: 8 bit subtype/length (0x14 = 20 bytes following)
+- F: 8 bit status flags (0x00 normal, 0x40 unlink, 0x80 battery replaced)
+- C: 8 bit sensor configuration
+- V: 16 bit firmware version
+- B: 8 bit battery level (0-100)
+- I: 16 bit device ID (little-endian)
+- X: 32 bit per-device constant (secondary ID)
+- T: 16 bit temperature, Celsius * 10 (little-endian, signed)
+- D: 8 bit TDS (total dissolved solids) in ppm
+- R: 16 bit reserved (always zero)
+- U: 16 bit unknown (byte 19 constant, byte 20 toggles 0/1)
+- K: 16 bit CRC-16/MODBUS over bytes 3-20 (little-endian)
+
+CRC16 (bytes 3-20, excludes header):
+poly=0x8005  init=0xFFFF  refin=true  refout=true  (CRC-16/MODBUS)
+
+Note: The display unit computes EC (electrical conductivity) from TDS:
+  EC (uS/cm) = TDS (ppm) * 20 / 11  (integer division, ~factor 0.55)
+*/
+
+#include "decoder.h"
+
+#define INKBIRD_P04R_CRC_POLY 0xA001  // reflected 0x8005
+#define INKBIRD_P04R_CRC_INIT 0xFFFF  // CRC-16/MODBUS
+#define INKBIRD_P04R_MSG_LEN  23
+
+static int inkbird_p04r_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    uint8_t const preamble_pattern[] = {0xaa, 0xaa, 0xaa, 0x2d, 0xd4};
+
+    uint8_t msg[INKBIRD_P04R_MSG_LEN];
+
+    if (bitbuffer->num_rows != 1
+            || bitbuffer->bits_per_row[0] < 187) {
+        decoder_logf(decoder, 2, __func__, "bit_per_row %u out of range", bitbuffer->bits_per_row[0]);
+        return DECODE_ABORT_LENGTH;
+    }
+
+    unsigned start_pos = bitbuffer_search(bitbuffer, 0, 0,
+            preamble_pattern, sizeof (preamble_pattern) * 8);
+
+    if (start_pos == bitbuffer->bits_per_row[0]) {
+        return DECODE_FAIL_SANITY;
+    }
+
+    start_pos += sizeof (preamble_pattern) * 8;
+    unsigned len = bitbuffer->bits_per_row[0] - start_pos;
+
+    decoder_logf(decoder, 2, __func__, "start_pos=%u len=%u", start_pos, len);
+
+    if (((len + 7) / 8) < INKBIRD_P04R_MSG_LEN) {
+        decoder_logf(decoder, 1, __func__, "%u too short", len);
+        return DECODE_ABORT_LENGTH;
+    }
+
+    unsigned extract_len = MIN(len, sizeof (msg) * 8);
+    bitbuffer_extract_bytes(bitbuffer, 0, start_pos, msg, extract_len);
+
+    // Verify header D391 and subtype 0x14
+    if (msg[0] != 0xD3 || msg[1] != 0x91 || msg[2] != 0x14) {
+        decoder_logf(decoder, 1, __func__, "bad header %02X%02X%02X", msg[0], msg[1], msg[2]);
+        return DECODE_FAIL_SANITY;
+    }
+
+    // CRC-16/MODBUS over bytes 3-20, stored LE at bytes 21-22
+    uint16_t crc_calculated = crc16lsb(msg + 3, 18, INKBIRD_P04R_CRC_POLY, INKBIRD_P04R_CRC_INIT);
+    uint16_t crc_received   = msg[22] << 8 | msg[21];
+
+    decoder_logf(decoder, 2, __func__, "CRC 0x%04X = 0x%04X", crc_calculated, crc_received);
+
+    if (crc_received != crc_calculated) {
+        decoder_logf(decoder, 1, __func__, "CRC check failed (0x%04X != 0x%04X)", crc_calculated, crc_received);
+        return DECODE_FAIL_MIC;
+    }
+
+    float battery_ok   = msg[7] * 0.01f;
+    uint16_t sensor_id = (msg[9] << 8 | msg[8]);
+    float temperature  = ((int16_t)(msg[15] << 8 | msg[14])) * 0.1f;
+    int tds_ppm        = msg[16];
+
+    decoder_logf(decoder, 1, __func__,
+            "status=0x%02X sensor_cfg=0x%02X id_ext=%02X%02X%02X%02X unk19=0x%02X unk20=0x%02X",
+            msg[3], msg[4], msg[10], msg[11], msg[12], msg[13], msg[19], msg[20]);
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",            "",                 DATA_STRING, "Inkbird-IBSP04R",
+            "id",               "",                 DATA_INT,    sensor_id,
+            "battery_ok",       "Battery level",    DATA_DOUBLE, battery_ok,
+            "temperature_C",    "Temperature",      DATA_FORMAT, "%.1f C", DATA_DOUBLE, temperature,
+            "tds_ppm",          "TDS",              DATA_FORMAT, "%d ppm", DATA_INT,    tds_ppm,
+            "mic",              "Integrity",        DATA_STRING, "CRC",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+static char const *const output_fields[] = {
+        "model",
+        "id",
+        "battery_ok",
+        "temperature_C",
+        "tds_ppm",
+        "mic",
+        NULL,
+};
+
+r_device const inkbird_p04r = {
+        .name        = "Inkbird IBS-P04R pool sensor",
+        .modulation  = FSK_PULSE_PCM,
+        .short_width = 100,
+        .long_width  = 100,
+        .reset_limit = 4000,
+        .decode_fn   = &inkbird_p04r_decode,
+        .fields      = output_fields,
+};


### PR DESCRIPTION
## Summary

- Add new decoder for the Inkbird IBS-P04R pool water quality sensor
- Decodes temperature (°C) and TDS (total dissolved solids, ppm) from FSK-PCM signals on 433.92 MHz
- Uses CRC-16/MODBUS for data integrity validation
- Related to the existing ITH-20R (protocol 194) but uses a different subtype, CRC parameters, payload length, and field layout

## Details

The IBS-P04R is a pool/spa water quality monitor that transmits temperature and TDS readings approximately every 80 seconds. The sensor uses the Inkbird device family header (0xD391) with subtype 0x14 (20-byte payload after header), compared to the ITH-20R's subtype 0x0F.

Key protocol differences from ITH-20R:
- CRC-16/MODBUS (poly=0x8005, init=0xFFFF, refin/refout=true) vs ITH-20R's CRC-16/BUYPASS
- 23-byte message length vs ITH-20R's 20 bytes
- Different field layout with TDS at byte 16

The display unit computes EC (electrical conductivity in µS/cm) from TDS locally: `EC = TDS × 20 / 11`.

Tested against 13 independent signal captures from a single device, all with verified CRC.

## Test plan

- [x] Builds cleanly with zero warnings
- [x] `style-check` passes
- [x] Decoder successfully decodes all 13 sample captures with CRC verification
- [x] Temperature matches known display reading (18.1°C = 64.6°F ≈ display's 64.5°F)
- [x] TDS matches known display reading (199 ppm = exact match)
- [x] `maintainer_update.py` auto-generated files updated (README.md, conf, man page)
- [ ] Sample `.cu8` files to be submitted to rtl_433_tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)