### PR TITLE
Add [Govee-H5310] pool/spa thermometer decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,26 +388,27 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [298]  TRW TPMS OOK OEM and Clone models
     [299]  TRW TPMS FSK OEM and Clone models
     [300]  Govee Water Leak Detector H5059
-    [301]  Astrostart 2000 Car Remote (-f 372.4M)
-    [302]  Compustar 1WG3R Car Remote
-    [303]  Chrysler Car Remote (-f 315.1M -s 920k)
-    [304]  Nidec Car Remote (-f 313.8M -s 1024k)
-    [305]  Audiovox PRO-OE3B Car Remote (-f 303.4M)
-    [306]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 833 bit/s)
-    [307]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 1667 bit/s)
-    [308]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 833 bit/s)
-    [309]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 1667 bit/s)
-    [310]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 2500 bit/s)
-    [311]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 5000 bit/s)
-    [312]  MIC 6SC2 Car Remote (-f 315.1M)
-    [313]  GM ABO1502T Car Remote (-f 314.9M)
-    [314]  Siemens 5WY72XX Car Remote (-f 315.1M)
-    [315]  Alps FWB1U545 Car Remote
-    [316]  Continental KR5V2X Car Remote (-f 313.8M -s 1024k)
-    [317]  Code Alarm FRDPC2002 Car Remote
-    [318]  RFM69 LowPowerLab Moteino board (-s 1000k)
-    [319]  Shenzhen Wale WL-TH6R Temperature & Humidity Sensor
-    [320]  Cellular Tracking Technologies LifeTag/PowerTag/HybridTag
+    [301]  Govee Pool/Spa Thermometer H5310
+    [302]  Astrostart 2000 Car Remote (-f 372.4M)
+    [303]  Compustar 1WG3R Car Remote
+    [304]  Chrysler Car Remote (-f 315.1M -s 920k)
+    [305]  Nidec Car Remote (-f 313.8M -s 1024k)
+    [306]  Audiovox PRO-OE3B Car Remote (-f 303.4M)
+    [307]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 833 bit/s)
+    [308]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 1667 bit/s)
+    [309]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 833 bit/s)
+    [310]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 1667 bit/s)
+    [311]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 2500 bit/s)
+    [312]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 5000 bit/s)
+    [313]  MIC 6SC2 Car Remote (-f 315.1M)
+    [314]  GM ABO1502T Car Remote (-f 314.9M)
+    [315]  Siemens 5WY72XX Car Remote (-f 315.1M)
+    [316]  Alps FWB1U545 Car Remote
+    [317]  Continental KR5V2X Car Remote (-f 313.8M -s 1024k)
+    [318]  Code Alarm FRDPC2002 Car Remote
+    [319]  RFM69 LowPowerLab Moteino board (-s 1000k)
+    [320]  Shenzhen Wale WL-TH6R Temperature & Humidity Sensor
+    [321]  Cellular Tracking Technologies LifeTag/PowerTag/HybridTag
 
 * Disabled by default, use -R n or a conf file to enable
 

--- a/README.md
+++ b/README.md
@@ -388,27 +388,27 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [298]  TRW TPMS OOK OEM and Clone models
     [299]  TRW TPMS FSK OEM and Clone models
     [300]  Govee Water Leak Detector H5059
-    [301]  Govee Pool/Spa Thermometer H5310
-    [302]  Astrostart 2000 Car Remote (-f 372.4M)
-    [303]  Compustar 1WG3R Car Remote
-    [304]  Chrysler Car Remote (-f 315.1M -s 920k)
-    [305]  Nidec Car Remote (-f 313.8M -s 1024k)
-    [306]  Audiovox PRO-OE3B Car Remote (-f 303.4M)
-    [307]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 833 bit/s)
-    [308]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 1667 bit/s)
-    [309]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 833 bit/s)
-    [310]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 1667 bit/s)
-    [311]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 2500 bit/s)
-    [312]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 5000 bit/s)
-    [313]  MIC 6SC2 Car Remote (-f 315.1M)
-    [314]  GM ABO1502T Car Remote (-f 314.9M)
-    [315]  Siemens 5WY72XX Car Remote (-f 315.1M)
-    [316]  Alps FWB1U545 Car Remote
-    [317]  Continental KR5V2X Car Remote (-f 313.8M -s 1024k)
-    [318]  Code Alarm FRDPC2002 Car Remote
-    [319]  RFM69 LowPowerLab Moteino board (-s 1000k)
-    [320]  Shenzhen Wale WL-TH6R Temperature & Humidity Sensor
-    [321]  Cellular Tracking Technologies LifeTag/PowerTag/HybridTag
+    [301]  Astrostart 2000 Car Remote (-f 372.4M)
+    [302]  Compustar 1WG3R Car Remote
+    [303]  Chrysler Car Remote (-f 315.1M -s 920k)
+    [304]  Nidec Car Remote (-f 313.8M -s 1024k)
+    [305]  Audiovox PRO-OE3B Car Remote (-f 303.4M)
+    [306]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 833 bit/s)
+    [307]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 1667 bit/s)
+    [308]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 833 bit/s)
+    [309]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 1667 bit/s)
+    [310]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 2500 bit/s)
+    [311]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 5000 bit/s)
+    [312]  MIC 6SC2 Car Remote (-f 315.1M)
+    [313]  GM ABO1502T Car Remote (-f 314.9M)
+    [314]  Siemens 5WY72XX Car Remote (-f 315.1M)
+    [315]  Alps FWB1U545 Car Remote
+    [316]  Continental KR5V2X Car Remote (-f 313.8M -s 1024k)
+    [317]  Code Alarm FRDPC2002 Car Remote
+    [318]  RFM69 LowPowerLab Moteino board (-s 1000k)
+    [319]  Shenzhen Wale WL-TH6R Temperature & Humidity Sensor
+    [320]  Cellular Tracking Technologies LifeTag/PowerTag/HybridTag
+    [321]  Govee Pool/Spa Thermometer H5310
 
 * Disabled by default, use -R n or a conf file to enable
 
@@ -418,7 +418,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
   [-d <RTL-SDR USB device index>] (default: 0)
   [-d :<RTL-SDR USB device serial (can be set with rtl_eeprom -s)>]
 	To set gain for RTL-SDR use -g <gain> to set an overall gain in dB.
