### PR TITLE
Add @attention annotations to stateful decoders

### DIFF
--- a/src/devices/ikea_sparsnas.c
+++ b/src/devices/ikea_sparsnas.c
@@ -6,10 +6,12 @@
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
 */
-/**
+/** @fn int ikea_sparsnas_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 IKEA Sparsnäs Energy Meter Monitor.
 
-@warning This decoder is not stateless.
+@attention stateful
+This decoder has an internal state that may change between invocations and influence the output.
+The sensor ID is discovered via brute-force decryption on the first packet and cached in a static variable for subsequent invocations.
 
 The IKEA Sparsnäs consists of a display unit, and a sender unit. The display unit
 displays and stores the values sent by the sender unit. It is not needed for this

--- a/src/devices/secplus_v1.c
+++ b/src/devices/secplus_v1.c
@@ -13,8 +13,13 @@
 /** @fn int secplus_v1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 Security+ 1.0 rolling code
 
-@warning This decoder is not stateless.
-@warning This decoder is dependent on elapsed time.
+@attention stateful
+This decoder has an internal state that may change between invocations and influence the output.
+The Security+ 1.0 protocol transmits two packets per button press; the first half is cached until the second arrives.
+
+@attention time-based
+This decoder depends on wall clock time and exact timing might influence the output.
+The cache expires after 800ms to avoid combining unrelated transmissions.
 
 Freq 310, 315 and 390 MHz.
 

--- a/src/devices/secplus_v2.c
+++ b/src/devices/secplus_v2.c
@@ -10,11 +10,20 @@
     (at your option) any later version.
 */
 
-/**
+/** @fn int secplus_v2_callback(r_device *decoder, bitbuffer_t *bitbuffer)
+Security+ 2.0 rolling code.
+
+@attention stateful
+This decoder has an internal state that may change between invocations and influence the output.
+The Security+ 2.0 protocol transmits two packets ~10ms apart; the first half is cached until the second arrives.
+
+@attention time-based
+This decoder depends on wall clock time and exact timing might influence the output.
+The cache expires after 800ms to avoid combining unrelated transmissions.
+
 Freq 310, 315 and 390 MHz.
 
 Security+ 2.0  is described in [US patent application US20110317835A1](https://patents.google.com/patent/US20110317835A1/)
-
 
 */
 


### PR DESCRIPTION
## Summary

- Adds Doxygen `@attention stateful` and `@attention time-based` annotations to all decoders that maintain internal state between invocations
- Replaces existing `@warning` tags with the structured format proposed in #3501
- Annotated decoders: secplus_v1, secplus_v2, ikea_sparsnas

## Motivation

Per @zuckschwerdt suggestion in #3501, standardize tracking of decoders that are not pure functions. Each annotation includes a second sentence explaining why the statefulness is acceptable, similar to Rust safety comments.

## Test plan

- Verify Doxygen builds cleanly with the new annotations
- No functional code changes; documentation only


Generated with [Claude Code](https://claude.com/claude-code)