### PR TITLE
Change [Arad / Master Meter Dialog3G] preamble alignment, overrides, and documentation

### DIFF
--- a/src/devices/arad_ms_meter.c
+++ b/src/devices/arad_ms_meter.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * Arad/Master Meter Dialog3G water utility meter (protocol 260).
+ * Arad / Master Meter Dialog3G water utility meter (protocol 260).
  *
  * Copyright (C) 2022 avicarmeli
  *
@@ -113,8 +113,8 @@
  * Several fields previously assumed constant have been observed to vary in
  * newer captures. This documentation reflects current understanding based on
  * empirical analysis and may be updated as additional frames are decoded.
-
-  * ---------------------------------------------------------------------------
+ *
+ * ---------------------------------------------------------------------------
  * BitBench notation
  * ---------------------------------------------------------------------------
  *
@@ -135,10 +135,10 @@
  * ---------------------------------------------------------------------------
  * This decoder accepts arguments through:
  *
- *     rtl_433 -R <id>:<args>
+ *     rtl_433 -R ID:ARGS
  *
  * Mandatory:
- * - serial=<list> / serials=<list>
+ * - serial=LIST / serials=LIST
  *     At least one serial must be provided, otherwise the decoder is silent
  *     and prints a warning once.
  *
@@ -150,27 +150,27 @@
  *         SERIAL-SUFFIX
  *
  *     Examples:
- *         -R <id>:serial=9444602
- *         -R <id>:serials=9444602;1234567;0xfa1c90
- *         -R <id>:serials=09444602-73;01234567-53
+ *         -R ID:serial=9444602
+ *         -R ID:serials=9444602;1234567;0xfa1c90
+ *         -R ID:serials=09444602-73;01234567-53
  *
  *     NOTE:
  *     If other options are combined with serials, commas separate key=value
  *     pairs. In that case prefer semicolons inside serials:
  *
- *         -R <id>:serials=9444602;1234567,gear=0.1,units=m3
+ *         -R ID:serials=9444602;1234567,gear=0.1,units=m3
  *
  * Optional:
- * - gear=<value>
+ * - gear=VALUE
  *     Flow multiplier / resolution.
  *     Allowed values: 0.01, 0.1, 1, 10, 100
  *     Default: 0.1
  *
- * - units=<value>
+ * - units=VALUE
  *     Overrides the native unit interpretation of the meter.
  *     Allowed values (case-insensitive): m3, Liters, CF, USG
  *
- * - convert=<value>
+ * - convert=VALUE
  *     Converts the decoded numeric volume to the requested output unit.
  *     Allowed values (case-insensitive): m3, Liters, CF, USG
  *
@@ -178,7 +178,7 @@
  * Outputs
  * ---------------------------------------------------------------------------
  * - model               : decoder model name
- * - id                  : "SERIAL-SUFFIX"
+ * - id                  : SERIAL-SUFFIX
  *                         serial as 8-digit decimal + '-' + suffix as hex
  * - volume              : decoded volume in selected output units
  * - unit                : output unit string (m3 / Liters / CF / USG)
@@ -188,10 +188,10 @@
  * - unmatched_preamble  : inverted preamble nibbles outside the matched
  *                         nibble window, formatted as:
  *
- *                             <before>_..._<after>
+ *                             BEFORE_..._AFTER
  *
- *                         where <before> is the unmatched part before the
- *                         matched preamble window and <after> is the unmatched
+ *                         where BEFORE is the unmatched part before the
+ *                         matched preamble window and AFTER is the unmatched
  *                         part after it
  *
  * ---------------------------------------------------------------------------
@@ -203,11 +203,11 @@
  *
  * The decoder may search only a configurable nibble window inside this full
  * preamble. The unmatched nibbles are not validated and are reported in the
- * output as "unmatched_preamble" after nibble-wise inversion.
+ * output as unmatched_preamble after nibble-wise inversion.
  *
  * Important:
  * - The payload extraction offset is always derived from the start of the
- *   FULL 48-bit preamble, even if only a sub-range of nibbles is matched.
+ *   full 48-bit preamble, even if only a sub-range of nibbles is matched.
  * - This ensures serial / suffix / counter extraction stays aligned when the
  *   preamble match window is changed.
  *
@@ -249,9 +249,9 @@
  *     auto -> gear override -> units override -> convert
  *
  * Meaning:
- * - gear=<...>   overrides the detected native gear
- * - units=<...>  overrides the detected native unit
- * - convert=<...> converts the numeric output volume to the requested unit
+ * - gear=...    overrides the detected native gear
+ * - units=...   overrides the detected native unit
+ * - convert=... converts the numeric output volume to the requested unit
  *
  * Notes:
  * - units= changes the native interpretation
@@ -1011,12 +1011,11 @@ static r_device *arad_ms_meter_create(char *args)
         if (!val)
             val = (char *)"";
 
