### PR TITLE
Fix http server truncating large get_stats/get_protocols JSON

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -78,6 +78,28 @@ jobs:
         run: |
           ./tests/symbolizer.py check
 
+  coverage_check_job:
+    runs-on: ubuntu-latest
+    name: Run tests with code coverage
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup
+        run: |
+          sudo apt-get update -q -y
+          sudo apt-get install -q -y --no-install-recommends cmake gcovr curl python3
+      - name: Build with coverage and run tests
+        # Builds with -DENABLE_COVERAGE=ON, runs ctest (incl. the HTTP server
+        # integration/dataflow/ws tests), and writes an HTML report. Exits
+        # non-zero if any test fails.
+        run: ./tests/coverage.sh "$GITHUB_WORKSPACE/build-coverage"
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: build-coverage/coverage-report
+          if-no-files-found: warn
+
   analyzer_check_job:
     # https://github.com/actions/virtual-environments
     # - Ubuntu 24.04 ubuntu-24.04

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 # CMake out-of-tree builds
 build*/
 
+# Code coverage artifacts (see tests/coverage.sh)
+*.gcda
+*.gcno
+*.gcov
+coverage-report/
+
 # IDE files
 .cproject
 .settings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,24 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND NOT "13.2.0" VERSION_GREATER CMAK
     add_definitions(-fanalyzer)
 endif()
 
+# Optional code coverage instrumentation (gcov/llvm-cov), for use with BUILD_TESTING.
+# Configure with -DENABLE_COVERAGE=ON, run `ctest`, then generate a report with
+# gcov/gcovr/lcov (see tests/coverage.sh). Forces -O0 and disables inlining so
+# coverage maps cleanly back to source lines.
+option(ENABLE_COVERAGE "Build with code coverage instrumentation (GCC/Clang)" OFF)
+if(ENABLE_COVERAGE)
+    if("${CMAKE_C_COMPILER_ID}" MATCHES "GNU|Clang")
+        message(STATUS "Code coverage instrumentation enabled")
+        add_compile_options(--coverage -O0 -g -fno-inline)
+        # --coverage on the link line pulls in the gcov runtime; set on the flag
+        # vars rather than add_link_options() to keep cmake_minimum_required (3.10).
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
+    else()
+        message(WARNING "ENABLE_COVERAGE is only supported on GCC/Clang, ignoring")
+    endif()
+endif()
+
 # Shut MSVC up about strdup and strtok
 if(MSVC)
     ADD_DEFINITIONS(-D_CRT_NONSTDC_NO_DEPRECATE)

--- a/include/abuf.h
+++ b/include/abuf.h
@@ -29,6 +29,7 @@ typedef struct abuf {
     char *head;
     char *tail;
     size_t left;
+    int overflow; ///< set when a write was dropped or truncated for lack of space
 } abuf_t;
 
 void abuf_init(abuf_t *buf, char *dst, size_t len);

--- a/include/abuf.h
+++ b/include/abuf.h
@@ -29,7 +29,7 @@ typedef struct abuf {
     char *head;
     char *tail;
     size_t left;
-    int overflow; ///< set when a write was dropped or truncated for lack of space
+    int overflow; ///< sticky: set if any write since abuf_init() was truncated for lack of space
 } abuf_t;
 
 void abuf_init(abuf_t *buf, char *dst, size_t len);
@@ -40,7 +40,7 @@ char *abuf_push(abuf_t *buf);
 
 void abuf_pop(abuf_t *buf, char *end);
 
-void abuf_cat(abuf_t *buf, const char *str);
+int abuf_cat(abuf_t *buf, const char *str);
 
 int abuf_printf(abuf_t *buf, _Printf_format_string_ char const *restrict format, ...)
 #if defined(__GNUC__) || defined(__clang__)

--- a/include/data.h
+++ b/include/data.h
@@ -212,4 +212,9 @@ R_API void print_array_value(data_output_t *output, data_array_t *array, char co
 
 R_API size_t data_print_jsons(data_t *data, char *dst, size_t len);
 
+/// Serialize `data` as JSON into a freshly allocated, NUL-terminated buffer that
+/// is grown until the whole document fits (never truncated). Caller frees the
+/// returned string. Returns NULL on allocation failure.
+R_API char *data_print_jsons_dup(data_t *data);
+
 #endif // INCLUDE_DATA_H_

--- a/src/abuf.c
+++ b/src/abuf.c
@@ -91,3 +91,82 @@ int abuf_printf(abuf_t *buf, _Printf_format_string_ char const *restrict format,
     va_end(ap);
     return n;
 }
+
+#ifdef _TEST
+#define ASSERT_EQUALS(a, b) \
+    do { \
+        if ((a) == (b)) \
+            ++passed; \
+        else { \
+            ++failed; \
+            fprintf(stderr, "FAIL: %d <> %d\n", (int)(a), (int)(b)); \
+        } \
+    } while (0)
+#define ASSERT_STR(a, b) \
+    do { \
+        if (strcmp((a), (b)) == 0) \
+            ++passed; \
+        else { \
+            ++failed; \
+            fprintf(stderr, "FAIL: \"%s\" <> \"%s\"\n", (a), (b)); \
+        } \
+    } while (0)
+
+int main(void)
+{
+    unsigned passed = 0;
+    unsigned failed = 0;
+    abuf_t b;
+    char buf[16];
+
+    fprintf(stderr, "abuf:: test\n");
+
+    // A plain append that fits the whole string and no overflow, and returns
+    // the source length (excluding the NUL), like abuf_printf().
+    fprintf(stderr, "abuf::abuf_cat(): fits\n");
+    abuf_init(&b, buf, sizeof(buf));
+    ASSERT_EQUALS(abuf_cat(&b, "abc"), 3);
+    ASSERT_STR(buf, "abc");
+    ASSERT_EQUALS(b.overflow, 0);
+
+    // Boundary: an exact fit (len + 1 == avail, the reserved NUL lands on the
+    // last byte) keeps the whole string and is NOT flagged as overflow.
+    fprintf(stderr, "abuf::abuf_cat(): exact fit\n");
+    char four[4];
+    abuf_init(&b, four, sizeof(four));
+    ASSERT_EQUALS(abuf_cat(&b, "abc"), 3);
+    ASSERT_STR(four, "abc");
+    ASSERT_EQUALS(b.overflow, 0);
+
+    // Boundary: one byte over (len + 1 > avail) truncates to fit, always
+    // NUL-terminates, sets overflow, and still returns the would-be length.
+    fprintf(stderr, "abuf::abuf_cat(): one over\n");
+    char three[3];
+    abuf_init(&b, three, sizeof(three));
+    ASSERT_EQUALS(abuf_cat(&b, "abc"), 3);
+    ASSERT_STR(three, "ab");
+    ASSERT_EQUALS(b.overflow, 1);
+
+    // Regression for the get_stats JSON corruption: once a chunk is truncated,
+    // a later smaller chunk must NOT slip into the leftover room. The result is
+    // a clean prefix and overflow stays sticky.
+    fprintf(stderr, "abuf::abuf_cat(): no append after truncation\n");
+    abuf_init(&b, buf, sizeof(buf));
+    abuf_cat(&b, "0123456789ABCDEF"); // 16 chars into a 16-byte buf: truncates
+    ASSERT_EQUALS(b.overflow, 1);
+    ASSERT_STR(buf, "0123456789ABCDE"); // last byte reserved for the NUL
+    abuf_cat(&b, "}");                  // the small closing chunk must not land
+    ASSERT_STR(buf, "0123456789ABCDE");
+    ASSERT_EQUALS(b.overflow, 1);
+
+    // A zero-length buffer can hold nothing, not even the NUL: every append
+    // overflows and writes nothing, but still reports the source length.
+    fprintf(stderr, "abuf::abuf_cat(): zero-length buffer\n");
+    abuf_init(&b, buf, 0);
+    ASSERT_EQUALS(abuf_cat(&b, "x"), 1);
+    ASSERT_EQUALS(b.overflow, 1);
+
+    fprintf(stderr, "abuf:: test (%u passed, %u failed)\n", passed, failed);
+    return failed;
+}
+#endif /* _TEST */

--- a/src/abuf.c
+++ b/src/abuf.c
@@ -42,17 +42,31 @@ void abuf_pop(abuf_t *buf, char *end)
     buf->tail = end;
 }
 