-	SoapySDR device driver is available.
+	SoapySDR device driver is not available.
   [-d ""] Open default SoapySDR device
   [-d driver=rtlsdr] Open e.g. specific SoapySDR device
 	To set gain for SoapySDR use -g ELEM=val,ELEM=val,... e.g. -g LNA=20,TIA=8,PGA=2 (for LimeSDR).

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -539,26 +539,27 @@ convert si
   protocol 298 # TRW TPMS OOK OEM and Clone models
   protocol 299 # TRW TPMS FSK OEM and Clone models
   protocol 300 # Govee Water Leak Detector H5059
-  protocol 301 # Astrostart 2000 Car Remote (-f 372.4M)
-  protocol 302 # Compustar 1WG3R Car Remote
-  protocol 303 # Chrysler Car Remote (-f 315.1M -s 920k)
-  protocol 304 # Nidec Car Remote (-f 313.8M -s 1024k)
-  protocol 305 # Audiovox PRO-OE3B Car Remote (-f 303.4M)
-  protocol 306 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 833 bit/s)
-  protocol 307 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 1667 bit/s)
-  protocol 308 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 833 bit/s)
-  protocol 309 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 1667 bit/s)
-  protocol 310 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 2500 bit/s)
-  protocol 311 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 5000 bit/s)
-  protocol 312 # MIC 6SC2 Car Remote (-f 315.1M)
-  protocol 313 # GM ABO1502T Car Remote (-f 314.9M)
-  protocol 314 # Siemens 5WY72XX Car Remote (-f 315.1M)
-  protocol 315 # Alps FWB1U545 Car Remote
-  protocol 316 # Continental KR5V2X Car Remote (-f 313.8M -s 1024k)
-  protocol 317 # Code Alarm FRDPC2002 Car Remote
-  protocol 318 # RFM69 LowPowerLab Moteino board (-s 1000k)
-  protocol 319 # Shenzhen Wale WL-TH6R Temperature & Humidity Sensor
-  protocol 320 # Cellular Tracking Technologies LifeTag/PowerTag/HybridTag
+  protocol 301 # Govee Pool/Spa Thermometer H5310
+  protocol 302 # Astrostart 2000 Car Remote (-f 372.4M)
+  protocol 303 # Compustar 1WG3R Car Remote
+  protocol 304 # Chrysler Car Remote (-f 315.1M -s 920k)
+  protocol 305 # Nidec Car Remote (-f 313.8M -s 1024k)
+  protocol 306 # Audiovox PRO-OE3B Car Remote (-f 303.4M)
+  protocol 307 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 833 bit/s)
+  protocol 308 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 1667 bit/s)
+  protocol 309 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 833 bit/s)
+  protocol 310 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 1667 bit/s)
+  protocol 311 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 2500 bit/s)
+  protocol 312 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 5000 bit/s)
+  protocol 313 # MIC 6SC2 Car Remote (-f 315.1M)
+  protocol 314 # GM ABO1502T Car Remote (-f 314.9M)
+  protocol 315 # Siemens 5WY72XX Car Remote (-f 315.1M)
+  protocol 316 # Alps FWB1U545 Car Remote
+  protocol 317 # Continental KR5V2X Car Remote (-f 313.8M -s 1024k)
+  protocol 318 # Code Alarm FRDPC2002 Car Remote
+  protocol 319 # RFM69 LowPowerLab Moteino board (-s 1000k)
+  protocol 320 # Shenzhen Wale WL-TH6R Temperature & Humidity Sensor
+  protocol 321 # Cellular Tracking Technologies LifeTag/PowerTag/HybridTag
 
 ## Flex devices (command line option "-X")
 

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -539,27 +539,27 @@ convert si
   protocol 298 # TRW TPMS OOK OEM and Clone models
   protocol 299 # TRW TPMS FSK OEM and Clone models
   protocol 300 # Govee Water Leak Detector H5059
-  protocol 301 # Govee Pool/Spa Thermometer H5310
-  protocol 302 # Astrostart 2000 Car Remote (-f 372.4M)
-  protocol 303 # Compustar 1WG3R Car Remote
-  protocol 304 # Chrysler Car Remote (-f 315.1M -s 920k)
-  protocol 305 # Nidec Car Remote (-f 313.8M -s 1024k)
-  protocol 306 # Audiovox PRO-OE3B Car Remote (-f 303.4M)
-  protocol 307 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 833 bit/s)
-  protocol 308 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 1667 bit/s)
-  protocol 309 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 833 bit/s)
-  protocol 310 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 1667 bit/s)
-  protocol 311 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 2500 bit/s)
-  protocol 312 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 5000 bit/s)
-  protocol 313 # MIC 6SC2 Car Remote (-f 315.1M)
-  protocol 314 # GM ABO1502T Car Remote (-f 314.9M)
-  protocol 315 # Siemens 5WY72XX Car Remote (-f 315.1M)
-  protocol 316 # Alps FWB1U545 Car Remote
-  protocol 317 # Continental KR5V2X Car Remote (-f 313.8M -s 1024k)
-  protocol 318 # Code Alarm FRDPC2002 Car Remote
-  protocol 319 # RFM69 LowPowerLab Moteino board (-s 1000k)
-  protocol 320 # Shenzhen Wale WL-TH6R Temperature & Humidity Sensor
-  protocol 321 # Cellular Tracking Technologies LifeTag/PowerTag/HybridTag
+  protocol 301 # Astrostart 2000 Car Remote (-f 372.4M)
+  protocol 302 # Compustar 1WG3R Car Remote
+  protocol 303 # Chrysler Car Remote (-f 315.1M -s 920k)
+  protocol 304 # Nidec Car Remote (-f 313.8M -s 1024k)
+  protocol 305 # Audiovox PRO-OE3B Car Remote (-f 303.4M)
+  protocol 306 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 833 bit/s)
+  protocol 307 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 1667 bit/s)
+  protocol 308 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 833 bit/s)
+  protocol 309 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 1667 bit/s)
+  protocol 310 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 2500 bit/s)
+  protocol 311 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 5000 bit/s)
+  protocol 312 # MIC 6SC2 Car Remote (-f 315.1M)
+  protocol 313 # GM ABO1502T Car Remote (-f 314.9M)
+  protocol 314 # Siemens 5WY72XX Car Remote (-f 315.1M)
+  protocol 315 # Alps FWB1U545 Car Remote
+  protocol 316 # Continental KR5V2X Car Remote (-f 313.8M -s 1024k)
+  protocol 317 # Code Alarm FRDPC2002 Car Remote
+  protocol 318 # RFM69 LowPowerLab Moteino board (-s 1000k)
+  protocol 319 # Shenzhen Wale WL-TH6R Temperature & Humidity Sensor
+  protocol 320 # Cellular Tracking Technologies LifeTag/PowerTag/HybridTag
+  protocol 321 # Govee Pool/Spa Thermometer H5310
 
 ## Flex devices (command line option "-X")
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -308,7 +308,6 @@
     DECL(tpms_trw_ook) \
     DECL(tpms_trw_fsk) \
     DECL(govee_h5059) \
