### PR TITLE
Add support for TPMS Shenzhen EGQ Q85 and Improve Abarth 124 Spider

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [153]  Cotech 36-7959, SwitchDocLabs FT020T wireless weather station with USB
     [154]  Standard Consumption Message Plus (SCMplus)
     [155]  Fine Offset Electronics WH1080/WH3080 Weather Station (FSK)
-    [156]  Abarth 124 Spider TPMS
+    [156]  Abarth 124 Spider and Shenzhen EGQ Q85 TPMS
     [157]  Missil ML0757 weather station
     [158]  Sharp SPC775 weather station
     [159]  Insteon

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -394,7 +394,7 @@ convert si
   protocol 153 # Cotech 36-7959, SwitchDocLabs FT020T wireless weather station with USB
   protocol 154 # Standard Consumption Message Plus (SCMplus)
   protocol 155 # Fine Offset Electronics WH1080/WH3080 Weather Station (FSK)
-  protocol 156 # Abarth 124 Spider TPMS
+  protocol 156 # Abarth 124 Spider and Shenzhen EGQ Q85 TPMS
   protocol 157 # Missil ML0757 weather station
   protocol 158 # Sharp SPC775 weather station
   protocol 159 # Insteon

--- a/src/devices/tpms_abarth124.c
+++ b/src/devices/tpms_abarth124.c
@@ -71,7 +71,6 @@ Data layout (nibbles):
 static int tpms_abarth124_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos, int type)
 {
     bitbuffer_t packet_bits = {0};
-    uint8_t *b;
     char id_str[4 * 2 + 1];
     char flags[1 * 2 + 1];
     int data_len;
@@ -91,12 +90,11 @@ static int tpms_abarth124_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsi
 
     // make sure we decoded the expected number of bits
     if (packet_bits.bits_per_row[0] < data_len) {
-        // decoder_logf(decoder, 0, __func__, "bitpos=%u start_pos=%u = %u", bitpos, start_pos, (start_pos - bitpos));
         decoder_log(decoder, 2, __func__, "Packet too short");
         return 0; //DECODE_FAIL_SANITY;
     }
 
-    b = packet_bits.bb[0];
+    uint8_t *b = packet_bits.bb[0];
 
     // check checksum (checksum8 xor) same for both type model
     int checksum = xor_bytes(b, 9);
@@ -124,7 +122,7 @@ static int tpms_abarth124_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsi
     /* clang-format off */
     data_t *data = data_make(
             "model",            "",             DATA_COND, type == MODEL_TG1C, DATA_STRING, "Abarth-124Spider",
-            "model",            "",             DATA_COND, type == MODEL_Q85,  DATA_STRING, "Shenzhen-EGQ-Q85",
+            "model",            "",             DATA_COND, type == MODEL_Q85,  DATA_STRING, "Shenzhen-EGQQ85",
             "type",             "",             DATA_STRING, "TPMS",
             "id",               "",             DATA_STRING, id_str,
             "flags",            "",             DATA_STRING, flags,
@@ -168,7 +166,7 @@ static int tpms_abarth124_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     // Find a preamble with enough bits after it that it could be a complete packet
     while ((bitpos = bitbuffer_search(bitbuffer, 0, bitpos, preamble_pattern, 24)) + 80 <=
             bitbuffer->bits_per_row[0]) {
-        events += tpms_abarth124_decode(decoder, bitbuffer, 0, bitpos + 24,type);
+        events += tpms_abarth124_decode(decoder, bitbuffer, 0, bitpos + 24, type);
         bitpos += 2;
     }
 

--- a/src/devices/tpms_abarth124.c
+++ b/src/devices/tpms_abarth124.c
@@ -1,5 +1,9 @@
-/**  @file
-    VDO Type TG1C FSK 9 byte Manchester encoded checksummed TPMS data.
+/** @file
+    VDO TPMS Type TG1C and Q85.
+
+    Copyright (C) TTigges for (VDO Type TG1C via) Abarth 124 Spider TPMS decoded
+    Protocol similar (and based on) Jansite Solar TPMS by Andreas Spiess and Christian W. Zuckschwerdt
+    Copyright (C) 2024 Bruno OCTAU (ProfBoc75) Add Shenzhen EGQ Q85 support
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -7,74 +11,130 @@
     (at your option) any later version.
 */
 
+#include "decoder.h"
+
 /**
-(VDO Type TG1C via) Abarth 124 Spider TPMS decoded by TTigges
-Protocol similar (and based on) Jansite Solar TPMS by Andreas Spiess and Christian W. Zuckschwerdt
+VDO TPMS Type TG1C and Q85.
 
-OEM Sensor is said to be a VDO Type TG1C, available in different cars,
-e.g.: Abarth 124 Spider, some Fiat 124 Spider, some Mazda MX-5 ND (and NC?) and probably some other Mazdas.
-Mazda reference/part no.: BHB637140A
-VDO reference/part no.: A2C1132410180
+VDO Type TG1C:
+- FSK  9 byte Manchester encoded, checksummed for 8 bytes TPMS data.
 
-Compatible with aftermarket sensors, e.g. Aligator sens.it RS3
+Q85 from Shenzhen EGQ Cloud technology CO,LTD:
+- FSK 12 byte Manchester encoded, checksummed for 8 bytes TPMS data + CRC/16 CCITT-FASLE for 10 bytes DATA.
 
-// Working Temperature: -50°C to 125°C
-// Working Frequency: 433.92MHz+-38KHz
-// Tire monitoring range value: 0kPa-350kPa+-7kPa (to be checked, VDO says 450/900kPa)
+TG1C (Abarth-124Spider):
+- OEM Sensor is said to be a VDO Type TG1C, available in different cars,
+- e.g.: Abarth 124 Spider, some Fiat 124 Spider, some Mazda MX-5 ND (and NC?) and probably some other Mazdas.
+- Mazda reference/part no.: BHB637140A
+- VDO reference/part no.: A2C1132410180
+- Compatible with aftermarket sensors, e.g. Aligator sens.it RS3
+- Working Temperature: -50°C to 125°C
+- Working Frequency: 433.92MHz+-38KHz
+- Tire monitoring range value: 0kPa-350kPa+-7kPa (to be checked, VDO says 450/900kPa)
+
+Q85 (Shenzhen-EGQ-Q85):
+- Analysis asked by @js-3972 in issue #2556
+- TPMS from Amazon here: https://www.amazon.com/dp/B0BK8SHDRZ?psc=1&ref=ppx_yo2ov_dt_b_product_details
+- Air pressure setting range: 0.1~6.0BA / 1.45~87psi
+- Temperature setting range: 60°C~110°C / 140ºF~230ºF
+- Working temperature: -20°C~80°C / -68ºF~176ºF
+- Storage temperature: -30°C~85°C / 86ºF~185ºF
+- Power-on voltage: DC 5V
+- Frequency: 433.92MHz±20.00MHZ (remark: more probably ±20.00KHZ than MHZ)
+- Very similar to Abarth 124Spider, message lengh is bigger including a 0x40 then a CRC/16 CCITT-FALSE, (little-endian)
+- Temperature (°C) offset is 55 C
+- Pressure (KPa) is divided by 3.
+
+Common payload:
+- The preamble is 0xaa..aa9 (or 0x55..556 depending on polarity)
 
 Data layout (nibbles):
-    II II II II ?? PP TT SS CC
+
+    Byte    00 01 02 03 04 05 06 07 08 09 10 11
+    TG1C    II II II II ?? PP TT SS CC
+    Q85     II II II II ?? PP TT SS CC FF CR CR
+
 - I: 32 bit ID
 - ?: 4 bit unknown (seems to change with status)
 - ?: 4 bit unknown (seems static)
-- P: 8 bit Pressure (multiplied by 1.38 = kPa)
-- T: 8 bit Temperature (deg. C offset by 50)
+- P: 8 bit Pressure (multiplied by 1.38 = kPa for TG1C, by 3 for Q85)
+- T: 8 bit Temperature (deg. C offset by 50 for TG1C, by 55 for Q85)
 - S: Status? (first nibble seems static, second nibble seems to change with status)
-- C: 8 bit Checksum (Checksum8 XOR on bytes 0 to 8)
-- The preamble is 0xaa..aa9 (or 0x55..556 depending on polarity)
+- CC: 8 bit Checksum (Checksum8 XOR on bytes 0 to 8)
+- F: 8 bit unknown (Q85 only, seems fixed = 0x40)
+- CR: 16 bit CRC/16 CCITT-FASLE. little-endian format (Q85 only, on bytes 0 to 9).
 */
 
-#include "decoder.h"
+#define MODEL_TG1C 1
+#define MODEL_Q85  2
 
-static int tpms_abarth124_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos)
+static int tpms_abarth124_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned row, unsigned bitpos, int type)
 {
     bitbuffer_t packet_bits = {0};
-    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, 72);
+    uint8_t *b;
+    char id_str[4 * 2 + 1];
+    char flags[1 * 2 + 1];
+    int data_len;
+    uint16_t crc_little_endian, crc_result;
+
+    // 9 byte or 12 byte
+    if (type == MODEL_TG1C) {
+        data_len = 72;
+    } else if (type == MODEL_Q85) {
+        data_len = 96;
+    } else {
+        decoder_log(decoder, 2, __func__, "Unknown model");
+        return 0; //return 0 instead of DECODE_ABORT_LENGTH, to avoid exit error : gave invalid return value -x: notify maintainer;
+    }
+
+    bitbuffer_manchester_decode(bitbuffer, row, bitpos, &packet_bits, data_len);
 
     // make sure we decoded the expected number of bits