-void abuf_cat(abuf_t *buf, char const *str)
+int abuf_cat(abuf_t *buf, char const *str)
 {
-    size_t len = strlen(str);
-    if (buf->left >= len + 1) {
-        memcpy(buf->tail, str, len + 1);
-        buf->tail += len;
-        buf->left -= len;
+    size_t len   = strlen(str);
+    size_t avail = buf->left;
+
+    // snprintf semantics: copy as much as fits and always NUL-terminate, rather
+    // than dropping the whole chunk on overflow. The old all-or-nothing variant
+    // left room behind a dropped chunk so the next, smaller append still landed,
+    // producing structurally invalid JSON.
+    if (avail > 0) {
+        size_t copy = len < avail - 1 ? len : avail - 1;
+        memcpy(buf->tail, str, copy);
+        buf->tail += copy;
+        buf->left -= copy;
+        *buf->tail = '\0';
     }
-    else {
+    // The whole string plus its terminating NUL must fit; an exact fit (len + 1
+    // == avail) is not an overflow, so the reserved NUL keeps "full" distinct
+    // from "truncated".
+    if (len + 1 > avail) {
         buf->overflow = 1;
     }
+
+    // Return the would-be length (excluding the NUL), like abuf_printf().
+    return (int)len;
 }
 
 int abuf_printf(abuf_t *buf, _Printf_format_string_ char const *restrict format, ...)

--- a/src/abuf.c
+++ b/src/abuf.c
@@ -21,6 +21,7 @@ void abuf_init(abuf_t *buf, char *dst, size_t len)
     buf->head = dst;
     buf->tail = dst;
     buf->left = len;
+    buf->overflow = 0;
 }
 
 void abuf_setnull(abuf_t *buf)
@@ -49,6 +50,9 @@ void abuf_cat(abuf_t *buf, char const *str)
         buf->tail += len;
         buf->left -= len;
     }
+    else {
+        buf->overflow = 1;
+    }
 }
 
 int abuf_printf(abuf_t *buf, _Printf_format_string_ char const *restrict format, ...)