-    DECL(govee_h5310) \
     DECL(astrostart_2000) \
     DECL(compustar_1wg3r) \
     DECL(chrysler_car_remote) \
@@ -329,6 +328,7 @@
     DECL(rfm69_lowpowerlab_moteino) \
     DECL(shenzhen_wale_wl_th6r) \
     DECL(ctt_life_power_hybrid) \
+    DECL(govee_h5310) \
     /* Add new decoders here. */
 
 #define DECL(name) extern r_device name;

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -308,6 +308,7 @@
     DECL(tpms_trw_ook) \
     DECL(tpms_trw_fsk) \
     DECL(govee_h5059) \
+    DECL(govee_h5310) \
     DECL(astrostart_2000) \
     DECL(compustar_1wg3r) \
     DECL(chrysler_car_remote) \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -156,6 +156,7 @@ add_library(r_433 STATIC
     devices/gm_car_remote.c
     devices/govee.c
     devices/govee_h5059.c
+    devices/govee_h5310.c
     devices/gridstream.c
     devices/gt_tmbbq05.c
     devices/gt_wt_02.c

--- a/src/devices/govee_h5059.c
+++ b/src/devices/govee_h5059.c
@@ -108,10 +108,12 @@ Top/bottom probe flags (confirmed 2026-06-14):
 
 Subtype 0x07 note:
 
-- Field observations indicate 0x07 commonly follows leak-active (0x06) frames and
-    likely represents dry/recovery state.
-- This is still marked as provisional and should be confirmed by correlating RF
-    captures with Govee gateway/app state transitions.
+- Observed following leak-active (0x06) frames, but the exact semantics are not
+    confirmed. Known triggers include the sensor recovering naturally (probe dries),
+    a manual alarm reset via the device button, and alarm suppression (which silences
+    the alert for ~1 hour while the probe may still be wet). Because of the
+    suppression case, subtype 0x07 cannot be interpreted as a "dry/recovered" signal,
+    so `detect_wet` is not emitted for this event type.
 
 Pairing mode notes (reverse-engineering observations):
 
@@ -307,6 +309,7 @@ r_device const govee_h5059 = {
         .reset_limit = 2000,
         .decode_fn   = &govee_h5059_decode,
         .fields      = output_fields,
-        .priority    = 10, // Govee-H5310 collision: if the H5310 decoder claims a
-                           // frame (temperature or periodic update) it's not H5059
+        .priority    = 10, // H5310 shares this family's framing and runs at higher
+                           // priority; H5310 claims temp/periodic/status/ping frames
+                           // first; H5059 only sees what H5310 passes.
 };

--- a/src/devices/govee_h5059.c
+++ b/src/devices/govee_h5059.c
@@ -24,8 +24,9 @@
 #define GOVEE_H5059_MSG_CLASS_OFFSET    0
 #define GOVEE_H5059_ID_OFFSET           1
 #define GOVEE_H5059_SUBTYPE_OFFSET      13
-#define GOVEE_H5059_LEAK_FLAG1_OFFSET   15
-#define GOVEE_H5059_LEAK_FLAG2_OFFSET   17
+#define GOVEE_H5059_LEAK_TOP_OFFSET     14
+#define GOVEE_H5059_LEAK_BOTTOM_OFFSET  15
+#define GOVEE_H5059_LEAK_ALARM_OFFSET   17
 
 #define GOVEE_H5059_LEAK_FLAG_ACTIVE    0x01
 
@@ -77,19 +78,33 @@ Decrypted payload (19+ bytes):
 - dec[1-4]: 32-bit device ID in wire byte order
 - dec[5-12]: unknown/reserved bytes
 - dec[13]: subtype (0x05 = button, 0x06 = leak, 0x07 = post-alarm)
-- dec[14]: unknown
-- dec[15]: state flag (checked with dec[17] for leak)
+- dec[14]: top probe wet flag (0x01 = top probe pair detects water)
+- dec[15]: bottom probe wet flag (0x01 = bottom probe pair detects water)
 - dec[16]: unknown
-- dec[17]: state flag (checked with dec[15] for leak)
+- dec[17]: alarm-active flag (non-zero while either probe pair is wet; seen as
+    0x01 on the initial leak frame and 0x02 on a follow-up frame ~1s later)
 - dec[18+]: unknown/variable payload
 
 Event mapping:
 
 - msg_class 0x11 + subtype 0x05: Button Press
-- msg_class 0x11 + subtype 0x06 + dec[15] == 0x01 + dec[17] == 0x01: Water Leak
+- msg_class 0x11 + subtype 0x06 + dec[17] != 0 + (dec[14] == 0x01 or dec[15] == 0x01): Water Leak
 - msg_class 0x11 + subtype 0x07: Post Alarm
 - msg_class 0x01: Pairing
 - msg_class 0x02: Class 0x02
+
+Top/bottom probe flags (confirmed 2026-06-14):
+
+- A bottom-probe-only leak produced dec[14]=0x00, dec[15]=0x01, dec[17]=0x01.
+- A top-probe-only leak produced dec[14]=0x01, dec[15]=0x00, dec[17]=0x01.
+- A simultaneous top+bottom leak's first frame matched the top-only pattern
+    (dec[14]=0x01, dec[15]=0x00); a follow-up subtype-0x08 frame ~1s later showed
+    both dec[14]=0x01 and dec[15]=0x01.
+- The original logic required dec[15] == 0x01 AND dec[17] == 0x01, which only
+    matched the bottom-probe case -- a top-probe-only leak fell through to the
+    generic "Telemetry" event and was never reported as "Water Leak". This is
+    fixed by checking dec[17] != 0 and either probe flag, and the specific probe
+    (top/bottom) is now reported via the leak_top/leak_bottom fields.
 
 Subtype 0x07 note:
 
@@ -215,15 +230,16 @@ static int govee_h5059_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     uint8_t msg_class = dec[GOVEE_H5059_MSG_CLASS_OFFSET];
     uint32_t id_wire  = ((uint32_t)dec[GOVEE_H5059_ID_OFFSET] << 24) |
-                       ((uint32_t)dec[GOVEE_H5059_ID_OFFSET + 1] << 16) |
-                       ((uint32_t)dec[GOVEE_H5059_ID_OFFSET + 2] << 8) |
-                       dec[GOVEE_H5059_ID_OFFSET + 3];
+                        ((uint32_t)dec[GOVEE_H5059_ID_OFFSET + 1] << 16) |
+                        ((uint32_t)dec[GOVEE_H5059_ID_OFFSET + 2] << 8) |
+                        dec[GOVEE_H5059_ID_OFFSET + 3];
     // The app-facing/canonical ID uses swapped 16-bit words relative to wire order.
     uint32_t id = ((id_wire & 0xffff) << 16) | ((id_wire >> 16) & 0xffff);
 
     int subtype     = enc_len > GOVEE_H5059_SUBTYPE_OFFSET ? dec[GOVEE_H5059_SUBTYPE_OFFSET] : -1;
-    int leak_flag_1 = enc_len > GOVEE_H5059_LEAK_FLAG1_OFFSET ? dec[GOVEE_H5059_LEAK_FLAG1_OFFSET] : -1;
-    int leak_flag_2 = enc_len > GOVEE_H5059_LEAK_FLAG2_OFFSET ? dec[GOVEE_H5059_LEAK_FLAG2_OFFSET] : -1;
+    int leak_top    = enc_len > GOVEE_H5059_LEAK_TOP_OFFSET ? dec[GOVEE_H5059_LEAK_TOP_OFFSET] : -1;
+    int leak_bottom = enc_len > GOVEE_H5059_LEAK_BOTTOM_OFFSET ? dec[GOVEE_H5059_LEAK_BOTTOM_OFFSET] : -1;
+    int leak_alarm  = enc_len > GOVEE_H5059_LEAK_ALARM_OFFSET ? dec[GOVEE_H5059_LEAK_ALARM_OFFSET] : -1;
     int leak_status = GOVEE_H5059_LEAK_UNKNOWN;
 
     char const *event = "Unknown";
@@ -233,7 +249,7 @@ static int govee_h5059_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             event       = "Button Press";
             leak_status = GOVEE_H5059_LEAK_DRY;
         }
