### PR TITLE
Fix automatic discriminator selection for file input

### DIFF
--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -73,10 +73,10 @@ typedef struct r_cfg {
     volatile sig_atomic_t hop_now; ///< flag to cause channel hopping, async written by signal handler and push_sdr_flow()
     volatile sig_atomic_t exit_async; ///< flag to cause exiting, async written by signal handler
     volatile sig_atomic_t exit_code; ///< 0=no err, 1=params or cmd line err, 2=sdr device read error, 3=usb init error, 5=USB error (reset), other=other error
-    int frequencies;
-    int frequency_index;
-    uint32_t frequency[MAX_FREQS];
-    uint32_t center_frequency;
+    int frequencies;                 ///< The number of entries in the frequency hopping list.
+    int frequency_index;             ///< The current position in the frequency hopping list.
+    uint32_t frequency[MAX_FREQS];   ///< A list of hopping frequencies.
+    uint32_t center_frequency;       ///< The current center frequency of the live or file input.
     int fsk_pulse_detect_mode;
     int hop_times;
     int hop_time[MAX_FREQS];

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1093,8 +1093,7 @@ static void process_sdr_frame(r_cfg_t *cfg, unsigned char *iq_buf, uint32_t len)
     // Select needed discriminator based on current frequency or manual setting
     unsigned fpdm = cfg->fsk_pulse_detect_mode;
     if (cfg->fsk_pulse_detect_mode == FSK_PULSE_DETECT_AUTO) {
-        // FIXME: this is wrong to be compatible with tests and won't work for file inputs
-        if (cfg->frequency[cfg->frequency_index] > FSK_PULSE_DETECTOR_LIMIT) {
+        if (cfg->center_frequency > FSK_PULSE_DETECTOR_LIMIT) {
             fpdm = FSK_PULSE_DETECT_NEW;
         }
         else {


### PR DESCRIPTION
The `center_frequency` should be used for discriminator selection in `sdr_callback()`.
With this change frequency information from input files will be used the same way as if it were live input.

This fix adds 13 fails to the tests though. It seems that these samples/protocols need the `classic` discriminator manually set:

- `sharp_spc775/01/sharp-1_917.2M_250k.cu8`
- `sharp_spc775/01/sharp-2_917.2M_250k.cu8`
- `insteon/03/g005_915M_1024k.cu8`
- `thermopro-211b/01/g144_915.1M_1000k_22.9degC.cu8`
- `thermopro-211b/01/g155_915.1M_1000k_23.0degC.cu8`
- `thermopro-211b/01/g097_915.1M_1000k_22.0degC.cu8`
- `thermopro-211b/01/g074_915.1M_1000k_21.2degC.cu8`
- `lacrosse_ltv/BreezePro_LTV-WSDTH01/g001_914.938M_2400k.cu8`
- `lacrosse_ltv/BreezePro_LTV-WSDTH01/g050_914.938M_2400k.cu8`
- `lacrosse_ltv/BreezePro_LTV-WSDTH01/g011_914.938M_2400k.cu8`
- `lacrosse_ltv/BreezePro_LTV-WSDTH01/g012_914.938M_2400k.cu8`
- `lacrosse_ltv/LTV-W1/g007_915M_1000k.cu8`
- `ESIC-EMT7110_power_meter/g016_868.28M_1024k.cu8`