@@ -56,12 +60,18 @@ int abuf_printf(abuf_t *buf, _Printf_format_string_ char const *restrict format,
     va_list ap;
     va_start(ap, format);
 
+    size_t avail = buf->left;
     int n = vsnprintf(buf->tail, buf->left, format, ap);
 
     if (n > 0) {
         size_t len = (size_t)n < buf->left ? (size_t)n : buf->left;
         buf->tail += len;
         buf->left -= len;
+    }
+    // vsnprintf returns the length it *would* have written (excluding the NUL).
+    // n >= avail means the string (or its terminating NUL) did not fit.
+    if (n < 0 || (size_t)n >= avail) {
+        buf->overflow = 1;
     }
 
     va_end(ap);

--- a/src/data.c
+++ b/src/data.c
@@ -510,6 +510,7 @@ static void R_API_CALLCONV format_jsons_string(data_output_t *output, const char
 
     size_t str_len = strlen(str);
     if (size < str_len + 3) {
+        jsons->msg.overflow = 1;
         return;
     }
 
@@ -550,9 +551,16 @@ static void R_API_CALLCONV format_jsons_string(data_output_t *output, const char
         *buf++ = *str;
         size--;
     }
+    // ran out of room before consuming the whole (escaped) string
+    if (*str) {
+        jsons->msg.overflow = 1;
+    }
     if (size >= 2) {
         *buf++ = '"';
         size--;
+    }
+    else {
+        jsons->msg.overflow = 1;
     }
     *buf = '\0';
 
@@ -586,7 +594,10 @@ static void R_API_CALLCONV format_jsons_int(data_output_t *output, int data, cha
     abuf_printf(&jsons->msg, "%d", data);
 }
 
-R_API size_t data_print_jsons(data_t *data, char *dst, size_t len)
+// Serialize into dst/len; reports via *overflow whether the buffer was too
+// small (the output is then truncated and not valid JSON). Returns the number
+// of bytes written (excluding the terminating NUL).
+static size_t data_print_jsons_buf(data_t *data, char *dst, size_t len, int *overflow)
 {
     data_print_jsons_t jsons = {
             .output = {
@@ -602,5 +613,40 @@ R_API size_t data_print_jsons(data_t *data, char *dst, size_t len)
 
     format_jsons_object(&jsons.output, data, NULL);
 
+    if (overflow) {
+        *overflow = jsons.msg.overflow;
+    }
     return len - jsons.msg.left;
+}
+
+R_API size_t data_print_jsons(data_t *data, char *dst, size_t len)
+{
+    return data_print_jsons_buf(data, dst, len, NULL);
+}
+
+R_API char *data_print_jsons_dup(data_t *data)
+{
+    // Grow the buffer until the whole document fits, so reports that scale with
+    // configuration (e.g. get_stats with many enabled decoders) are never
+    // truncated into invalid JSON. A fixed buffer silently corrupts the output
+    // once it overflows: abuf drops the oversized chunk but keeps appending the
+    // smaller ones that follow.
+    size_t len = 8192;
+    for (;;) {
+        char *buf = malloc(len);
+        if (!buf) {
+            WARN_MALLOC("data_print_jsons_dup()");
+            return NULL;
+        }
+        int overflow = 0;
+        data_print_jsons_buf(data, buf, len, &overflow);
+        if (!overflow) {
+            return buf; // complete and NUL-terminated
+        }
+        free(buf);
+        if (len > ((size_t)1 << 26)) { // 64 MiB sanity cap; no report is this big
+            return NULL;
+        }
+        len *= 2;
+    }
 }

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -559,25 +559,43 @@ static void rpc_exec(rpc_t *rpc, r_cfg_t *cfg)
         rpc->response(rpc, 2, NULL, cfg->conversion_mode);
     }
     else if (!strcmp(rpc->method, "get_stats")) {
-        char buf[20480]; // we expect the stats string to be around 15k bytes.
         data_t *data = create_report_data(cfg, 2/*report active devices*/);
         // flush_report_data(cfg); // snapshot, do not flush
-        data_print_jsons(data, buf, sizeof(buf));
-        rpc->response(rpc, 1, buf, 0);
+        // The stats report scales with the number of enabled decoders that have
+        // seen frames; a fixed buffer truncates it into invalid JSON, so grow to
+        // fit. See data_print_jsons_dup().
+        char *buf = data_print_jsons_dup(data);
+        if (!buf) {
+            rpc->response(rpc, -1, "Out of memory", 0);
+        }
+        else {
+            rpc->response(rpc, 1, buf, 0);
+            free(buf);
+        }
         data_free(data);
     }
     else if (!strcmp(rpc->method, "get_meta")) {
-        char buf[2048]; // we expect the meta string to be around 500 bytes.
         data_t *data = meta_data(cfg);
-        data_print_jsons(data, buf, sizeof(buf));
-        rpc->response(rpc, 1, buf, 0);
+        char *buf = data_print_jsons_dup(data);
+        if (!buf) {
+            rpc->response(rpc, -1, "Out of memory", 0);
+        }
+        else {
+            rpc->response(rpc, 1, buf, 0);
+            free(buf);
+        }
         data_free(data);
     }
     else if (!strcmp(rpc->method, "get_protocols")) {
-        char buf[102400]; // we expect the protocol string to be around 80k bytes.
         data_t *data = protocols_data(cfg);
-        data_print_jsons(data, buf, sizeof(buf));
-        rpc->response(rpc, 1, buf, 0);
+        char *buf = data_print_jsons_dup(data);
+        if (!buf) {
+            rpc->response(rpc, -1, "Out of memory", 0);
+        }
+        else {
+            rpc->response(rpc, 1, buf, 0);
+            free(buf);
+        }
         data_free(data);
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,36 @@ endforeach(testSrc)
 ########################################################################
 add_test(rtl_433_help ../src/rtl_433 -h)
 
+# Black-box test of the HTTP/WS API server. Starts rtl_433 in manual device
+# mode (no SDR), exercises each endpoint, and shuts it down cleanly. Skipped
+# on Windows (POSIX shell script) and when python3/curl are unavailable.
+if(UNIX)
+    find_program(BASH_PROGRAM sh)
+    find_program(CURL_PROGRAM curl)
+    find_program(PYTHON3_PROGRAM python3)
+    if(BASH_PROGRAM AND CURL_PROGRAM)
+        add_test(
+            NAME http_server_integration
+            COMMAND ${BASH_PROGRAM}
+                ${CMAKE_CURRENT_SOURCE_DIR}/http-integration-test.sh
+                $<TARGET_FILE:rtl_433>)
+        # Feeds a synthetic OOK signal over a fake rtl_tcp server so rtl_433 runs
+        # its live poll loop, then reads the decode back over the WS API. Needs
+        # python3 for the rtl_tcp server and ws probe.
+        if(PYTHON3_PROGRAM)
+            add_test(
+                NAME http_server_rtltcp
+                COMMAND ${BASH_PROGRAM}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/http-rtltcp-test.sh
+                    $<TARGET_FILE:rtl_433>)
+        else()
+            message(STATUS "Skipping http_server_rtltcp test (need python3)")
+        endif()
+    else()
+        message(STATUS "Skipping http_server_integration test (need sh and curl)")
+    endif()
+endif()
+
 ########################################################################
 # Define style checks
 ########################################################################

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 ########################################################################
 # target_compile_definitions was only added in CMake 2.8.11
 add_definitions(-D_TEST)
-foreach(testSrc bitbuffer.c fileformat.c optparse.c bit_util.c r_util.c)
+foreach(testSrc bitbuffer.c fileformat.c optparse.c bit_util.c r_util.c abuf.c)
     get_filename_component(testName ${testSrc} NAME_WE)
 
     # Note that r_util.c needs compat_time.c shims

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+#
+# Configure, build, and run the test suite with code-coverage instrumentation,
+# then produce a coverage report. Focuses the report on the HTTP server but
+# gcovr/lcov see the whole tree.
+#
+# Requires gcovr (apt install gcovr, or pip install gcovr) for the HTML/text
+# report; falls back to a raw `gcov` summary if gcovr is not installed.
+#
+# Usage: tests/coverage.sh [build-dir]
+#   build-dir defaults to ./build-coverage
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+SRC_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+BUILD_DIR=${1:-"$SRC_DIR/build-coverage"}
+
+echo ">> Configuring coverage build in $BUILD_DIR"
+cmake -S "$SRC_DIR" -B "$BUILD_DIR" \
+    -DENABLE_COVERAGE=ON \
+    -DBUILD_TESTING=ON \
+    -DENABLE_RTLSDR=OFF \
+    -DENABLE_SOAPYSDR=OFF \
+    -DCMAKE_BUILD_TYPE=None
+
+echo ">> Building"
+cmake --build "$BUILD_DIR" -j"$(nproc 2>/dev/null || echo 2)"
+
+echo ">> Running tests (ctest)"
+# Don't abort the report if a test fails; we still want coverage of what ran,
+# but remember the status so we can propagate it as our exit code (CI should
+# fail on a test failure even though the report is still produced/uploaded).
+ctest_rc=0
+( cd "$BUILD_DIR" && ctest --output-on-failure ) || ctest_rc=$?
+[ "$ctest_rc" -eq 0 ] || echo ">> (some tests failed, rc=$ctest_rc; continuing to report)"
+
+echo ">> Generating coverage report"
+if command -v gcovr >/dev/null 2>&1; then
+    mkdir -p "$BUILD_DIR/coverage-report"
+    # Whole-project summary to the terminal...
+    gcovr --root "$SRC_DIR" --object-directory "$BUILD_DIR" \
+        --exclude '.*/mongoose\.c' --exclude '.*/jsmn\.c' --print-summary \
+        --html-details "$BUILD_DIR/coverage-report/index.html"
+    echo
+    echo ">> HTTP server coverage:"
+    gcovr --root "$SRC_DIR" --object-directory "$BUILD_DIR" \
+        --filter '.*/http_server\.c' --txt
+    echo ">> Full HTML report: $BUILD_DIR/coverage-report/index.html"
+else
+    echo ">> gcovr not found; install it (apt: 'apt-get install gcovr', or 'pip install gcovr') for a nice report." >&2
+    echo ">> Falling back to raw gcov on http_server.c:"
+    GCDA=$(find "$BUILD_DIR" -name 'http_server.c.gcda' | head -1)
+    if [ -n "$GCDA" ]; then
+        ( cd "$(dirname "$GCDA")" && gcov -b http_server.c.gcno | sed -n '1,12p' )
+    else
+        echo ">> No http_server.c.gcda found - did the server exit cleanly?" >&2
+    fi
+fi
+
+# Propagate the test result so CI fails on a test failure (after reporting).
+exit "$ctest_rc"

--- a/tests/data-test.c
+++ b/tests/data-test.c
@@ -19,9 +19,70 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "data.h"
 #include "output_file.h"
+
+// Regression test for the get_stats JSON truncation bug: a report whose size
+// scales with configuration (here, a large array of device sub-objects, as the
+// HTTP server's get_stats builds for many enabled decoders) must serialize to
+// complete, valid JSON. The old fixed-buffer path silently corrupted the output
+// once it overflowed; data_print_jsons_dup() grows the buffer to fit.
+static int test_jsons_large_report(void)
+{
+    int failed = 0;
+    int n      = 230; // more than enough to exceed any reasonable fixed buffer
+
+    data_t **objs = calloc(n, sizeof(*objs));
+    for (int i = 0; i < n; ++i) {
+        objs[i] = data_make(
+                "device",       "", DATA_INT,    i,
+                "name",         "", DATA_STRING, "Some Reasonably Long Decoder Name For A Protocol",
+                "events",       "", DATA_INT,    8256,
+                "abort_length", "", DATA_INT,    8256,
+                NULL);
+    }
+    data_t *data = data_make(
+            "enabled", "", DATA_INT,   n,
+            "stats",   "", DATA_ARRAY, data_array(n, DATA_DATA, objs),
+            NULL);
+
+    // The grown buffer must hold the whole document: starts with '{', ends with
+    // '}', and is far larger than the smallest fixed buffer we test below.
+    char *full = data_print_jsons_dup(data);
+    if (!full) {
+        fprintf(stderr, "FAIL: data_print_jsons_dup returned NULL\n");
+        failed++;
+    }
+    else {
+        size_t full_len = strlen(full);
+        if (full[0] != '{' || full[full_len - 1] != '}') {
+            fprintf(stderr, "FAIL: grown JSON is not a complete object: ...%.20s\n",
+                    full + (full_len > 20 ? full_len - 20 : 0));
+            failed++;
+        }
+        if (full_len <= 20480) {
+            fprintf(stderr, "FAIL: test report (%zu bytes) too small to exercise growth\n", full_len);
+            failed++;
+        }
+
+        // Confirm the failure mode the fix addresses: a fixed buffer that is too
+        // small yields a truncated document that does NOT end with '}'.
+        char small[1024];
+        size_t w = data_print_jsons(data, small, sizeof(small));
+        if (w > 0 && w <= sizeof(small) && small[w - 1] == '}') {
+            fprintf(stderr, "FAIL: undersized buffer unexpectedly produced a complete object\n");
+            failed++;
+        }
+    }
+
+    free(full);
+    free(objs);
+    data_free(data);
+    return failed;
+}
 
 int main(void)
 {
@@ -54,4 +115,6 @@ int main(void)
     data_output_free(csv_output);
 
     data_free(data);
+
+    return test_jsons_large_report();
 }

--- a/tests/http-integration-test.sh
+++ b/tests/http-integration-test.sh
@@ -71,6 +71,26 @@ expect_body_contains() {
     esac
 }
 
+# expect_valid_json DESC curl-args... -- body must parse as JSON. Guards against
+# the getters truncating an oversized report into invalid JSON (see get_stats /
+# get_protocols, which now grow their output buffer to fit). Skipped when
+# python3 is unavailable to validate.
+HAVE_PY=0
+command -v python3 >/dev/null 2>&1 && HAVE_PY=1
+expect_valid_json() {
+    desc=$1; shift
+    if [ "$HAVE_PY" != 1 ]; then
+        echo "  skip: $desc (python3 not found)"
+        return
+    fi
+    body=$(curl -s --max-time 10 "$@")
+    if printf '%s' "$body" | python3 -c 'import sys,json; json.load(sys.stdin)' 2>/dev/null; then
+        pass "$desc (valid JSON)"
+    else
+        fail "$desc: response is not valid JSON"; printf '    got: %.200s\n' "$body" >&2
+    fi
+}
+
 # expect_stream DESC URL -- streaming endpoints stay open; we only check the
 # response headers, tolerating the curl timeout (exit 28) that follows.
 expect_stream() {
@@ -130,6 +150,11 @@ expect_status        "GET /cmd with no cmd"        200 "$BASE/cmd"
 # --- more RPC methods, to exercise the rpc_exec getter/setter branches ---
 expect_body_contains "GET /cmd get_protocols"      "Nice" "$BASE/cmd?cmd=get_protocols"
 expect_status        "GET /cmd get_stats"          200 "$BASE/cmd?cmd=get_stats"
+# These JSON-payload getters build large reports; verify the whole document is
+# well-formed (get_protocols is ~100k, well past the buffer's initial size).
+expect_valid_json    "GET /cmd get_protocols is valid JSON" "$BASE/cmd?cmd=get_protocols"
+expect_valid_json    "GET /cmd get_stats is valid JSON"     "$BASE/cmd?cmd=get_stats"
+expect_valid_json    "GET /cmd get_meta is valid JSON"      "$BASE/cmd?cmd=get_meta"
 expect_status        "GET /cmd get_center_frequency" 200 "$BASE/cmd?cmd=get_center_frequency"
 expect_status        "GET /cmd setter center_frequency" 200 "$BASE/cmd?cmd=center_frequency&val=433920000"
 expect_body_contains "GET /cmd unknown method is rejected" "Unknown method" "$BASE/cmd?cmd=no_such_method"

--- a/tests/http-integration-test.sh
+++ b/tests/http-integration-test.sh
@@ -1,0 +1,178 @@
+#!/bin/sh
+#
+# Black-box integration test for the rtl_433 HTTP/WS API server.
+#
+# Starts rtl_433 in "manual" device mode (-D manual), which runs the HTTP
+# server event loop without any SDR hardware or input file, exercises each
+# endpoint over the loopback interface, then shuts the server down with
+# SIGTERM so it exits cleanly (this is what lets gcov flush .gcda files when
+# the binary was built with -DENABLE_COVERAGE=ON).
+#
+# Usage: http-integration-test.sh [path-to-rtl_433-binary]
+#   Defaults to ../src/rtl_433 relative to this script.
+#   Override the port with PORT=NNNN, otherwise a free port is chosen.
+
+set -u
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+RTL_433=${1:-"$SCRIPT_DIR/../src/rtl_433"}
+HOST=127.0.0.1
+
+if [ ! -x "$RTL_433" ]; then
+    echo "ERROR: rtl_433 binary not found or not executable: $RTL_433" >&2
+    exit 99
+fi
+
+# Pick a free TCP port unless one was given, so parallel ctest runs don't collide.
+if [ -z "${PORT:-}" ]; then
+    PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' 2>/dev/null)
+fi
+PORT=${PORT:-18433}
+BASE="http://$HOST:$PORT"
+
+SERVER_LOG=$(mktemp 2>/dev/null || echo /tmp/rtl_433_http_test.$$.log)
+SERVER_PID=""
+FAILED=0
+PASSED=0
+
+cleanup() {
+    if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+        # SIGTERM -> clean shutdown -> atexit/gcov flush. Do NOT use SIGKILL.
+        kill -TERM "$SERVER_PID" 2>/dev/null
+        # give it a moment to drain and write coverage data
+        for _ in 1 2 3 4 5 6 7 8 9 10; do
+            kill -0 "$SERVER_PID" 2>/dev/null || break
+            sleep 0.3
+        done
+        kill -0 "$SERVER_PID" 2>/dev/null && kill -KILL "$SERVER_PID" 2>/dev/null
+        wait "$SERVER_PID" 2>/dev/null
+    fi
+    rm -f "$SERVER_LOG"
+}
+trap cleanup EXIT INT TERM
+
+fail() { echo "  NOT OK: $1" >&2; FAILED=$((FAILED + 1)); }
+pass() { echo "  ok: $1"; PASSED=$((PASSED + 1)); }
+
+# expect_status DESC EXPECTED_CODE curl-args...
+expect_status() {
+    desc=$1; want=$2; shift 2
+    got=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$@")
+    [ "$got" = "$want" ] && pass "$desc (HTTP $got)" || fail "$desc: expected HTTP $want, got $got"
+}
+
+# expect_body_contains DESC SUBSTRING curl-args...
+expect_body_contains() {
+    desc=$1; needle=$2; shift 2
+    body=$(curl -s --max-time 10 "$@")
+    case "$body" in
+        *"$needle"*) pass "$desc (body contains '$needle')" ;;
+        *) fail "$desc: body did not contain '$needle'"; printf '    got: %.200s\n' "$body" >&2 ;;
+    esac
+}
+
+# expect_stream DESC URL -- streaming endpoints stay open; we only check the
+# response headers, tolerating the curl timeout (exit 28) that follows.
+expect_stream() {
+    desc=$1; url=$2
+    hdr=$(curl -s -D - -o /dev/null --max-time 2 "$url" 2>/dev/null)
+    case "$hdr" in
+        *"200 OK"*) pass "$desc (200, stream open)" ;;
+        *) fail "$desc: no '200 OK' in response headers"; printf '    got: %.200s\n' "$hdr" >&2 ;;
+    esac
+}
+
+echo "Starting rtl_433 HTTP server: $RTL_433 -D manual -F $BASE"
+"$RTL_433" -D manual -F "http://$HOST:$PORT" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+# Wait for readiness (server prints/serves once the manual loop is up).
+ready=0
+for _ in $(seq 1 50); do
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "ERROR: server exited during startup" >&2
+        cat "$SERVER_LOG" >&2
+        exit 98
+    fi
+    if curl -s -o /dev/null --max-time 1 "$BASE/"; then
+        ready=1
+        break
+    fi
+    sleep 0.2
+done
+if [ "$ready" != 1 ]; then
+    echo "ERROR: server did not become ready on $BASE" >&2
+    cat "$SERVER_LOG" >&2
+    exit 97
+fi
+
+echo "Server ready on port $PORT (pid $SERVER_PID). Running checks:"
+
+# --- static / UI ---
+expect_status        "GET /  returns 200"          200 "$BASE/"
+expect_body_contains "GET /  serves index html"    "DOCTYPE html" "$BASE/"
+expect_status        "OPTIONS /  CORS preflight"   204 -X OPTIONS "$BASE/"
+expect_status        "GET /ui  redirects"          307 "$BASE/ui"
+
+# --- OpenMetrics / Prometheus ---
+expect_status        "GET /metrics returns 200"    200 "$BASE/metrics"
+expect_body_contains "GET /metrics is OpenMetrics" "# TYPE uptime_seconds counter" "$BASE/metrics"
+# Non-GET is rejected; send an explicit (empty) body so mongoose frames the
+# request rather than waiting for a body that curl's bare -X POST never sends.
+expect_status        "POST /metrics is rejected"   405 -d '' "$BASE/metrics"
+
+# --- /cmd RPC (GET query string and POST form) ---
+expect_body_contains "GET /cmd?cmd=get_meta"       "\"samp_rate\"" "$BASE/cmd?cmd=get_meta"
+expect_status        "GET /cmd?cmd=get_sample_rate" 200 "$BASE/cmd?cmd=get_sample_rate"
+expect_body_contains "POST /cmd form get_meta"     "\"samp_rate\"" -d "cmd=get_meta" "$BASE/cmd"
+expect_status        "GET /cmd with no cmd"        200 "$BASE/cmd"
+
+# --- more RPC methods, to exercise the rpc_exec getter/setter branches ---
+expect_body_contains "GET /cmd get_protocols"      "Nice" "$BASE/cmd?cmd=get_protocols"
+expect_status        "GET /cmd get_stats"          200 "$BASE/cmd?cmd=get_stats"
+expect_status        "GET /cmd get_center_frequency" 200 "$BASE/cmd?cmd=get_center_frequency"
+expect_status        "GET /cmd setter center_frequency" 200 "$BASE/cmd?cmd=center_frequency&val=433920000"
+expect_body_contains "GET /cmd unknown method is rejected" "Unknown method" "$BASE/cmd?cmd=no_such_method"
+
+# --- JSON-RPC ---
+expect_status        "POST /jsonrpc valid method"  200 \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"get_sample_rate"}' "$BASE/jsonrpc"
+expect_body_contains "POST /jsonrpc method with params" "result" \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":2,"method":"sample_rate","params":[1024000]}' "$BASE/jsonrpc"
+expect_status        "POST /jsonrpc malformed body does not crash" 200 \
+    -H 'Content-Type: application/json' -d 'not json at all' "$BASE/jsonrpc"
+
+# --- streaming endpoints ---
+expect_stream        "GET /stream opens"           "$BASE/stream"
+expect_stream        "GET /events opens"           "$BASE/events"
+
+# --- WebSocket: handshake, meta push, and an RPC round-trip ---
+if command -v python3 >/dev/null 2>&1; then
+    if ws_out=$(python3 "$SCRIPT_DIR/ws-probe.py" "$HOST" "$PORT" 10 2>&1); then
+        pass "websocket handshake + meta + rpc round-trip"
+    else
+        fail "websocket probe failed"
+        printf '%s\n' "$ws_out" | sed 's/^/    /' >&2
+    fi
+else
+    echo "  skip: websocket probe (python3 not found)"
+fi
+
+# --- robustness: unknown path must not crash the server ---
+curl -s -o /dev/null --max-time 2 "$BASE/no/such/path" 2>/dev/null
+if kill -0 "$SERVER_PID" 2>/dev/null; then
+    pass "server still alive after unknown path"
+else
+    fail "server died after request to unknown path"
+fi
+
+echo
+echo "Results: $PASSED passed, $FAILED failed"
+if [ "$FAILED" -ne 0 ]; then
+    echo "--- server log ---" >&2
+    cat "$SERVER_LOG" >&2
+    exit 1
+fi
+exit 0

