### PR TITLE
fix(http): web UI sends corrupt responses on /

### DIFF
--- a/src/http_server.c
+++ b/src/http_server.c
@@ -1096,8 +1096,7 @@ static void ev_handler(struct mg_connection *nc, int ev, void *ev_data)
             handle_options(nc, hm);
         }
         else if (mg_vcmp(&hm->uri, "/") == 0) {
-            handle_get(nc, hm, INDEX_HTML, sizeof(INDEX_HTML));
-            handle_redirect(nc, hm);
+            handle_get(nc, hm, INDEX_HTML, sizeof(INDEX_HTML) - 1);
         }
         else if (mg_vcmp(&hm->uri, "/ui") == 0) {
             handle_redirect(nc, hm);


### PR DESCRIPTION
This fixes an off-by-one error in calculating the Content-Length header. It also fixes sending two responses to a single request.

You can replicate this by running `-D manual -F http`, and then `curl http://localhost:8433`. You'll get an error about compressed data. If you try to load in a browser, you'll get a variety of different errors depending on the browser used.

This also fixes sending multiple responses - it looks like the `handle_redirect` should have been removed in c76d5e69.

I don't see any tests around the http server, so none added to cover this since that would involve setting up some sort of harness.