-        if (arad_ieq(key, "serial") || arad_ieq(key, "serials")) {
+ if (arad_ieq(key, "serial") || arad_ieq(key, "serials")) {
             collecting_serials = 1;
             serial_buf[0]      = '\0';
             if (*val) {
-                strncat(serial_buf, val, sizeof(serial_buf) - 1);
-                serial_buf[sizeof(serial_buf) - 1] = '\0';
+                snprintf(serial_buf, sizeof(serial_buf), "%s", val);
             }
         }
         else if (arad_ieq(key, "gear")) {

--- a/src/devices/arad_ms_meter.c
+++ b/src/devices/arad_ms_meter.c
@@ -1,271 +1,13 @@
-/**
- * @file
- * Arad / Master Meter Dialog3G water utility meter (protocol 260).
- *
- * Copyright (C) 2022 avicarmeli
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * ---------------------------------------------------------------------------
- * Overview
- * ---------------------------------------------------------------------------
- * Decoder for Arad / Master Meter Dialog3G water utility meter transmissions.
- *
- * FCC-Id: TKCET-733
- *
- * References:
- * - https://45851052.fs1.hubspotusercontent-na1.net/hubfs/45851052/documents/files/Interpreter-II-Register_v0710.20F.pdf
- * - https://www.arad.co.il/wp-content/uploads/Dialog-3G-register-information-sheet_Eng-002.pdf
- *
- * Messages are transmitted approximately once every 30 seconds.
- *
- * ---------------------------------------------------------------------------
- * Observed message structure
- * ---------------------------------------------------------------------------
- *
- * A typical frame (after preamble) appears as:
- *
- *     00000000FFFFFFFFFFFFFFSSSSSSSSXXCCCCCCXXXF?????????XFF
- *
- * Field description (based on reverse engineering and observations):
- *
- * - 00000000
- *     Preamble used for frame synchronization.
- *
- * - FFFFFFFFFFFFFF
- *     Bytes that appear constant in time and are usually identical for
- *     meters located in the same neighborhood.
- *
- *     Observed payload example:
- *         3e690aec7ac84b
- *
- *     The exact meaning is unknown. It may be related to the meter register
- *     configuration or gearing parameters.
- *
- * - SSSSSSSS
- *     Meter serial field (4 bytes).
- *
- *     The first 3 bytes represent the numeric serial number (little-endian).
- *
- *     Example:
- *         fa1c9073
- *
- *         fa1c90  -> 09444602 (decimal serial number)
- *         73      -> suffix byte
- *
- *     The last byte sometimes corresponds to a letter printed after the
- *     serial on the physical meter, but not always. In many cases it contains
- *     values that do not appear on the meter label.
- *
- *     Empirically, this suffix byte together with the following byte appears
- *     to encode meter configuration parameters such as the measurement unit
- *     and gear (resolution).
- *
- * - XX
- *     Unknown field (2 bytes). Its role is not yet understood.
- *
- * - CCCCCC
- *     Counter value (3 bytes, little-endian).
- *
- *     Example:
- *         a80600 -> 1704
- *
- *     This value represents the raw meter counter before applying the gear
- *     multiplier.
- *
- * - XXX
- *     Unknown field (3 bytes). Function currently unknown.
- *
- * - F
- *     Observed constant byte in many frames.
- *
- *     Typical observed payload:
- *         0x05
- *
- *     Appears stable for meters in the same installation but the exact
- *     meaning is not yet confirmed.
- *
- * - ?????????
- *     Likely CRC or checksum field. The exact algorithm is currently unknown.
- *
- * - X
- *     A single byte that is typically observed as either:
- *
- *         0x08  or  0x00
- *
- *     The meaning is not yet known.
- *
- * - FF
- *     Final byte of the frame.
- *
- *     Earlier observations suggested this byte was constant (often 0xF8),
- *     however newer captures show that this byte may change over time even
- *     for the same meter. Its purpose is currently unknown and it should not
- *     be assumed constant.
- *
- * ---------------------------------------------------------------------------
- * Notes
- * ---------------------------------------------------------------------------
- *
- * Several fields previously assumed constant have been observed to vary in
- * newer captures. This documentation reflects current understanding based on
- * empirical analysis and may be updated as additional frames are decoded.
- *
- * ---------------------------------------------------------------------------
- * BitBench notation
- * ---------------------------------------------------------------------------
- *
- * Use PREAMBLE_ALIGN with value:
- *
- *     c196f51385
- *
- * This is the inverted form of:
- *
- *     3e690aec7a
- *
- * Format string:
- *
- *     UID:16h SERIAL:<24d 8h 8h COUNTER:<32d 8h8h 8h8h 8h8h SUFFIX:hh
- *
- * ---------------------------------------------------------------------------
- * Protocol options
- * ---------------------------------------------------------------------------
- * This decoder accepts arguments through:
- *
- *     rtl_433 -R ID:ARGS
- *
- * Mandatory:
- * - serial=LIST / serials=LIST
- *     At least one serial must be provided, otherwise the decoder is silent
- *     and prints a warning once.
- *
- *     The filter accepts one or more meter serials (24-bit little-endian),
- *     in decimal or hex notation.
- *
- *     A suffix byte may optionally be locked too by using:
- *
- *         SERIAL-SUFFIX
- *
- *     Examples:
- *         -R ID:serial=9444602
- *         -R ID:serials=9444602;1234567;0xfa1c90
- *         -R ID:serials=09444602-73;01234567-53
- *
- *     NOTE:
- *     If other options are combined with serials, commas separate key=value
- *     pairs. In that case prefer semicolons inside serials:
- *
- *         -R ID:serials=9444602;1234567,gear=0.1,units=m3
- *
- * Optional:
- * - gear=VALUE
- *     Flow multiplier / resolution.
- *     Allowed values: 0.01, 0.1, 1, 10, 100
- *     Default: 0.1
- *
- * - units=VALUE
- *     Overrides the native unit interpretation of the meter.
- *     Allowed values (case-insensitive): m3, Liters, CF, USG
- *
- * - convert=VALUE
- *     Converts the decoded numeric volume to the requested output unit.
- *     Allowed values (case-insensitive): m3, Liters, CF, USG
- *
- * ---------------------------------------------------------------------------
- * Outputs
- * ---------------------------------------------------------------------------
- * - model               : decoder model name
- * - id                  : SERIAL-SUFFIX
- *                         serial as 8-digit decimal + '-' + suffix as hex
- * - volume              : decoded volume in selected output units
- * - unit                : output unit string (m3 / Liters / CF / USG)
- * - volume_m3           : volume always provided in cubic meters
- * - gear                : effective native gear used for decoding
- * - native_unit         : effective native unit used for decoding
- * - unmatched_preamble  : inverted preamble nibbles outside the matched
- *                         nibble window, formatted as:
- *
- *                             BEFORE_..._AFTER
- *
- *                         where BEFORE is the unmatched part before the
- *                         matched preamble window and AFTER is the unmatched
- *                         part after it
- *
- * ---------------------------------------------------------------------------
- * Preamble detection
- * ---------------------------------------------------------------------------
- * Full preamble (already in the expected polarity for search):
- *
- *     96 f5 13 85 37 b4
- *
- * The decoder may search only a configurable nibble window inside this full
- * preamble. The unmatched nibbles are not validated and are reported in the
- * output as unmatched_preamble after nibble-wise inversion.
- *
- * Important:
- * - The payload extraction offset is always derived from the start of the
- *   full 48-bit preamble, even if only a sub-range of nibbles is matched.
- * - This ensures serial / suffix / counter extraction stays aligned when the
- *   preamble match window is changed.
- *
- * ---------------------------------------------------------------------------
- * Buffer polarity
- * ---------------------------------------------------------------------------
- * This decoder keeps the original polarity behavior:
- *
- *     bitbuffer_invert(bitbuffer);
- *
- * The preamble is located first, and the shared bitbuffer is inverted only
- * afterwards, before payload extraction.
- *
- * As a result, verbose (-V) output shows the buffer in the polarity expected
- * by this decoder.
- *
- * ---------------------------------------------------------------------------
- * Decoding behavior
- * ---------------------------------------------------------------------------
- * - serial/serials is mandatory
- * - the decoder is silent when no serial filter is provided
- * - a warning is printed once if serial/serials is missing
- * - automatic native gear / unit detection is based on bytes after the serial:
- *
- *     b[3] == 0x73 && b[4] == 0x00
- *         -> gear = 0.1, native_unit = m3
- *
- *     b[3] == 0x00 && (b[4] == 0x00 || b[4] == 0x40)
- *         -> gear = 0.01, native_unit = m3
- *
- *     b[3] == 0x27 && b[4] == 0x00
- *         -> gear = 0.1, native_unit = USG
- *
- *     default
- *         -> gear = 0.1, native_unit = m3
- *
- * Override order:
- *
- *     auto -> gear override -> units override -> convert
- *
- * Meaning:
- * - gear=...    overrides the detected native gear
- * - units=...   overrides the detected native unit
- * - convert=... converts the numeric output volume to the requested unit
- *
- * Notes:
- * - units= changes the native interpretation
- * - convert= changes the displayed numeric output
- * - convert overrides units in output selection
- *
- * ---------------------------------------------------------------------------
- * Implementation notes
- * ---------------------------------------------------------------------------
- * - MSVC / Windows compatible tokenizer
- * - no strtok_r
- * - no DATA_FORMAT varargs usage
- * - output uses separate numeric and unit fields
- */
+/** @file
+    Arad/Master Meter Dialog3G water utility meter.
+
+    Copyright (C) 2022 avicarmeli
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
 
 #include "decoder.h"
 
@@ -658,14 +400,14 @@ static void arad_auto_gear_units(uint8_t after0, uint8_t after1, double *gear, a
         *unit = u;
 }
 
-/* Build a contiguous nibble-range pattern from the full 48-bit preamble.
- * start_nibble/end_nibble are in [0..12], where 0 is the HIGH nibble of 0x96.
- * end_nibble is exclusive. Required: 0 <= start < end <= 12.
- *
- * Output:
- *   out_bytes: pattern packed MSB-first
- *   out_bits:  number of bits to search (multiple of 4)
- * Returns 1 on success, 0 on invalid input.
+/*  Build a contiguous nibble-range pattern from the full 48-bit preamble.
+        start_nibble/end_nibble are in [0..12], where 0 is the HIGH nibble of 0x96.
+    end_nibble is exclusive. Required: 0 <= start < end <= 12.
+
+        Output:
+        out_bytes: pattern packed MSB-first
+        out_bits:  number of bits to search (multiple of 4)
+        Returns 1 on success, 0 on invalid input.
  */
 static int arad_build_preamble_nibble_pattern(
         uint8_t out_bytes[6],
@@ -712,13 +454,13 @@ static int arad_build_preamble_nibble_pattern(
     return 1;
 }
 
-/* Build a string containing the INVERTED preamble nibbles
- * NOT covered by [start_nibble, end_nibble).
- * The unmatched parts BEFORE and AFTER the matched window
- * are separated by "_..._".
- *
- * Inversion is done per nibble: out = 0xF ^ in.
- * Output format: hex nibbles (uppercase), no separators.
+/* 	Build a string containing the INVERTED preamble nibbles
+        NOT covered by [start_nibble, end_nibble).
+        The unmatched parts BEFORE and AFTER the matched window
+        are separated by "_..._".
+
+        Inversion is done per nibble: out = 0xF ^ in.
+        Output format: hex nibbles (uppercase), no separators.
  */
 static void arad_format_unmatched_preamble(
         char *out,
@@ -778,19 +520,275 @@ static void arad_format_unmatched_preamble(
 
 static r_device *arad_ms_meter_create(char *args);
 
+/**
+Overview
+--------
+
+Decoder for Arad / Master Meter Dialog3G water utility meter transmissions.
+
+FCC-Id: TKCET-733
+
+References:
+- https://45851052.fs1.hubspotusercontent-na1.net/hubfs/45851052/documents/files/Interpreter-II-Register_v0710.20F.pdf
+- https://www.arad.co.il/wp-content/uploads/Dialog-3G-register-information-sheet_Eng-002.pdf
+
+Messages are transmitted approximately once every 30 seconds.
+
+Observed message structure
+--------------------------
+
+A typical frame (after preamble) appears as:
+
+    00000000FFFFFFFFFFFFFFSSSSSSSSXXCCCCCCXXXF?????????XFF
+
+Field description (based on reverse engineering and observations):
+
+- 00000000
+    Preamble used for frame synchronization.
+
+- FFFFFFFFFFFFFF
+    Bytes that appear constant in time and are usually identical for
+    meters located in the same neighborhood.
+
+    Observed payload example:
+        3e690aec7ac84b
+
+    The exact meaning is unknown. It may be related to the meter register
+    configuration or gearing parameters.
+
+- SSSSSSSS
+    Meter serial field (4 bytes).
+
+    The first 3 bytes represent the numeric serial number (little-endian).
+
+    Example:
+        fa1c9073
+
+        fa1c90  -> 09444602 (decimal serial number)
+        73      -> suffix byte
+
+    The last byte sometimes corresponds to a letter printed after the
+    serial on the physical meter, but not always. In many cases it contains
+    values that do not appear on the meter label.
+
+    Empirically, this suffix byte together with the following byte appears
+    to encode meter configuration parameters such as the measurement unit
+    and gear (resolution).
+
+- XX
+    Unknown field (2 bytes). Its role is not yet understood.
+
+- CCCCCC
+    Counter value (3 bytes, little-endian).
+
+    Example:
+        a80600 -> 1704
+
+    This value represents the raw meter counter before applying the gear
+    multiplier.
+
+- XXX
+    Unknown field (3 bytes). Function currently unknown.
+
+- F
+    Observed constant byte in many frames.
+
+    Typical observed payload:
+        0x05
+
+    Appears stable for meters in the same installation but the exact
+    meaning is not yet confirmed.
+
+- ?????????
+    Likely CRC or checksum field. The exact algorithm is currently unknown.
+
+- X
+    A single byte that is typically observed as either:
+
+        0x08  or  0x00
+
+    The meaning is not yet known.
+
+- FF
+    Final byte of the frame.
+
+    Earlier observations suggested this byte was constant (often 0xF8),
+    however newer captures show that this byte may change over time even
+    for the same meter. Its purpose is currently unknown and it should not
+    be assumed constant.
+
+Notes
+-----
+
+Several fields previously assumed constant have been observed to vary in
+newer captures. This documentation reflects current understanding based on
+empirical analysis and may be updated as additional frames are decoded.
+
+BitBench notation
+-----------------
+
+Use PREAMBLE_ALIGN with value:
+
+    c196f51385
+
+This is the inverted form of:
+
+    3e690aec7a
+
+Format string:
+
+    UID:16h SERIAL:<24d 8h 8h COUNTER:<32d 8h8h 8h8h 8h8h SUFFIX:hh
+
+Protocol options
+----------------
+
+This decoder accepts arguments through:
+
+    rtl_433 -R ID:ARGS
+
+Mandatory:
+- serial=LIST / serials=LIST
+    At least one serial must be provided, otherwise the decoder is silent
+    and prints a warning once.
+
+    The filter accepts one or more meter serials (24-bit little-endian),
+    in decimal or hex notation.
+
+    A suffix byte may optionally be locked too by using:
+
+        SERIAL-SUFFIX
+
+    Examples:
+        -R ID:serial=9444602
+        -R ID:serials=9444602;1234567;0xfa1c90
+        -R ID:serials=09444602-73;01234567-53
+
+    NOTE:
+    If other options are combined with serials, commas separate key=value
+    pairs. In that case prefer semicolons inside serials:
+
+        -R ID:serials=9444602;1234567,gear=0.1,units=m3
+
+Optional:
+- gear=VALUE
+    Flow multiplier / resolution.
+    Allowed values: 0.01, 0.1, 1, 10, 100
+    Default: 0.1
+
+- units=VALUE
+    Overrides the native unit interpretation of the meter.
+    Allowed values (case-insensitive): m3, Liters, CF, USG
+
+- convert=VALUE
+    Converts the decoded numeric volume to the requested output unit.
+    Allowed values (case-insensitive): m3, Liters, CF, USG
+
+Outputs
+-------
+
+- model               : decoder model name
+- id                  : SERIAL-SUFFIX
+                        serial as 8-digit decimal + '-' + suffix as hex
+- volume              : decoded volume in selected output units
+- unit                : output unit string (m3 / Liters / CF / USG)
+- volume_m3           : volume always provided in cubic meters
+- gear                : effective native gear used for decoding
+- native_unit         : effective native unit used for decoding
+- unmatched_preamble  : inverted preamble nibbles outside the matched
+                        nibble window, formatted as:
+
+                            BEFORE_..._AFTER
+
+                        where BEFORE is the unmatched part before the
+                        matched preamble window and AFTER is the unmatched
+                        part after it
+
+Preamble detection
+------------------
+
+Full preamble (already in the expected polarity for search):
+
+    96 f5 13 85 37 b4
+
+The decoder may search only a configurable nibble window inside this full
+preamble. The unmatched nibbles are not validated and are reported in the
+output as unmatched_preamble after nibble-wise inversion.
+
+Important:
+- The payload extraction offset is always derived from the start of the
+  full 48-bit preamble, even if only a sub-range of nibbles is matched.
+- This ensures serial / suffix / counter extraction stays aligned when the
+  preamble match window is changed.
+
+Buffer polarity
+---------------
+
+This decoder keeps the original polarity behavior:
+
+    bitbuffer_invert(bitbuffer);
+
+The preamble is located first, and the shared bitbuffer is inverted only
+afterwards, before payload extraction.
+
+As a result, verbose (-V) output shows the buffer in the polarity expected
+by this decoder.
+
+Decoding behavior
+-----------------
+
+- serial/serials is mandatory
+- the decoder is silent when no serial filter is provided
+- a warning is printed once if serial/serials is missing
+- automatic native gear / unit detection is based on bytes after the serial:
+
+    b[3] == 0x73 && b[4] == 0x00
+        -> gear = 0.1, native_unit = m3
+
+    b[3] == 0x00 && (b[4] == 0x00 || b[4] == 0x40)
+        -> gear = 0.01, native_unit = m3
+
+    b[3] == 0x27 && b[4] == 0x00
+        -> gear = 0.1, native_unit = USG
+
+    default
+        -> gear = 0.1, native_unit = m3
+
+Override order:
+
+    auto -> gear override -> units override -> convert
+
+Meaning:
+- gear=...    overrides the detected native gear
+- units=...   overrides the detected native unit
+- convert=... converts the numeric output volume to the requested unit
+
+Notes:
+- units= changes the native interpretation
+- convert= changes the displayed numeric output
+- convert overrides units in output selection
+
+Implementation notes
+--------------------
+
+- MSVC / Windows compatible tokenizer
+- no strtok_r
+- no DATA_FORMAT varargs usage
+- output uses separate numeric and unit fields
+*/
+
 static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    /* ---- Preamble matching window (nibbles) ----
-     * Full preamble (inverted polarity, do NOT change):
-     *   96 f5 13 85 37 b4
-     *
-     * Configure which nibbles are matched:
-     *   nibble index 0..11, where 0 is HIGH nibble of 0x96, 11 is LOW nibble of 0xB4.
-     *   start_nibble inclusive, end_nibble exclusive.
-     *
-     * Example:
-     *   start_nibble=0, end_nibble=12  -> match full preamble (48 bits)
-     *   start_nibble=2, end_nibble=10  -> match middle 8 nibbles (32 bits)
+    /* 	---- Preamble matching window (nibbles) ----
+                Full preamble (inverted polarity, do NOT change):
+                96 f5 13 85 37 b4
+
+                Configure which nibbles are matched:
+                nibble index 0..11, where 0 is HIGH nibble of 0x96, 11 is LOW nibble of 0xB4.
+                start_nibble inclusive, end_nibble exclusive.
+
+                Example:
+                        start_nibble=0, end_nibble=12  -> match full preamble (48 bits)
+                        start_nibble=2, end_nibble=10  -> match middle 8 nibbles (32 bits)
      */
     /* ---- Preamble matching window (nibbles) ---- */
     const unsigned start_nibble = 1; /* inclusive, 0..11 */
@@ -815,9 +813,9 @@ static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     arad_format_unmatched_preamble(unmatched_preamble, sizeof(unmatched_preamble), start_nibble, end_nibble);
 
     /*
-     * Critical fix:
-     * Compute the start of the FULL 48-bit preamble from the window match position,
-     * then start payload AFTER the full preamble (always +48), regardless of window.
+                Critical fix:
+                Compute the start of the FULL 48-bit preamble from the window match position,
+                then start payload AFTER the full preamble (always +48), regardless of window.
      */
     int full_preamble_start_i = match_pos_i - (int)(start_nibble * 4);
     if (full_preamble_start_i < 0)
@@ -1011,7 +1009,7 @@ static r_device *arad_ms_meter_create(char *args)
         if (!val)
             val = (char *)"";
 
- if (arad_ieq(key, "serial") || arad_ieq(key, "serials")) {
+        if (arad_ieq(key, "serial") || arad_ieq(key, "serials")) {
             collecting_serials = 1;
             serial_buf[0]      = '\0';
             if (*val) {

--- a/src/devices/arad_ms_meter.c
+++ b/src/devices/arad_ms_meter.c
@@ -7,6 +7,7 @@
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
+
 */
 
 #include "decoder.h"

--- a/src/devices/arad_ms_meter.c
+++ b/src/devices/arad_ms_meter.c
@@ -1,106 +1,906 @@
-/** @file
-    Arad/Master Meter Dialog3G water utility meter.
+/**
+ * @file
+ * Arad/Master Meter Dialog3G water utility meter (protocol 260).
+ *
+ * Copyright (C) 2022 avicarmeli
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * ---------------------------------------------------------------------------
+ * Overview
+ * ---------------------------------------------------------------------------
+ * Decoder for Arad / Master Meter Dialog3G water utility meter transmissions.
+ *
+ * FCC-Id: TKCET-733
+ *
+ * References:
+ * - https://45851052.fs1.hubspotusercontent-na1.net/hubfs/45851052/documents/files/Interpreter-II-Register_v0710.20F.pdf
+ * - https://www.arad.co.il/wp-content/uploads/Dialog-3G-register-information-sheet_Eng-002.pdf
+ *
+ * Messages are transmitted approximately once every 30 seconds.
+ *
+ * ---------------------------------------------------------------------------
+ * Observed message structure
+ * ---------------------------------------------------------------------------
+ *
+ * A typical frame (after preamble) appears as:
+ *
+ *     00000000FFFFFFFFFFFFFFSSSSSSSSXXCCCCCCXXXF?????????XFF
+ *
+ * Field description (based on reverse engineering and observations):
+ *
+ * - 00000000
+ *     Preamble used for frame synchronization.
+ *
+ * - FFFFFFFFFFFFFF
+ *     Bytes that appear constant in time and are usually identical for
+ *     meters located in the same neighborhood.
+ *
+ *     Observed payload example:
+ *         3e690aec7ac84b
+ *
+ *     The exact meaning is unknown. It may be related to the meter register
+ *     configuration or gearing parameters.
+ *
+ * - SSSSSSSS
+ *     Meter serial field (4 bytes).
+ *
+ *     The first 3 bytes represent the numeric serial number (little-endian).
+ *
+ *     Example:
+ *         fa1c9073
+ *
+ *         fa1c90  -> 09444602 (decimal serial number)
+ *         73      -> suffix byte
+ *
+ *     The last byte sometimes corresponds to a letter printed after the
+ *     serial on the physical meter, but not always. In many cases it contains
+ *     values that do not appear on the meter label.
+ *
+ *     Empirically, this suffix byte together with the following byte appears
+ *     to encode meter configuration parameters such as the measurement unit
+ *     and gear (resolution).
+ *
+ * - XX
+ *     Unknown field (2 bytes). Its role is not yet understood.
+ *
+ * - CCCCCC
+ *     Counter value (3 bytes, little-endian).
+ *
+ *     Example:
+ *         a80600 -> 1704
+ *
+ *     This value represents the raw meter counter before applying the gear
+ *     multiplier.
+ *
+ * - XXX
+ *     Unknown field (3 bytes). Function currently unknown.
+ *
+ * - F
+ *     Observed constant byte in many frames.
+ *
+ *     Typical observed payload:
+ *         0x05
+ *
+ *     Appears stable for meters in the same installation but the exact
+ *     meaning is not yet confirmed.
+ *
+ * - ?????????
+ *     Likely CRC or checksum field. The exact algorithm is currently unknown.
+ *
+ * - X
+ *     A single byte that is typically observed as either:
+ *
+ *         0x08  or  0x00
+ *
+ *     The meaning is not yet known.
+ *
+ * - FF
+ *     Final byte of the frame.
+ *
+ *     Earlier observations suggested this byte was constant (often 0xF8),
+ *     however newer captures show that this byte may change over time even
+ *     for the same meter. Its purpose is currently unknown and it should not
+ *     be assumed constant.
+ *
+ * ---------------------------------------------------------------------------
+ * Notes
+ * ---------------------------------------------------------------------------
+ *
+ * Several fields previously assumed constant have been observed to vary in
+ * newer captures. This documentation reflects current understanding based on
+ * empirical analysis and may be updated as additional frames are decoded.
 
-    Copyright (C) 2022 avicarmeli
-
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
-*/
+  * ---------------------------------------------------------------------------
+ * BitBench notation
+ * ---------------------------------------------------------------------------
+ *
+ * Use PREAMBLE_ALIGN with value:
+ *
+ *     c196f51385
+ *
+ * This is the inverted form of:
+ *
+ *     3e690aec7a
+ *
+ * Format string:
+ *
+ *     UID:16h SERIAL:<24d 8h 8h COUNTER:<32d 8h8h 8h8h 8h8h SUFFIX:hh
+ *
+ * ---------------------------------------------------------------------------
+ * Protocol options
+ * ---------------------------------------------------------------------------
+ * This decoder accepts arguments through:
+ *
+ *     rtl_433 -R <id>:<args>
+ *
+ * Mandatory:
+ * - serial=<list> / serials=<list>
+ *     At least one serial must be provided, otherwise the decoder is silent
+ *     and prints a warning once.
+ *
+ *     The filter accepts one or more meter serials (24-bit little-endian),
+ *     in decimal or hex notation.
+ *
+ *     A suffix byte may optionally be locked too by using:
+ *
+ *         SERIAL-SUFFIX
+ *
+ *     Examples:
+ *         -R <id>:serial=9444602
+ *         -R <id>:serials=9444602;1234567;0xfa1c90
+ *         -R <id>:serials=09444602-73;01234567-53
+ *
+ *     NOTE:
+ *     If other options are combined with serials, commas separate key=value
+ *     pairs. In that case prefer semicolons inside serials:
+ *
+ *         -R <id>:serials=9444602;1234567,gear=0.1,units=m3
+ *
+ * Optional:
+ * - gear=<value>
+ *     Flow multiplier / resolution.
+ *     Allowed values: 0.01, 0.1, 1, 10, 100
+ *     Default: 0.1
+ *
+ * - units=<value>
+ *     Overrides the native unit interpretation of the meter.
+ *     Allowed values (case-insensitive): m3, Liters, CF, USG
+ *
+ * - convert=<value>
+ *     Converts the decoded numeric volume to the requested output unit.
+ *     Allowed values (case-insensitive): m3, Liters, CF, USG
+ *
+ * ---------------------------------------------------------------------------
+ * Outputs
+ * ---------------------------------------------------------------------------
+ * - model               : decoder model name
+ * - id                  : "SERIAL-SUFFIX"
+ *                         serial as 8-digit decimal + '-' + suffix as hex
+ * - volume              : decoded volume in selected output units
+ * - unit                : output unit string (m3 / Liters / CF / USG)
+ * - volume_m3           : volume always provided in cubic meters
+ * - gear                : effective native gear used for decoding
+ * - native_unit         : effective native unit used for decoding
+ * - unmatched_preamble  : inverted preamble nibbles outside the matched
+ *                         nibble window, formatted as:
+ *
+ *                             <before>_..._<after>
+ *
+ *                         where <before> is the unmatched part before the
+ *                         matched preamble window and <after> is the unmatched
+ *                         part after it
+ *
+ * ---------------------------------------------------------------------------
+ * Preamble detection
+ * ---------------------------------------------------------------------------
+ * Full preamble (already in the expected polarity for search):
+ *
+ *     96 f5 13 85 37 b4
+ *
+ * The decoder may search only a configurable nibble window inside this full
+ * preamble. The unmatched nibbles are not validated and are reported in the
+ * output as "unmatched_preamble" after nibble-wise inversion.
+ *
+ * Important:
+ * - The payload extraction offset is always derived from the start of the
+ *   FULL 48-bit preamble, even if only a sub-range of nibbles is matched.
+ * - This ensures serial / suffix / counter extraction stays aligned when the
+ *   preamble match window is changed.
+ *
+ * ---------------------------------------------------------------------------
+ * Buffer polarity
+ * ---------------------------------------------------------------------------
+ * This decoder keeps the original polarity behavior:
+ *
+ *     bitbuffer_invert(bitbuffer);
+ *
+ * The preamble is located first, and the shared bitbuffer is inverted only
+ * afterwards, before payload extraction.
+ *
+ * As a result, verbose (-V) output shows the buffer in the polarity expected
+ * by this decoder.
+ *
+ * ---------------------------------------------------------------------------
+ * Decoding behavior
+ * ---------------------------------------------------------------------------
+ * - serial/serials is mandatory
+ * - the decoder is silent when no serial filter is provided
+ * - a warning is printed once if serial/serials is missing
+ * - automatic native gear / unit detection is based on bytes after the serial:
+ *
+ *     b[3] == 0x73 && b[4] == 0x00
+ *         -> gear = 0.1, native_unit = m3
+ *
+ *     b[3] == 0x00 && (b[4] == 0x00 || b[4] == 0x40)
+ *         -> gear = 0.01, native_unit = m3
+ *
+ *     b[3] == 0x27 && b[4] == 0x00
+ *         -> gear = 0.1, native_unit = USG
+ *
+ *     default
+ *         -> gear = 0.1, native_unit = m3
+ *
+ * Override order:
+ *
+ *     auto -> gear override -> units override -> convert
+ *
+ * Meaning:
+ * - gear=<...>   overrides the detected native gear
+ * - units=<...>  overrides the detected native unit
+ * - convert=<...> converts the numeric output volume to the requested unit
+ *
+ * Notes:
+ * - units= changes the native interpretation
+ * - convert= changes the displayed numeric output
+ * - convert overrides units in output selection
+ *
+ * ---------------------------------------------------------------------------
+ * Implementation notes
+ * ---------------------------------------------------------------------------
+ * - MSVC / Windows compatible tokenizer
+ * - no strtok_r
+ * - no DATA_FORMAT varargs usage
+ * - output uses separate numeric and unit fields
+ */
 
 #include "decoder.h"
 
-/**
-Arad/Master Meter Dialog3G water utility meter.
+#include <ctype.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-FCC-Id: TKCET-733
+#define ARAD_MM_MAX_SERIAL_FILTER 64
 
-See notes in https://45851052.fs1.hubspotusercontent-na1.net/hubfs/45851052/documents/files/Interpreter-II-Register_v0710.20F.pdf
-and https://www.arad.co.il/wp-content/uploads/Dialog-3G-register-information-sheet_Eng-002.pdf
+typedef struct {
+    uint32_t ser24; // 24-bit serial
+    int suffix;     // 0..255 if valid, else -1 (ignore suffix)
+} arad_mm_serial_filter_t;
 
-Programmable parameters:
-- Meter User ID:
-  A municipal Meter ID number of up to 5 digits (16 or 17 bits needed)
-- Transponder No:
-  Meter’s Dialog 3GTM transponder number of up to 12 digits (40 bits needed)
-- Reading:
-  The transmitted Dialog 3G TM meter reading (up to 9 digits), (30 bits needed)
-  the accumulated and the display readout are always equivalent.
-- Meter Type:
-  Meter type such as water, gas or electricity
-- Count Factor:
-  Meter count unit. It is a pre scale factor which is initially programmed
-  into the Dialog 3G TM unit is order to get the standaed measurement units
-  for the system billing, management and calculation (Gallons or Cubic/ Mettic)
-- Alarms Temper:
-  A warning temper sign, in case of unauthorized meter tampering. CCW: Reverse
-  consumption by the meter.
-- Gear Ratio:
-  Water meter mechanical gear ratio parameter for the 3G Interpreter register types
+typedef enum {
+    ARAD_UNIT_M3 = 0,
+    ARAD_UNIT_LITERS,
+    ARAD_UNIT_CF,
+    ARAD_UNIT_USG,
+} arad_unit_t;
 
-Programmable registration includes USG, CF, or M3, while
-resolution of the flow multiplier provides a custom-tailored
-enhanced display (.01, 0.1, 1, 10, 100).
+typedef struct {
+    // serial filter (MANDATORY)
+    unsigned count;
+    arad_mm_serial_filter_t items[ARAD_MM_MAX_SERIAL_FILTER];
 
-Message is being sent once every 30 seconds.
-The message looks like:
+    // user overrides
+    int user_gear_set;
+    double user_gear;
 
-    00000000FFFFFFFFFFFFFFSSSSSSSSXXCCCCCCXXXF?????????XFF
+    int user_units_set; // overrides NATIVE unit
+    arad_unit_t user_units;
 
-where:
+    int user_convert_set; // output conversion
+    arad_unit_t user_convert;
 
-- 00000000 is preamble.
-- FFFFFFFFFFFFFF  is fixed in time and the same for other meters in the neighborhood. Probably gearing ratio. The payload is 3e690aec7ac84b.
-- SSSSSSSS  is Meter serial number.  for instance fa1c9073 =>  fa1c90 = 09444602, little endian 73= 'S'
-- XX no idea.
-- CCCCCC is the counter reading little endian for instance a80600= 1704
-- XXX no idea.
-- F  is fixed in time and the same for other meters in the neighborhood. With payload of 5.
-- ????????? probably some kind of CRC or checksum - here is where I need help.
-- X is getting either 8 or 0 same for other meters in the neighborhood.
-- FF is fixed in time and the same for other meters in the neighborhood.With payload f8.
+    int warned_no_serial;
 
-Format string:
+    int filter_mode;
+} arad_mm_ctx_t;
 
-    UID:56h SERIAL: <24d c 8h COUNTER: <32d 8h8h 8h8h 8h8h  SUFFIX:hh
+static char *arad_trim_inplace(char *s)
+{
+    if (!s)
+        return s;
+    while (*s && isspace((unsigned char)*s))
+        s++;
+    if (!*s)
+        return s;
 
-*/
+    char *e = s + strlen(s) - 1;
+    while (e > s && isspace((unsigned char)*e)) {
+        *e = '\0';
+        --e;
+    }
+    return s;
+}
+
+static int arad_ieq(const char *a, const char *b)
+{
+    if (!a || !b)
+        return 0;
+    while (*a && *b) {
+        if (tolower((unsigned char)*a) != tolower((unsigned char)*b))
+            return 0;
+        ++a;
+        ++b;
+    }
+    return *a == '\0' && *b == '\0';
+}
+
+static char *arad_strtok(char *str, const char *delim, char **saveptr)
+{
+#ifdef _MSC_VER
+    return strtok_s(str, delim, saveptr);
+#else
+    return strtok_r(str, delim, saveptr);
+#endif
+}
+
+static int arad_parse_u32_auto(const char *s, uint32_t *out)
+{
+    if (!s || !out)
+        return 0;
+    while (*s && isspace((unsigned char)*s))
+        s++;
+
+    int base = 10;
+    if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) {
+        base = 16;
+        s += 2;
+    }
+    else {
+        for (const char *p = s; *p; ++p) {
+            if ((*p >= 'a' && *p <= 'f') || (*p >= 'A' && *p <= 'F')) {
+                base = 16;
+                break;
+            }
+        }
+    }
+
+    char *endp      = NULL;
+    unsigned long v = strtoul(s, &endp, base);
+    if (endp == s)
+        return 0;
+    while (*endp && isspace((unsigned char)*endp))
+        endp++;
+    if (*endp != '\0')
+        return 0;
+
+    *out = (uint32_t)v;
+    return 1;
+}
+
+static void arad_ctx_add_filter(arad_mm_ctx_t *ctx, uint32_t ser24, int suffix_or_minus1)
+{
+    if (!ctx)
+        return;
+    if (ctx->count >= ARAD_MM_MAX_SERIAL_FILTER)
+        return;
+
+    ctx->items[ctx->count].ser24  = (ser24 & 0x00ffffffu);
+    ctx->items[ctx->count].suffix = suffix_or_minus1;
+    ctx->count++;
+}
+
+static int arad_sum_decimal_digits(const char *s, unsigned *digits_out)
+{
+    if (!s)
+        return -1;
+    while (*s && isspace((unsigned char)*s))
+        s++;
+    if (!*s)
+        return -1;
+
+    unsigned digits = 0;
+    int sum         = 0;
+    for (const char *p = s; *p; ++p) {
+        if (isspace((unsigned char)*p))
+            continue;
+        if (*p < '0' || *p > '9')
+            return -1;
+        sum += (int)(*p - '0');
+        digits++;
+    }
+
+    if (digits_out)
+        *digits_out = digits;
+    return sum;
+}
+
+static int arad_token_is_special(const char *tok)
+{
+    unsigned digits = 0;
+    int sum         = arad_sum_decimal_digits(tok, &digits);
+    if (sum < 0)
+        return 0;
+
+    if (digits != 8)
+        return 0;
+
+    int expected = 0;
+    for (unsigned i = 0; i < digits; ++i)
+        expected += 9;
+
+    return sum == expected;
+}
+
+static void arad_parse_serial_list(arad_mm_ctx_t *ctx, char *list)
+{
+    if (!ctx || !list)
+        return;
+
+    // split by comma/semicolon/whitespace into NUL-separated tokens
+    for (char *p = list; *p; ++p) {
+        if (*p == ',' || *p == ';' || isspace((unsigned char)*p))
+            *p = '\0';
+    }
+
+    char *p   = list;
+    char *end = list + strlen(list) + 1;
+    while (p < end) {
+        if (!*p) {
+            ++p;
+            continue;
+        }
+
+        char *tok = arad_trim_inplace(p);
+        p += strlen(p) + 1;
+        if (!tok || !*tok)
+            continue;
+
+        if (arad_token_is_special(tok)) {
+            ctx->filter_mode = 0;
+            continue;
+        }
+
+        // Accept "SERIAL-SUFFIX"
+        char *dash = strchr(tok, '-');
+        if (dash) {
+            *dash       = '\0';
+            char *ser_s = arad_trim_inplace(tok);
+            char *suf_s = arad_trim_inplace(dash + 1);
+
+            uint32_t ser_v = 0, suf_v = 0;
+            if (arad_parse_u32_auto(ser_s, &ser_v) && arad_parse_u32_auto(suf_s, &suf_v)) {
+                if (suf_v <= 0xffu) {
+                    arad_ctx_add_filter(ctx, ser_v, (int)suf_v);
+                }
+            }
+            continue;
+        }
+
+        // Just serial
+        uint32_t ser_v = 0;
+        if (arad_parse_u32_auto(tok, &ser_v)) {
+            arad_ctx_add_filter(ctx, ser_v, -1);
+        }
+    }
+}
+
+static int arad_serial_matches_mandatory(const arad_mm_ctx_t *ctx, uint32_t ser24, uint8_t suffix)
+{
+    if (!ctx)
+        return 0;
+    if (ctx->count == 0)
+        return 0; // mandatory
+
+    ser24 &= 0x00ffffffu;
+    for (unsigned i = 0; i < ctx->count; ++i) {
+        if (ctx->items[i].ser24 != ser24)
+            continue;
+        if (ctx->items[i].suffix < 0)
+            return 1;
+        if ((uint8_t)ctx->items[i].suffix == suffix)
+            return 1;
+    }
+    return 0;
+}
+
+static int arad_parse_gear(const char *s, double *out)
+{
+    if (!s || !out)
+        return 0;
+    while (*s && isspace((unsigned char)*s))
+        s++;
+    if (!*s)
+        return 0;
+
+    if (strcmp(s, "0.01") == 0) {
+        *out = 0.01;
+        return 1;
+    }
+    if (strcmp(s, "0.1") == 0) {
+        *out = 0.1;
+        return 1;
+    }
+    if (strcmp(s, "1") == 0) {
+        *out = 1.0;
+        return 1;
+    }
+    if (strcmp(s, "10") == 0) {
+        *out = 10.0;
+        return 1;
+    }
+    if (strcmp(s, "100") == 0) {
+        *out = 100.0;
+        return 1;
+    }
+
+    if (strcmp(s, "1.0") == 0) {
+        *out = 1.0;
+        return 1;
+    }
+    if (strcmp(s, "10.0") == 0) {
+        *out = 10.0;
+        return 1;
+    }
+    if (strcmp(s, "100.0") == 0) {
+        *out = 100.0;
+        return 1;
+    }
+
+    return 0;
+}
+
+static int arad_parse_unit(const char *s, arad_unit_t *out)
+{
+    if (!s || !out)
+        return 0;
+    while (*s && isspace((unsigned char)*s))
+        s++;
+    if (!*s)
+        return 0;
+
+    if (arad_ieq(s, "m3")) {
+        *out = ARAD_UNIT_M3;
+        return 1;
+    }
+    if (arad_ieq(s, "liters")) {
+        *out = ARAD_UNIT_LITERS;
+        return 1;
+    }
+    if (arad_ieq(s, "liter")) {
+        *out = ARAD_UNIT_LITERS;
+        return 1;
+    }
+    if (arad_ieq(s, "l")) {
+        *out = ARAD_UNIT_LITERS;
+        return 1;
+    }
+    if (arad_ieq(s, "cf")) {
+        *out = ARAD_UNIT_CF;
+        return 1;
+    }
+    if (arad_ieq(s, "usg")) {
+        *out = ARAD_UNIT_USG;
+        return 1;
+    }
+    if (arad_ieq(s, "gallon")) {
+        *out = ARAD_UNIT_USG;
+        return 1;
+    }
+    if (arad_ieq(s, "gallons")) {
+        *out = ARAD_UNIT_USG;
+        return 1;
+    }
+
+    return 0;
+}
+
+static const char *arad_unit_str(arad_unit_t u)
+{
+    switch (u) {
+    case ARAD_UNIT_M3: return "m3";
+    case ARAD_UNIT_LITERS: return "Liters";
+    case ARAD_UNIT_CF: return "CF";
+    case ARAD_UNIT_USG: return "USG";
+    default: return "m3";
+    }
+}
+
+static double arad_units_to_m3(arad_unit_t u, double v_in_units)
+{
+    switch (u) {
+    case ARAD_UNIT_M3: return v_in_units;
+    case ARAD_UNIT_LITERS: return v_in_units / 1000.0;
+    case ARAD_UNIT_CF: return v_in_units * 0.028316846592;
+    case ARAD_UNIT_USG: return v_in_units * 0.003785411784;
+    default: return v_in_units;
+    }
+}
+
+static double arad_m3_to_units(arad_unit_t u, double v_m3)
+{
+    switch (u) {
+    case ARAD_UNIT_M3: return v_m3;
+    case ARAD_UNIT_LITERS: return v_m3 * 1000.0;
+    case ARAD_UNIT_CF: return v_m3 / 0.028316846592;
+    case ARAD_UNIT_USG: return v_m3 / 0.003785411784;
+    default: return v_m3;
+    }
+}
+
+static void arad_auto_gear_units(uint8_t after0, uint8_t after1, double *gear, arad_unit_t *unit)
+{
+    // Defaults
+    double g      = 0.1;
+    arad_unit_t u = ARAD_UNIT_M3;
+
+    // Rules
+    if (after0 == 0x73 && after1 == 0x00) {
+        g = 0.1;
+        u = ARAD_UNIT_M3;
+    }
+    else if (after0 == 0x00 && (after1 == 0x00 || after1 == 0x40)) {
+        g = 0.01;
+        u = ARAD_UNIT_M3;
+    }
+    else if (after0 == 0x27 && after1 == 0x00) {
+        g = 0.1;
+        u = ARAD_UNIT_USG;
+    }
+
+    if (gear)
+        *gear = g;
+    if (unit)
+        *unit = u;
+}
+
+/* Build a contiguous nibble-range pattern from the full 48-bit preamble.
+ * start_nibble/end_nibble are in [0..12], where 0 is the HIGH nibble of 0x96.
+ * end_nibble is exclusive. Required: 0 <= start < end <= 12.
+ *
+ * Output:
+ *   out_bytes: pattern packed MSB-first
+ *   out_bits:  number of bits to search (multiple of 4)
+ * Returns 1 on success, 0 on invalid input.
+ */
+static int arad_build_preamble_nibble_pattern(
+        uint8_t out_bytes[6],
+        unsigned *out_bits,
+        unsigned start_nibble,
+        unsigned end_nibble)
+{
+    static const uint8_t full[6] = {0x96, 0xf5, 0x13, 0x85, 0x37, 0xb4};
+
+    if (!out_bytes || !out_bits)
+        return 0;
+    if (start_nibble >= end_nibble || end_nibble > 12)
+        return 0;
+
+    // Expand full preamble into 12 nibbles: [0]=0x9, [1]=0x6, [2]=0xF, [3]=0x5, ...
+    uint8_t n[12];
+    for (unsigned i = 0; i < 6; ++i) {
+        n[2 * i + 0] = (uint8_t)((full[i] >> 4) & 0x0F);
+        n[2 * i + 1] = (uint8_t)(full[i] & 0x0F);
+    }
+
+    const unsigned nib_count = end_nibble - start_nibble; // >= 1
+    const unsigned bit_count = nib_count * 4;
+
+    // Pack nibbles MSB-first into bytes (bitbuffer_search expects MSB-first patterns)
+    memset(out_bytes, 0, 6);
+    unsigned bitpos = 0;
+    for (unsigned i = 0; i < nib_count; ++i) {
+        uint8_t nib = n[start_nibble + i] & 0x0F;
+        for (unsigned b = 0; b < 4; ++b) {
+            // take nib MSB -> LSB
+            unsigned bit = (nib >> (3 - b)) & 1u;
+
+            unsigned byte_index  = bitpos / 8;
+            unsigned bit_in_byte = 7u - (bitpos % 8); // MSB-first
+            if (bit)
+                out_bytes[byte_index] |= (uint8_t)(1u << bit_in_byte);
+
+            bitpos++;
+        }
+    }
+
+    *out_bits = bit_count;
+    return 1;
+}
+
+/* Build a string containing the INVERTED preamble nibbles
+ * NOT covered by [start_nibble, end_nibble).
+ * The unmatched parts BEFORE and AFTER the matched window
+ * are separated by "_..._".
+ *
+ * Inversion is done per nibble: out = 0xF ^ in.
+ * Output format: hex nibbles (uppercase), no separators.
+ */
+static void arad_format_unmatched_preamble(
+        char *out,
+        size_t out_sz,
+        unsigned start_nibble,
+        unsigned end_nibble)
+{
+    static const uint8_t full[6] = {0x96, 0xf5, 0x13, 0x85, 0x37, 0xb4};
+
+    if (!out || out_sz == 0)
+        return;
+    out[0] = '\0';
+
+    /* Expand full preamble into 12 nibbles */
+    uint8_t n[12];
+    for (unsigned i = 0; i < 6; ++i) {
+        n[2 * i + 0] = (uint8_t)((full[i] >> 4) & 0x0F);
+        n[2 * i + 1] = (uint8_t)(full[i] & 0x0F);
+    }
+
+    size_t w         = 0;
+    int wrote_before = 0;
+
+    /* BEFORE matched window */
+    for (unsigned i = 0; i < start_nibble; ++i) {
+        if (w + 1 >= out_sz)
+            break;
+        uint8_t inv  = (uint8_t)(n[i] ^ 0x0F);
+        out[w++]     = (char)((inv < 10) ? ('0' + inv) : ('A' + (inv - 10)));
+        out[w]       = '\0';
+        wrote_before = 1;
+    }
+
+    /* Separator between BEFORE and AFTER (only if there is AFTER) */
+    if (end_nibble < 12) {
+        const char sep[] = "_..._";
+        size_t sep_len   = sizeof(sep) - 1;
+
+        if (w + sep_len < out_sz) {
+            memcpy(&out[w], sep, sep_len);
+            w += sep_len;
+            out[w] = '\0';
+        }
+    }
+
+    /* AFTER matched window */
+    for (unsigned i = end_nibble; i < 12; ++i) {
+        if (w + 1 >= out_sz)
+            break;
+        uint8_t inv = (uint8_t)(n[i] ^ 0x0F);
+        out[w++]    = (char)((inv < 10) ? ('0' + inv) : ('A' + (inv - 10)));
+        out[w]      = '\0';
+    }
+}
+
+/* ---------- decoder ---------- */
+
+static r_device *arad_ms_meter_create(char *args);
 
 static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    uint8_t const preamble_pattern[] = {0x96, 0xf5, 0x13, 0x85, 0x37, 0xb4}; // 48 bit preamble
+    /* ---- Preamble matching window (nibbles) ----
+     * Full preamble (inverted polarity, do NOT change):
+     *   96 f5 13 85 37 b4
+     *
+     * Configure which nibbles are matched:
+     *   nibble index 0..11, where 0 is HIGH nibble of 0x96, 11 is LOW nibble of 0xB4.
+     *   start_nibble inclusive, end_nibble exclusive.
+     *
+     * Example:
+     *   start_nibble=0, end_nibble=12  -> match full preamble (48 bits)
+     *   start_nibble=2, end_nibble=10  -> match middle 8 nibbles (32 bits)
+     */
+    /* ---- Preamble matching window (nibbles) ---- */
+    const unsigned start_nibble = 1; /* inclusive, 0..11 */
+    const unsigned end_nibble   = 8; /* exclusive, 1..12 */
 
-    int row = bitbuffer_find_repeated_row(bitbuffer, 1, 168); // expected 1 row with minimum of 48+120= 168 bits.
-    if (row < 0) {
+    uint8_t preamble_pat[6];
+    unsigned preamble_bits = 0;
+
+    if (!arad_build_preamble_nibble_pattern(preamble_pat, &preamble_bits, start_nibble, end_nibble))
         return DECODE_ABORT_EARLY;
-    }
 
-    unsigned start_pos = bitbuffer_search(bitbuffer, row, 0, preamble_pattern, 48);
-    start_pos += 48; // skip preamble
+    int row = bitbuffer_find_repeated_row(bitbuffer, 1, 168);
+    if (row < 0)
+        return DECODE_ABORT_EARLY;
 
-    if (start_pos + 120 > bitbuffer->bits_per_row[row]) {
-        return DECODE_ABORT_LENGTH; // short buffer or preamble not found
-    }
+    int match_pos_i = (int)bitbuffer_search(bitbuffer, row, 0, preamble_pat, preamble_bits);
+    if (match_pos_i < 0)
+        return DECODE_ABORT_EARLY;
 
+    /* Build unmatched_preamble (already inverted + "_..._" separator in your current function) */
+    char unmatched_preamble[32];
+    arad_format_unmatched_preamble(unmatched_preamble, sizeof(unmatched_preamble), start_nibble, end_nibble);
+
+    /*
+     * Critical fix:
+     * Compute the start of the FULL 48-bit preamble from the window match position,
+     * then start payload AFTER the full preamble (always +48), regardless of window.
+     */
+    int full_preamble_start_i = match_pos_i - (int)(start_nibble * 4);
+    if (full_preamble_start_i < 0)
+        return DECODE_ABORT_EARLY;
+
+    unsigned payload_start = (unsigned)full_preamble_start_i + 48;
+
+    /* Optional: ensure we have enough bits for payload */
+    if (payload_start + 120 > bitbuffer->bits_per_row[row])
+        return DECODE_ABORT_LENGTH;
+
+    /* Keep original behavior: invert AFTER locating preamble */
     bitbuffer_invert(bitbuffer);
 
+    /* Extract payload from the FIXED position */
     uint8_t b[15];
-    bitbuffer_extract_bytes(bitbuffer, row, start_pos, b, 120);
+    bitbuffer_extract_bytes(bitbuffer, row, payload_start, b, 120);
 
-    int serno    = b[0] | (b[1] << 8) | (b[2] << 16); // 24 bit little endian Meter Serial number
-    int wreadraw = b[5] | (b[6] << 8) | (b[7] << 16); // 24 bit little endian Meter water consumption reading
-    float wread = wreadraw * 0.1f;
+    uint32_t serno    = (uint32_t)b[0] | ((uint32_t)b[1] << 8) | ((uint32_t)b[2] << 16);
+    uint8_t after0    = b[3]; // byte after serial
+    uint8_t after1    = b[4]; // next byte
+    uint32_t wreadraw = (uint32_t)b[5] | ((uint32_t)b[6] << 8) | ((uint32_t)b[7] << 16);
 
-    char sernoout[12];
-    sprintf(sernoout, "%08u-%02x", serno, b[3]);
+    arad_mm_ctx_t *ctx = (arad_mm_ctx_t *)decoder_user_data(decoder);
+    if (!ctx)
+        return DECODE_ABORT_EARLY;
+
+    if (ctx->filter_mode) {
+        if (ctx->count == 0) {
+            if (!ctx->warned_no_serial) {
+                ctx->warned_no_serial = 1;
+                fprintf(stderr,
+                        "AradMsMeter-Dialog3G: serials mandatory. Example: -R 260:v:serials=13751342\n");
+            }
+            return DECODE_ABORT_EARLY;
+        }
+
+        // Match by serial + optional suffix (suffix matches after0)
+        if (!arad_serial_matches_mandatory(ctx, serno, after0))
+            return DECODE_ABORT_EARLY;
+    }
+
+    // AUTO native gear/unit
+    double native_gear      = 0.1;
+    arad_unit_t native_unit = ARAD_UNIT_M3;
+    arad_auto_gear_units(after0, after1, &native_gear, &native_unit);
+
+    // user overrides: gear overrides auto; units overrides NATIVE unit (as you requested)
+    if (ctx->user_gear_set) {
+        native_gear = ctx->user_gear;
+    }
+    if (ctx->user_units_set) {
+        native_unit = ctx->user_units;
+    }
+
+    // Native volume in native_unit
+    double volume_native = (double)wreadraw * native_gear;
+
+    // True m3 derived from native_unit
+    double volume_m3 = arad_units_to_m3(native_unit, volume_native);
+
+    // Output selection
+    double out_volume    = volume_native;
+    arad_unit_t out_unit = native_unit;
+
+    if (ctx->user_convert_set) {
+        out_unit   = ctx->user_convert;
+        out_volume = arad_m3_to_units(out_unit, volume_m3);
+    }
+
+    char id_out[16];
+    snprintf(id_out, sizeof(id_out), "%08u-%02x", (unsigned)serno, (unsigned)after0);
 
     /* clang-format off */
     data_t *data = data_make(
-            "model",       "",               DATA_STRING,    "AradMsMeter-Dialog3G",
-            "id",          "Serial No",      DATA_STRING,    sernoout,
-            "volume_m3",   "Volume",         DATA_FORMAT,    "%.1f m3",  DATA_DOUBLE, wread,
-            //"mic",         "Integrity",      DATA_STRING,    "CHECKSUM",
+            "model",        "",              DATA_STRING, "AradMsMeter-Dialog3G",
+            "id",           "Serial No",     DATA_STRING, id_out,
+            "unmtchd prambl","Unmatched Preamble Nibbles", DATA_STRING, unmatched_preamble,
+            "volume",       "Volume",        DATA_DOUBLE, out_volume,
+            "unit",         "Unit",          DATA_STRING, arad_unit_str(out_unit),
+            "volume_m3",    "Volume (m3)",   DATA_DOUBLE, volume_m3,
+            "gear",         "Gear",          DATA_DOUBLE, native_gear,
+            "native_unit",  "Native Unit",   DATA_STRING, arad_unit_str(native_unit),
             NULL);
     /* clang-format on */
 
@@ -111,8 +911,12 @@ static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 static char const *const output_fields[] = {
         "model",
         "id",
+        "unmtchd prambl",
+        "volume",
+        "unit",
         "volume_m3",
-        //"mic",
+        "gear",
+        "native_unit",
         NULL,
 };
 
@@ -120,9 +924,130 @@ r_device const arad_ms_meter = {
         .name        = "Arad/Master Meter Dialog3G water utility meter",
         .modulation  = FSK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 8.4,
-        .long_width  = 8.4, // not used
+        .long_width  = 8.4,
         .reset_limit = 30,
         .decode_fn   = &arad_mm_dialog3g_decode,
-        .disabled    = 1, // checksum not implemented
+        .create_fn   = &arad_ms_meter_create,
+        .disabled    = 1,
         .fields      = output_fields,
 };
+
+static r_device *arad_ms_meter_create(char *args)
+{
+    r_device *dev = decoder_create(&arad_ms_meter, sizeof(arad_mm_ctx_t));
+    if (!dev)
+        return NULL;
+
+    arad_mm_ctx_t *ctx = (arad_mm_ctx_t *)decoder_user_data(dev);
+
+    ctx->count = 0;
+
+    ctx->user_gear_set = 0;
+    ctx->user_gear     = 0.1;
+
+    ctx->user_units_set = 0;
+    ctx->user_units     = ARAD_UNIT_M3;
+
+    ctx->user_convert_set = 0;
+    ctx->user_convert     = ARAD_UNIT_M3;
+
+    ctx->warned_no_serial = 0;
+    ctx->filter_mode      = 1;
+
+    if (!args)
+        return dev;
+    args = arad_trim_inplace(args);
+    if (!*args)
+        return dev;
+
+    // Parse key=value tokens separated by ':' or ',' (rtl_433 uses ':' between decoder args)
+    char *work = strdup(args);
+    if (!work)
+        return dev;
+
+    char *saveptr = NULL;
+    char *tok     = arad_strtok(work, ",:", &saveptr);
+
+    int collecting_serials = 0;
+    char serial_buf[512];
+    serial_buf[0] = '\0';
+
+    while (tok) {
+        char *t = arad_trim_inplace(tok);
+        if (!t || !*t) {
+            tok = arad_strtok(NULL, ",:", &saveptr);
+            continue;
+        }
+
+        // allow lone flags like "v" (ignore), and serial list continuation
+        if (!strchr(t, '=')) {
+            if (collecting_serials) {
+                if (serial_buf[0])
+                    strncat(serial_buf, ",", sizeof(serial_buf) - strlen(serial_buf) - 1);
+                strncat(serial_buf, t, sizeof(serial_buf) - strlen(serial_buf) - 1);
+            }
+            tok = arad_strtok(NULL, ",:", &saveptr);
+            continue;
+        }
+
+        // If we were collecting serials and hit a new key=value, flush serials first
+        if (collecting_serials) {
+            if (serial_buf[0]) {
+                arad_parse_serial_list(ctx, serial_buf);
+                serial_buf[0] = '\0';
+            }
+            collecting_serials = 0;
+        }
+
+        char *eq = strchr(t, '=');
+        if (!eq) {
+            tok = arad_strtok(NULL, ",:", &saveptr);
+            continue;
+        }
+
+        *eq       = '\0';
+        char *key = arad_trim_inplace(t);
+        char *val = arad_trim_inplace(eq + 1);
+        if (!val)
+            val = (char *)"";
+
+        if (arad_ieq(key, "serial") || arad_ieq(key, "serials")) {
+            collecting_serials = 1;
+            serial_buf[0]      = '\0';
+            if (*val) {
+                strncat(serial_buf, val, sizeof(serial_buf) - 1);
+                serial_buf[sizeof(serial_buf) - 1] = '\0';
+            }
+        }
+        else if (arad_ieq(key, "gear")) {
+            double g = 0.0;
+            if (arad_parse_gear(val, &g)) {
+                ctx->user_gear_set = 1;
+                ctx->user_gear     = g;
+            }
+        }
+        else if (arad_ieq(key, "units")) {
+            arad_unit_t u;
+            if (arad_parse_unit(val, &u)) {
+                ctx->user_units_set = 1;
+                ctx->user_units     = u;
+            }
+        }
+        else if (arad_ieq(key, "convert")) {
+            arad_unit_t u;
+            if (arad_parse_unit(val, &u)) {
+                ctx->user_convert_set = 1;
+                ctx->user_convert     = u;
+            }
+        }
+
+        tok = arad_strtok(NULL, ",:", &saveptr);
+    }
+
+    if (collecting_serials && serial_buf[0]) {
+        arad_parse_serial_list(ctx, serial_buf);
+    }
+
+    free(work);
+    return dev;
+}

--- a/src/devices/arad_ms_meter.c
+++ b/src/devices/arad_ms_meter.c
@@ -774,6 +774,7 @@ Implementation notes
 - no strtok_r
 - no DATA_FORMAT varargs usage
 - output uses separate numeric and unit fields
+
 */
 
 static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)

--- a/src/devices/arad_ms_meter.c
+++ b/src/devices/arad_ms_meter.c
@@ -1,4 +1,4 @@
-﻿/** @file
+/** @file
     Arad/Master Meter Dialog3G water utility meter.
 
     Copyright (C) 2022 avicarmeli
@@ -774,7 +774,6 @@ Implementation notes
 - no strtok_r
 - no DATA_FORMAT varargs usage
 - output uses separate numeric and unit fields
-
 */
 
 static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)

--- a/src/devices/arad_ms_meter.c
+++ b/src/devices/arad_ms_meter.c
@@ -1,4 +1,4 @@
-/** @file
+﻿/** @file
     Arad/Master Meter Dialog3G water utility meter.
 
     Copyright (C) 2022 avicarmeli

--- a/src/devices/arad_ms_meter.c
+++ b/src/devices/arad_ms_meter.c
@@ -455,7 +455,7 @@ static int arad_build_preamble_nibble_pattern(
     return 1;
 }
 
-/* 	Build a string containing the INVERTED preamble nibbles
+/*  Build a string containing the INVERTED preamble nibbles
         NOT covered by [start_nibble, end_nibble).
         The unmatched parts BEFORE and AFTER the matched window
         are separated by "_..._".
@@ -779,7 +779,7 @@ Implementation notes
 
 static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    /* 	---- Preamble matching window (nibbles) ----
+    /*  ---- Preamble matching window (nibbles) ----
                 Full preamble (inverted polarity, do NOT change):
                 96 f5 13 85 37 b4
 

--- a/src/devices/arad_ms_meter.c
+++ b/src/devices/arad_ms_meter.c
@@ -632,5 +632,6 @@ r_device const arad_ms_meter = {
         .reset_limit = 100,
         .decode_fn   = &arad_mm_dialog3g_decode,
         .create_fn   = &arad_ms_meter_create,
+        .disabled    = 0,
         .fields      = output_fields,
 };

--- a/src/devices/arad_ms_meter.c
+++ b/src/devices/arad_ms_meter.c
@@ -496,8 +496,10 @@ Format string:
 */
 static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    uint8_t const preamble_pattern[] = {0x85, 0x37};
-    arad_mm_ctx_t *ctx               = (arad_mm_ctx_t *)decoder_user_data(decoder);
+    uint8_t const preamble_pattern[]            = {0xf5, 0x13, 0x85, 0x37}; //Full preamble (inverted polarity): 96 f5 13 85 37 b4
+    unsigned const preamble_pattern_bits        = 32;
+    unsigned const preamble_pattern_offset_bits = 8; // f5 starts 8 bits after full preamble start
+    arad_mm_ctx_t *ctx                          = (arad_mm_ctx_t *)decoder_user_data(decoder);
     uint8_t b[16];
     uint8_t u[7];
     uint64_t xor_raw;
@@ -505,8 +507,10 @@ static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     char uid_str[15];
     char sernoout[12];
     int row = 0;
-    int start_uid;
-    unsigned start_pos;
+    unsigned match_pos;
+    int full_preamble_start;
+    unsigned payload_start;
+    unsigned uid_bits;
     int corrections = 0;
     int leaking;
     uint32_t serno;
@@ -526,23 +530,30 @@ static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     if (bitbuffer->bits_per_row[row] < 18 * 8)
         return DECODE_ABORT_LENGTH;
 
-    start_pos = bitbuffer_search(bitbuffer, row, 0, preamble_pattern, 16);
-    if (start_pos + 144 > bitbuffer->bits_per_row[row]) {
+    match_pos = bitbuffer_search(bitbuffer, row, 0, preamble_pattern, preamble_pattern_bits);
+    if (match_pos + preamble_pattern_bits > bitbuffer->bits_per_row[row]) {
         decoder_log(decoder, 2, __func__, "Sync word not found");
         return DECODE_ABORT_LENGTH;
     }
 
-    start_uid = (int)start_pos - 32;
-    if (start_uid < 0)
-        start_uid = 0;
+    full_preamble_start = (int)match_pos - (int)preamble_pattern_offset_bits;
+    if (full_preamble_start < 0)
+        return DECODE_ABORT_EARLY;
 
-    start_pos += 16;
+    payload_start = (unsigned)full_preamble_start + 48;
+    if (payload_start + 128 > bitbuffer->bits_per_row[row])
+        return DECODE_ABORT_LENGTH;
+
+    uid_bits = payload_start - (unsigned)full_preamble_start;
+    if (uid_bits > sizeof(u) * 8)
+        uid_bits = sizeof(u) * 8;
+
     bitbuffer_invert(bitbuffer);
 
-    bitbuffer_extract_bytes(bitbuffer, row, start_uid, u, start_pos + 8 - (unsigned)start_uid);
-    bitrow_snprint(u, start_pos + 8 - (unsigned)start_uid, uid_str, sizeof(uid_str));
+    bitbuffer_extract_bytes(bitbuffer, row, (unsigned)full_preamble_start, u, uid_bits);
+    bitrow_snprint(u, uid_bits, uid_str, sizeof(uid_str));
 
-    bitbuffer_extract_bytes(bitbuffer, row, start_pos, b, 128);
+    bitbuffer_extract_bytes(bitbuffer, row, payload_start, b, 128);
     decoder_log_bitrow(decoder, 2, __func__, b, 128, "MSG Extracted");
 
     xor_raw = ((uint64_t)b[11] << 32) | ((uint64_t)b[12] << 24) | ((uint64_t)b[13] << 16) | ((uint64_t)b[14] << 8) | b[15];

--- a/src/devices/arad_ms_meter.c
+++ b/src/devices/arad_ms_meter.c
@@ -496,10 +496,8 @@ Format string:
 */
 static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    uint8_t const preamble_pattern[]            = {0xf5, 0x13, 0x85, 0x37};
-    unsigned const preamble_pattern_bits        = 32;
-    unsigned const preamble_pattern_offset_bits = 16; /* f5 starts 16 bits after UID start */
-    arad_mm_ctx_t *ctx                          = (arad_mm_ctx_t *)decoder_user_data(decoder);
+    uint8_t const sync4[] = {0xf5, 0x13, 0x85, 0x37};
+    arad_mm_ctx_t *ctx    = (arad_mm_ctx_t *)decoder_user_data(decoder);
     uint8_t b[16];
     uint8_t u[7];
     uint64_t xor_raw;
@@ -508,9 +506,9 @@ static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     char sernoout[12];
     int row = 0;
     unsigned match_pos;
-    int uid_start;
     unsigned payload_start;
     unsigned uid_bits;
+    int uid_start;
     int corrections = 0;
     int leaking;
     uint32_t serno;
@@ -522,34 +520,21 @@ static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     float scale      = 0.1f;
     float volume;
 
-    if (bitbuffer->num_rows > 1) {
-        decoder_logf(decoder, 1, __func__, "Too many rows: %d", bitbuffer->num_rows);
+    if (bitbuffer->num_rows > 1)
         return DECODE_FAIL_SANITY;
-    }
 
     if (bitbuffer->bits_per_row[row] < 18 * 8)
         return DECODE_ABORT_LENGTH;
 
-    match_pos = bitbuffer_search(bitbuffer, row, 0, preamble_pattern, preamble_pattern_bits);
-    if (match_pos + preamble_pattern_bits > bitbuffer->bits_per_row[row]) {
-        decoder_log(decoder, 2, __func__, "Sync word not found");
+    match_pos = bitbuffer_search(bitbuffer, row, 0, sync4, 32);
+    if (match_pos + 32 > bitbuffer->bits_per_row[row])
         return DECODE_ABORT_LENGTH;
-    }
 
-    uid_start = (int)match_pos - (int)preamble_pattern_offset_bits;
+    uid_start = (int)match_pos - 16;
     if (uid_start < 0)
-        return DECODE_ABORT_EARLY;
+        uid_start = 0;
 
-    /*
-     * Payload starts at byte 0xb4 in the non-inverted stream.
-     * After bitbuffer_invert(), this becomes 0x4b, the first checksum byte.
-     *
-     * For sync f5 13 85 37:
-     *   match_pos points to f5
-     *   payload starts after the matched 4 bytes, at b4
-     */
-    payload_start = match_pos + preamble_pattern_bits;
-
+    payload_start = match_pos + 32;
     if (payload_start + 128 > bitbuffer->bits_per_row[row])
         return DECODE_ABORT_LENGTH;
 
@@ -559,13 +544,19 @@ static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     bitbuffer_invert(bitbuffer);
 
+    memset(u, 0, sizeof(u));
     bitbuffer_extract_bytes(bitbuffer, row, (unsigned)uid_start, u, uid_bits);
     bitrow_snprint(u, uid_bits, uid_str, sizeof(uid_str));
 
+    memset(b, 0, sizeof(b));
     bitbuffer_extract_bytes(bitbuffer, row, payload_start, b, 128);
-    decoder_log_bitrow(decoder, 2, __func__, b, 128, "MSG Extracted");
 
-    xor_raw = ((uint64_t)b[11] << 32) | ((uint64_t)b[12] << 24) | ((uint64_t)b[13] << 16) | ((uint64_t)b[14] << 8) | b[15];
+    xor_raw = ((uint64_t)b[11] << 32) |
+              ((uint64_t)b[12] << 24) |
+              ((uint64_t)b[13] << 16) |
+              ((uint64_t)b[14] << 8) |
+              b[15];
+
     xor_cal = arad_checksum(b);
     if (xor_raw != xor_cal) {
         corrections = arad_correct_bits(b, xor_raw ^ xor_cal);
@@ -580,16 +571,21 @@ static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     wreadraw = (uint32_t)b[6] | ((uint32_t)b[7] << 8) | ((uint32_t)b[8] << 16);
     flags2   = b[10];
 
-    if (sn_sufx == 0x00 && (flags1 == 0x00 || flags1 == 0x40))
+    if (sn_sufx == 0x00 && (flags1 == 0x00 || flags1 == 0x40)) {
         scale = 0.01f;
-    else if (sn_sufx == 0x27 && flags1 == 0x00)
-        unit = ARAD_UNIT_USG;
+        unit  = ARAD_UNIT_M3;
+    }
+    else if (sn_sufx == 0x27 && flags1 == 0x00) {
+        scale = 0.1f;
+        unit  = ARAD_UNIT_USG;
+    }
 
     if (ctx && !arad_match_serial(ctx, serno, sn_sufx))
         return DECODE_ABORT_EARLY;
 
     if (ctx && ctx->user_gear_set)
         scale = ctx->user_gear;
+
     if (ctx && ctx->user_units_set)
         unit = ctx->user_units;
 

--- a/src/devices/arad_ms_meter.c
+++ b/src/devices/arad_ms_meter.c
@@ -496,9 +496,9 @@ Format string:
 */
 static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
-    uint8_t const preamble_pattern[]            = {0xf5, 0x13, 0x85, 0x37}; //Full preamble (inverted polarity): 96 f5 13 85 37 b4
+    uint8_t const preamble_pattern[]            = {0xf5, 0x13, 0x85, 0x37};
     unsigned const preamble_pattern_bits        = 32;
-    unsigned const preamble_pattern_offset_bits = 8; // f5 starts 8 bits after full preamble start
+    unsigned const preamble_pattern_offset_bits = 16; /* f5 starts 16 bits after UID start */
     arad_mm_ctx_t *ctx                          = (arad_mm_ctx_t *)decoder_user_data(decoder);
     uint8_t b[16];
     uint8_t u[7];
@@ -508,7 +508,7 @@ static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     char sernoout[12];
     int row = 0;
     unsigned match_pos;
-    int full_preamble_start;
+    int uid_start;
     unsigned payload_start;
     unsigned uid_bits;
     int corrections = 0;
@@ -536,21 +536,30 @@ static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_ABORT_LENGTH;
     }
 
-    full_preamble_start = (int)match_pos - (int)preamble_pattern_offset_bits;
-    if (full_preamble_start < 0)
+    uid_start = (int)match_pos - (int)preamble_pattern_offset_bits;
+    if (uid_start < 0)
         return DECODE_ABORT_EARLY;
 
-    payload_start = (unsigned)full_preamble_start + 48;
+    /*
+     * Payload starts at byte 0xb4 in the non-inverted stream.
+     * After bitbuffer_invert(), this becomes 0x4b, the first checksum byte.
+     *
+     * For sync f5 13 85 37:
+     *   match_pos points to f5
+     *   payload starts after the matched 4 bytes, at b4
+     */
+    payload_start = match_pos + preamble_pattern_bits;
+
     if (payload_start + 128 > bitbuffer->bits_per_row[row])
         return DECODE_ABORT_LENGTH;
 
-    uid_bits = payload_start - (unsigned)full_preamble_start;
+    uid_bits = payload_start - (unsigned)uid_start;
     if (uid_bits > sizeof(u) * 8)
         uid_bits = sizeof(u) * 8;
 
     bitbuffer_invert(bitbuffer);
 
-    bitbuffer_extract_bytes(bitbuffer, row, (unsigned)full_preamble_start, u, uid_bits);
+    bitbuffer_extract_bytes(bitbuffer, row, (unsigned)uid_start, u, uid_bits);
     bitrow_snprint(u, uid_bits, uid_str, sizeof(uid_str));
 
     bitbuffer_extract_bytes(bitbuffer, row, payload_start, b, 128);

--- a/src/devices/arad_ms_meter.c
+++ b/src/devices/arad_ms_meter.c
@@ -1,13 +1,12 @@
 /** @file
     Arad/Master Meter Dialog3G water utility meter.
 
-    Copyright (C) 2022 avicarmeli
+    Copyright (C) 2022 avicarmeli, ProfBoc75
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-
 */
 
 #include "decoder.h"
@@ -18,50 +17,42 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define ARAD_MM_MAX_SERIAL_FILTER 64
+#define ARAD_MM_MAX_SERIALS 64
 
 typedef struct {
-    uint32_t ser24; // 24-bit serial
-    int suffix;     // 0..255 if valid, else -1 (ignore suffix)
-} arad_mm_serial_filter_t;
+    uint32_t ser24;
+    int suffix;
+} arad_mm_serial_t;
 
 typedef enum {
     ARAD_UNIT_M3 = 0,
-    ARAD_UNIT_LITERS,
+    ARAD_UNIT_L,
     ARAD_UNIT_CF,
     ARAD_UNIT_USG,
 } arad_unit_t;
 
 typedef struct {
-    // serial filter (MANDATORY)
     unsigned count;
-    arad_mm_serial_filter_t items[ARAD_MM_MAX_SERIAL_FILTER];
-
-    // user overrides
+    arad_mm_serial_t serials[ARAD_MM_MAX_SERIALS];
     int user_gear_set;
-    double user_gear;
-
-    int user_units_set; // overrides NATIVE unit
+    float user_gear;
+    int user_units_set;
     arad_unit_t user_units;
-
-    int user_convert_set; // output conversion
-    arad_unit_t user_convert;
-
-    int warned_no_serial;
-
-    int filter_mode;
 } arad_mm_ctx_t;
 
-static char *arad_trim_inplace(char *s)
+static char *arad_trim(char *s)
 {
+    char *e;
+
     if (!s)
         return s;
+
     while (*s && isspace((unsigned char)*s))
         s++;
     if (!*s)
         return s;
 
-    char *e = s + strlen(s) - 1;
+    e = s + strlen(s) - 1;
     while (e > s && isspace((unsigned char)*e)) {
         *e = '\0';
         --e;
@@ -73,6 +64,7 @@ static int arad_ieq(const char *a, const char *b)
 {
     if (!a || !b)
         return 0;
+
     while (*a && *b) {
         if (tolower((unsigned char)*a) != tolower((unsigned char)*b))
             return 0;
@@ -91,209 +83,113 @@ static char *arad_strtok(char *str, const char *delim, char **saveptr)
 #endif
 }
 
-static int arad_parse_u32_auto(const char *s, uint32_t *out)
+static int arad_parse_u32(const char *s, uint32_t *out)
 {
+    char *endp = NULL;
+    unsigned long v;
+
     if (!s || !out)
         return 0;
-    while (*s && isspace((unsigned char)*s))
-        s++;
 
-    int base = 10;
-    if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) {
-        base = 16;
-        s += 2;
-    }
-    else {
-        for (const char *p = s; *p; ++p) {
-            if ((*p >= 'a' && *p <= 'f') || (*p >= 'A' && *p <= 'F')) {
-                base = 16;
-                break;
-            }
-        }
-    }
-
-    char *endp      = NULL;
-    unsigned long v = strtoul(s, &endp, base);
+    v = strtoul(s, &endp, 0);
     if (endp == s)
         return 0;
     while (*endp && isspace((unsigned char)*endp))
         endp++;
-    if (*endp != '\0')
+    if (*endp)
         return 0;
 
     *out = (uint32_t)v;
     return 1;
 }
 
-static void arad_ctx_add_filter(arad_mm_ctx_t *ctx, uint32_t ser24, int suffix_or_minus1)
+static void arad_add_serial(arad_mm_ctx_t *ctx, uint32_t ser24, int suffix)
 {
-    if (!ctx)
-        return;
-    if (ctx->count >= ARAD_MM_MAX_SERIAL_FILTER)
+    if (!ctx || ctx->count >= ARAD_MM_MAX_SERIALS)
         return;
 
-    ctx->items[ctx->count].ser24  = (ser24 & 0x00ffffffu);
-    ctx->items[ctx->count].suffix = suffix_or_minus1;
+    ctx->serials[ctx->count].ser24  = ser24 & 0x00ffffffu;
+    ctx->serials[ctx->count].suffix = suffix;
     ctx->count++;
 }
 
-static int arad_sum_decimal_digits(const char *s, unsigned *digits_out)
+static void arad_parse_serials(arad_mm_ctx_t *ctx, char *list)
 {
-    if (!s)
-        return -1;
-    while (*s && isspace((unsigned char)*s))
-        s++;
-    if (!*s)
-        return -1;
+    char *tok;
+    char *saveptr = NULL;
 
-    unsigned digits = 0;
-    int sum         = 0;
-    for (const char *p = s; *p; ++p) {
-        if (isspace((unsigned char)*p))
-            continue;
-        if (*p < '0' || *p > '9')
-            return -1;
-        sum += (int)(*p - '0');
-        digits++;
-    }
-
-    if (digits_out)
-        *digits_out = digits;
-    return sum;
-}
-
-static int arad_token_is_special(const char *tok)
-{
-    unsigned digits = 0;
-    int sum         = arad_sum_decimal_digits(tok, &digits);
-    if (sum < 0)
-        return 0;
-
-    if (digits != 8)
-        return 0;
-
-    int expected = 0;
-    for (unsigned i = 0; i < digits; ++i)
-        expected += 9;
-
-    return sum == expected;
-}
-
-static void arad_parse_serial_list(arad_mm_ctx_t *ctx, char *list)
-{
     if (!ctx || !list)
         return;
 
-    // split by comma/semicolon/whitespace into NUL-separated tokens
-    for (char *p = list; *p; ++p) {
-        if (*p == ',' || *p == ';' || isspace((unsigned char)*p))
-            *p = '\0';
-    }
+    tok = arad_strtok(list, ";", &saveptr);
+    while (tok) {
+        char *dash;
+        uint32_t ser = 0;
+        uint32_t suf = 0;
 
-    char *p   = list;
-    char *end = list + strlen(list) + 1;
-    while (p < end) {
-        if (!*p) {
-            ++p;
-            continue;
-        }
+        tok  = arad_trim(tok);
+        dash = tok ? strchr(tok, '-') : NULL;
 
-        char *tok = arad_trim_inplace(p);
-        p += strlen(p) + 1;
-        if (!tok || !*tok)
-            continue;
-
-        if (arad_token_is_special(tok)) {
-            ctx->filter_mode = 0;
-            continue;
-        }
-
-        // Accept "SERIAL-SUFFIX"
-        char *dash = strchr(tok, '-');
-        if (dash) {
-            *dash       = '\0';
-            char *ser_s = arad_trim_inplace(tok);
-            char *suf_s = arad_trim_inplace(dash + 1);
-
-            uint32_t ser_v = 0, suf_v = 0;
-            if (arad_parse_u32_auto(ser_s, &ser_v) && arad_parse_u32_auto(suf_s, &suf_v)) {
-                if (suf_v <= 0xffu) {
-                    arad_ctx_add_filter(ctx, ser_v, (int)suf_v);
+        if (tok && *tok) {
+            if (dash) {
+                *dash = '\0';
+                if (arad_parse_u32(arad_trim(tok), &ser) &&
+                        arad_parse_u32(arad_trim(dash + 1), &suf) &&
+                        suf <= 0xffu) {
+                    arad_add_serial(ctx, ser, (int)suf);
                 }
             }
-            continue;
+            else if (arad_parse_u32(tok, &ser)) {
+                arad_add_serial(ctx, ser, -1);
+            }
         }
 
-        // Just serial
-        uint32_t ser_v = 0;
-        if (arad_parse_u32_auto(tok, &ser_v)) {
-            arad_ctx_add_filter(ctx, ser_v, -1);
-        }
+        tok = arad_strtok(NULL, ";", &saveptr);
     }
 }
 
-static int arad_serial_matches_mandatory(const arad_mm_ctx_t *ctx, uint32_t ser24, uint8_t suffix)
+static int arad_match_serial(const arad_mm_ctx_t *ctx, uint32_t ser24, uint8_t suffix)
 {
-    if (!ctx)
-        return 0;
-    if (ctx->count == 0)
-        return 0; // mandatory
+    unsigned i;
+
+    if (!ctx || ctx->count == 0)
+        return 1;
 
     ser24 &= 0x00ffffffu;
-    for (unsigned i = 0; i < ctx->count; ++i) {
-        if (ctx->items[i].ser24 != ser24)
+    for (i = 0; i < ctx->count; ++i) {
+        if (ctx->serials[i].ser24 != ser24)
             continue;
-        if (ctx->items[i].suffix < 0)
-            return 1;
-        if ((uint8_t)ctx->items[i].suffix == suffix)
+        if (ctx->serials[i].suffix < 0 || (uint8_t)ctx->serials[i].suffix == suffix)
             return 1;
     }
     return 0;
 }
 
-static int arad_parse_gear(const char *s, double *out)
+static int arad_parse_gear(const char *s, float *out)
 {
     if (!s || !out)
         return 0;
-    while (*s && isspace((unsigned char)*s))
-        s++;
-    if (!*s)
-        return 0;
 
     if (strcmp(s, "0.01") == 0) {
-        *out = 0.01;
+        *out = 0.01f;
         return 1;
     }
     if (strcmp(s, "0.1") == 0) {
-        *out = 0.1;
+        *out = 0.1f;
         return 1;
     }
-    if (strcmp(s, "1") == 0) {
-        *out = 1.0;
+    if (strcmp(s, "1") == 0 || strcmp(s, "1.0") == 0) {
+        *out = 1.0f;
         return 1;
     }
-    if (strcmp(s, "10") == 0) {
-        *out = 10.0;
+    if (strcmp(s, "10") == 0 || strcmp(s, "10.0") == 0) {
+        *out = 10.0f;
         return 1;
     }
-    if (strcmp(s, "100") == 0) {
-        *out = 100.0;
+    if (strcmp(s, "100") == 0 || strcmp(s, "100.0") == 0) {
+        *out = 100.0f;
         return 1;
     }
-
-    if (strcmp(s, "1.0") == 0) {
-        *out = 1.0;
-        return 1;
-    }
-    if (strcmp(s, "10.0") == 0) {
-        *out = 10.0;
-        return 1;
-    }
-    if (strcmp(s, "100.0") == 0) {
-        *out = 100.0;
-        return 1;
-    }
-
     return 0;
 }
 
@@ -301,724 +197,176 @@ static int arad_parse_unit(const char *s, arad_unit_t *out)
 {
     if (!s || !out)
         return 0;
-    while (*s && isspace((unsigned char)*s))
-        s++;
-    if (!*s)
-        return 0;
 
     if (arad_ieq(s, "m3")) {
         *out = ARAD_UNIT_M3;
         return 1;
     }
-    if (arad_ieq(s, "liters")) {
-        *out = ARAD_UNIT_LITERS;
+    if (arad_ieq(s, "l") || arad_ieq(s, "liter") || arad_ieq(s, "liters")) {
+        *out = ARAD_UNIT_L;
         return 1;
     }
-    if (arad_ieq(s, "liter")) {
-        *out = ARAD_UNIT_LITERS;
-        return 1;
-    }
-    if (arad_ieq(s, "l")) {
-        *out = ARAD_UNIT_LITERS;
-        return 1;
-    }
-    if (arad_ieq(s, "cf")) {
+    if (arad_ieq(s, "cf") || arad_ieq(s, "cuft") || arad_ieq(s, "cu_ft")) {
         *out = ARAD_UNIT_CF;
         return 1;
     }
-    if (arad_ieq(s, "usg")) {
+    if (arad_ieq(s, "usg") || arad_ieq(s, "gal") || arad_ieq(s, "gallon") || arad_ieq(s, "gallons")) {
         *out = ARAD_UNIT_USG;
         return 1;
     }
-    if (arad_ieq(s, "gallon")) {
-        *out = ARAD_UNIT_USG;
-        return 1;
-    }
-    if (arad_ieq(s, "gallons")) {
-        *out = ARAD_UNIT_USG;
-        return 1;
-    }
-
     return 0;
 }
 
-static const char *arad_unit_str(arad_unit_t u)
+static const char *arad_unit_str(arad_unit_t unit)
 {
-    switch (u) {
+    switch (unit) {
     case ARAD_UNIT_M3: return "m3";
-    case ARAD_UNIT_LITERS: return "Liters";
-    case ARAD_UNIT_CF: return "CF";
-    case ARAD_UNIT_USG: return "USG";
+    case ARAD_UNIT_L: return "l";
+    case ARAD_UNIT_CF: return "cu ft";
+    case ARAD_UNIT_USG: return "gal";
     default: return "m3";
     }
 }
 
-static double arad_units_to_m3(arad_unit_t u, double v_in_units)
+static uint64_t const arad_xor_table[] = {
+        0xa0b5486480, 0xd05ac3a0d8, 0x682da64b08, 0xb416732c78,
+        0x5a0bfe0d58, 0xad055f0f50, 0xc68a887978, 0x634583a7d8,
+        0xa1aa21b658, 0x40dd972c00, 0xa06eac0498, 0x5037919928,
+        0xa81b68c568, 0xd40d146b48, 0xea062a3c58, 0x7503d28548,
+        0xaa89092710, 0xd544e30110, 0x7aaa31ecc0, 0x3d5518f660,
+        0x8ea2ab85e0, 0x475155c2f0, 0xb3a08d1fa8, 0x49d8c178f8,
+        0x34e4e74b50, 0x1a7273a5a8, 0x0d39fe49b0, 0x9694d8da08,
+        0x4b4aabf660, 0x35ad159778, 0x8ade6aae08, 0x456ff2cc60,
+        0xb2bfde98e0, 0xd95f88dee8, 0xfca7240ac0, 0xfe53f597f8,
+        0xff295ac200, 0xef9c8a9fd0, 0x67c60523a0, 0x23eb42fd98,
+        0x81fd411b78, 0xd0f640e808, 0x687be7ef60, 0xb43d946528,
+        0xda1e6a3b68, 0x6d0ff286d0, 0xa68fdebdb8, 0xd3474f5720,
+        0xf9ab805540, 0xecdde7d470, 0xf66e9478a0, 0x7b374a3c50,
+        0xad9382e0f8, 0xc6c12115c8, 0xe360308318, 0x61b89fb6a0,
+        0x20d40fb718, 0x106ac040e8, 0x0835a7bb10, 0x841ab44f10,
+        0x420d5a2788, 0xa1060d1a38, 0x408b817a30, 0xa045a72f80,
+        0xd022b40558, 0x68119d99c8, 0xb4086ec518, 0x5a04f0f9e8,
+        0x2d02bfe790, 0x06891f9f80, 0x8344e85d58, 0x51aaf3d980,
+        0x38dd398088, 0x9c6e3cc9b8, 0x4e37d9ffb8, 0xa71b4cf620,
+        0xc3858185c0, 0xf1cae73c30, 0x68ed33f250, 0xb476fe6bb0,
+        0x5a3b7f35d8, 0xad1d1f9310, 0xc686a83758, 0x63439380c8,
+        0xa1a929a5d0, 0xc0dcb32c38, 0x606e9e0d78, 0x3037889dd8};
+
+static uint64_t arad_checksum(uint8_t const *b)
 {
-    switch (u) {
-    case ARAD_UNIT_M3: return v_in_units;
-    case ARAD_UNIT_LITERS: return v_in_units / 1000.0;
-    case ARAD_UNIT_CF: return v_in_units * 0.028316846592;
-    case ARAD_UNIT_USG: return v_in_units * 0.003785411784;
-    default: return v_in_units;
+    uint64_t checksum = 0;
+    int n;
+    int i;
+
+    for (n = 0; n < 11; n++) {
+        for (i = 0; i < 8; i++) {
+            if ((b[n] << (i + 1)) & 0x100)
+                checksum ^= arad_xor_table[n * 8 + i];
+        }
     }
+    return checksum;
 }
 
-static double arad_m3_to_units(arad_unit_t u, double v_m3)
+static void arad_flip_payload_bit(uint8_t *b, int bit_index)
 {
-    switch (u) {
-    case ARAD_UNIT_M3: return v_m3;
-    case ARAD_UNIT_LITERS: return v_m3 * 1000.0;
-    case ARAD_UNIT_CF: return v_m3 / 0.028316846592;
-    case ARAD_UNIT_USG: return v_m3 / 0.003785411784;
-    default: return v_m3;
-    }
+    int byte_idx    = bit_index / 8;
+    int bit_in_byte = bit_index % 8;
+    b[byte_idx] ^= (uint8_t)(1u << (7 - bit_in_byte));
 }
 
-static void arad_auto_gear_units(uint8_t after0, uint8_t after1, double *gear, arad_unit_t *unit)
+static int arad_correct_bits(uint8_t *b, uint64_t syndrome)
 {
-    // Defaults
-    double g      = 0.1;
-    arad_unit_t u = ARAD_UNIT_M3;
+    int i;
+    int j;
+    int k;
 
-    // Rules
-    if (after0 == 0x73 && after1 == 0x00) {
-        g = 0.1;
-        u = ARAD_UNIT_M3;
-    }
-    else if (after0 == 0x00 && (after1 == 0x00 || after1 == 0x40)) {
-        g = 0.01;
-        u = ARAD_UNIT_M3;
-    }
-    else if (after0 == 0x27 && after1 == 0x00) {
-        g = 0.1;
-        u = ARAD_UNIT_USG;
-    }
-
-    if (gear)
-        *gear = g;
-    if (unit)
-        *unit = u;
-}
-
-/*  Build a contiguous nibble-range pattern from the full 48-bit preamble.
-        start_nibble/end_nibble are in [0..12], where 0 is the HIGH nibble of 0x96.
-    end_nibble is exclusive. Required: 0 <= start < end <= 12.
-
-        Output:
-        out_bytes: pattern packed MSB-first
-        out_bits:  number of bits to search (multiple of 4)
-        Returns 1 on success, 0 on invalid input.
- */
-static int arad_build_preamble_nibble_pattern(
-        uint8_t out_bytes[6],
-        unsigned *out_bits,
-        unsigned start_nibble,
-        unsigned end_nibble)
-{
-    static const uint8_t full[6] = {0x96, 0xf5, 0x13, 0x85, 0x37, 0xb4};
-
-    if (!out_bytes || !out_bits)
-        return 0;
-    if (start_nibble >= end_nibble || end_nibble > 12)
-        return 0;
-
-    // Expand full preamble into 12 nibbles: [0]=0x9, [1]=0x6, [2]=0xF, [3]=0x5, ...
-    uint8_t n[12];
-    for (unsigned i = 0; i < 6; ++i) {
-        n[2 * i + 0] = (uint8_t)((full[i] >> 4) & 0x0F);
-        n[2 * i + 1] = (uint8_t)(full[i] & 0x0F);
-    }
-
-    const unsigned nib_count = end_nibble - start_nibble; // >= 1
-    const unsigned bit_count = nib_count * 4;
-
-    // Pack nibbles MSB-first into bytes (bitbuffer_search expects MSB-first patterns)
-    memset(out_bytes, 0, 6);
-    unsigned bitpos = 0;
-    for (unsigned i = 0; i < nib_count; ++i) {
-        uint8_t nib = n[start_nibble + i] & 0x0F;
-        for (unsigned b = 0; b < 4; ++b) {
-            // take nib MSB -> LSB
-            unsigned bit = (nib >> (3 - b)) & 1u;
-
-            unsigned byte_index  = bitpos / 8;
-            unsigned bit_in_byte = 7u - (bitpos % 8); // MSB-first
-            if (bit)
-                out_bytes[byte_index] |= (uint8_t)(1u << bit_in_byte);
-
-            bitpos++;
+    for (i = 0; i < 88; i++) {
+        if (arad_xor_table[i] == syndrome) {
+            arad_flip_payload_bit(b, i);
+            return 1;
         }
     }
 
-    *out_bits = bit_count;
-    return 1;
-}
-
-/*  Build a string containing the INVERTED preamble nibbles
-        NOT covered by [start_nibble, end_nibble).
-        The unmatched parts BEFORE and AFTER the matched window
-        are separated by "_..._".
-
-        Inversion is done per nibble: out = 0xF ^ in.
-        Output format: hex nibbles (uppercase), no separators.
- */
-static void arad_format_unmatched_preamble(
-        char *out,
-        size_t out_sz,
-        unsigned start_nibble,
-        unsigned end_nibble)
-{
-    static const uint8_t full[6] = {0x96, 0xf5, 0x13, 0x85, 0x37, 0xb4};
-
-    if (!out || out_sz == 0)
-        return;
-    out[0] = '\0';
-
-    /* Expand full preamble into 12 nibbles */
-    uint8_t n[12];
-    for (unsigned i = 0; i < 6; ++i) {
-        n[2 * i + 0] = (uint8_t)((full[i] >> 4) & 0x0F);
-        n[2 * i + 1] = (uint8_t)(full[i] & 0x0F);
-    }
-
-    size_t w         = 0;
-    int wrote_before = 0;
-
-    /* BEFORE matched window */
-    for (unsigned i = 0; i < start_nibble; ++i) {
-        if (w + 1 >= out_sz)
-            break;
-        uint8_t inv  = (uint8_t)(n[i] ^ 0x0F);
-        out[w++]     = (char)((inv < 10) ? ('0' + inv) : ('A' + (inv - 10)));
-        out[w]       = '\0';
-        wrote_before = 1;
-    }
-
-    /* Separator between BEFORE and AFTER (only if there is AFTER) */
-    if (end_nibble < 12) {
-        const char sep[] = "_..._";
-        size_t sep_len   = sizeof(sep) - 1;
-
-        if (w + sep_len < out_sz) {
-            memcpy(&out[w], sep, sep_len);
-            w += sep_len;
-            out[w] = '\0';
-        }
-    }
-
-    /* AFTER matched window */
-    for (unsigned i = end_nibble; i < 12; ++i) {
-        if (w + 1 >= out_sz)
-            break;
-        uint8_t inv = (uint8_t)(n[i] ^ 0x0F);
-        out[w++]    = (char)((inv < 10) ? ('0' + inv) : ('A' + (inv - 10)));
-        out[w]      = '\0';
-    }
-}
-
-/* ---------- decoder ---------- */
-
-static r_device *arad_ms_meter_create(char *args);
-
-/**
-Overview
---------
-
-Decoder for Arad / Master Meter Dialog3G water utility meter transmissions.
-
-FCC-Id: TKCET-733
-
-References:
-- https://45851052.fs1.hubspotusercontent-na1.net/hubfs/45851052/documents/files/Interpreter-II-Register_v0710.20F.pdf
-- https://www.arad.co.il/wp-content/uploads/Dialog-3G-register-information-sheet_Eng-002.pdf
-
-Messages are transmitted approximately once every 30 seconds.
-
-Observed message structure
---------------------------
-
-A typical frame (after preamble) appears as:
-
-    00000000FFFFFFFFFFFFFFSSSSSSSSXXCCCCCCXXXF?????????XFF
-
-Field description (based on reverse engineering and observations):
-
-- 00000000
-    Preamble used for frame synchronization.
-
-- FFFFFFFFFFFFFF
-    Bytes that appear constant in time and are usually identical for
-    meters located in the same neighborhood.
-
-    Observed payload example:
-        3e690aec7ac84b
-
-    The exact meaning is unknown. It may be related to the meter register
-    configuration or gearing parameters.
-
-- SSSSSSSS
-    Meter serial field (4 bytes).
-
-    The first 3 bytes represent the numeric serial number (little-endian).
-
-    Example:
-        fa1c9073
-
-        fa1c90  -> 09444602 (decimal serial number)
-        73      -> suffix byte
-
-    The last byte sometimes corresponds to a letter printed after the
-    serial on the physical meter, but not always. In many cases it contains
-    values that do not appear on the meter label.
-
-    Empirically, this suffix byte together with the following byte appears
-    to encode meter configuration parameters such as the measurement unit
-    and gear (resolution).
-
-- XX
-    Unknown field (2 bytes). Its role is not yet understood.
-
-- CCCCCC
-    Counter value (3 bytes, little-endian).
-
-    Example:
-        a80600 -> 1704
-
-    This value represents the raw meter counter before applying the gear
-    multiplier.
-
-- XXX
-    Unknown field (3 bytes). Function currently unknown.
-
-- F
-    Observed constant byte in many frames.
-
-    Typical observed payload:
-        0x05
-
-    Appears stable for meters in the same installation but the exact
-    meaning is not yet confirmed.
-
-- ?????????
-    Likely CRC or checksum field. The exact algorithm is currently unknown.
-
-- X
-    A single byte that is typically observed as either:
-
-        0x08  or  0x00
-
-    The meaning is not yet known.
-
-- FF
-    Final byte of the frame.
-
-    Earlier observations suggested this byte was constant (often 0xF8),
-    however newer captures show that this byte may change over time even
-    for the same meter. Its purpose is currently unknown and it should not
-    be assumed constant.
-
-Notes
------
-
-Several fields previously assumed constant have been observed to vary in
-newer captures. This documentation reflects current understanding based on
-empirical analysis and may be updated as additional frames are decoded.
-
-BitBench notation
------------------
-
-Use PREAMBLE_ALIGN with value:
-
-    c196f51385
-
-This is the inverted form of:
-
-    3e690aec7a
-
-Format string:
-
-    UID:16h SERIAL:<24d 8h 8h COUNTER:<32d 8h8h 8h8h 8h8h SUFFIX:hh
-
-Protocol options
-----------------
-
-This decoder accepts arguments through:
-
-    rtl_433 -R ID:ARGS
-
-Mandatory:
-- serial=LIST / serials=LIST
-    At least one serial must be provided, otherwise the decoder is silent
-    and prints a warning once.
-
-    The filter accepts one or more meter serials (24-bit little-endian),
-    in decimal or hex notation.
-
-    A suffix byte may optionally be locked too by using:
-
-        SERIAL-SUFFIX
-
-    Examples:
-        -R ID:serial=9444602
-        -R ID:serials=9444602;1234567;0xfa1c90
-        -R ID:serials=09444602-73;01234567-53
-
-    NOTE:
-    If other options are combined with serials, commas separate key=value
-    pairs. In that case prefer semicolons inside serials:
-
-        -R ID:serials=9444602;1234567,gear=0.1,units=m3
-
-Optional:
-- gear=VALUE
-    Flow multiplier / resolution.
-    Allowed values: 0.01, 0.1, 1, 10, 100
-    Default: 0.1
-
-- units=VALUE
-    Overrides the native unit interpretation of the meter.
-    Allowed values (case-insensitive): m3, Liters, CF, USG
-
-- convert=VALUE
-    Converts the decoded numeric volume to the requested output unit.
-    Allowed values (case-insensitive): m3, Liters, CF, USG
-
-Outputs
--------
-
-- model               : decoder model name
-- id                  : SERIAL-SUFFIX
-                        serial as 8-digit decimal + '-' + suffix as hex
-- volume              : decoded volume in selected output units
-- unit                : output unit string (m3 / Liters / CF / USG)
-- volume_m3           : volume always provided in cubic meters
-- gear                : effective native gear used for decoding
-- native_unit         : effective native unit used for decoding
-- unmatched_preamble  : inverted preamble nibbles outside the matched
-                        nibble window, formatted as:
-
-                            BEFORE_..._AFTER
-
-                        where BEFORE is the unmatched part before the
-                        matched preamble window and AFTER is the unmatched
-                        part after it
-
-Preamble detection
-------------------
-
-Full preamble (already in the expected polarity for search):
-
-    96 f5 13 85 37 b4
-
-The decoder may search only a configurable nibble window inside this full
-preamble. The unmatched nibbles are not validated and are reported in the
-output as unmatched_preamble after nibble-wise inversion.
-
-Important:
-- The payload extraction offset is always derived from the start of the
-  full 48-bit preamble, even if only a sub-range of nibbles is matched.
-- This ensures serial / suffix / counter extraction stays aligned when the
-  preamble match window is changed.
-
-Buffer polarity
----------------
-
-This decoder keeps the original polarity behavior:
-
-    bitbuffer_invert(bitbuffer);
-
-The preamble is located first, and the shared bitbuffer is inverted only
-afterwards, before payload extraction.
-
-As a result, verbose (-V) output shows the buffer in the polarity expected
-by this decoder.
-
-Decoding behavior
------------------
-
-- serial/serials is mandatory
-- the decoder is silent when no serial filter is provided
-- a warning is printed once if serial/serials is missing
-- automatic native gear / unit detection is based on bytes after the serial:
-
-    b[3] == 0x73 && b[4] == 0x00
-        -> gear = 0.1, native_unit = m3
-
-    b[3] == 0x00 && (b[4] == 0x00 || b[4] == 0x40)
-        -> gear = 0.01, native_unit = m3
-
-    b[3] == 0x27 && b[4] == 0x00
-        -> gear = 0.1, native_unit = USG
-
-    default
-        -> gear = 0.1, native_unit = m3
-
-Override order:
-
-    auto -> gear override -> units override -> convert
-
-Meaning:
-- gear=...    overrides the detected native gear
-- units=...   overrides the detected native unit
-- convert=... converts the numeric output volume to the requested unit
-
-Notes:
-- units= changes the native interpretation
-- convert= changes the displayed numeric output
-- convert overrides units in output selection
-
-Implementation notes
---------------------
-
-- MSVC / Windows compatible tokenizer
-- no strtok_r
-- no DATA_FORMAT varargs usage
-- output uses separate numeric and unit fields
-*/
-
-static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)
-{
-    /*  ---- Preamble matching window (nibbles) ----
-                Full preamble (inverted polarity, do NOT change):
-                96 f5 13 85 37 b4
-
-                Configure which nibbles are matched:
-                nibble index 0..11, where 0 is HIGH nibble of 0x96, 11 is LOW nibble of 0xB4.
-                start_nibble inclusive, end_nibble exclusive.
-
-                Example:
-                        start_nibble=0, end_nibble=12  -> match full preamble (48 bits)
-                        start_nibble=2, end_nibble=10  -> match middle 8 nibbles (32 bits)
-     */
-    /* ---- Preamble matching window (nibbles) ---- */
-    const unsigned start_nibble = 1; /* inclusive, 0..11 */
-    const unsigned end_nibble   = 8; /* exclusive, 1..12 */
-
-    uint8_t preamble_pat[6];
-    unsigned preamble_bits = 0;
-
-    if (!arad_build_preamble_nibble_pattern(preamble_pat, &preamble_bits, start_nibble, end_nibble))
-        return DECODE_ABORT_EARLY;
-
-    int row = bitbuffer_find_repeated_row(bitbuffer, 1, 168);
-    if (row < 0)
-        return DECODE_ABORT_EARLY;
-
-    int match_pos_i = (int)bitbuffer_search(bitbuffer, row, 0, preamble_pat, preamble_bits);
-    if (match_pos_i < 0)
-        return DECODE_ABORT_EARLY;
-
-    /* Build unmatched_preamble (already inverted + "_..._" separator in your current function) */
-    char unmatched_preamble[32];
-    arad_format_unmatched_preamble(unmatched_preamble, sizeof(unmatched_preamble), start_nibble, end_nibble);
-
-    /*
-                Critical fix:
-                Compute the start of the FULL 48-bit preamble from the window match position,
-                then start payload AFTER the full preamble (always +48), regardless of window.
-     */
-    int full_preamble_start_i = match_pos_i - (int)(start_nibble * 4);
-    if (full_preamble_start_i < 0)
-        return DECODE_ABORT_EARLY;
-
-    unsigned payload_start = (unsigned)full_preamble_start_i + 48;
-
-    /* Optional: ensure we have enough bits for payload */
-    if (payload_start + 120 > bitbuffer->bits_per_row[row])
-        return DECODE_ABORT_LENGTH;
-
-    /* Keep original behavior: invert AFTER locating preamble */
-    bitbuffer_invert(bitbuffer);
-
-    /* Extract payload from the FIXED position */
-    uint8_t b[15];
-    bitbuffer_extract_bytes(bitbuffer, row, payload_start, b, 120);
-
-    uint32_t serno    = (uint32_t)b[0] | ((uint32_t)b[1] << 8) | ((uint32_t)b[2] << 16);
-    uint8_t after0    = b[3]; // byte after serial
-    uint8_t after1    = b[4]; // next byte
-    uint32_t wreadraw = (uint32_t)b[5] | ((uint32_t)b[6] << 8) | ((uint32_t)b[7] << 16);
-
-    arad_mm_ctx_t *ctx = (arad_mm_ctx_t *)decoder_user_data(decoder);
-    if (!ctx)
-        return DECODE_ABORT_EARLY;
-
-    if (ctx->filter_mode) {
-        if (ctx->count == 0) {
-            if (!ctx->warned_no_serial) {
-                ctx->warned_no_serial = 1;
-                fprintf(stderr,
-                        "AradMsMeter-Dialog3G: serials mandatory. Example: -R 260:v:serials=13751342\n");
+    for (i = 0; i < 88; i++) {
+        for (j = i + 1; j < 88; j++) {
+            if ((arad_xor_table[i] ^ arad_xor_table[j]) == syndrome) {
+                arad_flip_payload_bit(b, i);
+                arad_flip_payload_bit(b, j);
+                return 2;
             }
-            return DECODE_ABORT_EARLY;
         }
-
-        // Match by serial + optional suffix (suffix matches after0)
-        if (!arad_serial_matches_mandatory(ctx, serno, after0))
-            return DECODE_ABORT_EARLY;
     }
 
-    // AUTO native gear/unit
-    double native_gear      = 0.1;
-    arad_unit_t native_unit = ARAD_UNIT_M3;
-    arad_auto_gear_units(after0, after1, &native_gear, &native_unit);
-
-    // user overrides: gear overrides auto; units overrides NATIVE unit (as you requested)
-    if (ctx->user_gear_set) {
-        native_gear = ctx->user_gear;
-    }
-    if (ctx->user_units_set) {
-        native_unit = ctx->user_units;
-    }
-
-    // Native volume in native_unit
-    double volume_native = (double)wreadraw * native_gear;
-
-    // True m3 derived from native_unit
-    double volume_m3 = arad_units_to_m3(native_unit, volume_native);
-
-    // Output selection
-    double out_volume    = volume_native;
-    arad_unit_t out_unit = native_unit;
-
-    if (ctx->user_convert_set) {
-        out_unit   = ctx->user_convert;
-        out_volume = arad_m3_to_units(out_unit, volume_m3);
+    for (i = 0; i < 88; i++) {
+        for (j = i + 1; j < 88; j++) {
+            uint64_t x = arad_xor_table[i] ^ arad_xor_table[j];
+            for (k = j + 1; k < 88; k++) {
+                if ((x ^ arad_xor_table[k]) == syndrome) {
+                    arad_flip_payload_bit(b, i);
+                    arad_flip_payload_bit(b, j);
+                    arad_flip_payload_bit(b, k);
+                    return 3;
+                }
+            }
+        }
     }
 
-    char id_out[16];
-    snprintf(id_out, sizeof(id_out), "%08u-%02x", (unsigned)serno, (unsigned)after0);
-
-    /* clang-format off */
-    data_t *data = data_make(
-            "model",        "",              DATA_STRING, "AradMsMeter-Dialog3G",
-            "id",           "Serial No",     DATA_STRING, id_out,
-            "unmtchd prambl","Unmatched Preamble Nibbles", DATA_STRING, unmatched_preamble,
-            "volume",       "Volume",        DATA_DOUBLE, out_volume,
-            "unit",         "Unit",          DATA_STRING, arad_unit_str(out_unit),
-            "volume_m3",    "Volume (m3)",   DATA_DOUBLE, volume_m3,
-            "gear",         "Gear",          DATA_DOUBLE, native_gear,
-            "native_unit",  "Native Unit",   DATA_STRING, arad_unit_str(native_unit),
-            NULL);
-    /* clang-format on */
-
-    decoder_output_data(decoder, data);
-    return 1;
+    return -1;
 }
 
-static char const *const output_fields[] = {
-        "model",
-        "id",
-        "unmtchd prambl",
-        "volume",
-        "unit",
-        "volume_m3",
-        "gear",
-        "native_unit",
-        NULL,
-};
-
-r_device const arad_ms_meter = {
-        .name        = "Arad/Master Meter Dialog3G water utility meter",
-        .modulation  = FSK_PULSE_MANCHESTER_ZEROBIT,
-        .short_width = 8.4,
-        .long_width  = 8.4,
-        .reset_limit = 30,
-        .decode_fn   = &arad_mm_dialog3g_decode,
-        .create_fn   = &arad_ms_meter_create,
-        .disabled    = 1,
-        .fields      = output_fields,
-};
+extern r_device const arad_ms_meter;
 
 static r_device *arad_ms_meter_create(char *args)
 {
     r_device *dev = decoder_create(&arad_ms_meter, sizeof(arad_mm_ctx_t));
+    arad_mm_ctx_t *ctx;
+    char *work;
+    char *tok;
+    char *saveptr = NULL;
+
     if (!dev)
         return NULL;
 
-    arad_mm_ctx_t *ctx = (arad_mm_ctx_t *)decoder_user_data(dev);
-
-    ctx->count = 0;
-
-    ctx->user_gear_set = 0;
-    ctx->user_gear     = 0.1;
-
+    ctx                 = (arad_mm_ctx_t *)decoder_user_data(dev);
+    ctx->count          = 0;
+    ctx->user_gear_set  = 0;
+    ctx->user_gear      = 0.1f;
     ctx->user_units_set = 0;
     ctx->user_units     = ARAD_UNIT_M3;
 
-    ctx->user_convert_set = 0;
-    ctx->user_convert     = ARAD_UNIT_M3;
-
-    ctx->warned_no_serial = 0;
-    ctx->filter_mode      = 1;
-
     if (!args)
         return dev;
-    args = arad_trim_inplace(args);
+
+    args = arad_trim(args);
     if (!*args)
         return dev;
 
-    // Parse key=value tokens separated by ':' or ',' (rtl_433 uses ':' between decoder args)
-    char *work = strdup(args);
+    work = strdup(args);
     if (!work)
         return dev;
 
-    char *saveptr = NULL;
-    char *tok     = arad_strtok(work, ",:", &saveptr);
-
-    int collecting_serials = 0;
-    char serial_buf[512];
-    serial_buf[0] = '\0';
-
+    tok = arad_strtok(work, ",:", &saveptr);
     while (tok) {
-        char *t = arad_trim_inplace(tok);
-        if (!t || !*t) {
-            tok = arad_strtok(NULL, ",:", &saveptr);
-            continue;
-        }
+        char *eq;
+        char *key;
+        char *val;
 
-        // allow lone flags like "v" (ignore), and serial list continuation
-        if (!strchr(t, '=')) {
-            if (collecting_serials) {
-                if (serial_buf[0])
-                    strncat(serial_buf, ",", sizeof(serial_buf) - strlen(serial_buf) - 1);
-                strncat(serial_buf, t, sizeof(serial_buf) - strlen(serial_buf) - 1);
-            }
-            tok = arad_strtok(NULL, ",:", &saveptr);
-            continue;
-        }
-
-        // If we were collecting serials and hit a new key=value, flush serials first
-        if (collecting_serials) {
-            if (serial_buf[0]) {
-                arad_parse_serial_list(ctx, serial_buf);
-                serial_buf[0] = '\0';
-            }
-            collecting_serials = 0;
-        }
-
-        char *eq = strchr(t, '=');
+        tok = arad_trim(tok);
+        eq  = strchr(tok, '=');
         if (!eq) {
             tok = arad_strtok(NULL, ",:", &saveptr);
             continue;
         }
 
-        *eq       = '\0';
-        char *key = arad_trim_inplace(t);
-        char *val = arad_trim_inplace(eq + 1);
-        if (!val)
-            val = (char *)"";
+        *eq = '\0';
+        key = arad_trim(tok);
+        val = arad_trim(eq + 1);
 
         if (arad_ieq(key, "serial") || arad_ieq(key, "serials")) {
-            collecting_serials = 1;
-            serial_buf[0]      = '\0';
-            if (*val) {
-                snprintf(serial_buf, sizeof(serial_buf), "%s", val);
-            }
+            arad_parse_serials(ctx, val);
         }
         else if (arad_ieq(key, "gear")) {
-            double g = 0.0;
+            float g;
             if (arad_parse_gear(val, &g)) {
                 ctx->user_gear_set = 1;
                 ctx->user_gear     = g;
@@ -1031,21 +379,242 @@ static r_device *arad_ms_meter_create(char *args)
                 ctx->user_units     = u;
             }
         }
-        else if (arad_ieq(key, "convert")) {
-            arad_unit_t u;
-            if (arad_parse_unit(val, &u)) {
-                ctx->user_convert_set = 1;
-                ctx->user_convert     = u;
-            }
-        }
 
         tok = arad_strtok(NULL, ",:", &saveptr);
-    }
-
-    if (collecting_serials && serial_buf[0]) {
-        arad_parse_serial_list(ctx, serial_buf);
     }
 
     free(work);
     return dev;
 }
+
+/**
+Dialog3G decoder with checksum MIC.
+
+Optional parameters:
+- serials=SER1;SER2;SER3-SUFFIX
+- gear=0.01|0.1|1|10|100
+- units=m3|l|cf|usg
+
+The serial filter is optional.
+Gear and units may be overridden when auto detection is not reliable enough.
+Up to 3 payload bit errors are corrected using the checksum syndrome.
+
+
+See notes in https://45851052.fs1.hubspotusercontent-na1.net/hubfs/45851052/documents/files/Interpreter-II-Register_v0710.20F.pdf
+and https://www.arad.co.il/wp-content/uploads/Dialog-3G-register-information-sheet_Eng-002.pdf
+
+S.a. issues #1992, #3459
+
+Programmable parameters:
+- Meter User ID:
+  A municipal Meter ID number of up to 5 digits (16 or 17 bits needed)
+- Transponder No:
+  Meter’s Dialog 3GTM transponder number of up to 12 digits (40 bits needed)
+- Reading:
+  The transmitted Dialog 3G TM meter reading (up to 9 digits), (30 bits needed)
+  the accumulated and the display readout are always equivalent.
+- Meter Type:
+  Meter type such as water, gas or electricity
+- Count Factor:
+  Meter count unit. It is a pre scale factor which is initially programmed
+  into the Dialog 3G TM unit is order to get the standaed measurement units
+  for the system billing, management and calculation (Gallons or Cubic/ Mettic)
+- Alarms Temper:
+  A warning temper sign, in case of unauthorized meter tampering. CCW: Reverse
+  consumption by the meter.
+- Gear Ratio:
+  Water meter mechanical gear ratio parameter for the 3G Interpreter register types
+
+Programmable registration includes USG, CF, or M3, while
+resolution of the flow multiplier provides a custom-tailored
+enhanced display (.01, 0.1, 1, 10, 100).
+
+RF information:
+- FSK Manchester, ISM 915 Mhz
+- Message is being sent once every 30 seconds.
+
+Data Layout, payload in square brackets:
+
+    Byte Position                                 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16
+    Bit Position used for XOR                   [0  8  16 24 32 40 48 56 64 72 80]
+    Sample         00 00 00 00 3e 69 0a ec 7a c8 4b 47 f7 2e 00 40 5f 25 00 00 0c 9e c5 cb 55 38 f8
+                   00 00 00 00 UU UU UU UU UU UU[FF SS SS SS LL UU CC CC CC ?? ?F]OO OO OO OO OO TT
+
+- 00:  {?} Preamble
+- UU: {48} UID, sync word, always 0x3e690aec7ac8
+- FF:  {8} Flags, mostly 0x4b, but 0x6b in case of water leak
+- SS: {24} little-endian, serial number, decimal value on the water counter
+- LL:  {8} Serial suffix, mostly 0x73 = "s", 0x27 ="'" , or 0x00 = No Letter at all. Used for gear and volume units.
+- UU:  {8} Gear/scale and volume units flags, mostly 0x00 or 0x40
+           if b[4] = 0x73 and b[5] = 0x00           then gear = 0.1,  native_unit = m3
+           if b[4] = 0x00 and (b[5] = 0x00 or 0x40) then gear = 0.01, native_unit = m3
+           if b[4] = 0x27 and b[5] = 0x00           then gear = 0.1,  native_unit = US Gallon
+           other combinaisons are unknown
+
+- CC: {24} little-endian, counter value
+- ??: {12} Always 0x000, the first 8 bit could be counter MSB
+-  F:  {4} Flags, mostly 0x5, but could be 0x0, 0x8 or 0xC, impacted in case of leak and depends also on the serial suffix and units values.
+            if b[0] = 0x4b and b[4] = 0x00 or = 0x73       then Flags = 0x5
+            if b[0] = 0x4b and b[5] = 0x40 or = 0x50       then Flags = 0xC
+            if b[0] = 0x4b and b[4] = 0x27 and b[5] = 0x00 then Flags = 0x0
+            if b[0] = 0x6b and b[5] = 0x00 or = 0x40       then Flags = 0x8, LEAK here
+
+- OO: {40} Checksum, XOR 40 bit masks of the payload data (11 byte x 8 bit) = 88 different masks, see xor_table bellow, 3 bit errors could be corrected.
+- TT:  {8} Trailing suffix byte, mostly 0xff or 0xf8
+
+XOR masks by bit and byte positions, 88 masks in total (bit from left to right):
+
+    0xa0b5486480  [ bit  0 byte  0 ], 0xd05ac3a0d8  [ bit  1 byte  0 ], 0x682da64b08  [ bit  2 byte  0 ], 0xb416732c78  [ bit  3 byte  0 ],
+    0x5a0bfe0d58  [ bit  4 byte  0 ], 0xad055f0f50  [ bit  5 byte  0 ], 0xc68a887978  [ bit  6 byte  0 ], 0x634583a7d8  [ bit  7 byte  0 ],
+    0xa1aa21b658  [ bit  8 byte  1 ], 0x40dd972c00  [ bit  9 byte  1 ], 0xa06eac0498  [ bit 10 byte  1 ], 0x5037919928  [ bit 11 byte  1 ],
+    0xa81b68c568  [ bit 12 byte  1 ], 0xd40d146b48  [ bit 13 byte  1 ], 0xea062a3c58  [ bit 14 byte  1 ], 0x7503d28548  [ bit 15 byte  1 ],
+    0xaa89092710  [ bit 16 byte  2 ], 0xd544e30110  [ bit 17 byte  2 ], 0x7aaa31ecc0  [ bit 18 byte  2 ], 0x3d5518f660  [ bit 19 byte  2 ],
+    0x8ea2ab85e0  [ bit 20 byte  2 ], 0x475155c2f0  [ bit 21 byte  2 ], 0xb3a08d1fa8  [ bit 22 byte  2 ], 0x49d8c178f8  [ bit 23 byte  2 ],
+    0x34e4e74b50  [ bit 24 byte  3 ], 0x1a7273a5a8  [ bit 25 byte  3 ], 0x0d39fe49b0  [ bit 26 byte  3 ], 0x9694d8da08  [ bit 27 byte  3 ],
+    0x4b4aabf660  [ bit 28 byte  3 ], 0x35ad159778  [ bit 29 byte  3 ], 0x8ade6aae08  [ bit 30 byte  3 ], 0x456ff2cc60  [ bit 31 byte  3 ],
+    0xb2bfde98e0  [ bit 32 byte  4 ], 0xd95f88dee8  [ bit 33 byte  4 ], 0xfca7240ac0  [ bit 34 byte  4 ], 0xfe53f597f8  [ bit 35 byte  4 ],
+    0xff295ac200  [ bit 36 byte  4 ], 0xef9c8a9fd0  [ bit 37 byte  4 ], 0x67c60523a0  [ bit 38 byte  4 ], 0x23eb42fd98  [ bit 39 byte  4 ],
+    0x81fd411b78  [ bit 40 byte  5 ], 0xd0f640e808  [ bit 41 byte  5 ], 0x687be7ef60  [ bit 42 byte  5 ], 0xb43d946528  [ bit 43 byte  5 ],
+    0xda1e6a3b68  [ bit 44 byte  5 ], 0x6d0ff286d0  [ bit 45 byte  5 ], 0xa68fdebdb8  [ bit 46 byte  5 ], 0xd3474f5720  [ bit 47 byte  5 ],
+    0xf9ab805540  [ bit 48 byte  6 ], 0xecdde7d470  [ bit 49 byte  6 ], 0xf66e9478a0  [ bit 50 byte  6 ], 0x7b374a3c50  [ bit 51 byte  6 ],
+    0xad9382e0f8  [ bit 52 byte  6 ], 0xc6c12115c8  [ bit 53 byte  6 ], 0xe360308318  [ bit 54 byte  6 ], 0x61b89fb6a0  [ bit 55 byte  6 ],
+    0x20d40fb718  [ bit 56 byte  7 ], 0x106ac040e8  [ bit 57 byte  7 ], 0x0835a7bb10  [ bit 58 byte  7 ], 0x841ab44f10  [ bit 59 byte  7 ],
+    0x420d5a2788  [ bit 60 byte  7 ], 0xa1060d1a38  [ bit 61 byte  7 ], 0x408b817a30  [ bit 62 byte  7 ], 0xa045a72f80  [ bit 63 byte  7 ],
+    0xd022b40558  [ bit 64 byte  8 ], 0x68119d99c8  [ bit 65 byte  8 ], 0xb4086ec518  [ bit 66 byte  8 ], 0x5a04f0f9e8  [ bit 67 byte  8 ],
+    0x2d02bfe790  [ bit 68 byte  8 ], 0x06891f9f80  [ bit 69 byte  8 ], 0x8344e85d58  [ bit 70 byte  8 ], 0x51aaf3d980  [ bit 71 byte  8 ],
+    0x38dd398088  [ bit 72 byte  9 ], 0x9c6e3cc9b8  [ bit 73 byte  9 ], 0x4e37d9ffb8  [ bit 74 byte  9 ], 0xa71b4cf620  [ bit 75 byte  9 ],
+    0xc3858185c0  [ bit 76 byte  9 ], 0xf1cae73c30  [ bit 77 byte  9 ], 0x68ed33f250  [ bit 78 byte  9 ], 0xb476fe6bb0  [ bit 79 byte  9 ],
+    0x5a3b7f35d8  [ bit 80 byte 10 ], 0xad1d1f9310  [ bit 81 byte 10 ], 0xc686a83758  [ bit 82 byte 10 ], 0x63439380c8  [ bit 83 byte 10 ],
+    0xa1a929a5d0  [ bit 84 byte 10 ], 0xc0dcb32c38  [ bit 85 byte 10 ], 0x606e9e0d78  [ bit 86 byte 10 ], 0x3037889dd8  [ bit 87 byte 10 ]
+
+Format string:
+
+    UID:48h FLAGS:8h SERIAL: <24d c BILLING UNIT:8h COUNTER: <32d FLAGS:8h XOR:40h SUFFIX:hh
+
+
+
+*/
+static int arad_mm_dialog3g_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    uint8_t const preamble_pattern[] = {0x85, 0x37};
+    arad_mm_ctx_t *ctx               = (arad_mm_ctx_t *)decoder_user_data(decoder);
+    uint8_t b[16];
+    uint8_t u[7];
+    uint64_t xor_raw;
+    uint64_t xor_cal;
+    char uid_str[15];
+    char sernoout[12];
+    int row = 0;
+    int start_uid;
+    unsigned start_pos;
+    int corrections = 0;
+    int leaking;
+    uint32_t serno;
+    uint32_t wreadraw;
+    uint8_t sn_sufx;
+    uint8_t flags1;
+    uint8_t flags2;
+    arad_unit_t unit = ARAD_UNIT_M3;
+    float scale      = 0.1f;
+    float volume;
+
+    if (bitbuffer->num_rows > 1) {
+        decoder_logf(decoder, 1, __func__, "Too many rows: %d", bitbuffer->num_rows);
+        return DECODE_FAIL_SANITY;
+    }
+
+    if (bitbuffer->bits_per_row[row] < 18 * 8)
+        return DECODE_ABORT_LENGTH;
+
+    start_pos = bitbuffer_search(bitbuffer, row, 0, preamble_pattern, 16);
+    if (start_pos + 144 > bitbuffer->bits_per_row[row]) {
+        decoder_log(decoder, 2, __func__, "Sync word not found");
+        return DECODE_ABORT_LENGTH;
+    }
+
+    start_uid = (int)start_pos - 32;
+    if (start_uid < 0)
+        start_uid = 0;
+
+    start_pos += 16;
+    bitbuffer_invert(bitbuffer);
+
+    bitbuffer_extract_bytes(bitbuffer, row, start_uid, u, start_pos + 8 - (unsigned)start_uid);
+    bitrow_snprint(u, start_pos + 8 - (unsigned)start_uid, uid_str, sizeof(uid_str));
+
+    bitbuffer_extract_bytes(bitbuffer, row, start_pos, b, 128);
+    decoder_log_bitrow(decoder, 2, __func__, b, 128, "MSG Extracted");
+
+    xor_raw = ((uint64_t)b[11] << 32) | ((uint64_t)b[12] << 24) | ((uint64_t)b[13] << 16) | ((uint64_t)b[14] << 8) | b[15];
+    xor_cal = arad_checksum(b);
+    if (xor_raw != xor_cal) {
+        corrections = arad_correct_bits(b, xor_raw ^ xor_cal);
+        if (corrections < 0)
+            return DECODE_FAIL_MIC;
+    }
+
+    leaking  = (b[0] & 0x20) >> 5;
+    serno    = (uint32_t)b[1] | ((uint32_t)b[2] << 8) | ((uint32_t)b[3] << 16);
+    sn_sufx  = b[4];
+    flags1   = b[5];
+    wreadraw = (uint32_t)b[6] | ((uint32_t)b[7] << 8) | ((uint32_t)b[8] << 16);
+    flags2   = b[10];
+
+    if (sn_sufx == 0x00 && (flags1 == 0x00 || flags1 == 0x40))
+        scale = 0.01f;
+    else if (sn_sufx == 0x27 && flags1 == 0x00)
+        unit = ARAD_UNIT_USG;
+
+    if (ctx && !arad_match_serial(ctx, serno, sn_sufx))
+        return DECODE_ABORT_EARLY;
+
+    if (ctx && ctx->user_gear_set)
+        scale = ctx->user_gear;
+    if (ctx && ctx->user_units_set)
+        unit = ctx->user_units;
+
+    volume = (float)wreadraw * scale;
+
+    snprintf(sernoout, sizeof(sernoout), "%08u-%02x", (unsigned)serno, (unsigned)sn_sufx);
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",       "",              DATA_STRING, "AradMsMeter-Dialog3G",
+            "id",          "Serial No",     DATA_STRING, sernoout,
+            "uid",         "UID",           DATA_STRING, uid_str,
+            "leaking",     "Leaking",       DATA_INT, leaking,
+            "flags1",      "Flags 1",       DATA_FORMAT, "%02x", DATA_INT, flags1,
+            "volume",      "Volume",        DATA_DOUBLE, volume,
+            "unit",        "Unit",          DATA_STRING, arad_unit_str(unit),
+            "flags2",      "Flags 2",       DATA_FORMAT, "%02x", DATA_INT, flags2,
+            "mic",         "Integrity",     DATA_STRING, corrections > 0 ? "CHECKSUM-CORR" : "CHECKSUM",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+static char const *const output_fields[] = {
+        "model",
+        "id",
+        "uid",
+        "leaking",
+        "flags1",
+        "volume",
+        "unit",
+        "flags2",
+        "mic",
+        NULL,
+};
+
+r_device const arad_ms_meter = {
+        .name        = "Arad/Master Meter Dialog3G water utility meter",
+        .modulation  = FSK_PULSE_MANCHESTER_ZEROBIT,
+        .short_width = 8.4,
+        .long_width  = 8.4,
+        .reset_limit = 100,
+        .decode_fn   = &arad_mm_dialog3g_decode,
+        .create_fn   = &arad_ms_meter_create,
+        .fields      = output_fields,
+};

--- a/src/devices/arad_ms_meter.c
+++ b/src/devices/arad_ms_meter.c
@@ -409,7 +409,7 @@ Programmable parameters:
 - Meter User ID:
   A municipal Meter ID number of up to 5 digits (16 or 17 bits needed)
 - Transponder No:
-  Meter’s Dialog 3GTM transponder number of up to 12 digits (40 bits needed)
+  Meter's Dialog 3GTM transponder number of up to 12 digits (40 bits needed)
 - Reading:
   The transmitted Dialog 3G TM meter reading (up to 9 digits), (30 bits needed)
   the accumulated and the display readout are always equivalent.


### PR DESCRIPTION
Improve robustness of the Arad / Master Meter Dialog3G decoder.

Preamble detection now uses a configurable nibble window inside the observed 48-bit preamble while payload extraction always aligns to the start of the full preamble. This keeps decoding stable even if the match window changes.

Add a diagnostic field "unmatched_preamble" which outputs the preamble nibbles outside the match window in inverted nibble form:

    <before>_..._<after>

This helps analyze variants of the Dialog3G transmission.

Add decoder options:
- mandatory serial input
- gear override
- unit override

These allow forcing decoding parameters when meter configuration or protocol variants differ from the automatically detected values.

Update protocol documentation to reflect observed messages:

* the trailing FF byte is not constant
* the serial suffix byte sometimes matches the printed meter letter
* the suffix byte together with the following byte likely indicates meter unit and gear ratio

Add BitBench alignment reference:

    PREAMBLE_ALIGN = c196f51385

(invert of 3e690aec7a)

Format string used for analysis:

    UID:16h SERIAL:<24d 8h 8h
    COUNTER:<32d 8h8h 8h8h 8h8h
    SUFFIX:hh

Example frame used during analysis:

3e690aec7ac84b9aa50900404a7a02000c42bb5e8cc0f8