-        else if (subtype == GOVEE_H5059_SUBTYPE_LEAK && leak_flag_1 == GOVEE_H5059_LEAK_FLAG_ACTIVE && leak_flag_2 == GOVEE_H5059_LEAK_FLAG_ACTIVE) {
+        else if (subtype == GOVEE_H5059_SUBTYPE_LEAK && leak_alarm != 0 && (leak_top == GOVEE_H5059_LEAK_FLAG_ACTIVE || leak_bottom == GOVEE_H5059_LEAK_FLAG_ACTIVE)) {
             event       = "Water Leak";
             leak_status = GOVEE_H5059_LEAK_WET;
         }
@@ -257,6 +273,8 @@ static int govee_h5059_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "msg_class",    "",                 DATA_FORMAT, "0x%02x", DATA_INT, msg_class,
             "subtype",      "",                 DATA_COND,   subtype >= 0, DATA_FORMAT, "0x%02x", DATA_INT, subtype,
             "detect_wet",   "",                 DATA_COND,   leak_status >= 0, DATA_INT, leak_status,
+            "leak_top",     "",                 DATA_COND,   leak_status == GOVEE_H5059_LEAK_WET, DATA_INT, leak_top == GOVEE_H5059_LEAK_FLAG_ACTIVE,
+            "leak_bottom",  "",                 DATA_COND,   leak_status == GOVEE_H5059_LEAK_WET, DATA_INT, leak_bottom == GOVEE_H5059_LEAK_FLAG_ACTIVE,
             "mic",          "Integrity",        DATA_STRING, "CRC",
             NULL);
     /* clang-format on */
@@ -274,6 +292,8 @@ static char const *const output_fields[] = {
         "msg_class",
         "subtype",
         "detect_wet",
+        "leak_top",
+        "leak_bottom",
         "mic",
         NULL,
 };
@@ -287,4 +307,6 @@ r_device const govee_h5059 = {
         .reset_limit = 2000,
         .decode_fn   = &govee_h5059_decode,
         .fields      = output_fields,
+        .priority    = 10, // Govee-H5310 collision: if the H5310 decoder claims a
+                           // frame (temperature or periodic update) it's not H5059
 };

