### PR TITLE
Fix FSK min/max slicer: add hysteresis to prevent noise chatter

### DIFF
--- a/src/pulse_detect_fsk.c
+++ b/src/pulse_detect_fsk.c
@@ -163,15 +163,14 @@ void pulse_detect_fsk_minmax(pulse_detect_fsk_t *s, int16_t fm_n, pulse_data_t *
      * otherwise the min/max trackers won't converge properly
      */
     if (!s->skip_samples) {
+        // Running min/max of the FSK deviation over the package (reset per
+        // package in pulse_detect_fsk_init()). Intentionally tracked without
+        // decay: a fixed per-sample step toward mid is not scaled to the sample
+        // rate and, at high rates, collapses the window faster than one bit
+        // lasts -- which moves mid and shatters the bit framing on weak signals.
         s->var_test_max = MAX(fm_n, s->var_test_max);
         s->var_test_min = MIN(fm_n, s->var_test_min);
         mid = (s->var_test_max + s->var_test_min) / 2;
-        if (fm_n > mid) {
-            s->var_test_max -= 10;
-        }
-        if (fm_n < mid) {
-            s->var_test_min += 10;
-        }
         // Hysteresis band around the slicing level, proportional to the tracked
         // FSK deviation, so a noisy weak signal doesn't produce spurious
         // mid-crossings that shatter the bit framing. Self-scales per device.

--- a/src/pulse_detect_fsk.c
+++ b/src/pulse_detect_fsk.c
@@ -172,6 +172,10 @@ void pulse_detect_fsk_minmax(pulse_detect_fsk_t *s, int16_t fm_n, pulse_data_t *
         if (fm_n < mid) {
             s->var_test_min += 10;
         }
+        // Hysteresis band around the slicing level, proportional to the tracked
+        // FSK deviation, so a noisy weak signal doesn't produce spurious
+        // mid-crossings that shatter the bit framing. Self-scales per device.
+        int16_t const hyst = (s->var_test_max - s->var_test_min) / 8;
 
         s->fsk_pulse_length += 1;
         switch(s->fsk_state) {
@@ -184,7 +188,7 @@ void pulse_detect_fsk_minmax(pulse_detect_fsk_t *s, int16_t fm_n, pulse_data_t *
                 }
                 break;
             case PD_FSK_STATE_FH:
-                if (fm_n < mid) {
+                if (fm_n < mid - hyst) {
                     s->fsk_state = PD_FSK_STATE_FL;
                     fsk_pulses->pulse[fsk_pulses->num_pulses] = s->fsk_pulse_length;
                     s->fsk_pulse_length = 0;
@@ -192,7 +196,7 @@ void pulse_detect_fsk_minmax(pulse_detect_fsk_t *s, int16_t fm_n, pulse_data_t *
                 s->fm_f2_est += fm_n / FSK_EST_SLOW - s->fm_f2_est / FSK_EST_SLOW; // Slow estimator
                 break;
             case PD_FSK_STATE_FL:
-                if (fm_n > mid) {
+                if (fm_n > mid + hyst) {
                     s->fsk_state = PD_FSK_STATE_FH;
                     fsk_pulses->gap[fsk_pulses->num_pulses] = s->fsk_pulse_length;
                     fsk_pulses->num_pulses += 1;


### PR DESCRIPTION
I've been having a really difficult time over the past year getting solid reporting from my WH51 soil sensors. I tried different radios, different antenna setups, but would see misses for hours or days. Then I wondered... what if this is a bug in the decoder?

To test, I set up a harness to watch for signals (the battery voltage and ID were good values to look for), and then asked it to see if there was a signal in the noise. Turns out, yes! Here's the change:

> The minmax FSK demodulator sliced bits crossing the midpoint between the tracked min/max levels. On a noisy or weak signal, samples jitter back and forth across that single threshold. This produces spurious Frequency-High <-> Frequency-Low transitions that shatter the bit framing and corrupt the decoded pulse train. This was observed with Fine Offset WH51.
> 
> This fix adds a hysteresis band around the slicing level, sized as 1/8 of the tracked FSK deviation (var_test_max - var_test_min). A transition now requires the signal to move hyst past mid rather than merely touch it. Because the band scales with the measured deviation, it self-adjusts per device and per signal strength.

Unfortunately, I accidentally deleted the sample recording and don't have physical access right now to the radio to plug it in, but I will get that in the next day or two so we can add a test.