--- a/tests/http-rtltcp-test.sh
+++ b/tests/http-rtltcp-test.sh
@@ -1,0 +1,141 @@
+#!/bin/sh
+#
+# End-to-end read-back test of the rtl_433 HTTP/WS API over the *live* input
+# path.
+#
+# http-integration-test.sh can't do this: it serves an idle server (no decodes).
+# The one-shot -y/-r file path can't either -- it exit()s as soon as the input
+# is consumed (before the mg_mgr_poll loop), so no client could connect in time.
+# Only the live SDR/poll loop keeps the server up while a decode flows, which is
+# what the fake rtl_tcp source below gives us.
+#
+# Here a fake rtl_tcp server (tests/rtl_tcp_serve.py) streams a synthetic OOK
+# signal, so rtl_433 runs through its live SDR/poll loop and the HTTP server
+# stays up. We feed a known Nice Flor-s vector, wait for the decode, then connect
+# a WebSocket client and assert the event comes back in the server's history
+# replay -- a genuine event -> history -> broadcast -> wire round-trip.
+#
+# Usage: http-rtltcp-test.sh [path-to-rtl_433-binary]
+
+set -u
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+RTL_433=${1:-"$SCRIPT_DIR/../src/rtl_433"}
+HOST=127.0.0.1
+
+if [ ! -x "$RTL_433" ]; then
+    echo "ERROR: rtl_433 binary not found or not executable: $RTL_433" >&2
+    exit 99
+fi
+
+# A documented Nice Flor-s test vector (see src/devices/nice_flor_s.c). The
+# bitstring is 0xe7a760b94372e (52 bits) as the pulse slicer sees it;
+# rtl_tcp_serve.py renders short=1 / long=0 OOK pulses.
+DEVICE_NAME="Nice Flor-s remote control"
+BITS="1110011110100111011000001011100101000011011100101110"
+EXPECT_MODEL="Nice-FlorS"
+
+PROTO=$("$RTL_433" -R help 2>&1 \
+    | grep "$DEVICE_NAME" \
+    | grep -oE '\[[0-9]+\]' | head -1 | tr -d '[]')
+if [ -z "$PROTO" ]; then
+    echo "ERROR: could not find protocol number for '$DEVICE_NAME'" >&2
+    exit 98
+fi
+echo "Resolved '$DEVICE_NAME' to protocol -R $PROTO"
+
+# Pick two free ports (HTTP API + fake rtl_tcp) so parallel ctest runs don't collide.
+pick_port() {
+    python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' 2>/dev/null
+}
+HTTPPORT=${HTTPPORT:-$(pick_port)}
+TCPPORT=${TCPPORT:-$(pick_port)}
+HTTPPORT=${HTTPPORT:-18433}
+TCPPORT=${TCPPORT:-18533}
+BASE="http://$HOST:$HTTPPORT"
+
+SERVER_LOG=$(mktemp 2>/dev/null || echo /tmp/rtl_433_rtltcp_test.$$.log)
+TCP_LOG=$(mktemp 2>/dev/null || echo /tmp/rtl_433_rtltcp_srv.$$.log)
+RTL_PID=""
+TCP_PID=""
+
+cleanup() {
+    if [ -n "$RTL_PID" ] && kill -0 "$RTL_PID" 2>/dev/null; then
+        # SIGTERM -> clean shutdown -> atexit/gcov flush. Do NOT use SIGKILL.
+        kill -TERM "$RTL_PID" 2>/dev/null
+        for _ in 1 2 3 4 5 6 7 8 9 10; do
+            kill -0 "$RTL_PID" 2>/dev/null || break
+            sleep 0.3
+        done
+        kill -0 "$RTL_PID" 2>/dev/null && kill -KILL "$RTL_PID" 2>/dev/null
+        wait "$RTL_PID" 2>/dev/null
+    fi
+    if [ -n "$TCP_PID" ] && kill -0 "$TCP_PID" 2>/dev/null; then
+        kill -TERM "$TCP_PID" 2>/dev/null
+        wait "$TCP_PID" 2>/dev/null
+    fi
+    rm -f "$SERVER_LOG" "$TCP_LOG"
+}
+trap cleanup EXIT INT TERM
+
+# --- start the fake rtl_tcp server and wait until it is listening ---
+echo "Starting fake rtl_tcp server on $HOST:$TCPPORT"
+python3 "$SCRIPT_DIR/rtl_tcp_serve.py" --port "$TCPPORT" --bits "$BITS" \
+    >"$TCP_LOG" 2>&1 &
+TCP_PID=$!
+listening=0
+for _ in $(seq 1 50); do
+    if ! kill -0 "$TCP_PID" 2>/dev/null; then
+        echo "ERROR: rtl_tcp server exited during startup" >&2
+        cat "$TCP_LOG" >&2
+        exit 96
+    fi
+    grep -q "LISTENING" "$TCP_LOG" 2>/dev/null && { listening=1; break; }
+    sleep 0.1
+done
+if [ "$listening" != 1 ]; then
+    echo "ERROR: rtl_tcp server did not start listening" >&2
+    cat "$TCP_LOG" >&2
+    exit 96
+fi
+
+# --- start rtl_433 against it, with HTTP API + json so we can observe the decode ---
+echo "Starting rtl_433: -d rtl_tcp:$HOST:$TCPPORT -R $PROTO -F $BASE"
+"$RTL_433" -d "rtl_tcp:$HOST:$TCPPORT" -R "$PROTO" \
+    -F "http://$HOST:$HTTPPORT" -F json >"$SERVER_LOG" 2>&1 &
+RTL_PID=$!
+
+# Wait for the HTTP server to come up *and* for the decode to land (the signal
+# plays ~0.5 s into the stream). Polling the json output makes the WS read-back
+# deterministic: once the event is decoded it is in the history ring for replay.
+ready=0
+for _ in $(seq 1 100); do
+    if ! kill -0 "$RTL_PID" 2>/dev/null; then
+        echo "ERROR: rtl_433 exited during startup" >&2
+        cat "$SERVER_LOG" >&2
+        exit 95
+    fi
+    if grep -q "$EXPECT_MODEL" "$SERVER_LOG" 2>/dev/null \
+            && curl -s -o /dev/null --max-time 1 "$BASE/"; then
+        ready=1
+        break
+    fi
+    sleep 0.2
+done
+if [ "$ready" != 1 ]; then
+    echo "ERROR: never saw a '$EXPECT_MODEL' decode with the HTTP server up" >&2
+    cat "$SERVER_LOG" >&2
+    exit 94
+fi
+echo "Decode observed and HTTP server ready on $BASE"
+
+# --- the actual assertion: the decode is retrievable over the WS API ---
+echo "--- ws read-back ---"
+if python3 "$SCRIPT_DIR/ws-probe.py" "$HOST" "$HTTPPORT" 10 "$EXPECT_MODEL"; then
+    echo "ok: '$EXPECT_MODEL' decode round-tripped through the HTTP/WS API"
+    exit 0
+else
+    echo "NOT OK: decode did not come back over the WS API" >&2
+    cat "$SERVER_LOG" >&2
+    exit 1
+fi