--- a/src/devices/govee_h5310.c
+++ b/src/devices/govee_h5310.c
@@ -1,0 +1,430 @@
+/** @file
+    Govee Pool/Spa Thermometer H5310.
+
+    Copyright (C) 2026 Paul Antaki (\@Pablo1)
+
+    Based on the Govee H5059 decoder by Reece Neff <reeceneff@gmail.com>
+    (rtl_433 PR #3493). That work reverse-engineered the shared Govee FSK
+    protocol used by this device family -- the 2c 4c 4a sync words, the
+    128-byte XOR key, and the CRC-16/AUG-CCITT framing -- from a JTAG
+    firmware dump of an H5059. This H5310 decoder reuses that protocol
+    foundation and adds the LL=0x10 temperature-update, LL=0x3d
+    periodic-update, and LL=0x1c ping/connectivity payload layouts and the
+    temperature conversion.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#include "decoder.h"
+
+#define GOVEE_H5310_SYNC_LEN      3
+#define GOVEE_H5310_MIN_FRAME     7
+#define GOVEE_H5310_MAX_FRAME     128
+#define GOVEE_H5310_KEY_LEN       128
+
+#define GOVEE_H5310_CRC_POLY      0x1021
+#define GOVEE_H5310_CRC_INIT      0x1d0f
+
+#define GOVEE_H5310_MARKER_OFFSET 0
+#define GOVEE_H5310_ID_OFFSET     1
+
+// Temperature-update frame: outer length LL = 0x10, decrypts to a 13-byte payload.
+#define GOVEE_H5310_TEMP_OUTER_LEN      0x10
+#define GOVEE_H5310_TEMP_DECRYPTED_LEN  13
+#define GOVEE_H5310_TEMP_MARKER         0x11
+#define GOVEE_H5310_TEMP_BATTERY_OFFSET 6
+#define GOVEE_H5310_TEMP_LO_OFFSET      7
+#define GOVEE_H5310_TEMP_HI_OFFSET      8
+
+// Periodic-update frame: outer length LL = 0x3d, decrypts to a 58-byte payload.
+// Leading layout mirrors the temperature-update frame shifted left by one byte
+// (no constant 0x04 byte at dec[5]); the remainder is a rolling counter/nonce
+// followed by zero padding.
+#define GOVEE_H5310_PERIODIC_OUTER_LEN      0x3d
+#define GOVEE_H5310_PERIODIC_DECRYPTED_LEN  58
+#define GOVEE_H5310_PERIODIC_MARKER         0x1b
+#define GOVEE_H5310_PERIODIC_BATTERY_OFFSET 5
+#define GOVEE_H5310_PERIODIC_LO_OFFSET      6
+#define GOVEE_H5310_PERIODIC_HI_OFFSET      7
+
+// Status-reply frame: outer length LL = 0x1f, decrypts to a 28-byte payload.
+// Leading layout matches the temperature-update frame (device ID, shared
+// material, battery, temperature), but lacks the constant 0x04 byte at
+// dec[5] and carries additional trailing bytes. Sent in reply to a short
+// LL=0x0c poll frame (not decoded by this driver).
+#define GOVEE_H5310_STATUS_OUTER_LEN      0x1f
+#define GOVEE_H5310_STATUS_DECRYPTED_LEN  28
+#define GOVEE_H5310_STATUS_MARKER         0x71
+#define GOVEE_H5310_STATUS_BATTERY_OFFSET 5
+#define GOVEE_H5310_STATUS_LO_OFFSET      6
+#define GOVEE_H5310_STATUS_HI_OFFSET      7
+
+// Ping/connectivity frame: outer length LL = 0x1c, decrypts to a 25-byte payload.
+// Carries no battery or temperature data; observed as a connectivity check-in
+// (e.g. "Network Test", unit-display change, "long battery life" toggle).
+// Unlike the temperature-bearing frames, the device ID and shared material
+// are swapped: shared material is at dec[1-2], device ID at dec[3-4].
+#define GOVEE_H5310_PING_OUTER_LEN     0x1c
+#define GOVEE_H5310_PING_DECRYPTED_LEN 25
+#define GOVEE_H5310_PING_MARKER        0x70
+#define GOVEE_H5310_PING_ID_OFFSET     3
+
+// Temperature formula: T_C = (raw - OFFSET) / SLOPE, raw = lo_byte | (hi_byte << 8).
+// Slope fit over a 43->27 C sweep (R^2 = 0.986); offset calibrated against live
+// decoded-vs-displayed readings (see file header); not yet confirmed below ~26 C
+// or below 0 C.
+#define GOVEE_H5310_TEMP_SLOPE  10.0
+#define GOVEE_H5310_TEMP_OFFSET 33168
+
+// Plausible range for a pool/spa/ambient thermometer. Other Govee devices in
+// this family share the same outer frame envelope (sync words, XOR key, CRC)
+// and can, with a different payload layout, pass this decoder's length and
+// marker checks yet yield a nonsensical temperature. Rejecting values outside
+// this range discards such frames without needing to identify the foreign
+// device by ID.
+#define GOVEE_H5310_TEMP_MIN_C -20.0f
+#define GOVEE_H5310_TEMP_MAX_C 60.0f
+
+static uint8_t const govee_h5310_sync[]       = {0x2c, 0x4c, 0x4a};
+static uint8_t const govee_h5310_sync_skew1[] = {0x16, 0x26, 0x25};
+static uint8_t const govee_h5310_key[GOVEE_H5310_KEY_LEN + 1] =
+        "s6amyEvO8UslCY0eZjgc2S6APCVLgLxzFvL2Z5GWPW7fKVjy2oAU6uiKU3lZCHm62VYQQuCtgxzPgGd8UDRPVZpDRAsh5EdYq1E4j4morJ3vd6tWx8BiWOLDc2I8wKUK";
+
+/**
+Govee Pool/Spa Thermometer H5310.
+
+Modulation, timing, and transmission:
+
+The device uses FSK pulse PCM encoding, the same sync words, XOR key, and
+CRC-16/AUG-CCITT framing as the Govee H5059 water leak detector. Those
+shared protocol details were reverse-engineered by Reece Neff for the
+H5059 (rtl_433 PR #3493) and are reused here; see the file header.
+- Demod mode in rtl_433 is FSK_PULSE_PCM.
+- short_width = 100 us and long_width = 100 us (PCM symbol timing).
+- reset_limit = 2000 us.
+- The sensor transmits autonomously roughly every 10 minutes, plus on
+  significant temperature change.
+
+Sensor uplink frame format:
+
+    2C 4C 4A LL SS [ciphertext...] CC CC
+
+- 2C 4C 4A: sync word
+- LL: outer frame length in bytes (SS + ciphertext + CRC)
+- SS: XOR stream start offset (seed)
+- ciphertext: encrypted payload bytes
+- CC CC: CRC-16/AUG-CCITT, poly=0x1021, init=0x1d0f
+
+This decoder handles four frame types. Three of them -- temperature-update,
+periodic-update, and status-reply -- share the same leading payload layout
+(device ID, shared ID material, battery, temperature), shifted by one byte
+between temperature-update and the other two; the ping frame shares only the
+device ID / shared material fields:
+
+Temperature-update frame, LL == 0x10 (16), 13-byte decrypted payload. This
+frame appears to be triggered by a unit-change/forced-report action rather
+than sent on the autonomous schedule, and is comparatively rare:
+
+    byte:  0   1  2   3  4   5    6     7      8     9   10  11 12
+    val :  11  <id-2>  9c b2  04   bat  TL     TH    cc  ff  00 00
+
+- dec[0]: frame marker, constant 0x11
+- dec[1-2]: device ID (e.g. 71 b0 = Spa, f8 a7 = Pool)
+- dec[3-4]: constant 9c b2 (shared device-ID material)
+- dec[5]: constant 0x04
+- dec[6]: battery percent (0x64 = 100)
+- dec[7-8]: temperature raw, little-endian u16
+- dec[9-12]: cc ff 00 00 (constants / padding)
+
+Periodic-update frame, LL == 0x3d (61), 58-byte decrypted payload. This is the
+sensor's autonomous broadcast, observed at exactly 10-minute intervals. The
+leading bytes mirror the temperature-update layout shifted left by one byte
+(no constant 0x04 byte), followed by a rolling counter/nonce and zero padding:
+
+    byte:  0   1  2   3  4   5    6     7      8     9   10  11  12..57
+    val :  1b  <id-2>  9c b2  bat  TL    TH    cc  ff  00  00  <rolling/nonce, then zero padding>
+
+- dec[0]: frame marker, constant 0x1b
+- dec[1-2]: device ID (e.g. 71 b0 = Spa, f8 a7 = Pool)
+- dec[3-4]: constant 9c b2 (shared device-ID material)
+- dec[5]: battery percent
+- dec[6-7]: temperature raw, little-endian u16
+- dec[8-11]: cc ff 00 00 (constants / padding)
+- dec[12+]: rolling counter/nonce, then zero padding
+
+Status-reply frame, LL == 0x1f (31), 28-byte decrypted payload. Sent in
+response to a short LL=0x0c poll/status-request frame from the app or
+gateway (that poll frame is not decoded by this driver). The leading bytes
+match the temperature-update layout shifted left by one byte (no constant
+0x04 byte), like the periodic-update frame, followed by a constant and a
+few bytes that vary between replies, then zero padding:
+
+    byte:  0   1  2   3  4   5    6     7      8     9   10  11  12  13..27
+    val :  71  <id-2>  9c b2  bat  TL    TH    cc  ff  <varies, dec[10-12]>  00-padded
+
+- dec[0]: frame marker, constant 0x71
+- dec[1-2]: device ID (e.g. 71 b0 = Spa, f8 a7 = Pool)
+- dec[3-4]: constant 9c b2 (shared device-ID material)
+- dec[5]: battery percent
+- dec[6-7]: temperature raw, little-endian u16 -- matches the concurrent
+  temperature-update/periodic-update value
+- dec[8-9]: cc ff (constants)
+- dec[10-12]: varies between replies -- not yet decoded (counter/nonce
+  candidate)
+- dec[13-27]: zero padding
+
+Before this frame type was added, LL=0x1f frames were decrypted successfully
+by the H5059 decoder (same shared framing/key/CRC) but reported as model
+"Govee-H5059" with event "Unknown" -- claiming them here is both more accurate
+(this frame type has only been observed from H5310-family devices) and
+resolves that cross-model mislabeling.
+
+Ping/connectivity frame, LL == 0x1c (28), 25-byte decrypted payload. Carries
+no battery or temperature data. Observed correlating with app-side actions
+(Network Test, unit-display change, "long battery life" toggle on/off) for
+the Pool sensor, and also sent by the Spa; never observed from the H5059 leak
+detector, which only sends msg_class 0x11 telemetry:
+
+    byte:  0   1  2   3  4   5    6    7   8   9   10  11..24
+    val :  70  9c b2  <id-2>  6a   2e  <varies, counter/nonce + flag>  00-padded
+
+- dec[0]: frame marker, constant 0x70
+- dec[1-2]: constant 9c b2 (shared device-ID material) -- note this is in the
+  opposite order from the temperature-bearing frames, where the shared
+  material follows the device ID
+- dec[3-4]: device ID (e.g. 71 b0 = Spa, f8 a7 = Pool)
+- dec[5]: constant 0x6a
+- dec[6]: constant 0x2e
+- dec[7-10]: varies between frames -- likely a counter/nonce plus a status
+  flag, not yet decoded
+- dec[11-24]: zero padding
+
+Before this frame type was added, LL=0x1c frames were decrypted successfully
+by the H5059 decoder (same shared framing/key/CRC) but reported as model
+"Govee-H5059" with event "Unknown" -- claiming them here is both more accurate
+(this frame type has only been observed from H5310-family devices) and
+resolves that cross-model mislabeling.
+
+Device ID: the emitted `id_wire` is the full 32-bit on-wire ID (e.g.
+f8 a7 9c b2 -> 0xf8a79cb2) and `id` is the same value with its two 16-bit
+words swapped (0x9cb2f8a7), matching the rest of the Govee family
+(govee_h5059). The low 16 bits (9c b2) are shared family material; the
+device-distinguishing half is f8a7 (Pool) / 71b0 (Spa).
+
+Temperature formula (applies to the three temperature-bearing frame types
+above, using each frame's
+own low/high temperature byte offsets):
+
+    raw  = lo_byte + (hi_byte << 8)
+    T_C  = (raw - 33168) / 10.0
+
+The slope (1 raw count = 0.1 C) comes from a 43->27 C sweep (R^2 = 0.986). The
+offset was originally fit as 33178 from that sweep, but live captures on
+2026-06-13 found decoded temperatures consistently read 1.0 C low versus the
+sensor's own display (4 data points, two different temperatures, across both
+frame types above) -- so the offset was corrected to 33168. Sign behavior
+below 0 C is unverified; the formula predicts raw keeps counting down, but no
+cold-point capture has confirmed this yet.
+
+The wire value is always Celsius-based regardless of the sensor's selected
+display unit. Toggling the on-device display between C and F (25.8 C <->
+78.5 F) produced identical decoded values (25.800 C) before and after the
+toggle, in both directions -- the C/F setting only affects the sensor's local
+display, not the transmitted payload, so no unit-aware handling is needed
+here.
+
+`battery_pct` tracks the sensor's bar-graph battery indicator: 100% (0x64) at
+full bars, 65% at 3 bars, 47% at 2 bars, and 20% at 1 bar, all observed live
+by running a set of batteries down. At 0 bars (critical), the sensor stopped
+transmitting RF entirely -- no frame with battery_pct near 0 was ever
+received. So `battery_ok = battery_pct > 0` is effectively always true for
+any frame this decoder actually sees; the real "low battery" signal is the
+sensor going silent, which is a job for rtl_433's downstream
+"not seen recently" handling, not this decoder. The placeholder is left as-is
+since there's no in-band low-battery state to detect.
+
+Other frames in this family (e.g. LL == 0x0c short poll/status, and the H5059
+leak-detector's own msg_class 0x01/0x02/0x11 telemetry) are not recognized by
+this decoder and are ignored; the H5059 decoder may report some of these as
+event "Unknown". The H5310 decoder runs at the default priority (before
+H5059's reduced priority, see govee_h5059.c) so it gets first access to
+frames in this family.
+*/
+static int govee_h5310_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    uint8_t frame[GOVEE_H5310_MAX_FRAME];
+    uint8_t dec[GOVEE_H5310_MAX_FRAME];
+
+    int row           = -1;
+    unsigned sync_pos = 0;
+
+    // Stage 1: find a row that contains either the native sync or the known skewed sync.
+    for (int r = 0; r < bitbuffer->num_rows; ++r) {
+        if (bitbuffer->bits_per_row[r] < 8 * GOVEE_H5310_MIN_FRAME) {
+            continue;
+        }
+
+        unsigned pos = bitbuffer_search(bitbuffer, r, 0, govee_h5310_sync, GOVEE_H5310_SYNC_LEN * 8);
+        if (pos < bitbuffer->bits_per_row[r]) {
+            row      = r;
+            sync_pos = pos;
+            break;
+        }
+
+        // The device preamble is MSB-first; depending on demod lock, bytes can
+        // arrive shifted by one bit, turning 2c 4c 4a into 16 26 25.
+        unsigned skew_pos = bitbuffer_search(bitbuffer, r, 0, govee_h5310_sync_skew1, GOVEE_H5310_SYNC_LEN * 8);
+        if (skew_pos < bitbuffer->bits_per_row[r]) {
+            row      = r;
+            sync_pos = skew_pos + 1;
+            break;
+        }
+    }
+
+    if (row < 0) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    // Stage 2: validate envelope and reject malformed messages before payload parsing.
+    sync_pos += GOVEE_H5310_SYNC_LEN * 8;
+
+    unsigned bits_after_sync = bitbuffer->bits_per_row[row] - sync_pos;
+    if (bits_after_sync < 8 * 4) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    unsigned bytes_after_sync = bits_after_sync / 8;
+    if (bytes_after_sync > GOVEE_H5310_MAX_FRAME) {
+        bytes_after_sync = GOVEE_H5310_MAX_FRAME;
+    }
+
+    bitbuffer_extract_bytes(bitbuffer, row, sync_pos, frame, bytes_after_sync * 8);
+
+    uint8_t outer_len = frame[0];
+
+    int is_temp_frame     = (outer_len == GOVEE_H5310_TEMP_OUTER_LEN);
+    int is_periodic_frame = (outer_len == GOVEE_H5310_PERIODIC_OUTER_LEN);
+    int is_status_frame   = (outer_len == GOVEE_H5310_STATUS_OUTER_LEN);
+    int is_ping_frame     = (outer_len == GOVEE_H5310_PING_OUTER_LEN);
+    // Only the temperature-update, periodic-update, status-reply, and ping
+    // frames have a fixed outer length we recognize; ignore all other frame
+    // types in the family (short poll, leak telemetry) without erroring.
+    if (!is_temp_frame && !is_periodic_frame && !is_status_frame && !is_ping_frame) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    if (bytes_after_sync < (unsigned)(1 + outer_len)) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    uint8_t seed      = frame[1];
+    unsigned enc_len  = outer_len - 3;
+    unsigned crc_offs = 2 + enc_len;
+
+    uint16_t crc_calc = crc16(&frame[2], enc_len, GOVEE_H5310_CRC_POLY, GOVEE_H5310_CRC_INIT);
+    uint16_t crc_recv = ((uint16_t)frame[crc_offs] << 8) | frame[crc_offs + 1];
+    if (crc_calc != crc_recv) {
+        return DECODE_FAIL_MIC;
+    }
+
+    for (unsigned i = 0; i < enc_len; ++i) {
+        dec[i] = frame[2 + i] ^ govee_h5310_key[(i + seed) % GOVEE_H5310_KEY_LEN];
+    }
+
+    // A CRC-valid frame should carry the marker matching its outer length;
+    // guard against any other message subtype that happens to share this length.
+    uint8_t expected_marker = is_temp_frame       ? GOVEE_H5310_TEMP_MARKER
+                              : is_periodic_frame ? GOVEE_H5310_PERIODIC_MARKER
+                              : is_status_frame   ? GOVEE_H5310_STATUS_MARKER
+                                                  : GOVEE_H5310_PING_MARKER;
+    if (dec[GOVEE_H5310_MARKER_OFFSET] != expected_marker) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    // Assemble the full 32-bit device ID to match the rest of the Govee family
+    // (govee_h5059): id_wire is the on-wire byte order, id is the same value
+    // with its two 16-bit words swapped (the app-facing form). The low 16 bits
+    // (9c b2) are shared family material; the device-distinguishing half is
+    // f8a7 (Pool) / 71b0 (Spa). The temperature-bearing frames carry the device
+    // ID at dec[1-2] and the shared material at dec[3-4]; the ping frame carries
+    // them in the opposite order, so reassemble it to the same id_wire.
+    uint32_t id_wire;
+    if (is_ping_frame) {
+        id_wire = ((uint32_t)dec[GOVEE_H5310_PING_ID_OFFSET] << 24) | ((uint32_t)dec[GOVEE_H5310_PING_ID_OFFSET + 1] << 16) | ((uint32_t)dec[GOVEE_H5310_ID_OFFSET] << 8) | dec[GOVEE_H5310_ID_OFFSET + 1];
+    }
+    else {
+        id_wire = ((uint32_t)dec[GOVEE_H5310_ID_OFFSET] << 24) | ((uint32_t)dec[GOVEE_H5310_ID_OFFSET + 1] << 16) | ((uint32_t)dec[GOVEE_H5310_ID_OFFSET + 2] << 8) | dec[GOVEE_H5310_ID_OFFSET + 3];
+    }
+    uint32_t id = ((id_wire & 0xffff) << 16) | ((id_wire >> 16) & 0xffff);
+
+    int battery_pct = 0;
+    uint16_t raw    = 0;
+    char const *event;
+    if (is_temp_frame) {
+        battery_pct = dec[GOVEE_H5310_TEMP_BATTERY_OFFSET];
+        raw         = dec[GOVEE_H5310_TEMP_LO_OFFSET] | ((uint16_t)dec[GOVEE_H5310_TEMP_HI_OFFSET] << 8);
+        event       = "Temperature Update";
+    }
+    else if (is_periodic_frame) {
+        battery_pct = dec[GOVEE_H5310_PERIODIC_BATTERY_OFFSET];
+        raw         = dec[GOVEE_H5310_PERIODIC_LO_OFFSET] | ((uint16_t)dec[GOVEE_H5310_PERIODIC_HI_OFFSET] << 8);
+        event       = "Periodic Update";
+    }
+    else if (is_status_frame) {
+        battery_pct = dec[GOVEE_H5310_STATUS_BATTERY_OFFSET];
+        raw         = dec[GOVEE_H5310_STATUS_LO_OFFSET] | ((uint16_t)dec[GOVEE_H5310_STATUS_HI_OFFSET] << 8);
+        event       = "Status";
+    }
+    else {
+        event = "Ping";
+    }
+
+    float temperature_c = ((float)raw - GOVEE_H5310_TEMP_OFFSET) / GOVEE_H5310_TEMP_SLOPE;
+
+    if (!is_ping_frame && (temperature_c < GOVEE_H5310_TEMP_MIN_C || temperature_c > GOVEE_H5310_TEMP_MAX_C)) {
+        return DECODE_FAIL_SANITY;
+    }
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",            "",             DATA_STRING, "Govee-H5310",
+            "id",               "",             DATA_FORMAT, "%08x", DATA_INT, id,
+            "id_wire",          "",             DATA_FORMAT, "%08x", DATA_INT, id_wire,
+            "event",            "",             DATA_STRING, event,
+            "battery_ok",       "Battery",      DATA_COND, !is_ping_frame, DATA_INT,    battery_pct > 0,
+            "battery_pct",      "Battery",      DATA_COND, !is_ping_frame, DATA_INT,    battery_pct,
+            "temperature_C",    "Temperature",  DATA_COND, !is_ping_frame, DATA_FORMAT, "%.1f C", DATA_DOUBLE, (double)temperature_c,
+            "mic",              "Integrity",    DATA_STRING, "CRC",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+/* Output fields for -F csv column order and optional field filtering. */
+static char const *const output_fields[] = {
+        "model",
+        "id",
+        "id_wire",
+        "event",
+        "battery_ok",
+        "battery_pct",
+        "temperature_C",
+        "mic",
+        NULL,
+};
+
+/* Device registration and demod timing profile. */
+r_device const govee_h5310 = {
+        .name        = "Govee Pool/Spa Thermometer H5310",
+        .modulation  = FSK_PULSE_PCM,
+        .short_width = 100,
+        .long_width  = 100,
+        .reset_limit = 2000,
+        .decode_fn   = &govee_h5310_decode,
+        .fields      = output_fields,
+};