-    if (packet_bits.bits_per_row[0] < 72) {
+    if (packet_bits.bits_per_row[0] < data_len) {
         // decoder_logf(decoder, 0, __func__, "bitpos=%u start_pos=%u = %u", bitpos, start_pos, (start_pos - bitpos));
-        return 0; // DECODE_FAIL_SANITY;
+        decoder_log(decoder, 2, __func__, "Packet too short");
+        return 0; //DECODE_FAIL_SANITY;
     }
 
-    uint8_t *b = packet_bits.bb[0];
+    b = packet_bits.bb[0];
 
-    // check checksum (checksum8 xor)
-    int const checksum = xor_bytes(b, 9);
+    // check checksum (checksum8 xor) same for both type model
+    int checksum = xor_bytes(b, 9);
     if (checksum != 0) {
-        return 0; // DECODE_FAIL_MIC;
+        decoder_log(decoder, 2, __func__, "Checksum failed");
+        return 0; //DECODE_FAIL_MIC;
     }
 
-    int const pressure    = b[5];
-    int const temperature = b[6];
-    int const status      = b[7];
-    // int const checksum    = b[8];
+    int press_raw = b[5];
+    int temp_raw  = b[6];
+    int status    = b[7];
+    sprintf(flags, "%02x", b[4]);
+    sprintf(id_str, "%02x%02x%02x%02x", b[0], b[1], b[2], b[3]);
 
-    char flags[1 * 2 + 1];
-    snprintf(flags, sizeof(flags), "%02x", b[4]);
-    char id_str[4 * 2 + 1];
-    snprintf(id_str, sizeof(id_str), "%02x%02x%02x%02x", b[0], b[1], b[2], b[3]);
+    if (type == MODEL_Q85) {
+        // check CRC for 0 to 9 byte only if type Q85, CRC 16 CCITT-FALSE little-endian
+        crc_little_endian = (b[11] << 8 ) | b[10];
+        crc_result = crc16(b, 10, 0x1021,0xffff); // CRC-16 CCITT-FALSE
+        if (crc_result != crc_little_endian) {
+            decoder_log(decoder, 2, __func__, "CRC Failed");
+            return 0; //DECODE_FAIL_MIC;
+        }
+    }
 
     /* clang-format off */
     data_t *data = data_make(
-            "model",            "",             DATA_STRING, "Abarth-124Spider",
+            "model",            "",             DATA_COND, type == MODEL_TG1C, DATA_STRING, "Abarth-124Spider",
+            "model",            "",             DATA_COND, type == MODEL_Q85,  DATA_STRING, "Shenzhen-EGQ-Q85",
             "type",             "",             DATA_STRING, "TPMS",
             "id",               "",             DATA_STRING, id_str,
             "flags",            "",             DATA_STRING, flags,
-            "pressure_kPa",     "Pressure",     DATA_FORMAT, "%.0f kPa", DATA_DOUBLE, (float)pressure * 1.38,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.0f C", DATA_DOUBLE, (float)temperature - 50.0,
+            "pressure_kPa",     "Pressure",     DATA_COND, type == MODEL_TG1C, DATA_FORMAT, "%.0f kPa", DATA_DOUBLE, (float)press_raw * 1.38,
+            "pressure_kPa",     "Pressure",     DATA_COND, type == MODEL_Q85,  DATA_FORMAT, "%.0f kPa", DATA_DOUBLE, (float)press_raw * 3,
+            "temperature_C",    "Temperature",  DATA_COND, type == MODEL_TG1C, DATA_FORMAT, "%.0f C", DATA_DOUBLE, (float)temp_raw - 50.0,
+            "temperature_C",    "Temperature",  DATA_COND, type == MODEL_Q85,  DATA_FORMAT, "%.0f C", DATA_DOUBLE, (float)temp_raw - 55.0,
             "status",           "",             DATA_INT, status,
-            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
+            "mic",              "Integrity",    DATA_COND, type == MODEL_TG1C, DATA_STRING, "CHECKSUM",
+            "mic",              "Integrity",    DATA_COND, type == MODEL_Q85,  DATA_STRING, "CRC",
             NULL);
     /* clang-format on */
 
@@ -90,12 +150,25 @@ static int tpms_abarth124_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     unsigned bitpos = 0;
     int events      = 0;
+    int type        = 0;
 
     bitbuffer_invert(bitbuffer);
+    unsigned bits = bitbuffer->bits_per_row[0];
+
+    // Define the type model , around 195 bits for TG1C MC encoded (result is 72 bits), around 353 bits for Q85 MC encoded (result is 96 bits)
+    if (bits > 150 && bits < 210) {
+        type = MODEL_TG1C;
+    } else if ( bits > 210 && bits < 400) {
+        type = MODEL_Q85;
+    } else {
+        decoder_log(decoder, 2, __func__, "Length does not match");
+        return DECODE_ABORT_LENGTH;
+    }
+
     // Find a preamble with enough bits after it that it could be a complete packet
     while ((bitpos = bitbuffer_search(bitbuffer, 0, bitpos, preamble_pattern, 24)) + 80 <=
             bitbuffer->bits_per_row[0]) {
-        events += tpms_abarth124_decode(decoder, bitbuffer, 0, bitpos + 24);
+        events += tpms_abarth124_decode(decoder, bitbuffer, 0, bitpos + 24,type);
         bitpos += 2;
     }
 
@@ -116,7 +189,7 @@ static char const *const output_fields[] = {
 };
 
 r_device const tpms_abarth124 = {
-        .name        = "Abarth 124 Spider TPMS",
+        .name        = "Abarth 124 Spider and Shenzhen EGQ Q85 TPMS",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 52,  // 12-13 samples @250k
         .long_width  = 52,  // FSK

--- a/src/devices/tpms_abarth124.c
+++ b/src/devices/tpms_abarth124.c
@@ -33,7 +33,7 @@ TG1C (Abarth-124Spider):
 - Tire monitoring range value: 0kPa-350kPa+-7kPa (to be checked, VDO says 450/900kPa)
 
 Q85 (Shenzhen-EGQ-Q85):
-- Analysis asked by @js-3972 in issue #2556
+- Analysis asked by \@js-3972 in issue #2556
 - TPMS from Amazon here: https://www.amazon.com/dp/B0BK8SHDRZ?psc=1&ref=ppx_yo2ov_dt_b_product_details
 - Air pressure setting range: 0.1~6.0BA / 1.45~87psi
 - Temperature setting range: 60°C~110°C / 140ºF~230ºF


### PR DESCRIPTION
This is related to an old issue #2556 opened 3 years ago, reported by @js-3972.
I rework the Abarth 124 Spider decoder to take into account the TPMS Shenzhen EGQ Q85 sensor.

3 majors gaps have been identified and added into this PR:
- EGQ Q85 data layout is common to Abarth 124 Spider (72 bits) plus a CRC 16 CCITT-FALSE data (96 bits).
- Temperature (°C) offset is 55 C instead 50
- Pressure (KPa) is scale by 3 instead of 1.38