--- a/tests/rtl_tcp_serve.py
+++ b/tests/rtl_tcp_serve.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Minimal fake rtl_tcp server for black-box testing rtl_433's live input path.
+
+Speaks just enough of the rtl_tcp protocol to feed rtl_433 a synthetic OOK
+signal over TCP. This drives rtl_433 through its live SDR/poll loop -- which
+keeps the HTTP/WS server responsive -- instead of the one-shot `-r`/`-y` file
+path that exit()s as soon as the input is consumed (rtl_433.c, the test-data
+block that ends in exit(0), runs *before* the mg_mgr_poll loop). That makes it
+possible to feed a decode and then read it back over the HTTP API while the
+server is still up.
+
+rtl_tcp wire protocol (only the parts rtl_433 needs):
+  server -> client: 12-byte header  b"RTL0" + uint32be tuner_type + uint32be gain_count
+  client -> server: 5-byte commands (1 byte cmd + uint32be param) -- drained and ignored
+  server -> client: raw CU8 IQ sample stream (interleaved unsigned 8-bit I,Q)
+
+The signal is synthesized as OOK_PULSE_PWM to match the rtl_433 pulse slicer:
+short pulse = bit 1, long pulse = bit 0, an optional trailing sync pulse to
+close the row, framed by a lead-in gap (long enough to settle the detector's
+noise estimate) and a final reset gap. After the burst it streams silence so the
+TCP connection -- and therefore rtl_433's server -- stays up until the client
+goes away or we are signalled.
+
+Pure standard library so it runs in CI without extra packages.
+
+Usage: rtl_tcp_serve.py --port N --bits BITSTRING [options]
+  --port N         TCP port to listen on (required; use the same one in -d rtl_tcp:...)
+  --bits S         data bits as a string of '0'/'1' (short=1, long=0)
+  --rate HZ        sample rate the signal is generated for (default 250000)
+  --short US       short pulse width  (default 500)
+  --long US        long pulse width   (default 1000)
+  --sync US        trailing sync pulse width, 0 to omit (default 1500)
+  --gap US         inter-pulse gap    (default 500)
+  --lead-in US     leading silence    (default 8000; must exceed ~1024 samples)
+  --reset US       trailing silence   (default 6000; must exceed the reset_limit)
+Prints "LISTENING <port>" to stdout once bound, so a caller can synchronize.
+"""
+import argparse
+import math
+import socket
+import struct
+import sys
+import threading
+
+
+def synth_cu8(bits, rate, short_us, long_us, sync_us, gap_us, lead_in_us, reset_us):
+    """Return CU8 bytes for an OOK_PULSE_PWM burst (short=1, long=0)."""
+    samples_per_us = rate / 1e6
+    tone_hz = 50000.0  # IF offset so "on" is a real tone, not pure DC
+    buf = bytearray()
+    phase = [0.0]
+
+    def emit(us, on):
+        for _ in range(int(round(us * samples_per_us))):
+            if on:
+                i = 128 + int(100 * math.cos(phase[0]))
+                q = 128 + int(100 * math.sin(phase[0]))
+                phase[0] += 2 * math.pi * tone_hz / rate
+            else:
+                i = q = 128
+            buf.append(max(0, min(255, i)))
+            buf.append(max(0, min(255, q)))
+
+    emit(lead_in_us, False)
+    for b in bits:
+        emit(short_us if b == "1" else long_us, True)
+        emit(gap_us, False)
+    if sync_us > 0:
+        emit(sync_us, True)  # closes the data row -> trailing empty row
+    emit(reset_us, False)
+    return bytes(buf)
+
+
+def drain_commands(conn):
+    """Read and discard the 5-byte rtl_tcp commands rtl_433 sends (set freq,
+    rate, gain, ...). We honor none of them; the signal is pre-synthesized."""
+    try:
+        while True:
+            if not conn.recv(4096):
+                return
+    except OSError:
+        return
+
+
+def serve(port, payload):
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", port))
+    srv.listen(1)
+    bound = srv.getsockname()[1]
+    print("LISTENING %d" % bound, flush=True)
+
+    conn, _ = srv.accept()
+    srv.close()
+    try:
+        # rtl_tcp dongle-info header: magic + tuner type (5 = R820T) + gain count.
+        conn.sendall(b"RTL0" + struct.pack(">II", 5, 0))
+        threading.Thread(target=drain_commands, args=(conn,), daemon=True).start()
+
+        conn.sendall(payload)
+        # Keep the stream (and thus rtl_433's server) alive with silence until
+        # the client disconnects or we're killed.
+        silence = bytes([128]) * 16384
+        while True:
+            conn.sendall(silence)
+    except OSError:
+        pass  # client went away -- normal shutdown
+    finally:
+        try:
+            conn.close()
+        except OSError:
+            pass
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--port", type=int, required=True)
+    p.add_argument("--bits", required=True)
+    p.add_argument("--rate", type=int, default=250000)
+    p.add_argument("--short", type=float, default=500)
+    p.add_argument("--long", type=float, default=1000)
+    p.add_argument("--sync", type=float, default=1500)
+    p.add_argument("--gap", type=float, default=500)
+    p.add_argument("--lead-in", type=float, default=8000)
+    p.add_argument("--reset", type=float, default=6000)
+    a = p.parse_args()
+    if any(c not in "01" for c in a.bits):
+        print("error: --bits must be a string of 0/1", file=sys.stderr)
+        return 2
+    payload = synth_cu8(a.bits, a.rate, a.short, a.long, a.sync,
+                        a.gap, getattr(a, "lead_in"), a.reset)
+    serve(a.port, payload)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ws-probe.py
+++ b/tests/ws-probe.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Minimal WebSocket probe for the rtl_433 HTTP/WS API.
+
+Connects to a running rtl_433 HTTP server (started elsewhere, e.g. with
+`-D manual -F http://host:port`), completes the WebSocket handshake, reads the
+meta frame the server pushes on connect, then sends a JSON-RPC command frame
+and reads the reply. This exercises the server's WebSocket code paths
+(handshake -> meta/history push -> handle_ws_rpc -> rpc_response_ws).
+
+Pure standard library so it runs in CI without extra packages.
+
+Usage: ws-probe.py HOST PORT [timeout_seconds] [expect_substring]
+If expect_substring is given, the probe also asserts that a pushed frame (the
+history the server replays on connect, or a live broadcast) contains it -- used
+to confirm a decoded event is retrievable over the WS API.
+Exit 0 on success, non-zero otherwise; received text frames go to stdout.
+"""
+import base64
+import json
+import os
+import socket
+import sys
+
+OP_TEXT = 0x1
+OP_CLOSE = 0x8
+OP_PING = 0x9
+
+
+def recv_exact(sock, n):
+    buf = b""
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise EOFError("connection closed by server")
+        buf += chunk
+    return buf
+
+
+def read_frame(sock):
+    """Read one WebSocket frame, return (opcode, payload_bytes)."""
+    b0, b1 = recv_exact(sock, 2)
+    opcode = b0 & 0x0F
+    masked = b1 & 0x80
+    length = b1 & 0x7F
+    if length == 126:
+        length = int.from_bytes(recv_exact(sock, 2), "big")
+    elif length == 127:
+        length = int.from_bytes(recv_exact(sock, 8), "big")
+    mask = recv_exact(sock, 4) if masked else b""
+    payload = recv_exact(sock, length) if length else b""
+    if masked:
+        payload = bytes(p ^ mask[i % 4] for i, p in enumerate(payload))
+    return opcode, payload
+
+
+def send_text(sock, text):
+    """Send a masked text frame (clients MUST mask, per RFC 6455)."""
+    data = text.encode("utf-8")
+    n = len(data)
+    header = bytes([0x80 | OP_TEXT])  # FIN + text
+    if n < 126:
+        header += bytes([0x80 | n])
+    elif n < 65536:
+        header += bytes([0x80 | 126]) + n.to_bytes(2, "big")
+    else:
+        header += bytes([0x80 | 127]) + n.to_bytes(8, "big")
+    mask = os.urandom(4)
+    masked = bytes(b ^ mask[i % 4] for i, b in enumerate(data))
+    sock.sendall(header + mask + masked)
+
+
+def handshake(sock, host, port):
+    key = base64.b64encode(os.urandom(16)).decode()
+    req = (
+        "GET / HTTP/1.1\r\n"
+        f"Host: {host}:{port}\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        f"Sec-WebSocket-Key: {key}\r\n"
+        "Sec-WebSocket-Version: 13\r\n"
+        "\r\n"
+    )
+    sock.sendall(req.encode())
+    resp = b""
+    while b"\r\n\r\n" not in resp:
+        resp += recv_exact(sock, 1)
+    status = resp.split(b"\r\n", 1)[0].decode(errors="replace")
+    if "101" not in status:
+        raise RuntimeError(f"handshake failed: {status!r}")
+
+
+def read_text_frame(sock):
+    """Read frames until a text frame arrives, answering pings, ignoring close."""
+    while True:
+        opcode, payload = read_frame(sock)
+        if opcode == OP_TEXT:
+            return payload.decode("utf-8", errors="replace")
+        if opcode == OP_PING:
+            continue  # server ping; ignore for this short-lived probe
+        if opcode == OP_CLOSE:
+            raise EOFError("server sent close frame")
+
+
+def read_until_contains(sock, needle, max_frames=20):
+    """Read text frames until one contains needle. The server also broadcasts
+    log messages over the same socket, so skip frames that aren't the one we
+    want. Returns the matching frame or None if max_frames is exhausted."""
+    for _ in range(max_frames):
+        frame = read_text_frame(sock)
+        print("  <<", frame)
+        if needle in frame:
+            return frame
+    return None
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("usage: ws-probe.py HOST PORT [timeout]", file=sys.stderr)
+        return 2
+    host = sys.argv[1]
+    port = int(sys.argv[2])
+    timeout = float(sys.argv[3]) if len(sys.argv) > 3 else 10.0
+    expect = sys.argv[4] if len(sys.argv) > 4 else None
+
+    sock = socket.create_connection((host, port), timeout=timeout)
+    sock.settimeout(timeout)
+    try:
+        handshake(sock, host, port)
+
+        # On connect the server pushes the meta frame (and history, empty here).
+        if read_until_contains(sock, "center_frequency") is None:
+            print("FAIL: never received a meta frame with 'center_frequency'", file=sys.stderr)
+            return 1
+
+        # If asked, confirm a decoded event is retrievable over the WS API: the
+        # server replays its history ring on connect, so a decode that already
+        # happened arrives as a pushed frame (a live broadcast also matches).
+        if expect is not None:
+            if read_until_contains(sock, expect, max_frames=200) is None:
+                print("FAIL: never received a frame containing %r" % expect, file=sys.stderr)
+                return 1
+
+        # The WebSocket RPC uses the simple {"cmd": ...} form (json_parse),
+        # NOT the JSON-RPC envelope the /jsonrpc HTTP endpoint expects.
+        send_text(sock, json.dumps({"cmd": "get_sample_rate"}))
+        reply = read_until_contains(sock, "\"result\"")
+        if reply is None:
+            print("FAIL: no rpc reply containing 'result'", file=sys.stderr)
+            return 1
+
+        print("OK: websocket handshake, meta push, and rpc round-trip")
+        return 0
+    finally:
+        try:
+            sock.close()
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
With all protocols enabled, invalid JSON is returned from get_stats and get_protocols. This PR fixes that by changing from fixed buffers to dynamically growing ones.

This uses the test code being added in https://github.com/merbanan/rtl_433/pull/3548.