--- a/src/devices/govee_h5310.c
+++ b/src/devices/govee_h5310.c
@@ -72,10 +72,7 @@
 #define GOVEE_H5310_PING_MARKER        0x70
 #define GOVEE_H5310_PING_ID_OFFSET     3
 
-// Temperature formula: T_C = (raw - OFFSET) / SLOPE, raw = lo_byte | (hi_byte << 8).
-// Slope fit over a 43->27 C sweep (R^2 = 0.986); offset calibrated against live
-// decoded-vs-displayed readings (see file header); not yet confirmed below ~26 C
-// or below 0 C.
+// T_C = (raw - OFFSET) / SLOPE; raw is little-endian u16. Sign below 0 C unverified.
 #define GOVEE_H5310_TEMP_SLOPE  10.0
 #define GOVEE_H5310_TEMP_OFFSET 33168
 
@@ -344,13 +341,8 @@ static int govee_h5310_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_ABORT_EARLY;
     }
 
-    // Assemble the full 32-bit device ID to match the rest of the Govee family
-    // (govee_h5059): id_wire is the on-wire byte order, id is the same value
-    // with its two 16-bit words swapped (the app-facing form). The low 16 bits
-    // (9c b2) are shared family material; the device-distinguishing half is
-    // f8a7 (Pool) / 71b0 (Spa). The temperature-bearing frames carry the device
-    // ID at dec[1-2] and the shared material at dec[3-4]; the ping frame carries
-    // them in the opposite order, so reassemble it to the same id_wire.
+    // Ping frame has shared material and device ID in the opposite order from the
+    // temperature-bearing frames; reassemble to the canonical id_wire layout.
     uint32_t id_wire;
     if (is_ping_frame) {
         id_wire = ((uint32_t)dec[GOVEE_H5310_PING_ID_OFFSET] << 24) | ((uint32_t)dec[GOVEE_H5310_PING_ID_OFFSET + 1] << 16) | ((uint32_t)dec[GOVEE_H5310_ID_OFFSET] << 8) | dec[GOVEE_H5310_ID_OFFSET + 1];


### PR DESCRIPTION
Adds a decoder for the Govee H5310 pool/spa thermometer.

The H5310 uses the same FSK framing (sync word `2c 4c 4a`, 128-byte XOR key,
CRC-16/AUG-CCITT) reverse-engineered by Reece Neff for the H5059 water leak
detector (#3493). This PR adds the four H5310-specific payload layouts:

- **Temperature Update** (LL=0x10): triggered by a forced report or unit-change action
- **Periodic Update** (LL=0x3d): the sensor's autonomous ~10-minute broadcast
- **Status Reply** (LL=0x1f): sent in response to a gateway poll
- **Ping** (LL=0x1c): connectivity heartbeat, no temperature/battery data

Also fixes a bug in the H5059 decoder where top-probe-only water leaks were
not reported (the old condition only matched when both probe flags were set).

Temperature formula: `T_C = (raw - 33168) / 10.0`, confirmed against the
sensor's own display across two physical units (Pool and Spa) at multiple
temperatures. Wire encoding is always Celsius regardless of the display unit
setting.

The H5310 decoder runs at default priority (0); H5059 is set to priority 10
so H5310 claims shared-envelope frames first.

Test captures will be submitted separately to rtl_433_tests.