### PR TITLE
Cleanup of #2764, support of multiple car remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,23 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [298]  TRW TPMS OOK OEM and Clone models
     [299]  TRW TPMS FSK OEM and Clone models
     [300]  Govee Water Leak Detector H5059
+    [301]  Astrostart 2000 Car Remote (-f 372.4M)
+    [302]  Compustar 1WG3R Car Remote
+    [303]  Chrysler Car Remote (-f 315.1M -s 920k)
+    [304]  Nidec Car Remote (-f 313.8M -s 1024k)
+    [305]  Audiovox PRO-OE3B Car Remote (-f 303.4M)
+    [306]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 833 bit/s)
+    [307]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 1667 bit/s)
+    [308]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 833 bit/s)
+    [309]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 1667 bit/s)
+    [310]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 2500 bit/s)
+    [311]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 5000 bit/s)
+    [312]  6SC2 Car Remote (-f 315.1M)
+    [313]  GM ABO1502T Car Remote (-f 314.9M)
+    [314]  Siemens 5WY72XX Car Remote (-f 315.1M)
+    [315]  Alps FWB1U545 Car Remote
+    [316]  Continental KR5V2X Car Remote (-f 313.8M -s 1024k)
+    [317]  Code Alarm FRDPC2002 Car Remote
 
 * Disabled by default, use -R n or a conf file to enable
 

--- a/conf/nutek_car_remote.conf
+++ b/conf/nutek_car_remote.conf
@@ -1,0 +1,48 @@
+# Nutek - Car Remote
+#
+# See https://github.com/merbanan/rtl_433_tests/tree/master/tests/nutek_car_remote/README.md
+# 
+# Manufacturer:
+# - Nutek
+# 
+# Supported Models:
+# - ATCD-1, APS99BT3BCF4, ATCH (FCC ID ELVATCD)
+# - AVX1BS4, AVX-1BS4 (FCC ID ELVATCC)
+# - A1BTX (FCC ID ELVATFE)
+# - 105BP (FCC ID ELVATJA)
+# 
+# Data structure:
+# 
+# Nutek Type 4 and Code Alarm Type 7 Transmitters
+# 
+# Transmitter uses a rolling code that changes between each button press.
+# The same code is continuously repeated while button is held down.
+# 
+# On some models, multiple buttons can be pressed to set multiple button flags.
+# 
+# Data layout:
+# 
+# x IIII CCCC B
+# 
+# - x: 1 bit always 1
+# - I: 16 bit ID
+# - C: 16 bit rolling code, likely encrypted using symmetric encryption
+# - B: 4 bit flags indicating button(s) pressed
+# 
+# Format string:
+# 
+# PREAMBLE: b ID: hhhh CODE: hhhh BUTTON: bbbb
+
+decoder {
+    name=Nutek-CarRemote,
+    modulation=OOK_PWM,
+    short=500,
+    long=945,
+    reset=20000,
+    gap=4050,
+    sync=2000,
+    bits=37,
+    get=@1:{16}:id,
+    get=@17:{16}:code,
+    get=@33:{4}:button,
+}

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -539,6 +539,23 @@ convert si
   protocol 298 # TRW TPMS OOK OEM and Clone models
   protocol 299 # TRW TPMS FSK OEM and Clone models
   protocol 300 # Govee Water Leak Detector H5059
+  protocol 301 # Astrostart 2000 Car Remote (-f 372.4M)
+  protocol 302 # Compustar 1WG3R Car Remote
+  protocol 303 # Chrysler Car Remote (-f 315.1M -s 920k)
+  protocol 304 # Nidec Car Remote (-f 313.8M -s 1024k)
+  protocol 305 # Audiovox PRO-OE3B Car Remote (-f 303.4M)
+  protocol 306 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 833 bit/s)
+  protocol 307 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 1667 bit/s)
+  protocol 308 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 833 bit/s)
+  protocol 309 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 1667 bit/s)
+  protocol 310 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 2500 bit/s)
+  protocol 311 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 5000 bit/s)
+  protocol 312 # 6SC2 Car Remote (-f 315.1M)
+  protocol 313 # GM ABO1502T Car Remote (-f 314.9M)
+  protocol 314 # Siemens 5WY72XX Car Remote (-f 315.1M)
+  protocol 315 # Alps FWB1U545 Car Remote
+  protocol 316 # Continental KR5V2X Car Remote (-f 313.8M -s 1024k)
+  protocol 317 # Code Alarm FRDPC2002 Car Remote
 
 ## Flex devices (command line option "-X")
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -308,6 +308,23 @@
     DECL(tpms_trw_ook) \
     DECL(tpms_trw_fsk) \
     DECL(govee_h5059) \
