### PR TITLE
build: Change version info to generated header file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,9 +35,6 @@ if(GIT_COMMIT) # is a git repo
     git_timestamp(GIT_TIMESTAMP)
     message(STATUS "Found Git version: ${GIT_REFSPEC} commit ${GIT_COMMIT} from ${GIT_TIMESTAMP_ISO}")
     message(STATUS "Using Git version tag: ${GIT_VERSION} on ${GIT_BRANCH} at ${GIT_TIMESTAMP}")
-    ADD_DEFINITIONS(-DGIT_VERSION=${GIT_VERSION})
-    ADD_DEFINITIONS(-DGIT_BRANCH=${GIT_BRANCH})
-    ADD_DEFINITIONS(-DGIT_TIMESTAMP=${GIT_TIMESTAMP})
 endif()
 
 ########################################################################
@@ -56,9 +53,16 @@ if(NOT GIT_COMMIT AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/CHANGELOG.md")
     if(RELEASE_VERSIONS)
         list(GET RELEASE_VERSIONS 0 RELEASE_VERSION)
         message(STATUS "Found Release version: ${RELEASE_VERSION}")
-        ADD_DEFINITIONS(-DGIT_VERSION=${RELEASE_VERSION})
+        set(GIT_VERSION ${RELEASE_VERSION})
     endif()
 endif()
+
+########################################################################
+# Write version info to header file
+########################################################################
+configure_file(${CMAKE_CURRENT_LIST_DIR}/include/version.h.in
+    ${CMAKE_CURRENT_LIST_DIR}/include/version.h
+)
 
 ########################################################################
 # Compiler specific setup

--- a/include/r_api.h
+++ b/include/r_api.h
@@ -23,8 +23,6 @@ struct mg_mgr;
 
 /* general */
 
-char const *version_string(void);
-
 struct r_cfg *r_create_cfg(void);
 
 void r_init_cfg(struct r_cfg *cfg);

--- a/include/r_version.h
+++ b/include/r_version.h
@@ -1,0 +1,17 @@
+/** @file
+    Generic RF data receiver and decoder for ISM band devices using RTL-SDR and SoapySDR.
+
+    Copyright (C) 2026 Christian W. Zuckschwerdt <zany@triq.net>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#ifndef INCLUDE_R_VERSION_H_
+#define INCLUDE_R_VERSION_H_
+
+char const *version_string(void);
+
+#endif /* INCLUDE_R_VERSION_H_ */

--- a/include/version.h.in
+++ b/include/version.h.in
@@ -1,0 +1,3 @@
+#cmakedefine GIT_VERSION "@GIT_VERSION@"
+#cmakedefine GIT_BRANCH "@GIT_BRANCH@"
+#cmakedefine GIT_TIMESTAMP "@GIT_TIMESTAMP@"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(r_433 STATIC
     pulse_slicer.c
     r_api.c
     r_util.c
+    r_version.c
     raw_output.c
     rfraw.c
     samp_grab.c

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -44,12 +44,6 @@
 #include "fatal.h"
 #include "http_server.h"
 
-#if defined __has_include
-#if __has_include("version.h")
-#include "version.h"
-#endif
-#endif
-
 #ifndef _WIN32
 #include <sys/stat.h>
 #endif
@@ -70,33 +64,6 @@
 #else
 #include "getopt/getopt.h"
 #endif
-
-char const *version_string(void)
-{
-    return "rtl_433"
-#ifdef GIT_VERSION
-            " version " GIT_VERSION
-#ifdef GIT_BRANCH
-            " branch " GIT_BRANCH
-#endif
-#ifdef GIT_TIMESTAMP
-            " at " GIT_TIMESTAMP
-#endif
-#else
-            " version unknown"
-#endif
-            " inputs file rtl_tcp"
-#ifdef RTLSDR
-            " RTL-SDR"
-#endif
-#ifdef SOAPYSDR
-            " SoapySDR"
-#endif
-#ifdef OPENSSL
-            " with TLS"
-#endif
-            ;
-}
 
 /* helper */
 

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -43,6 +43,7 @@
 #include "logger.h"
 #include "fatal.h"
 #include "http_server.h"
+#include "version.h"
 
 #ifndef _WIN32
 #include <sys/stat.h>
@@ -69,17 +70,13 @@ char const *version_string(void)
 {
     return "rtl_433"
 #ifdef GIT_VERSION
-#define STR_VALUE(arg) #arg
-#define STR_EXPAND(s) STR_VALUE(s)
-            " version " STR_EXPAND(GIT_VERSION)
+            " version " GIT_VERSION
 #ifdef GIT_BRANCH
-            " branch " STR_EXPAND(GIT_BRANCH)
+            " branch " GIT_BRANCH
 #endif
 #ifdef GIT_TIMESTAMP
-            " at " STR_EXPAND(GIT_TIMESTAMP)
+            " at " GIT_TIMESTAMP
 #endif
-#undef STR_VALUE
-#undef STR_EXPAND
 #else
             " version unknown"
 #endif

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -43,7 +43,12 @@
 #include "logger.h"
 #include "fatal.h"
 #include "http_server.h"
+
+#if defined __has_include
+#if __has_include("version.h")
 #include "version.h"
+#endif
+#endif
 
 #ifndef _WIN32
 #include <sys/stat.h>

--- a/src/r_version.c
+++ b/src/r_version.c
@@ -1,0 +1,46 @@
+/** @file
+    Generic RF data receiver and decoder for ISM band devices using RTL-SDR and SoapySDR.
+
+    Copyright (C) 2026 Christian W. Zuckschwerdt <zany@triq.net>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#include "r_version.h"
+
+/* Include version.h if it exists, otherwise there is simply no version information. */
+#if defined __has_include
+#if __has_include("version.h")
+#include "version.h"
+#endif
+#endif
+
+char const *version_string(void)
+{
+    return "rtl_433"
+#ifdef GIT_VERSION
+           " version " GIT_VERSION
+#ifdef GIT_BRANCH
+           " branch " GIT_BRANCH
+#endif
+#ifdef GIT_TIMESTAMP
+           " at " GIT_TIMESTAMP
+#endif
+#else
+           " version unknown"
+#endif
+           " inputs file rtl_tcp"
+#ifdef RTLSDR
+           " RTL-SDR"
+#endif
+#ifdef SOAPYSDR
+           " SoapySDR"
+#endif
+#ifdef OPENSSL
+           " with TLS"
+#endif
+            ;
+}

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -32,6 +32,7 @@
 #include "r_private.h"
 #include "r_device.h"
 #include "r_api.h"
+#include "r_version.h"
 #include "sdr.h"
 #include "baseband.h"
 #include "pulse_analyzer.h"


### PR DESCRIPTION
This changes the mechanism to define version information for the builds from compiler arguments to a header file.

Allows for incremental builds even across version info changes.
