### PR TITLE
ert_idm + scmplus: print 32-bit consumption counters as unsigned

### DIFF
--- a/src/devices/ert_idm.c
+++ b/src/devices/ert_idm.c
@@ -282,7 +282,7 @@ static int ert_idm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             // "AsynchronousCounters",             "",     DATA_INT,    AsynchronousCounters,
 
             "PowerOutageFlags",                 "",     DATA_STRING,       PowerOutageFlags_str ,
-            "LastConsumptionCount",             "",     DATA_INT,       LastConsumptionCount,
+            "LastConsumptionCount",             "",     DATA_FORMAT, "%u", DATA_INT,       LastConsumptionCount,
             "DifferentialConsumptionIntervals", "",     DATA_ARRAY, data_array(47, DATA_INT, DifferentialConsumptionIntervals),
             "TransmitTimeOffset",               "",     DATA_INT,       TransmitTimeOffset,
             "MeterIdCRC",                       "",     DATA_FORMAT, "0x%04X", DATA_INT, MeterIdCRC,
@@ -567,13 +567,13 @@ static int ert_netidm_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "TamperCounters",                   "",     DATA_STRING,       TamperCounters_str,
             // "AsynchronousCounters",             "",     DATA_FORMAT, "0x%02X", DATA_INT, AsynchronousCounters,
             "Unknown_field_1",                  "",     DATA_STRING,    Unknown_field_1_str,
-            "LastGenerationCount",              "",     DATA_INT,       LastGenerationCount,
+            "LastGenerationCount",              "",     DATA_FORMAT, "%u", DATA_INT,       LastGenerationCount,
             "Unknown_field_2",                  "",     DATA_STRING,    Unknown_field_2_str,
 
             // "AsynchronousCounters",             "",     DATA_STRING,    AsynchronousCounters_str,
 
             // "PowerOutageFlags",                 "",     DATA_STRING,       PowerOutageFlags_str ,
-            "LastConsumptionCount",             "",     DATA_INT,       LastConsumptionCount,
+            "LastConsumptionCount",             "",     DATA_FORMAT, "%u", DATA_INT,       LastConsumptionCount,
             "DifferentialConsumptionIntervals", "",     DATA_ARRAY, data_array(27, DATA_INT, DifferentialConsumptionIntervals),
             "TransmitTimeOffset",               "",     DATA_INT,       TransmitTimeOffset,
             "MeterIdCRC",                       "",     DATA_FORMAT, "0x%04X", DATA_INT, MeterIdCRC,

--- a/src/devices/scmplus.c
+++ b/src/devices/scmplus.c
@@ -144,7 +144,7 @@ static int scmplus_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "ProtocolID",       "Protocol_ID",      DATA_STRING, protocol_id_str, // TODO: this should be int
             "EndpointType",     "Endpoint_Type",    DATA_STRING, endpoint_type_str, // TODO: this should be int
             "EndpointID",       "Endpoint_ID",      DATA_INT,    endpoint_id, // TODO: remove this (see "id")
-            "Consumption",      "",                 DATA_INT,    consumption_data,
+            "Consumption",      "",                 DATA_FORMAT, "%u", DATA_INT,    consumption_data,
             "Tamper",           "",                 DATA_STRING, physical_tamper_str, // TODO: should be int
             "PacketCRC",        "crc",              DATA_STRING, crc_str, // TODO: remove this
             "MeterType",        "Meter_Type",       DATA_STRING, meter_type,


### PR DESCRIPTION
## Problem

`LastConsumptionCount` (IDM and NETIDM), `LastGenerationCount` (NETIDM), and `Consumption` (SCMplus) are parsed as `uint32_t` in the decoder but emitted via `DATA_INT`, which formats them as signed `int`. Once a meter's lifetime counter rolls past 2^31 (≈ 2.15 billion ticks), the displayed value flips negative.

Observed in the wild on multiple Itron NETIDM meters in the US:

```
NETIDM id=61275461  LastConsumptionCount=-2059230912   (actually 2,235,736,384 unsigned)
NETIDM id=61275410  LastConsumptionCount=-2138865248   (actually 2,156,102,048 unsigned)
NETIDM id=27688239  LastConsumptionCount=-2067643536   (actually 2,227,323,760 unsigned)
```

All values cluster near `INT32_MIN = -2,147,483,648` — the smoking gun for a signed-vs-unsigned printf mismatch.

## Fix

Use the existing `DATA_FORMAT, "%u", DATA_INT, value` idiom — already used in `emontx.c`, `holman_ws5029.c`, `emax.c`, and others — to render these counters correctly as unsigned. The underlying `int` storage holds the right bit pattern; only the format string changes.

Affected sites:
- `src/devices/ert_idm.c:285` — IDM `LastConsumptionCount`
- `src/devices/ert_idm.c:570` — NETIDM `LastGenerationCount`
- `src/devices/ert_idm.c:576` — NETIDM `LastConsumptionCount`
- `src/devices/scmplus.c:147` — SCMplus `Consumption`

The 9-bit and 14-bit `DifferentialConsumptionIntervals` values are well within `int` range and don't need the change.

## Not changed

- `ert_scm.c` `consumption_data` is constructed from only 3 bytes (24-bit, max 16,777,215) and can never overflow `int32`, so it's left alone.

## Testing

Tested locally against live Itron meters with high lifetime counters. Negative displays now render as their correct unsigned values.