+    DECL(astrostart_2000) \
+    DECL(compustar_1wg3r) \
+    DECL(chrysler_car_remote) \
+    DECL(nidec_car_remote) \
+    DECL(audiovox_pro_oe3b) \
+    DECL(hcs361_txwak_0_bsel_0) \
+    DECL(hcs361_txwak_0_bsel_1) \
+    DECL(hcs361_txwak_1_bsel_0) \
+    DECL(hcs361_txwak_1_bsel_1) \
+    DECL(hcs361_vpwm_1_bsel_0) \
+    DECL(hcs361_vpwm_1_bsel_1) \
+    DECL(six_sc_two_car_remote) \
+    DECL(gm_car_remote) \
+    DECL(siemens_5wy72xx_car_remote) \
+    DECL(alps_fwb1u545_car_remote) \
+    DECL(continental_car_remote) \
+    DECL(code_alarm_frdpc2000_car_remote) \
 
     /* Add new decoders here. */
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,11 +43,13 @@ add_library(r_433 STATIC
     sdr.c
     term_ctl.c
     write_sigrok.c
+    devices/6sc2.c
     devices/abmt.c
     devices/acurite.c
     devices/acurite_01185m.c
     devices/akhan_100F14.c
     devices/alecto.c
+    devices/alps_fwb1u545.c
     devices/ambient_weather.c
     devices/ambientweather_tx8300.c
     devices/ambientweather_wh31e.c
@@ -57,7 +59,9 @@ add_library(r_433 STATIC
     devices/arad_ms_meter.c
     devices/archos_tbh.c
     devices/arexx_ml.c
+    devices/astrostart_2000.c
     devices/atech_ws308.c
+    devices/audiovox_pro_oe3b.c
     devices/auriol_4ld5661.c
     devices/auriol_aft77b2.c
     devices/auriol_afw2a1.c
@@ -86,9 +90,13 @@ add_library(r_433 STATIC
     devices/ced7000.c
     devices/celsia_czc1.c
     devices/chamberlain_cwpirc.c
+    devices/chrysler_car_remote.c
     devices/chuango.c
     devices/cmr113.c
+    devices/code_alarm_car_remote.c
     devices/companion_wtr001.c
+    devices/compustar_1wg3r.c
+    devices/continental_car_remote.c
     devices/cotech_36_7959.c
     devices/current_cost.c
     devices/danfoss.c
@@ -142,6 +150,7 @@ add_library(r_433 STATIC
     devices/generic_remote.c
     devices/generic_temperature_sensor.c
     devices/geo_minim.c
+    devices/gm_car_remote.c
     devices/govee.c
     devices/govee_h5059.c
     devices/gridstream.c
@@ -149,6 +158,7 @@ add_library(r_433 STATIC
     devices/gt_wt_02.c
     devices/gt_wt_03.c
     devices/hcs200.c
+    devices/hcs361.c
     devices/hideki.c
     devices/holman_ws5029.c
     devices/homelead_hg9901.c
@@ -198,6 +208,7 @@ add_library(r_433 STATIC
     devices/nexa.c
     devices/nexus.c
     devices/nice_flor_s.c
+    devices/nidec_car_remote.c
     devices/norgo.c
     devices/oil_smart.c
     devices/oil_standard.c
@@ -236,6 +247,7 @@ add_library(r_433 STATIC
     devices/secplus_v1.c
     devices/secplus_v2.c
     devices/sharp_spc775.c
+    devices/siemens_5wy72xx.c
     devices/silvercrest.c
     devices/simplisafe.c
     devices/simplisafe_gen3.c

--- a/src/devices/6sc2.c
+++ b/src/devices/6sc2.c
@@ -1,0 +1,119 @@
+/** @file
+    6SC2 - Car Remote.
+
+    Copyright (C) 2024 Ethan Halsall
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+/** @fn int six_sc_two_car_remote_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+6SC2 - Car Remote (315 MHz)
+
+Manufacturer:
+- Unknown
+
+Supported Models:
+- 6SC2 CMGU
+- 6SC2 CDFA
+
+Data structure:
+
+The transmitter uses a rolling code message with an unencrypted sequence number.
+
+Button operation:
+This transmitter has up to 4 buttons which can be pressed once to transmit a single message
+
+Data layout:
+
+Bytes are reflected
+
+PPPP EEEEEEEE bbbb uuuu SSSS CC
+
+- P: 16 bit preamble
+- E: 32 bit encrypted
+- b: 4 bit button
+- u: 4 bit unknown
+- S: 16 bit sequence
+- C: 8 bit checksum
+
+Format string:
+
+PREAMBLE: hhhh ENCRYPTED: hh hh hh hh BUTTON: bbbb UNKNOWN: bbbb SEQUENCE: hhhh CHECKSUM: hh
+
+*/
+
+#include "decoder.h"
+
+static int six_sc_two_car_remote_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    int row = bitbuffer_find_repeated_row(bitbuffer, 1, 48);
+
+    if (bitbuffer->bits_per_row[row] > 88) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    uint8_t *bytes = bitbuffer->bb[row];
+
+    if (bytes[0] != 0x55 || bytes[1] != 0x54) {
+        return DECODE_FAIL_SANITY;
+    }
+
+    if (xor_bytes(bytes + 2, 9)) {
+        return DECODE_FAIL_MIC;
+    }
+
+    // The transmission is LSB first, big endian.
+    uint32_t encrypted = (uint32_t)reverse8(bytes[5]) << 24 | (uint32_t)reverse8(bytes[4]) << 16 | (uint32_t)reverse8(bytes[3]) << 8 | reverse8(bytes[2]);
+    int button         = reverse8(bytes[6]) & 0xf;
+    int sequence       = (reverse8(bytes[8]) << 8) | reverse8(bytes[7]);
+
+    char encrypted_str[9];
+    snprintf(encrypted_str, sizeof(encrypted_str), "%08X", encrypted);
+
+    char const *button_str;
+
+    /* clang-format off */
+    switch (button) {
+        case 0x1: button_str = "Unlock"; break;
+        case 0x2: button_str = "Lock"; break;
+        case 0x3: button_str = "Trunk"; break;
+        case 0x4: button_str = "Panic"; break;
+        default:  button_str = "?"; break;
+    }
+    /* clang-format on */
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",       "model",       DATA_STRING, "6SC2-CarRemote",
+            "encrypted",   "",            DATA_STRING, encrypted_str,
+            "button_code", "Button Code", DATA_INT,    button,
+            "button_str",  "Button",      DATA_STRING, button_str,
+            "sequence",    "Sequence",    DATA_INT,    sequence,
+            "mic",         "Integrity",   DATA_STRING, "CHECKSUM",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+static char const *const output_fields[] = {
+        "model",
+        "encrypted",
+        "button_code",
+        "button_str",
+        "sequence",
+        "mic",
+        NULL,
+};
+
+r_device const six_sc_two_car_remote = {
+        .name        = "6SC2 Car Remote (-f 315.1M)",
+        .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
+        .short_width = 250,
+        .reset_limit = 10000,
+        .decode_fn   = &six_sc_two_car_remote_decode,
+        .fields      = output_fields,
+};

--- a/src/devices/alps_fwb1u545.c
+++ b/src/devices/alps_fwb1u545.c
@@ -1,0 +1,115 @@
+/** @file
+    Alps FWB1U545 - Car Remote.
+
+    Copyright (C) 2024 Ethan Halsall
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+/** @fn int alps_fwb1u545_car_remote_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+Alps FWB1U545 - Car Remote.
+
+Manufacturer:
+- Alps Electric
+
+Supported Models:
+- FWB1U545, (FCC ID CWTWB1U545) (OEM for Honda)
+
+Data structure:
+
+The transmitter uses a fixed code an unencrypted sequence number.
+
+Button operation:
+This transmitter has up to 4 buttons which can be pressed once to transmit a single message.
+
+Data layout:
+
+Data is little endian
+
+PP IIIIIIII bbbbbbbb bbbbbbbb SSSS CC
+
+- P: 8 bit preamble
+- I: 32 bit ID
+- b: 8 bit button code
+- b: 8 bit button code (copy)
+- S: 16 bit sequence
+- C: 4 bit unknown, maybe checksum or crc
+
+Format string:
+
+PREAMBLE: bbbbbbbb ID: hhhhhhhh BUTTON: bbbbbbbb BUTTON_XOR: bbbbbbbb SEQUENCE: hhhh UNKNOWN: bbbb
+
+*/
+
+#include "decoder.h"
+
+static int alps_fwb1u545_car_remote_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    if (bitbuffer->bits_per_row[0] != 76 || bitbuffer->num_rows > 1) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    uint8_t *bytes = bitbuffer->bb[0];
+
+    // check preamble and button XOR
+    if (bytes[0] != 0x55 || bytes[5] != bytes[6]) {
+        return DECODE_FAIL_SANITY;
+    }
+
+    // parse payload
+    uint32_t id = (uint32_t)bytes[1] << 24 | (uint32_t)bytes[2] << 16 | (uint32_t)bytes[3] << 8 | bytes[4];
+    if (id == 0 || id == 0xffffffff) {
+        return DECODE_FAIL_SANITY;
+    }
+
+    char id_str[9];
+    snprintf(id_str, sizeof(id_str), "%08X", id);
+
+    int button   = bytes[5] >> 4;
+    int sequence = (bytes[7] << 8) | bytes[8];
+
+    // map buttons
+    const char *button_str;
+    /* clang-format off */
+    switch (button) {
+        case 0xe: button_str = "Lock"; break;
+        case 0xc: button_str = "Panic"; break;
+        case 0x5: button_str = "Panic Held"; break;
+        case 0x1: button_str = "Unlock"; break;
+        default:  button_str = "?"; break;
+    }
+    /* clang-format on */
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",       "model",       DATA_STRING, "Alps-FWB1U545",
+            "id",          "ID",          DATA_STRING, id_str,
+            "button_code", "Button Code", DATA_INT,    button,
+            "button_str",  "Button",      DATA_STRING, button_str,
+            "sequence",    "Sequence",    DATA_INT,    sequence,
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+static char const *const output_fields[] = {
+        "model",
+        "id",
+        "button_code",
+        "button_str",
+        "sequence",
+        NULL,
+};
+
+r_device const alps_fwb1u545_car_remote = {
+        .name        = "Alps FWB1U545 Car Remote",
+        .modulation  = FSK_PULSE_MANCHESTER_ZEROBIT,
+        .short_width = 500,
+        .reset_limit = 1500,
+        .decode_fn   = &alps_fwb1u545_car_remote_decode,
+        .fields      = output_fields,
+};

--- a/src/devices/astrostart_2000.c
+++ b/src/devices/astrostart_2000.c
@@ -1,0 +1,169 @@
+/** @file
+    Astrostart 2000 - Car Remote.
+
+    Copyright (C) 2024 Ethan Halsall
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+/** @fn int astrostart_2000_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+Astrostart 2000 - Car Remote 372.4 MHz
+
+Manufacturer:
+- Astroflex
+
+Supported Models:
+- Astrostart 2000 (FCC ID J5F-TX2000)
+- Astrostart 3000 (FCC ID J5F-TX2000)
+
+Data structure:
+
+Astrostart 2000, 3000 Transmitters
+
+The transmitter uses a fixed code message. Each button press will always send three messages.
+
+Button operation:
+This transmitter has 5 (Astrostart 2000) or 6 (Astrostart 3000) buttons.
+One or two buttons at a time can be pressed and held to send a unique code.
+Pressing three buttons will result in a code, but is not unique to different button combinations.
+
+Using the primary / secondary serial number:
+
+The transmitter supports two sending two serial numbers.
+Press and hold a button combination once to use the primary serial number.
+
+The second serial number can be used by pressing the buttons in the below sequence:
+1. Press a button or button combination twice, holding the combinations on the second press.
+2. Hold the buttons down until you hear the four beeps / see the led flash slowly four times.
+
+Note: The panic button will always send two messages on the primary serial number, and one message on the secondary number.
+
+Data layout:
+
+B X IIII cccc
+
+- B: 8 bit button code
+- X: 8 bit inverse of the button code
+- I: 32 bit remote id
+- c: 4 bit checksum of remote id
+
+Format string:
+
+BUTTON: bbbbbbbb INVERSE: bbbbbbbb ID: hhhhhhhh CHECKSUM: h
+
+*/
+
+#include "decoder.h"
+
+static int astrostart_2000_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    if (bitbuffer->bits_per_row[0] != 52) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    if (bitbuffer->num_rows != 1) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    uint8_t *bytes = bitbuffer->bb[0];
+
+    if (bytes[0] != (~bytes[1] & 0xff)) {
+        return DECODE_FAIL_MIC;
+    }
+
+    int actual_checksum   = bytes[6] >> 4;
+    int expected_checksum = 0;
+
+    for (int i = 2; i < 6; i++) {
+        expected_checksum = (expected_checksum + (bytes[i] >> 4)) & 0xf;
+        expected_checksum = (expected_checksum + bytes[i]) & 0xf;
+    }
+
+    if (actual_checksum != expected_checksum) {
+        return DECODE_FAIL_MIC;
+    }
+
+    // parse id
+    uint32_t id = (uint32_t)bytes[2] << 24 | (uint32_t)bytes[3] << 16 | (uint32_t)bytes[4] << 8 | bytes[5];
+    char id_str[9];
+    snprintf(id_str, sizeof(id_str), "%08X", id);
+
+    // parse button
+    int button          = bytes[0];
+    char button_str[64] = "";
+
+    typedef struct {
+        const char *name;
+        const uint8_t len;
+        const uint8_t *vals;
+    } Button;
+
+    /* clang-format off */
+    const Button button_map[7] = {
+        { .name = "Lock",     .len = 6, .vals = (uint8_t[]){ 0x2b, 0x03, 0x27, 0x0f, 0x35, 0x37 } },
+        { .name = "Panic",    .len = 6, .vals = (uint8_t[]){ 0x1f, 0x35, 0x0d, 0x25, 0x15, 0x2d } },
+        { .name = "Start",    .len = 6, .vals = (uint8_t[]){ 0x13, 0x37, 0x2d, 0x33, 0x3d, 0x3b } },
+        { .name = "Stop",     .len = 6, .vals = (uint8_t[]){ 0x2f, 0x0d, 0x33, 0x03, 0x1d, 0x17 } },
+        { .name = "Trunk",    .len = 6, .vals = (uint8_t[]){ 0x23, 0x25, 0x3d, 0x1d, 0x27, 0x07 } },
+        { .name = "Unlock",   .len = 6, .vals = (uint8_t[]){ 0x0b, 0x15, 0x3b, 0x17, 0x07, 0x0f } },
+        { .name = "Multiple", .len = 1, .vals = (uint8_t[]){ 0x3F } }
+    };
+    /* clang-format on */
+    const char *delimiter = "; ";
+    const char *unknown   = "?";
+
+    int matches = 0;
+    // iterate over the button-to-value map to record which button(s) are pressed
+    for (int i = 0; i < 7; i++) {
+        for (int j = 0; j < button_map[i].len; j++) {
+            if (button == button_map[i].vals[j]) { // if the button values matches the value in the map
+                if (matches) {
+                    strcat(button_str, delimiter); // append a delimiter if there are multiple buttons matching
+                }
+                strcat(button_str, button_map[i].name); // append the button name
+                matches++;                              // record the match
+                break;                                  // move to the next button
+            }
+        }
+    }
+
+    if (!matches) {
+        strcat(button_str, unknown);
+    }
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",       "model",       DATA_STRING, "Astrostart-2000",
+            "id",          "ID",          DATA_STRING, id_str,
+            "button_code", "Button Code", DATA_INT,    button,
+            "button_str",  "Button",      DATA_STRING, button_str,
+            "mic",         "Integrity",   DATA_STRING, "CHECKSUM",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+static char const *const output_fields[] = {
+        "model",
+        "id",
+        "button_code",
+        "button_str",
+        "mic",
+        NULL,
+};
+
+r_device const astrostart_2000 = {
+        .name        = "Astrostart 2000 Car Remote (-f 372.4M)",
+        .modulation  = OOK_PULSE_PPM,
+        .short_width = 326,
+        .long_width  = 526,
+        .reset_limit = 541,
+        .gap_limit   = 541,
+        .tolerance   = 80,
+        .decode_fn   = &astrostart_2000_decode,
+        .fields      = output_fields,
+};

--- a/src/devices/audiovox_pro_oe3b.c
+++ b/src/devices/audiovox_pro_oe3b.c
@@ -1,0 +1,130 @@
+/** @file
+    Audiovox - PRO-OE3B Car Remote.
+
+    Copyright (C) 2024 Ethan Halsall
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+/** @fn int audiovox_pro_oe3b_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+Audiovox - Car Remote
+
+Manufacturer:
+- Audiovox
+
+Supported Models:
+- PRO-OE3B, AVX01BT3CL3 (FCC ID BGAOE3B)
+- PRO-OE4B, AVX01BT3CL3 (FCC ID BGAOE3B)
+
+Data structure:
+
+This transmitter uses a fixed code transmitting on 302.9 MHz.
+The same code is continuously repeated while button is held down.
+Multiple buttons can be pressed to set multiple button flags.
+
+Data layout:
+
+Bits are inverted.
+
+IIII 110b1b1b 1111
+
+- I: 16 bit ID
+- 1: always set to 1
+- 0: always set to 0
+- b: 3 bit flags indicating button(s) pressed
+- 1: always set to 1
+
+Format string:
+
+ID: hhhh x b x TRUNK:b x UNLOCK: b x LOCK: b h
+
+*/
+
+#include "decoder.h"
+
+static int audiovox_pro_oe3b_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    if (bitbuffer->bits_per_row[0] != 25) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    if (bitbuffer->num_rows != 1) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    uint8_t *bytes = bitbuffer->bb[0];
+
+    if (bytes[2] & 0xaa || bytes[2] == 0x55) {
+        return DECODE_FAIL_SANITY;
+    }
+
+    bitbuffer_invert(bitbuffer);
+
+    uint16_t id = (bytes[0] << 8) | bytes[1];
+    if (id == 0 || id == 0xffff) {
+        return DECODE_FAIL_SANITY;
+    }
+
+    char id_str[5];
+    snprintf(id_str, sizeof(id_str), "%04X", id);
+
+    // parse buttons
+    char button_str[64]           = "";
+    char const *delimiter         = "; ";
+    char const *button_strings[4] = {
+            "Lock",
+            "Unlock",
+            "Option",
+            "Trunk",
+    };
+
+    int matches = 0;
+    int mask    = 0x01;
+    for (int i = 0; i < 4; i++) {
+        if (bytes[2] & mask) {
+            if (matches) {
+                strcat(button_str, delimiter);
+            }
+            strcat(button_str, button_strings[i]);
+            matches++;
+        };
+        mask <<= 2;
+    }
+
+    if (!matches) {
+        return DECODE_FAIL_SANITY;
+    }
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",      "model",      DATA_STRING, "Audiovox-PROOE3B",
+            "id",         "ID",         DATA_STRING, id_str,
+            "button_str", "Button",     DATA_STRING, button_str,
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+static char const *const output_fields[] = {
+        "model",
+        "id",
+        "button_str",
+        NULL,
+};
+
+r_device const audiovox_pro_oe3b = {
+        .name        = "Audiovox PRO-OE3B Car Remote (-f 303.4M)",
+        .modulation  = OOK_PULSE_PWM,
+        .short_width = 445,
+        .long_width  = 895,
+        .reset_limit = 1790,
+        .gap_limit   = 1790,
+        .sync_width  = 1368,
+        .decode_fn   = &audiovox_pro_oe3b_decode,
+        .priority    = 10,
+        .fields      = output_fields,
+};

--- a/src/devices/chrysler_car_remote.c
+++ b/src/devices/chrysler_car_remote.c
@@ -1,0 +1,160 @@
+/** @file
+    Chrysler - Car Remote.
+
+    Copyright (C) 2024 Ethan Halsall
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+/** @fn int chrysler_car_remote_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+Chrysler - Car Remote (315 MHz)
+
+Manufacturer:
+- Chrysler
+
+Supported Models:
+- 56008761
+- 56008762 (FCC ID GQ43VT7T)
+- 04686366
+- 56021903AA
+
+Data structure:
+
+The transmitter uses a fixed code message.
+
+Button operation:
+This transmitter has 3 buttons which can be pressed once to transmit a single message
+Multiple buttons can be pressed down to send unique codes.
+
+row | data       | bits
+1   | [preamble] | 25
+2   | [packet]   | 49
+3   | [packet]   | 48
+
+Data layout:
+
+Bytes are inverted and reflected
+
+IIIIIIII bbbb x d xx CC
+- I: 32 bit remote ID
+- b: 4 bit button code
+- x: 1 bit unknown
+- d: 1 bit set to 1 when multiple buttons are pressed
+- x: 2 bit unknown
+- C: 8 bit checksum
+
+Format string:
+
+ID: hhhhhhhh BUTTON: bbbb x MULTIPLE: b xx CHECKSUM: bbbbbbbb
+
+*/
+
+#include "decoder.h"
+
+static int chrysler_car_remote_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    int events = 0;
+
+    bitbuffer_invert(bitbuffer);
+
+    for (int row = 0; row < bitbuffer->num_rows; row++) {
+        int offset;
+
+        if (bitbuffer->bits_per_row[row] >= 49) {
+            // try 49 bits from the end
+            offset = 49;
+        }
+        else if (bitbuffer->bits_per_row[row] == 48) {
+            // try 48 bits from the end
+            offset = 48;
+        }
+        else {
+            continue; // return DECODE_ABORT_LENGTH;
+        }
+
+        uint8_t bytes[6];
+        bitbuffer_extract_bytes(bitbuffer, row, bitbuffer->bits_per_row[row] - offset, bytes, 48);
+        reflect_bytes(bytes, 6);
+
+        int sum = add_bytes(bytes, 5);
+        if ((sum & 0xff) != bytes[5]) {
+            continue; // return DECODE_FAIL_MIC;
+        }
+
+        if (sum == 0 || sum == 0xff * 5) {
+            continue; // return DECODE_FAIL_SANITY;
+        }
+
+        // parse id
+        uint32_t id = (uint32_t)bytes[0] << 24 | (uint32_t)bytes[1] << 16 | (uint32_t)bytes[2] << 8 | bytes[3];
+        char id_str[9];
+        snprintf(id_str, sizeof(id_str), "%08X", id);
+
+        // parse button
+        int button      = bytes[4] >> 4;
+        int multi_press = (bytes[4] & 0x4) != 0;
+
+        char button_str[64]           = "";
+        char const *delimiter         = "; ";
+        char const *button_strings[3] = {
+                "Unlock",
+                "Lock",
+                "Panic"};
+
+        int matches = 0;
+        int mask    = 0x01;
+        for (int i = 0; i < 3; i++) {
+            if (button & mask) {
+                if (matches) {
+                    strcat(button_str, delimiter);
+                }
+                strcat(button_str, button_strings[i]);
+                matches++;
+            };
+            mask <<= 1;
+        }
+
+        if (!matches || (matches > 1 && !multi_press) || (matches == 1 && multi_press)) {
+            continue; // return DECODE_FAIL_SANITY;
+        }
+
+        /* clang-format off */
+        data_t *data = data_make(
+                "model",       "model",       DATA_STRING, "Chrysler-CarRemote",
+                "id",          "ID",          DATA_STRING, id_str,
+                "button_code", "Button Code", DATA_INT,    button,
+                "button_str",  "Button",      DATA_STRING, button_str,
+                "mic",         "Integrity",   DATA_STRING, "CHECKSUM",
+                NULL);
+        /* clang-format on */
+
+        decoder_output_data(decoder, data);
+        events++;
+    }
+
+    return events;
+}
+
+static char const *const output_fields[] = {
+        "model",
+        "id",
+        "button_code",
+        "button_str",
+        "mic",
+        NULL,
+};
+
+r_device const chrysler_car_remote = {
+        .name        = "Chrysler Car Remote (-f 315.1M -s 920k)",
+        .modulation  = OOK_PULSE_PWM,
+        .short_width = 350,      // 1x TE
+        .long_width  = 350 * 2,  // 2x TE
+        .reset_limit = 350 * 50, // 50x TE
+        .sync_width  = 350 * 21, // 22X TE
+        .gap_limit   = 350 * 12, // 12x TE
+        .tolerance   = 100,
+        .decode_fn   = &chrysler_car_remote_decode,
+        .fields      = output_fields,
+};

--- a/src/devices/chuango.c
+++ b/src/devices/chuango.c
@@ -24,6 +24,8 @@ Tested devices:
 - SMK-500 Smoke sensor (Default: 24H Zone)
 - WI-200 Water sensor (Default: 24H Zone)
 - newer DWC-102 additionally generates a cmd=12 signal on door/windows being closed
+- Compustar 700R Car Remote
+- Compustar 900R Car Remote
 
 Note: simple 24 bit fixed ID protocol (x1527 style) and should be handled by the flex decoder.
 

--- a/src/devices/code_alarm_car_remote.c
+++ b/src/devices/code_alarm_car_remote.c
@@ -1,0 +1,145 @@
+/** @file
+    Code Alarm - FRDPC2002 Car Remote.
+
+    Copyright (C) 2024 Ethan Halsall
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+/** @fn int code_alarm_frdpc2000_car_remote_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+Code Alarm - Car Remote
+
+Manufacturer:
+- Code Alarm
+
+Supported Models:
+- FRDPC2002, GOH-FRDPC2002
+
+Data structure:
+
+This transmitter uses a rolling code.
+The same code is continuously repeated while button is held down.
+Multiple buttons can be pressed to set multiple button flags.
+
+Data layout:
+
+PPPP uuuu bbbb IIIIIIII uuuu
+
+- P: 32 bit Preamble, all 0x00
+- u: 4 bit unknown
+- b: 4 bit button flags
+- I: 24 bit ID (This is 32 bits raw, and each byte is XOR'd to form a 24 bit ID)
+- u: 4 bit unknown
+
+Format string:
+
+PREAMBLE: hhhh UNKNOWN: bbbb BUTTON: bbbb ID: hhhhhhhh bbbbbbbb
+
+*/
+
+#include "decoder.h"
+
+static int code_alarm_frdpc2000_car_remote_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    if (bitbuffer->bits_per_row[0] != 60) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    if (bitbuffer->bb[0][0] != 0x00 || bitbuffer->bb[0][1] != 0x00) {
+        return DECODE_FAIL_SANITY;
+    }
+
+    uint8_t bytes[5];
+    bitbuffer_extract_bytes(bitbuffer, 0, 19, bytes, 40);
+
+    int bytes_sum = add_bytes(bytes, 5);
+    if (bytes_sum == 0 || bytes_sum >= 0xff * 5) {
+        return DECODE_FAIL_SANITY;
+    }
+
+    uint8_t code[5];
+    bitbuffer_extract_bytes(bitbuffer, 0, 23, code, 36); // manual tied to FCC id states a 36bit rolling code
+
+    char data_str[11];
+    snprintf(data_str, sizeof(data_str), "%02X%02X%02X%02X%02X", bytes[0], bytes[1], bytes[2], bytes[3], bytes[4]);
+
+    uint32_t id = ((code[0] ^ code[1]) << 16) | ((code[1] ^ code[2]) << 8) | (code[2] ^ code[3]);
+    char id_str[7];
+    snprintf(id_str, sizeof(id_str), "%06X", id);
+
+    // parse button
+    int button          = bytes[0] >> 4;
+    char button_str[64] = "";
+
+    typedef struct {
+        const char *name;
+        const uint8_t len;
+        const uint8_t *vals;
+    } Button;
+
+    /* clang-format off */
+    const Button button_map[5] = {
+        { .name = "Multiple", .len = 1,  .vals = (uint8_t[]){ 0x7 } },
+        { .name = "Lock",     .len = 2,  .vals = (uint8_t[]){ 0x6, 0x4 } },
+        { .name = "Panic",    .len = 2,  .vals = (uint8_t[]){ 0x1, 0x3 } },
+        { .name = "Start",    .len = 2,  .vals = (uint8_t[]){ 0x0, 0x3 } },
+        { .name = "Unlock",   .len = 2,  .vals = (uint8_t[]){ 0x5, 0x4 } },
+    };
+    /* clang-format on */
+    const char *delimiter = "; ";
+    const char *unknown   = "?";
+
+    int matches = 0;
+    // iterate over the button-to-value map to record which button(s) are pressed
+    for (int i = 0; i < 5; i++) {
+        for (int j = 0; j < button_map[i].len; j++) {
+            if (button == button_map[i].vals[j]) { // if the button values matches the value in the map
+                if (matches) {
+                    strcat(button_str, delimiter); // append a delimiter if there are multiple buttons matching
+                }
+                strcat(button_str, button_map[i].name); // append the button name
+                matches++;                              // record the match
+                break;                                  // move to the next button
+            }
+        }
+    }
+
+    if (!matches) {
+        strcat(button_str, unknown);
+    }
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",       "model",       DATA_STRING, "CodeAlarm-FRDPC2002",
+            "id",          "ID",          DATA_STRING, id_str,
+            "button_code", "Button Code", DATA_INT,    button,
+            "button_str",  "Button",      DATA_STRING, button_str,
+            "data",        "Data",        DATA_STRING, data_str,
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+static char const *const output_fields[] = {
+        "model",
+        "id",
+        "button_code",
+        "button_str",
+        "data",
+        NULL,
+};
+
+r_device const code_alarm_frdpc2000_car_remote = {
+        .name        = "Code Alarm FRDPC2002 Car Remote",
+        .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
+        .short_width = 550,
+        .long_width  = 1100,
+        .reset_limit = 1600,
+        .tolerance   = 100,
+        .decode_fn   = &code_alarm_frdpc2000_car_remote_decode,
+        .fields      = output_fields,
+};

--- a/src/devices/compustar_1wg3r.c
+++ b/src/devices/compustar_1wg3r.c
@@ -1,0 +1,200 @@
+/** @file
+    Compustar 1WG3R - Car Remote.
+
+    Copyright (C) 2024 Ethan Halsall
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+/** @fn int compustar_1wg3r_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+Compustar 1WG3R - Car Remote
+
+Manufacturer:
+- Compustar
+
+Supported Models:
+- 1WG3R-SH
+- 1WAMR-1900
+
+Data structure:
+
+Compustar 1WG3R Transmitters
+
+The transmitter uses a fixed code message.
+
+Button operation:
+This transmitter has 4 buttons which can be pressed once to transmit a single message
+Multiple buttons can be pressed down to send unique codes.
+
+Panic:
+Press and hold the lock button for 3 seconds.
+
+Long Press:
+Hold the button combination down for 2.5 seconds to send a long press signal.
+
+Secondary mode:
+Press and hold the unlock and the trunk buttons (II & III) at the same time. (press and hold for 2.5 seconds)
+The LED will flash slowly indicating the remote is in the secondary mode.
+Button presses sent in batches by the remote when secondary mode is activated.
+
+Data layout:
+
+IIII x bbbbbbbb iiiiiiii z
+
+- I: 16 bit remote ID
+- x: 3 bit unknown (always set to 111)
+- i: 8 bit inverted button code
+- b: 8 bit button code
+- z: 1 bit unknown (always set to 0)
+
+Format string:
+
+ID: hhhh UNKNOWN: bbb BUTTON_INVERSE: bbbbbbbb BUTTON: bbbbbbbb UNKNOWN: b
+
+*/
+
+#include "decoder.h"
+#include "fatal.h"
+#include <stdlib.h>
+
+static int compustar_1wg3r_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    int rows_data_idx  = -1;
+    data_t **rows_data = malloc(bitbuffer->num_rows * sizeof(data_t *));
+    if (!rows_data) {
+        WARN_MALLOC("compustar_1wg3r_decode()");
+        return -1; // NOTE: returns error on alloc failure.
+    }
+
+    // loop through all of the rows and only return unique valid results
+    // programming mode will send a sequence of key presses all in one message
+    int previous_row = -1;
+    for (int current_row = 0; current_row < bitbuffer->num_rows; current_row++) {
+        uint8_t *bytes = bitbuffer->bb[current_row];
+
+        // reset row count for the row separator
+        if (bitbuffer->bits_per_row[current_row] == 5 && (bytes[0] & 0xf8) == 0xf8) {
+            previous_row = -1;
+            continue;
+        }
+
+        if ((bytes[2] & 0xe0) != 0xe0 || (bytes[4] & 1) != 0x0) {
+            continue; // DECODE_ABORT_EARLY;
+        }
+
+        if ((bytes[0] == 0xff && bytes[1] == 0xff) ||
+                (bytes[0] == 0x00 && bytes[1] == 0x00)) {
+            continue; // DECODE_FAIL_SANITY;
+        }
+
+        uint16_t id = (bytes[0] << 8) | bytes[1];
+        char id_str[5];
+        snprintf(id_str, sizeof(id_str), "%04X", id);
+
+        int button_inverse = ((bytes[2] << 3) & 0xff) | bytes[3] >> 5;
+        int button         = ((bytes[3] << 3) & 0xff) | bytes[4] >> 5;
+
+        if ((~button_inverse & 0xff) != button) {
+            continue; // DECODE_FAIL_MIC;
+        }
+
+        // parse button
+        char button_str[128] = "";
+
+        typedef struct {
+            const char *name;
+            const uint8_t len;
+            const uint8_t *vals;
+        } Button;
+
+        /* clang-format off */
+        const Button button_map[6] = {
+            { .name = "Lock",       .len = 13,  .vals = (uint8_t[]){ 0x03, 0x05, 0x09, 0x0b, 0x0d, 0x0f, 0x1f, 0x17, 0x13, 0x15, 0x19, 0x1b, 0x1d } },
+            { .name = "Panic",      .len = 1,   .vals = (uint8_t[]){ 0x18 } },
+            { .name = "Start",      .len = 16,  .vals = (uint8_t[]){ 0x09, 0x0a, 0x0c, 0x0b, 0x0e, 0x0d, 0x04, 0x1f, 0x08, 0x19, 0x1a, 0x1c, 0x1b, 0x1e, 0x1d, 0x12 } },
+            { .name = "Trunk",      .len = 15,  .vals = (uint8_t[]){ 0x05, 0x06, 0x0c, 0x0e, 0x0d, 0x1f, 0x17, 0x02, 0x15, 0x16, 0x1c, 0x1e, 0x1d, 0x08, 0x14 } },
+            { .name = "Unlock",     .len = 13,  .vals = (uint8_t[]){ 0x03, 0x06, 0x0a, 0x0b, 0x0e, 0x1f, 0x07, 0x17, 0x13, 0x16, 0x1a, 0x1b, 0x1e } },
+            { .name = "Long Press", .len = 28,  .vals = (uint8_t[]){ 0x23, 0x31, 0x13, 0x16, 0x17, 0x1a, 0x1b, 0x1e, 0x15, 0x16, 0x1c, 0x1e, 0x1d, 0x08, 0x14, 0x08, 0x19, 0x1a, 0x1c, 0x1b, 0x1e, 0x1d, 0x12, 0x13, 0x15, 0x19, 0x1b, 0x1d } },
+        };
+        /* clang-format on */
+        const char *delimiter = "; ";
+        const char *unknown   = "?";
+
+        int matches = 0;
+        // iterate over the button-to-value map to record which button(s) are pressed
+        for (int i = 0; i < 6; i++) {
+            for (int j = 0; j < button_map[i].len; j++) {
+                if ((button & 0x7f) == button_map[i].vals[j]) { // if the button values matches the value in the map
+                    if (matches) {
+                        strcat(button_str, delimiter); // append a delimiter if there are multiple buttons matching
+                    }
+                    strcat(button_str, button_map[i].name); // append the button name
+                    matches++;                              // record the match
+                    break;                                  // move to the next button
+                }
+            }
+        }
+
+        if (!matches) {
+            strcat(button_str, unknown);
+        }
+
+        if (button & 0x80) {
+            if (matches) {
+                strcat(button_str, delimiter); // append a delimiter if there are multiple buttons matching
+            }
+            strcat(button_str, "Secondary Mode"); // append the button name
+        }
+
+        if (previous_row >= 0 && bitbuffer_compare_rows(bitbuffer, previous_row, current_row, 35)) {
+            continue; // duplicate of previous valid message
+        }
+
+        previous_row = current_row;
+        rows_data_idx++;
+        /* clang-format off */
+        rows_data[rows_data_idx] = data_make(
+                "model",        "model",       DATA_STRING, "Compustar-1WG3R",
+                "id",           "ID",          DATA_STRING, id_str,
+                "button_code",  "Button Code", DATA_INT,    button,
+                "button_str",   "Button",      DATA_STRING, button_str,
+                "mic",          "Integrity",   DATA_STRING, "CHECKSUM",
+                NULL);
+        /* clang-format on */
+    }
+
+    // send the messages in order
+    for (int i = 0; i <= rows_data_idx; i++) {
+        decoder_output_data(decoder, rows_data[i]);
+    }
+
+    free(rows_data);
+
+    if (rows_data_idx < 0) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    return rows_data_idx + 1;
+}
+
+static char const *const output_fields[] = {
+        "model",
+        "id",
+        "button_code",
+        "button_str",
+        "mic",
+        NULL,
+};
+
+r_device const compustar_1wg3r = {
+        .name        = "Compustar 1WG3R Car Remote",
+        .modulation  = OOK_PULSE_PWM,
+        .short_width = 708,
+        .long_width  = 1076,
+        .reset_limit = 1532,
+        .sync_width  = 1448,
+        .decode_fn   = &compustar_1wg3r_decode,
+        .fields      = output_fields,
+};

--- a/src/devices/continental_car_remote.c
+++ b/src/devices/continental_car_remote.c
@@ -1,0 +1,139 @@
+/** @file
+    Continental - Car Remote.
+
+    Copyright (C) 2024 Ethan Halsall
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+/** @fn int continental_car_remote_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+Continental - Car Remote (313 MHz)
+
+Manufacturer:
+- Continental
+
+Supported Models:
+- 72147-SNA-A01 (FCC ID KR5V2X) (OEM for Honda)
+
+Data structure:
+
+The transmitter uses a rolling with an unencrypted sequence number.
+
+Button operation:
+The unlock, lock buttons can be pressed once to transmit a single message.
+The trunk, panic buttons will transmit the same code on a short press.
+The trunk, panic buttons will transmit the unique code on a long press.
+The panic button will repeat the panic code as long as it is held.
+
+Data layout:
+
+The decoder will match on the last 20 bits of the preamble: 0xf0f06
+
+PPPPP IIIIIIII UU bbbb U IIIII EEEEEEEE CC
+
+- P: 20 bit preamble (following a longer wakeup sequence)
+- I: 32 bit remote ID
+- U: 8 bit unknown
+- b: 4 b bit button code
+- U: 4 bit unknown
+- E: 32 bit encrypted code
+- C: 8 XOR of entire payload
+
+Format string:
+
+PREAMBLE: bbbbbbbb bbbbbbbb bbbb ID: hhhhhhhh UNKNOWN: bbbbbbbb BUTTON: bbbb UNKNOWN: bbbb SEQUENCE: hhhhhh CODE: hhhhhhhhhh CHECKSUM: hh
+
+*/
+
+#include "decoder.h"
+
+static int continental_car_remote_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    if (bitbuffer->bits_per_row[0] < 132) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    uint8_t pattern[8] = {0xf0, 0xf0, 0x60};
+    int offset         = bitbuffer_search(bitbuffer, 0, 0, pattern, 20) + 20;
+
+    if (bitbuffer->bits_per_row[0] - offset < 112) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    uint8_t bytes[14];
+    bitbuffer_extract_bytes(bitbuffer, 0, offset, bytes, 112);
+
+    uint32_t id        = (uint32_t)bytes[0] << 24 | (uint32_t)bytes[1] << 16 | (uint32_t)bytes[2] << 8 | bytes[3];
+    int button         = bytes[5] >> 4;
+    int sequence       = (bytes[6] << 16) | (bytes[7] << 8) | bytes[8];
+    uint32_t encrypted = (uint32_t)bytes[9] << 24 | (uint32_t)bytes[10] << 16 | (uint32_t)bytes[11] << 8 | bytes[12];
+
+    if (id == 0 ||
+            button == 0 ||
+            sequence == 0 ||
+            id == 0xfffffff ||
+            encrypted == 0xfffffff ||
+            sequence == 0xffffff) {
+        return DECODE_FAIL_SANITY;
+    }
+
+    if (xor_bytes(bytes, 14)) {
+        return DECODE_FAIL_MIC;
+    }
+
+    char id_str[9];
+    snprintf(id_str, sizeof(id_str), "%08X", id);
+
+    char encrypted_str[9];
+    snprintf(encrypted_str, sizeof(encrypted_str), "%08X", encrypted);
+
+    char const *button_str;
+    /* clang-format off */
+    switch (button) {
+        case 0x1: button_str = "Lock"; break;
+        case 0x3: button_str = "Unlock"; break;
+        case 0x9: button_str = "Trunk Long Press"; break;
+        case 0xa: button_str = "Trunk/Panic Short Press"; break;
+        case 0xb: button_str = "Panic Long Press"; break;
+        default: button_str = "?"; break;
+    }
+    /* clang-format on */
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",       "model",       DATA_STRING, "Continental-KR5V2X",
+            "id",          "ID",          DATA_STRING, id_str,
+            "encrypted",   "",            DATA_STRING, encrypted_str,
+            "sequence",    "Sequence",    DATA_INT,    sequence,
+            "button_code", "Button Code", DATA_INT,    button,
+            "button_str",  "Button",      DATA_STRING, button_str,
+            "mic",         "Integrity",   DATA_STRING, "CHECKSUM",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+static char const *const output_fields[] = {
+        "model",
+        "id",
+        "encrypted",
+        "sequence",
+        "button_code",
+        "button_str",
+        "mic",
+        NULL,
+};
+
+r_device const continental_car_remote = {
+        .name        = "Continental KR5V2X Car Remote (-f 313.8M -s 1024k)",
+        .modulation  = FSK_PULSE_MANCHESTER_ZEROBIT,
+        .short_width = 100,
+        .long_width  = 200,
+        .reset_limit = 1500,
+        .decode_fn   = &continental_car_remote_decode,
+        .fields      = output_fields,
+};

--- a/src/devices/gm_car_remote.c
+++ b/src/devices/gm_car_remote.c
@@ -1,0 +1,135 @@
+/** @file
+    GM - Car Remote.
+
+    Copyright (C) 2024 Ethan Halsall
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+/** @fn int gm_car_remote_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+General Motors - Car Remote (315 MHz)
+
+Manufacturer:
+- General Motors
+
+Supported Models:
+- ABO1502T
+
+Data structure:
+
+The transmitter uses a rolling code message with an unencrypted sequence number.
+
+Button operation:
+This transmitter has 2 to 4 buttons which can be pressed once to transmit a single message
+Pressing both lock and unlock appears to send a fixed code, possibly a PRNG seed or secret key for the rolling code.
+
+Data layout:
+
+PP xxxx cccc IIIIIIII SSSSSS EEEEEE CC
+
+- P: 8 bit unknown, possibly part of the ID
+- c: 4 bit checksum of button code
+- b: 4 bit button code
+- I: 32 bit ID
+- S: 24 bit sequence
+- E: 24 bit encrypted
+- C: 8 bit checksum of entire payload
+
+Format string:
+
+UNKNOWN: bbbbbbbb BUTTON_CHECKSUM: bbbb BUTTON: bbbb ID: hhhhhhhh SEQUENCE: hhhhhh ENCRYPTED: hhhhhh CHECKSUM: hh
+
+*/
+
+#include "decoder.h"
+
+static int gm_car_remote_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    if (bitbuffer->bits_per_row[0] < 113 || bitbuffer->num_rows > 1) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    // a long wake up payload is sent that may be truncated, so start from the end of the payload.
+    int offset = bitbuffer->bits_per_row[0] - 113;
+
+    uint8_t bytes[14];
+    bitbuffer_extract_bytes(bitbuffer, 0, offset, bytes, 112);
+
+    // check one byte from the wake up signal
+    if (bytes[0] != 0xff) {
+        return DECODE_FAIL_SANITY;
+    }
+
+    // validate mic
+    int button_checksum = add_nibbles(bytes + 2, 1);
+    if (button_checksum == 0 || (button_checksum & 0xf) != 0) {
+        return DECODE_FAIL_MIC;
+    }
+
+    int full_checksum = add_bytes(bytes + 1, 13);
+    if (full_checksum == 0 || (full_checksum & 0xff) != 0) {
+        return DECODE_FAIL_MIC;
+    }
+
+    // parse payload
+    int button         = bytes[2] & 0x7;
+    uint32_t id        = (uint32_t)bytes[3] << 24 | (uint32_t)bytes[4] << 16 | (uint32_t)bytes[5] << 8 | bytes[6];
+    int sequence       = (bytes[7] << 16) | (bytes[8] << 8) | bytes[9];
+    uint32_t encrypted = (uint32_t)bytes[10] << 16 | (uint32_t)bytes[11] << 8 | bytes[12];
+
+    char id_str[12];
+    snprintf(id_str, sizeof(id_str), "%02X%08X", bytes[1], id);
+
+    char encrypted_str[8];
+    snprintf(encrypted_str, sizeof(encrypted_str), "%06X", encrypted);
+
+    char const *button_str;
+
+    /* clang-format off */
+    switch (button) {
+        case 0x1: button_str = "Unlock"; break;
+        case 0x2: button_str = "Lock"; break;
+        case 0x3: button_str = "Trunk"; break;
+        case 0x4: button_str = "Panic"; break;
+        default: button_str = "?"; break;
+    }
+    /* clang-format on */
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",       "model",       DATA_STRING, "GM-ABO1502T",
+            "id",          "ID",          DATA_STRING, id_str,
+            "encrypted",   "",            DATA_STRING, encrypted_str,
+            "button_code", "Button Code", DATA_INT,    button,
+            "button_str",  "Button",      DATA_STRING, button_str,
+            "sequence",    "Sequence",    DATA_INT,    sequence,
+            "mic",         "Integrity",   DATA_STRING, "CHECKSUM",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+static char const *const output_fields[] = {
+        "model",
+        "id",
+        "encrypted",
+        "button_code",
+        "button_str",
+        "sequence",
+        "mic",
+        NULL,
+};
+
+r_device const gm_car_remote = {
+        .name        = "GM ABO1502T Car Remote (-f 314.9M)",
+        .modulation  = OOK_PULSE_PPM,
+        .short_width = 300,
+        .long_width  = 500,
+        .reset_limit = 20000,
+        .decode_fn   = &gm_car_remote_decode,
+        .fields      = output_fields,
+};

--- a/src/devices/hcs361.c
+++ b/src/devices/hcs361.c
@@ -1,0 +1,260 @@
+/** @file
+    Microchip HCS361 KeeLoq Code Hopping Encoder based remotes.
+
+    Copyright (C) 2024 Ethan Halsall
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+/** @fn hcs361_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+Microchip HCS361 KeeLoq Code Hopping Encoder based remotes.
+
+Data Format:
+
+66 bits transmitted, LSB first.
+
+Extended Serial Number Disabled:
+
+|  0-31 | Encrypted Portion
+| 32-59 | Serial Number
+| 60-63 | Button Status (S3, S0, S1, S2)
+|  64   | Battery Low
+| 65-66 | CRC
+
+Extended Serial Number Enabled:
+
+|  0-31 | Encrypted Portion
+| 32-63 | Serial Number
+|  64   | Battery Low
+| 65-66 | CRC
+
+Note that the button bits are (MSB/first sent to LSB) S3, S0, S1, S2.
+Hardware buttons might map to combinations of these bits.
+
+- Datasheet HCS361: https://ww1.microchip.com/downloads/aemDocuments/documents/MCU08/ProductDocuments/DataSheets/40146F.pdf
+
+Known Devices:
+- Manufacturer / Model
+  - Leer - OUTE_ELC (FCC ID KOBLEAR1XT)
+  - Marelli - (FCC ID KBRASTU15)
+  - Jeep / Chrysler remote
+
+Pulse Format / Timing:
+
+PWM timings and code format varies based on EEPROM configuration.
+
+Logic:
+- 0 = long
+- 1 = short
+
+Timing is selected by the two flags coded into the EEPROM.
+
+- TXWAK: Bit Format Select Or Wake-Up
+  - When VPWM is enabled, this bit will enable the wake-up signal.
+- BSEL: Baud Rate Select
+  - When disabled, baud rate is 833 bits / second.
+  - When enabled, baud rate is 1667 bits / second.
+
+*/
+
+#include "decoder.h"
+
+static int hcs361_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    if (bitbuffer->num_rows < 2 || bitbuffer->bits_per_row[1] != 67) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    // sync
+    if (bitbuffer->bits_per_row[0] == 6 && bitbuffer->bb[0][0] != 0xfc) {
+        return DECODE_FAIL_SANITY;
+    }
+    // no sync
+    if (bitbuffer->bits_per_row[0] == 12) {
+        uint16_t preamble = (bitbuffer->bb[0][0]) << 8 | bitbuffer->bb[0][1];
+        if (
+                preamble != 0xaaa0 && // PIWM modulation
+                preamble != 0xfff0)   // PWM modulation
+        {
+            return DECODE_FAIL_SANITY;
+        }
+    }
+
+    // Second row is data
+    uint8_t *b = bitbuffer->bb[1];
+
+    // No need to decode/extract values for simple test
+    if (b[1] == 0xff && b[2] == 0xff && b[3] == 0xff && b[4] == 0xff && b[5] == 0xff && b[6] == 0xff && b[7] == 0xff) {
+        decoder_log(decoder, 2, __func__, "DECODE_FAIL_SANITY data all 0xff");
+        return DECODE_FAIL_SANITY;
+    }
+
+    int crc         = 0;
+    int crc_bat_low = 0;
+    int actual_crc  = (b[8] >> 5) & 0x3;
+
+    for (int i = 0; i < 65; i++) {
+        int bit     = (b[i / 8] >> (7 - (i % 8)));
+        int crc_bit = ((crc >> 1) ^ bit) & 0x1;
+
+        // datasheet recommends checking the final crc bit for bat low flag if it is flipped
+        if (i == 64) {
+            int crc_bit_bat_low = ((crc >> 1) ^ ~bit) & 0x1;
+            crc_bat_low         = crc_bit_bat_low | (((crc_bit_bat_low ^ crc) << 1) & 0x2);
+        }
+
+        crc = crc_bit | (((crc_bit ^ crc) << 1) & 0x2);
+    }
+
+    if (actual_crc != crc && actual_crc != crc_bat_low) {
+        return DECODE_FAIL_MIC;
+    }
+
+    // The transmission is LSB first, big endian.
+    uint32_t encrypted = (uint32_t)reverse8(b[3]) << 24 | (uint32_t)reverse8(b[2]) << 16 | (uint32_t)reverse8(b[1]) << 8 | reverse8(b[0]);
+    uint32_t serial    = (uint32_t)reverse8(b[7] & 0xf0) << 24 | (uint32_t)reverse8(b[6]) << 16 | (uint32_t)reverse8(b[5]) << 8 | reverse8(b[4]);
+    int btn            = (b[7] & 0x0f);
+    int btn_num        = (btn & 0x08) | ((btn & 0x01) << 2) | (btn & 0x02) | ((btn & 0x04) >> 2); // S3, S0, S1, S2
+    int battery_ok     = (b[8] & 0x80) == 0x80;
+
+    char encrypted_str[9];
+    snprintf(encrypted_str, sizeof(encrypted_str), "%08X", encrypted);
+    char serial_str[9];
+    snprintf(serial_str, sizeof(serial_str), "%08X", serial);
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",            "",             DATA_STRING,    "Microchip-HCS361",
+            "id",               "",             DATA_STRING,    serial_str,
+            "battery_ok",       "Battery",      DATA_INT,       battery_ok,
+            "button",           "Button",       DATA_INT,       btn_num,
+            "encrypted",        "",             DATA_STRING,    encrypted_str,
+            "mic",              "Integrity",    DATA_STRING,    "CRC",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+static char const *const output_fields[] = {
+        "model",
+        "id",
+        "battery_ok",
+        "button",
+        "encrypted",
+        "mic",
+        NULL,
+};
+
+/*
+PWM Mode:
+TXWAK: 0
+BSEL:  0
+TE:    (min: 260us), (avg: 400us), (max: 620us)
+*/
+r_device const hcs361_txwak_0_bsel_0 = {
+        .name        = "Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 833 bit/s)",
+        .modulation  = OOK_PULSE_PWM,
+        .short_width = 400,            // Short     1x  TE
+        .long_width  = 800,            // Long      2x  TE
+        .gap_limit   = 1200,           // Gap       3x  TE
+        .reset_limit = 7200,           // Reset     18x TE
+        .tolerance   = 140,            // Tolerance 140 us
+        .sync_width  = 4000,           // Sync      10x TE
+        .decode_fn   = &hcs361_decode, // 111111     [sync 10x TE] [header 10x TE] [data] [guard time]
+        .fields      = output_fields,
+};
+
+/*
+PWM Mode:
+TXWAK: 0
+BSEL:  1
+TE:    (min: 130us), (avg: 200us), (max: 310us)
+*/
+r_device const hcs361_txwak_0_bsel_1 = {
+        .name        = "Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 1667 bit/s)",
+        .modulation  = OOK_PULSE_PWM,
+        .short_width = 200,            // Short     1x  TE
+        .long_width  = 400,            // Long      2x  TE
+        .gap_limit   = 600,            // Gap       3x  TE
+        .reset_limit = 13600,          // Reset     34x TE
+        .tolerance   = 70,             // Tolerance 70  us
+        .sync_width  = 2000,           // Sync      10x TE
+        .decode_fn   = &hcs361_decode, // 111111     [sync 10x TE] [header 10x TE] [data] [guard time]
+        .fields      = output_fields,
+};
+
+/*
+PWM Mode:
+TXWAK: 1
+BSEL:  0
+TE:    (min: 130us), (avg: 200us), (max: 310us)
+*/
+r_device const hcs361_txwak_1_bsel_0 = {
+        .name        = "Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 833 bit/s)",
+        .modulation  = OOK_PULSE_PWM,
+        .short_width = 200,            // Short     1x  TE
+        .long_width  = 400,            // Long      2x  TE
+        .gap_limit   = 1200,           // Gap       6x  TE
+        .reset_limit = 6800,           // Reset     34x TE
+        .tolerance   = 140,            // Tolerance 70  us
+        .decode_fn   = &hcs361_decode, // 1111111111               [header 10x TE] [data] [guard time]
+        .fields      = output_fields,
+};
+
+/*
+PWM Mode:
+TXWAK: 1
+BSEL:  1
+TE:    (min: 65us),  (avg: 100us), (max: 155us)
+*/
+r_device const hcs361_txwak_1_bsel_1 = {
+        .name        = "Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 1667 bit/s)",
+        .modulation  = OOK_PULSE_PWM,
+        .short_width = 100,            // Short     1x  TE
+        .long_width  = 200,            // Long      2x  TE
+        .gap_limit   = 600,            // Gap       6x  TE
+        .reset_limit = 6600,           // Reset     66x TE
+        .tolerance   = 70,             // Tolerance 35  us
+        .decode_fn   = &hcs361_decode, // 1111111111               [header 10x TE] [data] [guard time]
+        .fields      = output_fields,
+};
+
+/*
+VPWM Mode:
+BSEL:  0
+TE:    (min: 260us), (avg: 400us), (max: 620us)
+*/
+r_device const hcs361_vpwm_1_bsel_0 = {
+        .name        = "Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 2500 bit/s)",
+        .modulation  = OOK_PULSE_PIWM_DC,
+        .short_width = 400,            // Short     1x  TE
+        .long_width  = 800,            // Long      2x  TE
+        .gap_limit   = 4000,           // Gap       3x  TE
+        .reset_limit = 45600,          // Reset     114x TE
+        .tolerance   = 140,            // Tolerance 140 us
+        .sync_width  = 4000,           // Sync      10x TE
+        .decode_fn   = &hcs361_decode, // 111111     [sync 10x TE] [header 10x TE] [data] [guard time]
+        .fields      = output_fields,
+};
+
+/*
+VPWM Mode:
+BSEL:  1
+TE:    (min: 130us), (avg: 200us), (max: 310us)
+*/
+r_device const hcs361_vpwm_1_bsel_1 = {
+        .name        = "Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 5000 bit/s)",
+        .modulation  = OOK_PULSE_PIWM_DC,
+        .short_width = 200,            // Short     1x   TE
+        .long_width  = 400,            // Long      2x   TE
+        .gap_limit   = 2000,           // Gap       3x   TE
+        .reset_limit = 45200,          // Reset     114x TE
+        .tolerance   = 70,             // Tolerance 140  us
+        .sync_width  = 2000,           // Sync      10x  TE
+        .decode_fn   = &hcs361_decode, // 111111     [sync 10x TE] [header 10x TE] [data] [guard time]
+        .fields      = output_fields,
+};

--- a/src/devices/nidec_car_remote.c
+++ b/src/devices/nidec_car_remote.c
@@ -1,0 +1,134 @@
+/** @file
+    Nidec - Car Remote.
+
+    Copyright (C) 2024 Ethan Halsall
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+/** @fn int nidec_car_remote_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+Nidec - Car Remote (313 MHz)
+
+Manufacturer:
+- Nidec
+
+Supported Models:
+- OUCG8D-344H-A (OEM for Honda)
+
+Data structure:
+
+The transmitter uses a rolling code message.
+
+Button operation:
+The unlock, lock buttons can be pressed once to transmit a single message.
+The trunk, panic buttons will transmit the same code on a short press.
+The trunk, panic buttons will transmit the unique code on a long press.
+The panic button will repeat the panic code as long as it is held.
+
+Data layout:
+
+Bytes are inverted.
+
+The decoder will match on the last 64 bits of the preamble: 0xfffffff0
+
+SSSS IIIIII uuuu bbbb CC
+
+- I: 16 bit sequence that increments on each code transmitted
+- I: 24 bit remote ID
+- u: 4 bit unknown
+- b: 4 bit button code
+- C: 16 bit unknown code, possibly a checksum or rolling code
+
+Format string:
+
+SEQUENCE hhhh ID: hhhhhh UNKNOWN: bbbb BUTTON: bbbb CODE: hhhh
+
+*/
+
+#include "decoder.h"
+
+static int nidec_car_remote_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    if (bitbuffer->bits_per_row[0] < 128) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    uint8_t pattern[8] = {0xff, 0xff, 0xff, 0xf0};
+    int offset         = bitbuffer_search(bitbuffer, 0, 0, pattern, 32) + 32;
+
+    if (bitbuffer->bits_per_row[0] - offset < 56) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    bitbuffer_invert(bitbuffer);
+
+    uint8_t bytes[8];
+    bitbuffer_extract_bytes(bitbuffer, 0, offset, bytes, 64);
+
+    int sequence  = (bytes[0] << 8) | bytes[1];
+    uint32_t id   = (uint32_t)bytes[2] << 16 | (uint32_t)bytes[3] << 8 | bytes[4];
+    int button    = bytes[5] & 0xf;
+    uint16_t code = (uint16_t)bytes[6] << 8 | bytes[7];
+
+    if (id == 0 ||
+            button == 0 ||
+            sequence == 0 ||
+            id == 0xffffff ||
+            sequence == 0xffff) {
+        return DECODE_FAIL_SANITY;
+    }
+
+    char id_str[7];
+    snprintf(id_str, sizeof(id_str), "%06X", id);
+
+    char code_str[5];
+    snprintf(code_str, sizeof(code_str), "%04X", code);
+
+    char const *button_str;
+    /* clang-format off */
+    switch (button) {
+        case 0x3: button_str = "Lock"; break;
+        case 0x4: button_str = "Unlock"; break;
+        case 0x5: button_str = "Trunk/Panic Short Press"; break;
+        case 0x6: button_str = "Panic Long Press"; break;
+        case 0xf: button_str = "Trunk Long Press"; break;
+        default: button_str = "?"; break;
+    }
+    /* clang-format on */
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",       "model",       DATA_STRING, "Nidec-OUCG8D",
+            "id",          "ID",          DATA_STRING, id_str,
+            "code",        "",            DATA_STRING, code_str,
+            "sequence",    "Sequence",    DATA_INT,    sequence,
+            "button_code", "Button Code", DATA_INT,    button,
+            "button_str",  "Button",      DATA_STRING, button_str,
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+static char const *const output_fields[] = {
+        "model",
+        "id",
+        "code",
+        "sequence",
+        "button_code",
+        "button_str",
+        NULL,
+};
+
+r_device const nidec_car_remote = {
+        .name        = "Nidec Car Remote (-f 313.8M -s 1024k)",
+        .modulation  = FSK_PULSE_PWM,
+        .short_width = 250,
+        .long_width  = 500,
+        .reset_limit = 1000,
+        .decode_fn   = &nidec_car_remote_decode,
+        .fields      = output_fields,
+};

--- a/src/devices/siemens_5wy72xx.c
+++ b/src/devices/siemens_5wy72xx.c
@@ -1,0 +1,138 @@
+/** @file
+    Siemens 5WY72XX - Car Remote.
+
+    Copyright (C) 2024 Ethan Halsall
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+/** @fn int siemens_5wy72xx_car_remote_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+    Siemens 5WY72XX - Car Remote.
+Siemens - Car Remote (315 MHz)
+
+Manufacturer:
+- Siemens
+
+Supported Models:
+- 5WY72XX, (FCC ID M3N5WY72XX) (OEM for DaimlerChrysler SKREEK CS and RS vehicle platforms.)
+
+Data structure:
+
+The transmitter uses a rolling code message with an unencrypted sequence number.
+
+Button operation:
+This transmitter has up to 6 buttons which can be pressed once to transmit a single message.
+Multiple buttons can be pressed to send unique codes.
+
+Data layout:
+
+Data is little endian
+
+PPPP IIIIIIII bbbbbbbb SSSS EEEEEEEE CC
+
+- P: 16 bit preamble (not included in XOR checksum)
+- c: 32 bit ID
+- b: 8 bit button code
+- S: 16 bit sequence
+- E: 32 bit encrypted
+- C: 8 bit XOR of entire payload, except preamble
+
+Format string:
+
+PREAMBLE: hhhh ID: hhhhhhhh BUTTON: bbbbbbbb SEQUENCE: hhhh ENCRYPTED: hhhhhhhh XOR: hh xxxx
+
+*/
+
+#include "decoder.h"
+
+static int siemens_5wy72xx_car_remote_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    if (bitbuffer->bits_per_row[0] < 113 || bitbuffer->num_rows > 1) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    const uint8_t pattern[2] = {0x60, 0x01};
+    int offset               = bitbuffer_search(bitbuffer, 0, 0, pattern, 16) + 16;
+
+    uint8_t bytes[12];
+    bitbuffer_extract_bytes(bitbuffer, 0, offset, bytes, 96);
+
+    int sum = add_bytes(bytes, 12);
+    if (sum == 0 || sum == 0xff * 12) {
+        return DECODE_FAIL_SANITY;
+    }
+
+    if (xor_bytes(bytes, 12) != 0) {
+        return DECODE_FAIL_MIC;
+    }
+
+    // parse payload
+    char id_str[9];
+    snprintf(id_str, sizeof(id_str), "%02X%02X%02X%02X", bytes[3], bytes[2], bytes[1], bytes[0]);
+    int button   = bytes[4];
+    int sequence = (bytes[5] << 8) | bytes[6];
+    char encrypted_str[9];
+    snprintf(encrypted_str, sizeof(encrypted_str), "%02X%02X%02X%02X", bytes[10], bytes[9], bytes[8], bytes[7]);
+
+    // parse buttons
+    char button_str[64]           = "";
+    char const *delimiter         = "; ";
+    char const *button_strings[6] = {
+            "Lock",       // 0x01
+            "Unlock",     // 0x02
+            "Trunk",      // 0x04
+            "Panic",      // 0x0f
+            "Left Door",  // 0x10
+            "Right Door", // 0x20
+    };
+
+    int matches = 0;
+    int mask    = 0x01;
+    for (int i = 0; i < 6; i++) {
+        if (button & mask) {
+            if (matches) {
+                strcat(button_str, delimiter);
+            }
+            strcat(button_str, button_strings[i]);
+            matches++;
+        };
+        mask <<= 1;
+    }
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",            "model",       DATA_STRING, "Siemens-5WY72XX",
+            "id",               "ID",          DATA_STRING, id_str,
+            "encrypted",        "",            DATA_STRING, encrypted_str,
+            "button_code",      "Button Code", DATA_INT,    button,
+            "button_str",       "Button",      DATA_STRING, button_str,
+            "sequence",         "Sequence",    DATA_INT,    sequence,
+            "mic",              "Integrity",   DATA_STRING, "CHECKSUM",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+static char const *const output_fields[] = {
+        "model",
+        "id",
+        "encrypted",
+        "button_code",
+        "button_str",
+        "sequence",
+        "mic",
+        NULL,
+};
+
+r_device const siemens_5wy72xx_car_remote = {
+        .name        = "Siemens 5WY72XX Car Remote (-f 315.1M)",
+        .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
+        .short_width = 220,
+        .reset_limit = 10000,
+        .decode_fn   = &siemens_5wy72xx_car_remote_decode,
+        .fields      = output_fields,
+};


### PR DESCRIPTION
Add support for multiple car remotes / keyfobs.

See merbanan/rtl_433_tests#462 for decode samples and documentation.

Manufacturer / Model:
- Astroflex
  - Astrostart 2000
  - Astrostart 3000
- Alps
  - FWB1U545
- Audiovox
  - PRO-OE3B, AVX01BT3CL3 (FCC ID BGAOE3B)
- Code Alarm
  - FRDPC2002
- Compustar
  - 1WG3R-SH
  - 1WAMR-1900
- Continental
  - KR5V2X
- Chrysler
  - 56008761
  - 56008762 (FCC ID GQ43VT7T)
  - 04686366
  - 56021903AA
- General Motors
  - ABO1502T
- Microchip
  - HCS361
- Nidec
  - OUCG8D-344H-A
- Nutek
  - ATCD-1
  - APS99BT3BCF4, ATCH (FCC ID ELVATCD)
  - AVX1BS4, AVX-1BS4 (FCC ID ELVATCC)
  - A1BTX (FCC ID ELVATFE)
  - 105BP (FCC ID ELVATJA)
- Siemens
  - 5WY72XX
- Unknown
  - 6SC2

Resolves #2754

Assisted-by: Qwen : 3.6 Plus