### PR TITLE
Add [Govee-H5112] dual-probe thermometer decoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ coverage-report/
 .cache
 .vs
 .idea
+.vscode
 cmake-build-debug/
 
 # Editor files
@@ -31,6 +32,9 @@ cmake-build-debug/
 # Development files
 /_*/
 /rtl_433_tests
+
+# CMake-generated at build time (see include/version.h.in)
+/include/version.h
 
 # File manager files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -388,26 +388,27 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [298]  TRW TPMS OOK OEM and Clone models
     [299]  TRW TPMS FSK OEM and Clone models
     [300]  Govee Water Leak Detector H5059
-    [301]  Astrostart 2000 Car Remote (-f 372.4M)
-    [302]  Compustar 1WG3R Car Remote
-    [303]  Chrysler Car Remote (-f 315.1M -s 920k)
-    [304]  Nidec Car Remote (-f 313.8M -s 1024k)
-    [305]  Audiovox PRO-OE3B Car Remote (-f 303.4M)
-    [306]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 833 bit/s)
-    [307]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 1667 bit/s)
-    [308]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 833 bit/s)
-    [309]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 1667 bit/s)
-    [310]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 2500 bit/s)
-    [311]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 5000 bit/s)
-    [312]  MIC 6SC2 Car Remote (-f 315.1M)
-    [313]  GM ABO1502T Car Remote (-f 314.9M)
-    [314]  Siemens 5WY72XX Car Remote (-f 315.1M)
-    [315]  Alps FWB1U545 Car Remote
-    [316]  Continental KR5V2X Car Remote (-f 313.8M -s 1024k)
-    [317]  Code Alarm FRDPC2002 Car Remote
-    [318]  RFM69 LowPowerLab Moteino board (-s 1000k)
-    [319]  Shenzhen Wale WL-TH6R Temperature & Humidity Sensor
-    [320]  Cellular Tracking Technologies LifeTag/PowerTag/HybridTag
+    [301]  Govee Pool/Spa Thermometer H5310
+    [302]  Astrostart 2000 Car Remote (-f 372.4M)
+    [303]  Compustar 1WG3R Car Remote
+    [304]  Chrysler Car Remote (-f 315.1M -s 920k)
+    [305]  Nidec Car Remote (-f 313.8M -s 1024k)
+    [306]  Audiovox PRO-OE3B Car Remote (-f 303.4M)
+    [307]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 833 bit/s)
+    [308]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 1667 bit/s)
+    [309]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 833 bit/s)
+    [310]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 1667 bit/s)
+    [311]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 2500 bit/s)
+    [312]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 5000 bit/s)
+    [313]  MIC 6SC2 Car Remote (-f 315.1M)
+    [314]  GM ABO1502T Car Remote (-f 314.9M)
+    [315]  Siemens 5WY72XX Car Remote (-f 315.1M)
+    [316]  Alps FWB1U545 Car Remote
+    [317]  Continental KR5V2X Car Remote (-f 313.8M -s 1024k)
+    [318]  Code Alarm FRDPC2002 Car Remote
+    [319]  RFM69 LowPowerLab Moteino board (-s 1000k)
+    [320]  Shenzhen Wale WL-TH6R Temperature & Humidity Sensor
+    [321]  Cellular Tracking Technologies LifeTag/PowerTag/HybridTag
 
 * Disabled by default, use -R n or a conf file to enable
 

--- a/README.md
+++ b/README.md
@@ -388,27 +388,28 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [298]  TRW TPMS OOK OEM and Clone models
     [299]  TRW TPMS FSK OEM and Clone models
     [300]  Govee Water Leak Detector H5059
-    [301]  Govee Pool/Spa Thermometer H5310
-    [302]  Astrostart 2000 Car Remote (-f 372.4M)
-    [303]  Compustar 1WG3R Car Remote
-    [304]  Chrysler Car Remote (-f 315.1M -s 920k)
-    [305]  Nidec Car Remote (-f 313.8M -s 1024k)
-    [306]  Audiovox PRO-OE3B Car Remote (-f 303.4M)
-    [307]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 833 bit/s)
-    [308]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 1667 bit/s)
-    [309]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 833 bit/s)
-    [310]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 1667 bit/s)
-    [311]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 2500 bit/s)
-    [312]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 5000 bit/s)
-    [313]  MIC 6SC2 Car Remote (-f 315.1M)
-    [314]  GM ABO1502T Car Remote (-f 314.9M)
-    [315]  Siemens 5WY72XX Car Remote (-f 315.1M)
-    [316]  Alps FWB1U545 Car Remote
-    [317]  Continental KR5V2X Car Remote (-f 313.8M -s 1024k)
-    [318]  Code Alarm FRDPC2002 Car Remote
-    [319]  RFM69 LowPowerLab Moteino board (-s 1000k)
-    [320]  Shenzhen Wale WL-TH6R Temperature & Humidity Sensor
-    [321]  Cellular Tracking Technologies LifeTag/PowerTag/HybridTag
+    [301]  Astrostart 2000 Car Remote (-f 372.4M)
+    [302]  Compustar 1WG3R Car Remote
+    [303]  Chrysler Car Remote (-f 315.1M -s 920k)
+    [304]  Nidec Car Remote (-f 313.8M -s 1024k)
+    [305]  Audiovox PRO-OE3B Car Remote (-f 303.4M)
+    [306]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 833 bit/s)
+    [307]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 1667 bit/s)
+    [308]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 833 bit/s)
+    [309]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 1667 bit/s)
+    [310]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 2500 bit/s)
+    [311]  Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 5000 bit/s)
+    [312]  MIC 6SC2 Car Remote (-f 315.1M)
+    [313]  GM ABO1502T Car Remote (-f 314.9M)
+    [314]  Siemens 5WY72XX Car Remote (-f 315.1M)
+    [315]  Alps FWB1U545 Car Remote
+    [316]  Continental KR5V2X Car Remote (-f 313.8M -s 1024k)
+    [317]  Code Alarm FRDPC2002 Car Remote
+    [318]  RFM69 LowPowerLab Moteino board (-s 1000k)
+    [319]  Shenzhen Wale WL-TH6R Temperature & Humidity Sensor
+    [320]  Cellular Tracking Technologies LifeTag/PowerTag/HybridTag
+    [321]  Govee Pool/Spa Thermometer H5310
+    [322]  Govee H5112 Dual-Probe Thermometer
 
 * Disabled by default, use -R n or a conf file to enable
 
@@ -418,7 +419,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
   [-d <RTL-SDR USB device index>] (default: 0)
   [-d :<RTL-SDR USB device serial (can be set with rtl_eeprom -s)>]
 	To set gain for RTL-SDR use -g <gain> to set an overall gain in dB.
-	SoapySDR device driver is available.
+	SoapySDR device driver is not available.
   [-d ""] Open default SoapySDR device
   [-d driver=rtlsdr] Open e.g. specific SoapySDR device
 	To set gain for SoapySDR use -g ELEM=val,ELEM=val,... e.g. -g LNA=20,TIA=8,PGA=2 (for LimeSDR).

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -539,26 +539,27 @@ convert si
   protocol 298 # TRW TPMS OOK OEM and Clone models
   protocol 299 # TRW TPMS FSK OEM and Clone models
   protocol 300 # Govee Water Leak Detector H5059
-  protocol 301 # Astrostart 2000 Car Remote (-f 372.4M)
-  protocol 302 # Compustar 1WG3R Car Remote
-  protocol 303 # Chrysler Car Remote (-f 315.1M -s 920k)
-  protocol 304 # Nidec Car Remote (-f 313.8M -s 1024k)
-  protocol 305 # Audiovox PRO-OE3B Car Remote (-f 303.4M)
-  protocol 306 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 833 bit/s)
-  protocol 307 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 1667 bit/s)
-  protocol 308 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 833 bit/s)
-  protocol 309 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 1667 bit/s)
-  protocol 310 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 2500 bit/s)
-  protocol 311 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 5000 bit/s)
-  protocol 312 # MIC 6SC2 Car Remote (-f 315.1M)
-  protocol 313 # GM ABO1502T Car Remote (-f 314.9M)
-  protocol 314 # Siemens 5WY72XX Car Remote (-f 315.1M)
-  protocol 315 # Alps FWB1U545 Car Remote
-  protocol 316 # Continental KR5V2X Car Remote (-f 313.8M -s 1024k)
-  protocol 317 # Code Alarm FRDPC2002 Car Remote
-  protocol 318 # RFM69 LowPowerLab Moteino board (-s 1000k)
-  protocol 319 # Shenzhen Wale WL-TH6R Temperature & Humidity Sensor
-  protocol 320 # Cellular Tracking Technologies LifeTag/PowerTag/HybridTag
+  protocol 301 # Govee Pool/Spa Thermometer H5310
+  protocol 302 # Astrostart 2000 Car Remote (-f 372.4M)
+  protocol 303 # Compustar 1WG3R Car Remote
+  protocol 304 # Chrysler Car Remote (-f 315.1M -s 920k)
+  protocol 305 # Nidec Car Remote (-f 313.8M -s 1024k)
+  protocol 306 # Audiovox PRO-OE3B Car Remote (-f 303.4M)
+  protocol 307 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 833 bit/s)
+  protocol 308 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 1667 bit/s)
+  protocol 309 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 833 bit/s)
+  protocol 310 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 1667 bit/s)
+  protocol 311 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 2500 bit/s)
+  protocol 312 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 5000 bit/s)
+  protocol 313 # MIC 6SC2 Car Remote (-f 315.1M)
+  protocol 314 # GM ABO1502T Car Remote (-f 314.9M)
+  protocol 315 # Siemens 5WY72XX Car Remote (-f 315.1M)
+  protocol 316 # Alps FWB1U545 Car Remote
+  protocol 317 # Continental KR5V2X Car Remote (-f 313.8M -s 1024k)
+  protocol 318 # Code Alarm FRDPC2002 Car Remote
+  protocol 319 # RFM69 LowPowerLab Moteino board (-s 1000k)
+  protocol 320 # Shenzhen Wale WL-TH6R Temperature & Humidity Sensor
+  protocol 321 # Cellular Tracking Technologies LifeTag/PowerTag/HybridTag
 
 ## Flex devices (command line option "-X")
 

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -539,27 +539,28 @@ convert si
   protocol 298 # TRW TPMS OOK OEM and Clone models
   protocol 299 # TRW TPMS FSK OEM and Clone models
   protocol 300 # Govee Water Leak Detector H5059
-  protocol 301 # Govee Pool/Spa Thermometer H5310
-  protocol 302 # Astrostart 2000 Car Remote (-f 372.4M)
-  protocol 303 # Compustar 1WG3R Car Remote
-  protocol 304 # Chrysler Car Remote (-f 315.1M -s 920k)
-  protocol 305 # Nidec Car Remote (-f 313.8M -s 1024k)
-  protocol 306 # Audiovox PRO-OE3B Car Remote (-f 303.4M)
-  protocol 307 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 833 bit/s)
-  protocol 308 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 1667 bit/s)
-  protocol 309 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 833 bit/s)
-  protocol 310 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 1667 bit/s)
-  protocol 311 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 2500 bit/s)
-  protocol 312 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 5000 bit/s)
-  protocol 313 # MIC 6SC2 Car Remote (-f 315.1M)
-  protocol 314 # GM ABO1502T Car Remote (-f 314.9M)
-  protocol 315 # Siemens 5WY72XX Car Remote (-f 315.1M)
-  protocol 316 # Alps FWB1U545 Car Remote
-  protocol 317 # Continental KR5V2X Car Remote (-f 313.8M -s 1024k)
-  protocol 318 # Code Alarm FRDPC2002 Car Remote
-  protocol 319 # RFM69 LowPowerLab Moteino board (-s 1000k)
-  protocol 320 # Shenzhen Wale WL-TH6R Temperature & Humidity Sensor
-  protocol 321 # Cellular Tracking Technologies LifeTag/PowerTag/HybridTag
+  protocol 301 # Astrostart 2000 Car Remote (-f 372.4M)
+  protocol 302 # Compustar 1WG3R Car Remote
+  protocol 303 # Chrysler Car Remote (-f 315.1M -s 920k)
+  protocol 304 # Nidec Car Remote (-f 313.8M -s 1024k)
+  protocol 305 # Audiovox PRO-OE3B Car Remote (-f 303.4M)
+  protocol 306 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 833 bit/s)
+  protocol 307 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (Sync, 1667 bit/s)
+  protocol 308 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 833 bit/s)
+  protocol 309 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (No Sync, 1667 bit/s)
+  protocol 310 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 2500 bit/s)
+  protocol 311 # Microchip HCS361 KeeLoq Hopping Encoder based remotes (-f 315.1M) (PIWM, 5000 bit/s)
+  protocol 312 # MIC 6SC2 Car Remote (-f 315.1M)
+  protocol 313 # GM ABO1502T Car Remote (-f 314.9M)
+  protocol 314 # Siemens 5WY72XX Car Remote (-f 315.1M)
+  protocol 315 # Alps FWB1U545 Car Remote
+  protocol 316 # Continental KR5V2X Car Remote (-f 313.8M -s 1024k)
+  protocol 317 # Code Alarm FRDPC2002 Car Remote
+  protocol 318 # RFM69 LowPowerLab Moteino board (-s 1000k)
+  protocol 319 # Shenzhen Wale WL-TH6R Temperature & Humidity Sensor
+  protocol 320 # Cellular Tracking Technologies LifeTag/PowerTag/HybridTag
+  protocol 321 # Govee Pool/Spa Thermometer H5310
+  protocol 322 # Govee H5112 Dual-Probe Thermometer
 
 ## Flex devices (command line option "-X")
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -308,7 +308,6 @@
     DECL(tpms_trw_ook) \
     DECL(tpms_trw_fsk) \
     DECL(govee_h5059) \
-    DECL(govee_h5310) \
     DECL(astrostart_2000) \
     DECL(compustar_1wg3r) \
     DECL(chrysler_car_remote) \
@@ -329,6 +328,8 @@
     DECL(rfm69_lowpowerlab_moteino) \
     DECL(shenzhen_wale_wl_th6r) \
     DECL(ctt_life_power_hybrid) \
+    DECL(govee_h5310) \
+    DECL(govee_h5112) \
     /* Add new decoders here. */
 
 #define DECL(name) extern r_device name;

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -308,6 +308,7 @@
     DECL(tpms_trw_ook) \
     DECL(tpms_trw_fsk) \
     DECL(govee_h5059) \
+    DECL(govee_h5310) \
     DECL(astrostart_2000) \
     DECL(compustar_1wg3r) \
     DECL(chrysler_car_remote) \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -156,6 +156,7 @@ add_library(r_433 STATIC
     devices/gm_car_remote.c
     devices/govee.c
     devices/govee_h5059.c
+    devices/govee_h5310.c
     devices/gridstream.c
     devices/gt_tmbbq05.c
     devices/gt_wt_02.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -156,6 +156,7 @@ add_library(r_433 STATIC
     devices/gm_car_remote.c
     devices/govee.c
     devices/govee_h5059.c
+    devices/govee_h5112.c
     devices/govee_h5310.c
     devices/gridstream.c
     devices/gt_tmbbq05.c

--- a/src/devices/govee_h5059.c
+++ b/src/devices/govee_h5059.c
@@ -24,8 +24,9 @@
 #define GOVEE_H5059_MSG_CLASS_OFFSET    0
 #define GOVEE_H5059_ID_OFFSET           1
 #define GOVEE_H5059_SUBTYPE_OFFSET      13
-#define GOVEE_H5059_LEAK_FLAG1_OFFSET   15
-#define GOVEE_H5059_LEAK_FLAG2_OFFSET   17
+#define GOVEE_H5059_LEAK_TOP_OFFSET     14
+#define GOVEE_H5059_LEAK_BOTTOM_OFFSET  15
+#define GOVEE_H5059_LEAK_ALARM_OFFSET   17
 
 #define GOVEE_H5059_LEAK_FLAG_ACTIVE    0x01
 
@@ -77,19 +78,33 @@ Decrypted payload (19+ bytes):
 - dec[1-4]: 32-bit device ID in wire byte order
 - dec[5-12]: unknown/reserved bytes
 - dec[13]: subtype (0x05 = button, 0x06 = leak, 0x07 = post-alarm)
-- dec[14]: unknown
-- dec[15]: state flag (checked with dec[17] for leak)
+- dec[14]: top probe wet flag (0x01 = top probe pair detects water)
+- dec[15]: bottom probe wet flag (0x01 = bottom probe pair detects water)
 - dec[16]: unknown
-- dec[17]: state flag (checked with dec[15] for leak)
+- dec[17]: alarm-active flag (non-zero while either probe pair is wet; seen as
+    0x01 on the initial leak frame and 0x02 on a follow-up frame ~1s later)
 - dec[18+]: unknown/variable payload
 
 Event mapping:
 
 - msg_class 0x11 + subtype 0x05: Button Press
-- msg_class 0x11 + subtype 0x06 + dec[15] == 0x01 + dec[17] == 0x01: Water Leak
+- msg_class 0x11 + subtype 0x06 + dec[17] != 0 + (dec[14] == 0x01 or dec[15] == 0x01): Water Leak
 - msg_class 0x11 + subtype 0x07: Post Alarm
 - msg_class 0x01: Pairing
 - msg_class 0x02: Class 0x02
+
+Top/bottom probe flags (confirmed 2026-06-14):
+
+- A bottom-probe-only leak produced dec[14]=0x00, dec[15]=0x01, dec[17]=0x01.
+- A top-probe-only leak produced dec[14]=0x01, dec[15]=0x00, dec[17]=0x01.
+- A simultaneous top+bottom leak's first frame matched the top-only pattern
+    (dec[14]=0x01, dec[15]=0x00); a follow-up subtype-0x08 frame ~1s later showed
+    both dec[14]=0x01 and dec[15]=0x01.
+- The original logic required dec[15] == 0x01 AND dec[17] == 0x01, which only
+    matched the bottom-probe case -- a top-probe-only leak fell through to the
+    generic "Telemetry" event and was never reported as "Water Leak". This is
+    fixed by checking dec[17] != 0 and either probe flag, and the specific probe
+    (top/bottom) is now reported via the leak_top/leak_bottom fields.
 
 Subtype 0x07 note:
 
@@ -215,15 +230,16 @@ static int govee_h5059_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     uint8_t msg_class = dec[GOVEE_H5059_MSG_CLASS_OFFSET];
     uint32_t id_wire  = ((uint32_t)dec[GOVEE_H5059_ID_OFFSET] << 24) |
-                       ((uint32_t)dec[GOVEE_H5059_ID_OFFSET + 1] << 16) |
-                       ((uint32_t)dec[GOVEE_H5059_ID_OFFSET + 2] << 8) |
-                       dec[GOVEE_H5059_ID_OFFSET + 3];
+                        ((uint32_t)dec[GOVEE_H5059_ID_OFFSET + 1] << 16) |
+                        ((uint32_t)dec[GOVEE_H5059_ID_OFFSET + 2] << 8) |
+                        dec[GOVEE_H5059_ID_OFFSET + 3];
     // The app-facing/canonical ID uses swapped 16-bit words relative to wire order.
     uint32_t id = ((id_wire & 0xffff) << 16) | ((id_wire >> 16) & 0xffff);
 
     int subtype     = enc_len > GOVEE_H5059_SUBTYPE_OFFSET ? dec[GOVEE_H5059_SUBTYPE_OFFSET] : -1;
-    int leak_flag_1 = enc_len > GOVEE_H5059_LEAK_FLAG1_OFFSET ? dec[GOVEE_H5059_LEAK_FLAG1_OFFSET] : -1;
-    int leak_flag_2 = enc_len > GOVEE_H5059_LEAK_FLAG2_OFFSET ? dec[GOVEE_H5059_LEAK_FLAG2_OFFSET] : -1;
+    int leak_top    = enc_len > GOVEE_H5059_LEAK_TOP_OFFSET ? dec[GOVEE_H5059_LEAK_TOP_OFFSET] : -1;
+    int leak_bottom = enc_len > GOVEE_H5059_LEAK_BOTTOM_OFFSET ? dec[GOVEE_H5059_LEAK_BOTTOM_OFFSET] : -1;
+    int leak_alarm  = enc_len > GOVEE_H5059_LEAK_ALARM_OFFSET ? dec[GOVEE_H5059_LEAK_ALARM_OFFSET] : -1;
     int leak_status = GOVEE_H5059_LEAK_UNKNOWN;
 
     char const *event = "Unknown";
@@ -233,7 +249,7 @@ static int govee_h5059_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             event       = "Button Press";
             leak_status = GOVEE_H5059_LEAK_DRY;
         }
-        else if (subtype == GOVEE_H5059_SUBTYPE_LEAK && leak_flag_1 == GOVEE_H5059_LEAK_FLAG_ACTIVE && leak_flag_2 == GOVEE_H5059_LEAK_FLAG_ACTIVE) {
+        else if (subtype == GOVEE_H5059_SUBTYPE_LEAK && leak_alarm != 0 && (leak_top == GOVEE_H5059_LEAK_FLAG_ACTIVE || leak_bottom == GOVEE_H5059_LEAK_FLAG_ACTIVE)) {
             event       = "Water Leak";
             leak_status = GOVEE_H5059_LEAK_WET;
         }
@@ -257,6 +273,8 @@ static int govee_h5059_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "msg_class",    "",                 DATA_FORMAT, "0x%02x", DATA_INT, msg_class,
             "subtype",      "",                 DATA_COND,   subtype >= 0, DATA_FORMAT, "0x%02x", DATA_INT, subtype,
             "detect_wet",   "",                 DATA_COND,   leak_status >= 0, DATA_INT, leak_status,
+            "leak_top",     "",                 DATA_COND,   leak_status == GOVEE_H5059_LEAK_WET, DATA_INT, leak_top == GOVEE_H5059_LEAK_FLAG_ACTIVE,
+            "leak_bottom",  "",                 DATA_COND,   leak_status == GOVEE_H5059_LEAK_WET, DATA_INT, leak_bottom == GOVEE_H5059_LEAK_FLAG_ACTIVE,
             "mic",          "Integrity",        DATA_STRING, "CRC",
             NULL);
     /* clang-format on */
@@ -274,6 +292,8 @@ static char const *const output_fields[] = {
         "msg_class",
         "subtype",
         "detect_wet",
+        "leak_top",
+        "leak_bottom",
         "mic",
         NULL,
 };
@@ -287,4 +307,6 @@ r_device const govee_h5059 = {
         .reset_limit = 2000,
         .decode_fn   = &govee_h5059_decode,
         .fields      = output_fields,
+        .priority    = 10, // Govee-H5310 collision: if the H5310 decoder claims a
+                           // frame (temperature or periodic update) it's not H5059
 };

--- a/src/devices/govee_h5059.c
+++ b/src/devices/govee_h5059.c
@@ -108,10 +108,12 @@ Top/bottom probe flags (confirmed 2026-06-14):
 
 Subtype 0x07 note:
 
-- Field observations indicate 0x07 commonly follows leak-active (0x06) frames and
-    likely represents dry/recovery state.
-- This is still marked as provisional and should be confirmed by correlating RF
-    captures with Govee gateway/app state transitions.
+- Observed following leak-active (0x06) frames, but the exact semantics are not
+    confirmed. Known triggers include the sensor recovering naturally (probe dries),
+    a manual alarm reset via the device button, and alarm suppression (which silences
+    the alert for ~1 hour while the probe may still be wet). Because of the
+    suppression case, subtype 0x07 cannot be interpreted as a "dry/recovered" signal,
+    so `detect_wet` is not emitted for this event type.
 
 Pairing mode notes (reverse-engineering observations):
 
@@ -263,6 +265,9 @@ static int govee_h5059_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     else if (msg_class == GOVEE_H5059_MSG_CLASS_OTHER) {
         event = "Class 0x02";
     }
+    else {
+        return DECODE_ABORT_EARLY;
+    }
 
     /* clang-format off */
     data_t *data = data_make(
@@ -307,6 +312,7 @@ r_device const govee_h5059 = {
         .reset_limit = 2000,
         .decode_fn   = &govee_h5059_decode,
         .fields      = output_fields,
-        .priority    = 10, // Govee-H5310 collision: if the H5310 decoder claims a
-                           // frame (temperature or periodic update) it's not H5059
+        .priority    = 10, // H5310 shares this family's framing and runs at higher
+                           // priority; H5310 claims temp/periodic/status/ping frames
+                           // first; H5059 only sees what H5310 passes.
 };

--- a/src/devices/govee_h5112.c
+++ b/src/devices/govee_h5112.c
@@ -16,7 +16,6 @@
 */
 
 #include "decoder.h"
-#include <math.h>
 
 #define GOVEE_H5112_SYNC_LEN  3
 #define GOVEE_H5112_MIN_FRAME 7
@@ -37,46 +36,34 @@
 #define GOVEE_H5112_MSG_CLASS_OFFSET 0
 #define GOVEE_H5112_ID_OFFSET        1  // 4 bytes (big-endian wire order)
 #define GOVEE_H5112_BATTERY_OFFSET   5  // battery percent (0x64 = 100%)
-#define GOVEE_H5112_PROBE2_OFFSET    6  // probe 2 temperature (8-bit modular counter)
-#define GOVEE_H5112_PROBE1_FINE      7  // probe 1 temperature, low 8 bits of 14-bit ADC value
-#define GOVEE_H5112_PROBE1_COARSE    8  // probe 1 temperature, high 6 bits [5:0]; bits [7:6] = purpose unknown
-#define GOVEE_H5112_HUMID_OFFSET     9  // probe 1 humidity
+#define GOVEE_H5112_SENSOR_OFFSET    6  // 4-byte packed sensor word, dec[6..9]
 
-// Probe 1 temperature: 14-bit fixed-point ADC value at 80 counts per °C.
-// Combined value = dec[PROBE1_FINE] + (dec[PROBE1_COARSE] & 0x3F) * 256.
-// T_C = (combined - GOVEE_H5112_PROBE1_BIAS) / GOVEE_H5112_PROBE1_SCALE
-// Bias = 3200 places 0 °C at the midpoint of the 14-bit range.
-#define GOVEE_H5112_PROBE1_BIAS  3200
-#define GOVEE_H5112_PROBE1_SCALE 80.0f
-
-// Probe 2 temperature: 8-bit modular counter at 10 counts per °C, bias 144.
-// T_C = (dec[PROBE2_OFFSET] - GOVEE_H5112_PROBE2_BIAS) / GOVEE_H5112_PROBE2_SCALE
-// Wraps every 25.6 °C; absolute value requires stateful wrap-count tracking.
-#define GOVEE_H5112_PROBE2_BIAS  144
-#define GOVEE_H5112_PROBE2_SCALE 10.0f
-#define GOVEE_H5112_PROBE2_WRAP  25.6f  // modular period in °C
-#define GOVEE_H5112_MAX_DEVICES  8      // max simultaneously tracked devices
-
-// Humidity: dec[HUMID_OFFSET] * GOVEE_H5112_HUMID_SCALE = % RH.
-#define GOVEE_H5112_HUMID_SCALE 0.4f
+// dec[6..9] is one 32-bit little-endian word packing both probe temperatures
+// and humidity, written by the device's firmware sensor-packing routine.
+// Field layout (bit positions within the 32-bit word):
+//   bits [0:10]  (11 bits) = probe 2 temperature
+//   bits [11:21] (11 bits) = probe 1 temperature
+//   bits [22:31] (10 bits) = humidity
+// Both temperature fields use the same scale/bias: count = (T_C + 40) * 10,
+// i.e. 0.1 °C resolution, zero-anchored at -40 °C. Humidity: count = RH% * 10.
+// Firmware-verified bit-exact: forward-encoding real app-displayed readings
+// reproduces the real RF bytes exactly, and decoding the in-frame history
+// buffer with this layout (no app data needed) traces a smooth temperature
+// curve through real wrap-boundary crossings -- see project notes.
+#define GOVEE_H5112_FIELD_SCALE   10.0f  // counts per °C, and per % RH
+#define GOVEE_H5112_TEMP_BIAS_C   40.0f  // °C added to zero-anchor the temp fields
+#define GOVEE_H5112_PROBE2_MASK   0x7ffu
+#define GOVEE_H5112_PROBE1_SHIFT  11
+#define GOVEE_H5112_PROBE1_MASK   0x7ffu
+#define GOVEE_H5112_HUMID_SHIFT   22
+#define GOVEE_H5112_HUMID_MASK    0x3ffu
 
 // History buffer: dec[17-56], 10 × 4-byte records of [d6, d7, d8, d9],
 // sampled at ~1-minute intervals within the 10-minute reporting window,
-// oldest record first (dec[17-20] oldest, dec[53-56] most recent).
+// oldest record first (dec[17-20] oldest, dec[53-56] most recent). Each
+// record uses the same packed-word layout as the live dec[6..9] fields.
 #define GOVEE_H5112_HISTORY_OFFSET 17
 #define GOVEE_H5112_HISTORY_COUNT  10
-
-
-// Per-device state for probe-2 wrap-count tracking.
-// k is initialised to 0 on first decode; updated by detecting 25.6 °C boundary
-// crossings between consecutive frames (|Δt2_mod| > 12.8 °C).
-// T_true = T_mod + k * GOVEE_H5112_PROBE2_WRAP
-static struct {
-    uint32_t id_wire;
-    float    t2_mod; // last raw modular value before k-correction
-    int      k;
-    int      valid;
-} govee_h5112_devs[GOVEE_H5112_MAX_DEVICES];
 
 static uint8_t const govee_h5112_sync[]       = {0x2c, 0x4c, 0x4a};
 static uint8_t const govee_h5112_sync_skew1[] = {0x16, 0x26, 0x25};
@@ -118,91 +105,86 @@ Sensor uplink frame format (common to the Govee FSK device family):
 Periodic sensor report (msg_class 0x13), 57-byte decrypted payload.
 This is the device's autonomous broadcast, transmitted every ~10 minutes.
 
-    byte:   0    1  2  3  4   5     6       7   8     9    10  11   12  13    14-16   17-56
-    field:  13  <id_wire 4B>  bat  p2_temp  p1_fine  p1_coarse  hum  00  <time_s LE>  const  <history>
+    byte:   0    1  2  3  4   5    6  7  8  9   10  11   12  13    14-16   17-56
+    field:  13  <id_wire 4B>  bat  <sensor word, 4B>  flags  00  <time_s LE>  const  <history>
 
 Triggered status response (msg_class 0x71), 28-byte decrypted payload.
 Sent in response to a gateway poll (msg_class 0x70 ping). Contains the
 same sensor fields as 0x13 in the same byte positions, but omits the
-history buffer, seconds counter, and constant marker bytes. Humidity is
-present in dec[9]; the app may display the cached 0x13 value instead when
-humidity appears unchanged between triggers.
+history buffer, seconds counter, and constant marker bytes.
 
-    byte:   0    1  2  3  4   5     6       7   8     9    10   11  12  13
-    field:  71  <id_wire 4B>  bat  p2_temp  p1_fine  p1_coarse  hum  ?   00  <session_id LE>
+    byte:   0    1  2  3  4   5    6  7  8  9    10  11  12  13
+    field:  71  <id_wire 4B>  bat  <sensor word, 4B>  ?   00  <session_id LE>
 
 - dec[0]:  0x13 or 0x71, msg_class (identifies this frame type)
 - dec[1-4]: device ID in wire byte order (big-endian); lower 16 bits are a
     pairing token shared by all devices bound to the same gateway
 - dec[5]:  battery percent (0x64 = 100%)
-- dec[6]:  probe 2 temperature, 8-bit modular counter;
-    T_C = (dec[6] - 144) / 10.0  (mod 25.6 °C; wraps every 25.6 °C)
-    Absolute temperature requires stateful wrap-count tracking across frames;
-    see the k-tracking logic in govee_h5112_decode().
-- dec[7]:  probe 1 temperature, low 8 bits of 14-bit ADC value (fine)
-- dec[8]:  bits [5:0] = probe 1 temperature, high 6 bits of 14-bit ADC value (coarse)
-    T_C = (dec[7] + (dec[8] & 0x3F) * 256 - 3200) / 80.0
-    Absolute temperature, no wrapping. Range: -40 °C to > 60 °C.
-    Resolution: 0.0125 °C (reported to 0.1 °C precision).
-    bits [7:6] = purpose unknown; all four values appear across frames and
-    within the history buffer with no discernible pattern. Originally
-    hypothesised to be a rolling packet counter, but confirmed NOT cyclic
-    (0→1→2→3→0) and NOT a probe 2 temperature-range indicator.
-- dec[9]:  probe 1 humidity; humidity_pct = dec[9] * 0.4
+- dec[6-9]: one 32-bit little-endian packed sensor word (see below) holding
+    probe 2 temperature, probe 1 temperature, and humidity. This matches the
+    bit-packing of the firmware's own sensor-encoding routine, confirmed by
+    disassembling a dumped firmware image -- not just calibration-fitted from
+    RF captures.
 - dec[10]: status/flags byte. bit[7] = display unit (0=°C, 1=°F), confirmed from
     gateway unit-change command responses. bit[6] = config/state flag of
     undetermined meaning; usually differs between units (one unit sets it, another
     clears it) but it is NOT a fixed per-device constant -- one unit was observed
-    with it both set and clear. Verified NOT correlated with probe temperature or
-    the probe 2 wrap count k (checked over 86 frames spanning probe 1 +0.4..+25.9 °C
-    and probe 2 modular -11.1 °C). bits[5:0] = 0 in all captures.
-    NOT a probe-swap flag (the two probe connectors are physically different).
+    with it both set and clear. Verified NOT correlated with probe temperature
+    (checked over 86 frames spanning probe 1 +0.4..+25.9 °C). bits[5:0] = 0 in
+    all captures. NOT a probe-swap flag (the two probe connectors are physically
+    different).
 - dec[11]: 0x00 (reserved or padding; full byte unused across all captures)
 - dec[12-13]: seconds counter, little-endian 16-bit, increments at 1 Hz
 - dec[14-15]: 0x37 0x6a (constant marker bytes, observed stable across all captures;
     earlier firmware builds showed 0x36 0x6a)
 - dec[16]: history record count; normally 10 (0x0a), less on a freshly powered device
-- dec[17-56]: rolling history buffer -- 10 x 4-byte records (oldest first),
-    each record mirrors [dec[6], dec[7], dec[8], dec[9]] from that period
+- dec[17-56]: rolling history buffer -- 10 x 4-byte records (oldest first), each
+    record is a packed sensor word in the same layout as dec[6-9]
 
-Probe 1 temperature derivation:
+Sensor word derivation (dec[6..9], and each 4-byte history record):
 
-dec[7] and dec[8][5:0] together form a 14-bit fixed-point ADC value at
-80 counts per °C with a bias of 3200 (= 40 °C * 80), placing 0 °C at the
-midpoint of the counter range. The encoding is equivalent to a 14-bit
-integer split across two bytes; the high byte's top 2 bits (dec[8][7:6])
-have an unknown purpose and are masked out.
+The firmware packs both probe temperatures and humidity into one 32-bit
+little-endian word, written verbatim as 4 consecutive bytes:
 
-Formula: T_C = (dec[7] + (dec[8] & 0x3F) * 256 - 3200) / 80.0
+    packed = dec[6] | (dec[7] << 8) | (dec[8] << 16) | (dec[9] << 24)
+    probe2_field   =  packed        & 0x7ff   // bits [0:10],  11 bits
+    probe1_field   = (packed >> 11) & 0x7ff   // bits [11:21], 11 bits
+    humidity_field = (packed >> 22) & 0x3ff   // bits [22:31], 10 bits
 
-Verified against confirmed app readings:
-- dec[7]=0x98, dec[8][5:0]=14: (152 + 3584 - 3200) / 80 =  6.700 °C (app: 6.7 °C, error 0.000)
-- dec[7]=0x9a, dec[8][5:0]=20: (154 + 5120 - 3200) / 80 = 25.925 °C (app: 25.9 °C, error 0.025)
-- dec[7]=0xa2, dec[8][5:0]=20: (162 + 5120 - 3200) / 80 = 26.025 °C (app: 26.0 °C, error 0.025)
-- dec[7]=0xa9, dec[8][5:0]=5:  (169 + 1280 - 3200) / 80 = -21.888 °C (freezer, no app reading)
+    temperature_2_C = probe2_field / 10.0 - 40.0
+    temperature_C   = probe1_field / 10.0 - 40.0
+    humidity        = humidity_field / 10.0
 
-Probe 2 temperature derivation:
+Both temperature fields use the identical scale/bias (0.1 °C/count,
+zero-anchored at -40 °C) -- probe 2 is a direct absolute reading, not a
+modular counter; no per-device wrap-count state is needed or maintained.
+Equivalently, byte-by-byte without reassembling the 32-bit word:
 
-dec[6] is an 8-bit modular counter at 10 counts per °C with bias 144:
-  dec[6] = (T_probe2 * 10 + 144) mod 256
+    dec[6]        = probe2 bits [0:7]
+    dec[7] & 0x07 = probe2 bits [8:10]
+    dec[7] >> 3   = probe1 bits [0:4]
+    dec[8] & 0x3f = probe1 bits [5:10]
+    dec[8] >> 6   = humidity bits [0:1]
+    dec[9]        = humidity bits [2:9]
 
-The modular value T_mod = (dec[6] - 144) / 10.0 is exact but wraps every
-25.6 °C. Recovering absolute temperature requires tracking the wrap count k
-across consecutive frames and applying T = T_mod + k * 25.6.
+This formula is firmware-verified bit-exact, not just calibration-fitted:
+the device's firmware (FR8016HA, dumped via UART bootloader exploit and
+disassembled) contains this exact symmetric 11/11/10-bit packing function.
+Confirmed two independent ways: (1) forward-encoding real app-displayed
+temperature/humidity readings reproduces the real RF bytes exactly across
+multiple frames, multiple devices, and multiple probe-2 absolute ranges;
+(2) decoding the in-frame history buffer with this formula (no app data
+involved at all) traces a smooth, physically continuous temperature curve
+through real-world temperature excursions, including 25.6 °C wrap-boundary
+crossings that an earlier modular-plus-tracked-wrap-count model could not
+represent without an external wrap counter.
 
-This decoder maintains per-device k state and seeds it on first decode using
-T1 ≈ T2 (correct when both probes start at the same temperature, which is the
-normal case -- the Govee app requires pairing at room temperature before
-deploying the probes). If rtl_433 is restarted while probe 2 is already in a
-cold environment, the seeded k may be wrong by ±1 until the next 25.6 °C
-boundary crossing self-corrects it.
-
-Humidity derivation:
-
-dec[9] * 0.4 = % RH (probe 1 sensor only; probe 2 is temperature-only).
-Verified exact against app readings at room temperature:
-- dec[9]=0x75 (117): 117 * 0.4 = 46.8 % (app: 46.8 %, error 0.0)
-- dec[9]=0xf2 (242): 242 * 0.4 = 96.8 % (app: 97.1 %, error 0.3)
+Verified examples (real captured dec[] bytes vs. confirmed app readings):
+- dec[6-9] = 0xde 0x9a 0x56 0xd0: probe2=33.4 °C, probe1=32.3 °C, hum=83.3 %
+  (app: 33.4 / 32.3 / 83.3 -- exact)
+- dec[6-9] = 0x9c 0x18 0x0d 0xa0: probe2=-24.4 °C, probe1=1.9 °C, hum=64.0 %
+  (app: -24.4 / 1.9 / 64.0 -- exact; probe2 well below the 25.6 °C wrap period,
+  read directly with no wrap-count tracking)
 
 Device ID:
 
@@ -248,9 +230,23 @@ All gateway-originated frames share the same outer header:
   msg_class 0x11 (device → gateway): pairing response. Sent in reply to
     0x07. dec[1-4] = the proposed id_wire being accepted; dec[5] = subtype
     (0x01 in pairing context); dec[6-10] = same sensor fields as 0x71.
-    Both probes are at room temperature at pairing time by design, so the
-    initial wrap count k=0 is always correct when the device is first set up.
 */
+// Unpacks a 4-byte little-endian sensor word (dec[6..9], or a history
+// record in the same layout) into probe 1/probe 2 temperature and humidity.
+// See the "Sensor word derivation" doc comment above for the bit layout.
+static void govee_h5112_unpack_sensor(uint8_t const *b, double *temp1_c, double *temp2_c, double *humidity)
+{
+    uint32_t packed = (uint32_t)b[0] | ((uint32_t)b[1] << 8) | ((uint32_t)b[2] << 16) | ((uint32_t)b[3] << 24);
+
+    uint32_t probe2_field = packed & GOVEE_H5112_PROBE2_MASK;
+    uint32_t probe1_field = (packed >> GOVEE_H5112_PROBE1_SHIFT) & GOVEE_H5112_PROBE1_MASK;
+    uint32_t humid_field  = (packed >> GOVEE_H5112_HUMID_SHIFT) & GOVEE_H5112_HUMID_MASK;
+
+    *temp2_c  = probe2_field / (double)GOVEE_H5112_FIELD_SCALE - GOVEE_H5112_TEMP_BIAS_C;
+    *temp1_c  = probe1_field / (double)GOVEE_H5112_FIELD_SCALE - GOVEE_H5112_TEMP_BIAS_C;
+    *humidity = humid_field / (double)GOVEE_H5112_FIELD_SCALE;
+}
+
 static int govee_h5112_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     uint8_t frame[GOVEE_H5112_MAX_FRAME];
@@ -331,6 +327,7 @@ static int govee_h5112_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     uint8_t msg_class = dec[GOVEE_H5112_MSG_CLASS_OFFSET];
     if (msg_class != GOVEE_H5112_MSG_PERIODIC && msg_class != GOVEE_H5112_MSG_TRIGGERED) {
         decoder_logf(decoder, 1, __func__, "unknown msg_class 0x%02x", msg_class);
+        decoder_log_bitrow(decoder, 1, __func__, dec, enc_len * 8, "unknown frame dec[] bytes");
         return DECODE_ABORT_EARLY;
     }
 
@@ -343,55 +340,12 @@ static int govee_h5112_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     int battery_pct = dec[GOVEE_H5112_BATTERY_OFFSET];
 
-    // Probe 1 temperature: 14-bit ADC value at 80 counts/°C, bias 3200 (= 40 °C * 80).
-    int probe1_raw = (int)dec[GOVEE_H5112_PROBE1_FINE]
-            + (int)(dec[GOVEE_H5112_PROBE1_COARSE] & 0x3F) * 256
-            - GOVEE_H5112_PROBE1_BIAS;
-    float probe1_c = probe1_raw / GOVEE_H5112_PROBE1_SCALE;
+    double probe1_c, probe2_c, humidity;
+    govee_h5112_unpack_sensor(&dec[GOVEE_H5112_SENSOR_OFFSET], &probe1_c, &probe2_c, &humidity);
 
-    // Probe 2 temperature: 8-bit modular counter at 10 counts/°C, bias 144.
-    // Wraps every 25.6 °C.  Recover absolute temperature by tracking wrap-count k
-    // per device across consecutive frames.  k starts at 0 on first decode; a jump
-    // of |Δt2_mod| > 12.8 °C between frames indicates a boundary crossing.
-    char  probe2_raw_str[5]; // "0xNN\0"
-    snprintf(probe2_raw_str, sizeof(probe2_raw_str), "0x%02x", dec[GOVEE_H5112_PROBE2_OFFSET]);
-    float probe2_mod = ((int)dec[GOVEE_H5112_PROBE2_OFFSET] - GOVEE_H5112_PROBE2_BIAS)
-            / GOVEE_H5112_PROBE2_SCALE;
-    float probe2_c = probe2_mod; // updated below with k-correction
-    int   probe2_k = 0;          // wrap count, also applied to history records
-    for (int i = 0; i < GOVEE_H5112_MAX_DEVICES; i++) {
-        if (govee_h5112_devs[i].valid && govee_h5112_devs[i].id_wire == id_wire) {
-            float delta = probe2_mod - govee_h5112_devs[i].t2_mod;
-            if (delta >= GOVEE_H5112_PROBE2_WRAP * 0.5f)
-                govee_h5112_devs[i].k--;
-            else if (delta <= -GOVEE_H5112_PROBE2_WRAP * 0.5f)
-                govee_h5112_devs[i].k++;
-            govee_h5112_devs[i].t2_mod = probe2_mod;
-            probe2_k = govee_h5112_devs[i].k;
-            probe2_c = probe2_mod + probe2_k * GOVEE_H5112_PROBE2_WRAP;
-            break;
-        }
-        if (!govee_h5112_devs[i].valid) {
-            // Seed k from probe 1 (assumes T2 ≈ T1 on first decode; wrong if
-            // probes are in different environments, but best available guess).
-            int k0 = (int)roundf((probe1_c - probe2_mod) / GOVEE_H5112_PROBE2_WRAP);
-            govee_h5112_devs[i].id_wire = id_wire;
-            govee_h5112_devs[i].t2_mod  = probe2_mod;
-            govee_h5112_devs[i].k       = k0;
-            govee_h5112_devs[i].valid   = 1;
-            probe2_k = k0;
-            probe2_c = probe2_mod + k0 * GOVEE_H5112_PROBE2_WRAP;
-            break;
-        }
-    }
-
-    // Probe 1 humidity: dec[9] * 0.4 = % RH.
-    float humidity = dec[GOVEE_H5112_HUMID_OFFSET] * GOVEE_H5112_HUMID_SCALE;
-
-    // History buffer: 10 × 4-byte records of [d6, d7, d8, d9], oldest first.
-    // Same k correction applied to T2 as the current frame (all records are
-    // from the same 10-minute window so k is stable, except during a wrap
-    // crossing, where the oldest records may be off by one period).
+    // History buffer: 10 × 4-byte records, oldest first, each a packed sensor
+    // word in the same layout as dec[6..9]. Stateless -- no wrap-count
+    // tracking needed; probe 2 is read as a direct absolute value here too.
     double hist_t1[GOVEE_H5112_HISTORY_COUNT];
     double hist_t2[GOVEE_H5112_HISTORY_COUNT];
     double hist_hum[GOVEE_H5112_HISTORY_COUNT];
@@ -400,13 +354,7 @@ static int govee_h5112_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     if (has_history) {
         for (int i = 0; i < GOVEE_H5112_HISTORY_COUNT; i++) {
             unsigned base = GOVEE_H5112_HISTORY_OFFSET + (unsigned)i * 4;
-            int ht1_raw = (int)dec[base + 1]
-                    + (int)(dec[base + 2] & 0x3F) * 256
-                    - GOVEE_H5112_PROBE1_BIAS;
-            hist_t1[i]  = ht1_raw / (double)GOVEE_H5112_PROBE1_SCALE;
-            hist_t2[i]  = ((int)dec[base] - GOVEE_H5112_PROBE2_BIAS) / (double)GOVEE_H5112_PROBE2_SCALE
-                    + probe2_k * GOVEE_H5112_PROBE2_WRAP;
-            hist_hum[i] = dec[base + 3] * (double)GOVEE_H5112_HUMID_SCALE;
+            govee_h5112_unpack_sensor(&dec[base], &hist_t1[i], &hist_t2[i], &hist_hum[i]);
         }
     }
 
@@ -417,10 +365,9 @@ static int govee_h5112_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "id_wire",          "",             DATA_FORMAT, "%08x", DATA_INT, id_wire,
             "battery_ok",       "Battery",      DATA_INT,    battery_pct > 0,
             "battery_pct",      "Battery",      DATA_INT,    battery_pct,
-            "temperature_C",    "Temperature",  DATA_FORMAT, "%.3f C", DATA_DOUBLE, (double)probe1_c,
-            "temperature_2_C",  "Temperature2", DATA_FORMAT, "%.1f C", DATA_DOUBLE, (double)probe2_c,
-            "temperature_2_raw","Temperature2 raw byte", DATA_STRING, probe2_raw_str,
-            "humidity",         "Humidity",     DATA_FORMAT, "%.1f %%", DATA_DOUBLE, (double)humidity,
+            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, probe1_c,
+            "temperature_2_C",  "Temperature2", DATA_FORMAT, "%.1f C", DATA_DOUBLE, probe2_c,
+            "humidity",         "Humidity",     DATA_FORMAT, "%.1f %%", DATA_DOUBLE, humidity,
             "mic",              "Integrity",    DATA_STRING, "CRC",
             NULL);
     /* clang-format on */
@@ -443,7 +390,6 @@ static char const *const output_fields[] = {
         "battery_pct",
         "temperature_C",
         "temperature_2_C",
-        "temperature_2_raw",
         "humidity",
         "temperature_C_history",
         "temperature_2_C_history",

--- a/src/devices/govee_h5112.c
+++ b/src/devices/govee_h5112.c
@@ -1,0 +1,466 @@
+/** @file
+    Govee Dual-Probe Thermometer H5112.
+
+    Copyright (C) 2026 Paul Antaki (\@Pablo1)
+
+    Based on the Govee H5059 decoder by Reece Neff <reeceneff@gmail.com>
+    (rtl_433 PR #3493), which reverse-engineered the shared Govee FSK
+    protocol used by this device family -- the 2c 4c 4a sync words, the
+    128-byte XOR key, and the CRC-16/AUG-CCITT framing. That protocol
+    foundation is reused here unchanged.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#include "decoder.h"
+#include <math.h>
+
+#define GOVEE_H5112_SYNC_LEN  3
+#define GOVEE_H5112_MIN_FRAME 7
+#define GOVEE_H5112_MAX_FRAME 128
+#define GOVEE_H5112_KEY_LEN   128
+
+#define GOVEE_H5112_CRC_POLY  0x1021
+#define GOVEE_H5112_CRC_INIT  0x1d0f
+
+// msg_class values this decoder handles.
+#define GOVEE_H5112_MSG_PERIODIC  0x13  // autonomous periodic report (~10 min)
+#define GOVEE_H5112_MSG_TRIGGERED 0x71  // gateway-triggered status response
+
+// Minimum decrypted bytes needed to read all sensor fields (through dec[9]).
+#define GOVEE_H5112_MIN_DEC 10
+
+// Byte offsets in the decrypted payload.
+#define GOVEE_H5112_MSG_CLASS_OFFSET 0
+#define GOVEE_H5112_ID_OFFSET        1  // 4 bytes (big-endian wire order)
+#define GOVEE_H5112_BATTERY_OFFSET   5  // battery percent (0x64 = 100%)
+#define GOVEE_H5112_PROBE2_OFFSET    6  // probe 2 temperature (8-bit modular counter)
+#define GOVEE_H5112_PROBE1_FINE      7  // probe 1 temperature, low 8 bits of 14-bit ADC value
+#define GOVEE_H5112_PROBE1_COARSE    8  // probe 1 temperature, high 6 bits [5:0]; bits [7:6] = purpose unknown
+#define GOVEE_H5112_HUMID_OFFSET     9  // probe 1 humidity
+
+// Probe 1 temperature: 14-bit fixed-point ADC value at 80 counts per °C.
+// Combined value = dec[PROBE1_FINE] + (dec[PROBE1_COARSE] & 0x3F) * 256.
+// T_C = (combined - GOVEE_H5112_PROBE1_BIAS) / GOVEE_H5112_PROBE1_SCALE
+// Bias = 3200 places 0 °C at the midpoint of the 14-bit range.
+#define GOVEE_H5112_PROBE1_BIAS  3200
+#define GOVEE_H5112_PROBE1_SCALE 80.0f
+
+// Probe 2 temperature: 8-bit modular counter at 10 counts per °C, bias 144.
+// T_C = (dec[PROBE2_OFFSET] - GOVEE_H5112_PROBE2_BIAS) / GOVEE_H5112_PROBE2_SCALE
+// Wraps every 25.6 °C; absolute value requires stateful wrap-count tracking.
+#define GOVEE_H5112_PROBE2_BIAS  144
+#define GOVEE_H5112_PROBE2_SCALE 10.0f
+#define GOVEE_H5112_PROBE2_WRAP  25.6f  // modular period in °C
+#define GOVEE_H5112_MAX_DEVICES  8      // max simultaneously tracked devices
+
+// Humidity: dec[HUMID_OFFSET] * GOVEE_H5112_HUMID_SCALE = % RH.
+#define GOVEE_H5112_HUMID_SCALE 0.4f
+
+// History buffer: dec[17-56], 10 × 4-byte records of [d6, d7, d8, d9],
+// sampled at ~1-minute intervals within the 10-minute reporting window,
+// oldest record first (dec[17-20] oldest, dec[53-56] most recent).
+#define GOVEE_H5112_HISTORY_OFFSET 17
+#define GOVEE_H5112_HISTORY_COUNT  10
+
+
+// Per-device state for probe-2 wrap-count tracking.
+// k is initialised to 0 on first decode; updated by detecting 25.6 °C boundary
+// crossings between consecutive frames (|Δt2_mod| > 12.8 °C).
+// T_true = T_mod + k * GOVEE_H5112_PROBE2_WRAP
+static struct {
+    uint32_t id_wire;
+    float    t2_mod; // last raw modular value before k-correction
+    int      k;
+    int      valid;
+} govee_h5112_devs[GOVEE_H5112_MAX_DEVICES];
+
+static uint8_t const govee_h5112_sync[]       = {0x2c, 0x4c, 0x4a};
+static uint8_t const govee_h5112_sync_skew1[] = {0x16, 0x26, 0x25};
+static uint8_t const govee_h5112_key[GOVEE_H5112_KEY_LEN + 1] =
+        "s6amyEvO8UslCY0eZjgc2S6APCVLgLxzFvL2Z5GWPW7fKVjy2oAU6uiKU3lZCHm62VYQQuCtgxzPgGd8UDRPVZpDRAsh5EdYq1E4j4morJ3vd6tWx8BiWOLDc2I8wKUK";
+
+/**
+Govee Dual-Probe Thermometer H5112.
+
+The H5112 is a general-purpose dual-probe thermometer. Both probes cover
+the full device range (documented upper bound 140 °F / 60 °C; no lower
+bound specified). Probe 1 includes a humidity sensor; probe 2 is
+temperature-only. Typical deployments include refrigerators, freezers,
+wine cellars, greenhouses, and other environments.
+
+Modulation, timing, and transmission:
+
+The device uses FSK pulse PCM encoding, sharing the same sync words,
+XOR key, and CRC-16/AUG-CCITT framing as the Govee H5059 water leak
+detector and the H5310 pool/spa thermometer. Those shared protocol
+details were reverse-engineered by Reece Neff for the H5059 (PR #3493).
+- Demod mode in rtl_433 is FSK_PULSE_PCM.
+- short_width = 100 us and long_width = 100 us (PCM symbol timing).
+- reset_limit = 2000 us.
+- The sensor transmits autonomously approximately every 10 minutes.
+- All temperature and humidity data is carried on the 912 MHz Sub-1G uplink;
+  the companion app updates only when an RF frame is received.
+
+Sensor uplink frame format (common to the Govee FSK device family):
+
+    2C 4C 4A LL SS [ciphertext...] CC CC
+
+- 2C 4C 4A: sync word
+- LL: outer frame length in bytes (SS + ciphertext + CRC)
+- SS: XOR stream start offset (seed)
+- ciphertext: encrypted payload bytes
+- CC CC: CRC-16/AUG-CCITT, poly=0x1021, init=0x1d0f
+
+Periodic sensor report (msg_class 0x13), 57-byte decrypted payload.
+This is the device's autonomous broadcast, transmitted every ~10 minutes.
+
+    byte:   0    1  2  3  4   5     6       7   8     9    10  11   12  13    14-16   17-56
+    field:  13  <id_wire 4B>  bat  p2_temp  p1_fine  p1_coarse  hum  00  <time_s LE>  const  <history>
+
+Triggered status response (msg_class 0x71), 28-byte decrypted payload.
+Sent in response to a gateway poll (msg_class 0x70 ping). Contains the
+same sensor fields as 0x13 in the same byte positions, but omits the
+history buffer, seconds counter, and constant marker bytes. Humidity is
+present in dec[9]; the app may display the cached 0x13 value instead when
+humidity appears unchanged between triggers.
+
+    byte:   0    1  2  3  4   5     6       7   8     9    10   11  12  13
+    field:  71  <id_wire 4B>  bat  p2_temp  p1_fine  p1_coarse  hum  ?   00  <session_id LE>
+
+- dec[0]:  0x13 or 0x71, msg_class (identifies this frame type)
+- dec[1-4]: device ID in wire byte order (big-endian); lower 16 bits are a
+    pairing token shared by all devices bound to the same gateway
+- dec[5]:  battery percent (0x64 = 100%)
+- dec[6]:  probe 2 temperature, 8-bit modular counter;
+    T_C = (dec[6] - 144) / 10.0  (mod 25.6 °C; wraps every 25.6 °C)
+    Absolute temperature requires stateful wrap-count tracking across frames;
+    see the k-tracking logic in govee_h5112_decode().
+- dec[7]:  probe 1 temperature, low 8 bits of 14-bit ADC value (fine)
+- dec[8]:  bits [5:0] = probe 1 temperature, high 6 bits of 14-bit ADC value (coarse)
+    T_C = (dec[7] + (dec[8] & 0x3F) * 256 - 3200) / 80.0
+    Absolute temperature, no wrapping. Range: -40 °C to > 60 °C.
+    Resolution: 0.0125 °C (reported to 0.1 °C precision).
+    bits [7:6] = purpose unknown; all four values appear across frames and
+    within the history buffer with no discernible pattern. Originally
+    hypothesised to be a rolling packet counter, but confirmed NOT cyclic
+    (0→1→2→3→0) and NOT a probe 2 temperature-range indicator.
+- dec[9]:  probe 1 humidity; humidity_pct = dec[9] * 0.4
+- dec[10]: status/flags byte. bit[7] = display unit (0=°C, 1=°F), confirmed from
+    gateway unit-change command responses. bit[6] = config/state flag of
+    undetermined meaning; usually differs between units (one unit sets it, another
+    clears it) but it is NOT a fixed per-device constant -- one unit was observed
+    with it both set and clear. Verified NOT correlated with probe temperature or
+    the probe 2 wrap count k (checked over 86 frames spanning probe 1 +0.4..+25.9 °C
+    and probe 2 modular -11.1 °C). bits[5:0] = 0 in all captures.
+    NOT a probe-swap flag (the two probe connectors are physically different).
+- dec[11]: 0x00 (reserved or padding; full byte unused across all captures)
+- dec[12-13]: seconds counter, little-endian 16-bit, increments at 1 Hz
+- dec[14-15]: 0x37 0x6a (constant marker bytes, observed stable across all captures;
+    earlier firmware builds showed 0x36 0x6a)
+- dec[16]: history record count; normally 10 (0x0a), less on a freshly powered device
+- dec[17-56]: rolling history buffer -- 10 x 4-byte records (oldest first),
+    each record mirrors [dec[6], dec[7], dec[8], dec[9]] from that period
+
+Probe 1 temperature derivation:
+
+dec[7] and dec[8][5:0] together form a 14-bit fixed-point ADC value at
+80 counts per °C with a bias of 3200 (= 40 °C * 80), placing 0 °C at the
+midpoint of the counter range. The encoding is equivalent to a 14-bit
+integer split across two bytes; the high byte's top 2 bits (dec[8][7:6])
+have an unknown purpose and are masked out.
+
+Formula: T_C = (dec[7] + (dec[8] & 0x3F) * 256 - 3200) / 80.0
+
+Verified against confirmed app readings:
+- dec[7]=0x98, dec[8][5:0]=14: (152 + 3584 - 3200) / 80 =  6.700 °C (app: 6.7 °C, error 0.000)
+- dec[7]=0x9a, dec[8][5:0]=20: (154 + 5120 - 3200) / 80 = 25.925 °C (app: 25.9 °C, error 0.025)
+- dec[7]=0xa2, dec[8][5:0]=20: (162 + 5120 - 3200) / 80 = 26.025 °C (app: 26.0 °C, error 0.025)
+- dec[7]=0xa9, dec[8][5:0]=5:  (169 + 1280 - 3200) / 80 = -21.888 °C (freezer, no app reading)
+
+Probe 2 temperature derivation:
+
+dec[6] is an 8-bit modular counter at 10 counts per °C with bias 144:
+  dec[6] = (T_probe2 * 10 + 144) mod 256
+
+The modular value T_mod = (dec[6] - 144) / 10.0 is exact but wraps every
+25.6 °C. Recovering absolute temperature requires tracking the wrap count k
+across consecutive frames and applying T = T_mod + k * 25.6.
+
+This decoder maintains per-device k state and seeds it on first decode using
+T1 ≈ T2 (correct when both probes start at the same temperature, which is the
+normal case -- the Govee app requires pairing at room temperature before
+deploying the probes). If rtl_433 is restarted while probe 2 is already in a
+cold environment, the seeded k may be wrong by ±1 until the next 25.6 °C
+boundary crossing self-corrects it.
+
+Humidity derivation:
+
+dec[9] * 0.4 = % RH (probe 1 sensor only; probe 2 is temperature-only).
+Verified exact against app readings at room temperature:
+- dec[9]=0x75 (117): 117 * 0.4 = 46.8 % (app: 46.8 %, error 0.0)
+- dec[9]=0xf2 (242): 242 * 0.4 = 96.8 % (app: 97.1 %, error 0.3)
+
+Device ID:
+
+`id_wire` is the full 32-bit on-wire device ID (e.g. 0x0b279cb2); `id`
+is the same value with its two 16-bit half-words swapped (0x9cb20b27),
+following the convention of the Govee H5059 and H5310 decoders. The low
+16 bits of id_wire are a pairing token shared by all devices bound to
+the same gateway (0x9cb2 in all observed captures).
+
+Priority and coexistence:
+
+This decoder runs at priority 5, after the H5310 decoder (priority 0,
+which claims LL=0x10/0x1c/0x1f/0x3d frames first) but before the H5059
+decoder (priority 10). H5112 frames carry a variable outer length; they
+are claimed by checking dec[0] == 0x13 or 0x71 post-decryption.
+The H5059 decoder would otherwise report these as event "Unknown".
+
+Gateway and pairing frames -- observed but not decoded by this decoder:
+
+All gateway-originated frames share the same outer header:
+  dec[1-2] = gateway pairing token (low 16 bits of all device IDs on gateway)
+  dec[3-4] = target device high-word ID
+  dec[5-6] = 0x6A 0x37 (constant across all captures)
+  dec[7-8] = gateway uptime counter, big-endian 16-bit, ~100 ms ticks
+
+  msg_class 0x70 (gateway → device): command frame. dec[9]=command,
+    dec[10]=payload. Device always responds with 0x71 echoing dec[9-10] in
+    its own dec[12-13]. Known commands: 0x35=network test/poll, 0x02=set
+    unit (0x00=°C / 0x01=°F), 0x17=gateway alerts (0x00=off / 0x01=on).
+    Always transmitted twice for RF reliability.
+
+  msg_class 0x36 (gateway → device): alarm settings push. Device responds
+    with 0x71 where dec[12-13] = {0x36, 0x00}. Payload not decoded.
+
+  msg_class 0x07 (gateway → device): pairing invitation. Gateway proposes
+    a new random high-word device ID in dec[3-4]; the full new id_wire is
+    {dec[3]:02x}{dec[4]:02x} + pairing_token. Two frames with different
+    proposed IDs are burst-transmitted simultaneously; device accepts both.
+
+  msg_class 0x08 (gateway → device): delete/unpair. Removes the device
+    from the gateway; device ceases transmitting periodic frames.
+
+  msg_class 0x11 (device → gateway): pairing response. Sent in reply to
+    0x07. dec[1-4] = the proposed id_wire being accepted; dec[5] = subtype
+    (0x01 in pairing context); dec[6-10] = same sensor fields as 0x71.
+    Both probes are at room temperature at pairing time by design, so the
+    initial wrap count k=0 is always correct when the device is first set up.
+*/
+static int govee_h5112_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    uint8_t frame[GOVEE_H5112_MAX_FRAME];
+    uint8_t dec[GOVEE_H5112_MAX_FRAME];
+
+    int row           = -1;
+    unsigned sync_pos = 0;
+
+    // Stage 1: find a row that contains either the native sync or the known skewed sync.
+    for (int r = 0; r < bitbuffer->num_rows; ++r) {
+        if (bitbuffer->bits_per_row[r] < 8 * GOVEE_H5112_MIN_FRAME) {
+            continue;
+        }
+
+        unsigned pos = bitbuffer_search(bitbuffer, r, 0, govee_h5112_sync, GOVEE_H5112_SYNC_LEN * 8);
+        if (pos < bitbuffer->bits_per_row[r]) {
+            row      = r;
+            sync_pos = pos;
+            break;
+        }
+
+        // The device preamble is MSB-first; depending on demod lock, bytes can
+        // arrive shifted by one bit, turning 2c 4c 4a into 16 26 25.
+        unsigned skew_pos = bitbuffer_search(bitbuffer, r, 0, govee_h5112_sync_skew1, GOVEE_H5112_SYNC_LEN * 8);
+        if (skew_pos < bitbuffer->bits_per_row[r]) {
+            row      = r;
+            sync_pos = skew_pos + 1;
+            break;
+        }
+    }
+
+    if (row < 0) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    // Stage 2: validate envelope and reject malformed messages before payload parsing.
+    sync_pos += GOVEE_H5112_SYNC_LEN * 8;
+
+    unsigned bits_after_sync = bitbuffer->bits_per_row[row] - sync_pos;
+    if (bits_after_sync < 8 * 4) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    unsigned bytes_after_sync = bits_after_sync / 8;
+    if (bytes_after_sync > GOVEE_H5112_MAX_FRAME) {
+        bytes_after_sync = GOVEE_H5112_MAX_FRAME;
+    }
+
+    bitbuffer_extract_bytes(bitbuffer, row, sync_pos, frame, bytes_after_sync * 8);
+
+    uint8_t outer_len = frame[0];
+    if (outer_len < 4 || outer_len > GOVEE_H5112_MAX_FRAME - 1) {
+        return DECODE_FAIL_SANITY;
+    }
+
+    if (bytes_after_sync < (unsigned)(1 + outer_len)) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    uint8_t seed      = frame[1];
+    unsigned enc_len  = outer_len - 3;
+    unsigned crc_offs = 2 + enc_len;
+
+    if (enc_len < GOVEE_H5112_MIN_DEC || enc_len > sizeof(dec)) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    uint16_t crc_calc = crc16(&frame[2], enc_len, GOVEE_H5112_CRC_POLY, GOVEE_H5112_CRC_INIT);
+    uint16_t crc_recv = ((uint16_t)frame[crc_offs] << 8) | frame[crc_offs + 1];
+    if (crc_calc != crc_recv) {
+        return DECODE_FAIL_MIC;
+    }
+
+    for (unsigned i = 0; i < enc_len; ++i) {
+        dec[i] = frame[2 + i] ^ govee_h5112_key[(i + seed) % GOVEE_H5112_KEY_LEN];
+    }
+
+    uint8_t msg_class = dec[GOVEE_H5112_MSG_CLASS_OFFSET];
+    if (msg_class != GOVEE_H5112_MSG_PERIODIC && msg_class != GOVEE_H5112_MSG_TRIGGERED) {
+        decoder_logf(decoder, 1, __func__, "unknown msg_class 0x%02x", msg_class);
+        return DECODE_ABORT_EARLY;
+    }
+
+    uint32_t id_wire = ((uint32_t)dec[GOVEE_H5112_ID_OFFSET] << 24)
+            | ((uint32_t)dec[GOVEE_H5112_ID_OFFSET + 1] << 16)
+            | ((uint32_t)dec[GOVEE_H5112_ID_OFFSET + 2] << 8)
+            | dec[GOVEE_H5112_ID_OFFSET + 3];
+    // Canonical ID: two 16-bit half-words swapped, matching govee_h5059/h5310.
+    uint32_t id = ((id_wire & 0xffff) << 16) | ((id_wire >> 16) & 0xffff);
+
+    int battery_pct = dec[GOVEE_H5112_BATTERY_OFFSET];
+
+    // Probe 1 temperature: 14-bit ADC value at 80 counts/°C, bias 3200 (= 40 °C * 80).
+    int probe1_raw = (int)dec[GOVEE_H5112_PROBE1_FINE]
+            + (int)(dec[GOVEE_H5112_PROBE1_COARSE] & 0x3F) * 256
+            - GOVEE_H5112_PROBE1_BIAS;
+    float probe1_c = probe1_raw / GOVEE_H5112_PROBE1_SCALE;
+
+    // Probe 2 temperature: 8-bit modular counter at 10 counts/°C, bias 144.
+    // Wraps every 25.6 °C.  Recover absolute temperature by tracking wrap-count k
+    // per device across consecutive frames.  k starts at 0 on first decode; a jump
+    // of |Δt2_mod| > 12.8 °C between frames indicates a boundary crossing.
+    char  probe2_raw_str[5]; // "0xNN\0"
+    snprintf(probe2_raw_str, sizeof(probe2_raw_str), "0x%02x", dec[GOVEE_H5112_PROBE2_OFFSET]);
+    float probe2_mod = ((int)dec[GOVEE_H5112_PROBE2_OFFSET] - GOVEE_H5112_PROBE2_BIAS)
+            / GOVEE_H5112_PROBE2_SCALE;
+    float probe2_c = probe2_mod; // updated below with k-correction
+    int   probe2_k = 0;          // wrap count, also applied to history records
+    for (int i = 0; i < GOVEE_H5112_MAX_DEVICES; i++) {
+        if (govee_h5112_devs[i].valid && govee_h5112_devs[i].id_wire == id_wire) {
+            float delta = probe2_mod - govee_h5112_devs[i].t2_mod;
+            if (delta >= GOVEE_H5112_PROBE2_WRAP * 0.5f)
+                govee_h5112_devs[i].k--;
+            else if (delta <= -GOVEE_H5112_PROBE2_WRAP * 0.5f)
+                govee_h5112_devs[i].k++;
+            govee_h5112_devs[i].t2_mod = probe2_mod;
+            probe2_k = govee_h5112_devs[i].k;
+            probe2_c = probe2_mod + probe2_k * GOVEE_H5112_PROBE2_WRAP;
+            break;
+        }
+        if (!govee_h5112_devs[i].valid) {
+            // Seed k from probe 1 (assumes T2 ≈ T1 on first decode; wrong if
+            // probes are in different environments, but best available guess).
+            int k0 = (int)roundf((probe1_c - probe2_mod) / GOVEE_H5112_PROBE2_WRAP);
+            govee_h5112_devs[i].id_wire = id_wire;
+            govee_h5112_devs[i].t2_mod  = probe2_mod;
+            govee_h5112_devs[i].k       = k0;
+            govee_h5112_devs[i].valid   = 1;
+            probe2_k = k0;
+            probe2_c = probe2_mod + k0 * GOVEE_H5112_PROBE2_WRAP;
+            break;
+        }
+    }
+
+    // Probe 1 humidity: dec[9] * 0.4 = % RH.
+    float humidity = dec[GOVEE_H5112_HUMID_OFFSET] * GOVEE_H5112_HUMID_SCALE;
+
+    // History buffer: 10 × 4-byte records of [d6, d7, d8, d9], oldest first.
+    // Same k correction applied to T2 as the current frame (all records are
+    // from the same 10-minute window so k is stable, except during a wrap
+    // crossing, where the oldest records may be off by one period).
+    double hist_t1[GOVEE_H5112_HISTORY_COUNT];
+    double hist_t2[GOVEE_H5112_HISTORY_COUNT];
+    double hist_hum[GOVEE_H5112_HISTORY_COUNT];
+    int has_history = (msg_class == GOVEE_H5112_MSG_PERIODIC)
+            && (enc_len >= GOVEE_H5112_HISTORY_OFFSET + GOVEE_H5112_HISTORY_COUNT * 4);
+    if (has_history) {
+        for (int i = 0; i < GOVEE_H5112_HISTORY_COUNT; i++) {
+            unsigned base = GOVEE_H5112_HISTORY_OFFSET + (unsigned)i * 4;
+            int ht1_raw = (int)dec[base + 1]
+                    + (int)(dec[base + 2] & 0x3F) * 256
+                    - GOVEE_H5112_PROBE1_BIAS;
+            hist_t1[i]  = ht1_raw / (double)GOVEE_H5112_PROBE1_SCALE;
+            hist_t2[i]  = ((int)dec[base] - GOVEE_H5112_PROBE2_BIAS) / (double)GOVEE_H5112_PROBE2_SCALE
+                    + probe2_k * GOVEE_H5112_PROBE2_WRAP;
+            hist_hum[i] = dec[base + 3] * (double)GOVEE_H5112_HUMID_SCALE;
+        }
+    }
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",            "",             DATA_STRING, "Govee-H5112",
+            "id",               "",             DATA_FORMAT, "%08x", DATA_INT, id,
+            "id_wire",          "",             DATA_FORMAT, "%08x", DATA_INT, id_wire,
+            "battery_ok",       "Battery",      DATA_INT,    battery_pct > 0,
+            "battery_pct",      "Battery",      DATA_INT,    battery_pct,
+            "temperature_C",    "Temperature",  DATA_FORMAT, "%.3f C", DATA_DOUBLE, (double)probe1_c,
+            "temperature_2_C",  "Temperature2", DATA_FORMAT, "%.1f C", DATA_DOUBLE, (double)probe2_c,
+            "temperature_2_raw","Temperature2 raw byte", DATA_STRING, probe2_raw_str,
+            "humidity",         "Humidity",     DATA_FORMAT, "%.1f %%", DATA_DOUBLE, (double)humidity,
+            "mic",              "Integrity",    DATA_STRING, "CRC",
+            NULL);
+    /* clang-format on */
+    if (has_history) {
+        data = data_ary(data, "temperature_C_history",   "Temperature history",  NULL, data_array(GOVEE_H5112_HISTORY_COUNT, DATA_DOUBLE, hist_t1));
+        data = data_ary(data, "temperature_2_C_history", "Temperature2 history", NULL, data_array(GOVEE_H5112_HISTORY_COUNT, DATA_DOUBLE, hist_t2));
+        data = data_ary(data, "humidity_history",        "Humidity history",     NULL, data_array(GOVEE_H5112_HISTORY_COUNT, DATA_DOUBLE, hist_hum));
+    }
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+/* Output fields for -F csv column order and optional field filtering. */
+static char const *const output_fields[] = {
+        "model",
+        "id",
+        "id_wire",
+        "battery_ok",
+        "battery_pct",
+        "temperature_C",
+        "temperature_2_C",
+        "temperature_2_raw",
+        "humidity",
+        "temperature_C_history",
+        "temperature_2_C_history",
+        "humidity_history",
+        "mic",
+        NULL,
+};
+
+/* Device registration and demod timing profile. */
+r_device const govee_h5112 = {
+        .name        = "Govee H5112 Dual-Probe Thermometer",
+        .modulation  = FSK_PULSE_PCM,
+        .short_width = 100,
+        .long_width  = 100,
+        .reset_limit = 2000,
+        .decode_fn   = &govee_h5112_decode,
+        .fields      = output_fields,
+        .priority    = 5, // Between H5310 (priority 0) and H5059 (priority 10).
+                          // Claims msg_class 0x13 frames before H5059 does.
+};

--- a/src/devices/govee_h5310.c
+++ b/src/devices/govee_h5310.c
@@ -1,0 +1,430 @@
+/** @file
+    Govee Pool/Spa Thermometer H5310.
+
+    Copyright (C) 2026 Paul Antaki (\@Pablo1)
+
+    Based on the Govee H5059 decoder by Reece Neff <reeceneff@gmail.com>
+    (rtl_433 PR #3493). That work reverse-engineered the shared Govee FSK
+    protocol used by this device family -- the 2c 4c 4a sync words, the
+    128-byte XOR key, and the CRC-16/AUG-CCITT framing -- from a JTAG
+    firmware dump of an H5059. This H5310 decoder reuses that protocol
+    foundation and adds the LL=0x10 temperature-update, LL=0x3d
+    periodic-update, and LL=0x1c ping/connectivity payload layouts and the
+    temperature conversion.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#include "decoder.h"
+
+#define GOVEE_H5310_SYNC_LEN      3
+#define GOVEE_H5310_MIN_FRAME     7
+#define GOVEE_H5310_MAX_FRAME     128
+#define GOVEE_H5310_KEY_LEN       128
+
+#define GOVEE_H5310_CRC_POLY      0x1021
+#define GOVEE_H5310_CRC_INIT      0x1d0f
+
+#define GOVEE_H5310_MARKER_OFFSET 0
+#define GOVEE_H5310_ID_OFFSET     1
+
+// Temperature-update frame: outer length LL = 0x10, decrypts to a 13-byte payload.
+#define GOVEE_H5310_TEMP_OUTER_LEN      0x10
+#define GOVEE_H5310_TEMP_DECRYPTED_LEN  13
+#define GOVEE_H5310_TEMP_MARKER         0x11
+#define GOVEE_H5310_TEMP_BATTERY_OFFSET 6
+#define GOVEE_H5310_TEMP_LO_OFFSET      7
+#define GOVEE_H5310_TEMP_HI_OFFSET      8
+
+// Periodic-update frame: outer length LL = 0x3d, decrypts to a 58-byte payload.
+// Leading layout mirrors the temperature-update frame shifted left by one byte
+// (no constant 0x04 byte at dec[5]); the remainder is a rolling counter/nonce
+// followed by zero padding.
+#define GOVEE_H5310_PERIODIC_OUTER_LEN      0x3d
+#define GOVEE_H5310_PERIODIC_DECRYPTED_LEN  58
+#define GOVEE_H5310_PERIODIC_MARKER         0x1b
+#define GOVEE_H5310_PERIODIC_BATTERY_OFFSET 5
+#define GOVEE_H5310_PERIODIC_LO_OFFSET      6
+#define GOVEE_H5310_PERIODIC_HI_OFFSET      7
+
+// Status-reply frame: outer length LL = 0x1f, decrypts to a 28-byte payload.
+// Leading layout matches the temperature-update frame (device ID, shared
+// material, battery, temperature), but lacks the constant 0x04 byte at
+// dec[5] and carries additional trailing bytes. Sent in reply to a short
+// LL=0x0c poll frame (not decoded by this driver).
+#define GOVEE_H5310_STATUS_OUTER_LEN      0x1f
+#define GOVEE_H5310_STATUS_DECRYPTED_LEN  28
+#define GOVEE_H5310_STATUS_MARKER         0x71
+#define GOVEE_H5310_STATUS_BATTERY_OFFSET 5
+#define GOVEE_H5310_STATUS_LO_OFFSET      6
+#define GOVEE_H5310_STATUS_HI_OFFSET      7
+
+// Ping/connectivity frame: outer length LL = 0x1c, decrypts to a 25-byte payload.
+// Carries no battery or temperature data; observed as a connectivity check-in
+// (e.g. "Network Test", unit-display change, "long battery life" toggle).
+// Unlike the temperature-bearing frames, the device ID and shared material
+// are swapped: shared material is at dec[1-2], device ID at dec[3-4].
+#define GOVEE_H5310_PING_OUTER_LEN     0x1c
+#define GOVEE_H5310_PING_DECRYPTED_LEN 25
+#define GOVEE_H5310_PING_MARKER        0x70
+#define GOVEE_H5310_PING_ID_OFFSET     3
+
+// Temperature formula: T_C = (raw - OFFSET) / SLOPE, raw = lo_byte | (hi_byte << 8).
+// Slope fit over a 43->27 C sweep (R^2 = 0.986); offset calibrated against live
+// decoded-vs-displayed readings (see file header); not yet confirmed below ~26 C
+// or below 0 C.
+#define GOVEE_H5310_TEMP_SLOPE  10.0
+#define GOVEE_H5310_TEMP_OFFSET 33168
+
+// Plausible range for a pool/spa/ambient thermometer. Other Govee devices in
+// this family share the same outer frame envelope (sync words, XOR key, CRC)
+// and can, with a different payload layout, pass this decoder's length and
+// marker checks yet yield a nonsensical temperature. Rejecting values outside
+// this range discards such frames without needing to identify the foreign
+// device by ID.
+#define GOVEE_H5310_TEMP_MIN_C -20.0f
+#define GOVEE_H5310_TEMP_MAX_C 60.0f
+
+static uint8_t const govee_h5310_sync[]       = {0x2c, 0x4c, 0x4a};
+static uint8_t const govee_h5310_sync_skew1[] = {0x16, 0x26, 0x25};
+static uint8_t const govee_h5310_key[GOVEE_H5310_KEY_LEN + 1] =
+        "s6amyEvO8UslCY0eZjgc2S6APCVLgLxzFvL2Z5GWPW7fKVjy2oAU6uiKU3lZCHm62VYQQuCtgxzPgGd8UDRPVZpDRAsh5EdYq1E4j4morJ3vd6tWx8BiWOLDc2I8wKUK";
+
+/**
+Govee Pool/Spa Thermometer H5310.
+
+Modulation, timing, and transmission:
+
+The device uses FSK pulse PCM encoding, the same sync words, XOR key, and
+CRC-16/AUG-CCITT framing as the Govee H5059 water leak detector. Those
+shared protocol details were reverse-engineered by Reece Neff for the
+H5059 (rtl_433 PR #3493) and are reused here; see the file header.
+- Demod mode in rtl_433 is FSK_PULSE_PCM.
+- short_width = 100 us and long_width = 100 us (PCM symbol timing).
+- reset_limit = 2000 us.
+- The sensor transmits autonomously roughly every 10 minutes, plus on
+  significant temperature change.
+
+Sensor uplink frame format:
+
+    2C 4C 4A LL SS [ciphertext...] CC CC
+
+- 2C 4C 4A: sync word
+- LL: outer frame length in bytes (SS + ciphertext + CRC)
+- SS: XOR stream start offset (seed)
+- ciphertext: encrypted payload bytes
+- CC CC: CRC-16/AUG-CCITT, poly=0x1021, init=0x1d0f
+
+This decoder handles four frame types. Three of them -- temperature-update,
+periodic-update, and status-reply -- share the same leading payload layout
+(device ID, shared ID material, battery, temperature), shifted by one byte
+between temperature-update and the other two; the ping frame shares only the
+device ID / shared material fields:
+
+Temperature-update frame, LL == 0x10 (16), 13-byte decrypted payload. This
+frame appears to be triggered by a unit-change/forced-report action rather
+than sent on the autonomous schedule, and is comparatively rare:
+
+    byte:  0   1  2   3  4   5    6     7      8     9   10  11 12
+    val :  11  <id-2>  9c b2  04   bat  TL     TH    cc  ff  00 00
+
+- dec[0]: frame marker, constant 0x11
+- dec[1-2]: device ID (e.g. 71 b0 = Spa, f8 a7 = Pool)
+- dec[3-4]: constant 9c b2 (shared device-ID material)
+- dec[5]: constant 0x04
+- dec[6]: battery percent (0x64 = 100)
+- dec[7-8]: temperature raw, little-endian u16
+- dec[9-12]: cc ff 00 00 (constants / padding)
+
+Periodic-update frame, LL == 0x3d (61), 58-byte decrypted payload. This is the
+sensor's autonomous broadcast, observed at exactly 10-minute intervals. The
+leading bytes mirror the temperature-update layout shifted left by one byte
+(no constant 0x04 byte), followed by a rolling counter/nonce and zero padding:
+
+    byte:  0   1  2   3  4   5    6     7      8     9   10  11  12..57
+    val :  1b  <id-2>  9c b2  bat  TL    TH    cc  ff  00  00  <rolling/nonce, then zero padding>
+
+- dec[0]: frame marker, constant 0x1b
+- dec[1-2]: device ID (e.g. 71 b0 = Spa, f8 a7 = Pool)
+- dec[3-4]: constant 9c b2 (shared device-ID material)
+- dec[5]: battery percent
+- dec[6-7]: temperature raw, little-endian u16
+- dec[8-11]: cc ff 00 00 (constants / padding)
+- dec[12+]: rolling counter/nonce, then zero padding
+
+Status-reply frame, LL == 0x1f (31), 28-byte decrypted payload. Sent in
+response to a short LL=0x0c poll/status-request frame from the app or
+gateway (that poll frame is not decoded by this driver). The leading bytes
+match the temperature-update layout shifted left by one byte (no constant
+0x04 byte), like the periodic-update frame, followed by a constant and a
+few bytes that vary between replies, then zero padding:
+
+    byte:  0   1  2   3  4   5    6     7      8     9   10  11  12  13..27
+    val :  71  <id-2>  9c b2  bat  TL    TH    cc  ff  <varies, dec[10-12]>  00-padded
+
+- dec[0]: frame marker, constant 0x71
+- dec[1-2]: device ID (e.g. 71 b0 = Spa, f8 a7 = Pool)
+- dec[3-4]: constant 9c b2 (shared device-ID material)
+- dec[5]: battery percent
+- dec[6-7]: temperature raw, little-endian u16 -- matches the concurrent
+  temperature-update/periodic-update value
+- dec[8-9]: cc ff (constants)
+- dec[10-12]: varies between replies -- not yet decoded (counter/nonce
+  candidate)
+- dec[13-27]: zero padding
+
+Before this frame type was added, LL=0x1f frames were decrypted successfully
+by the H5059 decoder (same shared framing/key/CRC) but reported as model
+"Govee-H5059" with event "Unknown" -- claiming them here is both more accurate
+(this frame type has only been observed from H5310-family devices) and
+resolves that cross-model mislabeling.
+
+Ping/connectivity frame, LL == 0x1c (28), 25-byte decrypted payload. Carries
+no battery or temperature data. Observed correlating with app-side actions
+(Network Test, unit-display change, "long battery life" toggle on/off) for
+the Pool sensor, and also sent by the Spa; never observed from the H5059 leak
+detector, which only sends msg_class 0x11 telemetry:
+
+    byte:  0   1  2   3  4   5    6    7   8   9   10  11..24
+    val :  70  9c b2  <id-2>  6a   2e  <varies, counter/nonce + flag>  00-padded
+
+- dec[0]: frame marker, constant 0x70
+- dec[1-2]: constant 9c b2 (shared device-ID material) -- note this is in the
+  opposite order from the temperature-bearing frames, where the shared
+  material follows the device ID
+- dec[3-4]: device ID (e.g. 71 b0 = Spa, f8 a7 = Pool)
+- dec[5]: constant 0x6a
+- dec[6]: constant 0x2e
+- dec[7-10]: varies between frames -- likely a counter/nonce plus a status
+  flag, not yet decoded
+- dec[11-24]: zero padding
+
+Before this frame type was added, LL=0x1c frames were decrypted successfully
+by the H5059 decoder (same shared framing/key/CRC) but reported as model
+"Govee-H5059" with event "Unknown" -- claiming them here is both more accurate
+(this frame type has only been observed from H5310-family devices) and
+resolves that cross-model mislabeling.
+
+Device ID: the emitted `id_wire` is the full 32-bit on-wire ID (e.g.
+f8 a7 9c b2 -> 0xf8a79cb2) and `id` is the same value with its two 16-bit
+words swapped (0x9cb2f8a7), matching the rest of the Govee family
+(govee_h5059). The low 16 bits (9c b2) are shared family material; the
+device-distinguishing half is f8a7 (Pool) / 71b0 (Spa).
+
+Temperature formula (applies to the three temperature-bearing frame types
+above, using each frame's
+own low/high temperature byte offsets):
+
+    raw  = lo_byte + (hi_byte << 8)
+    T_C  = (raw - 33168) / 10.0
+
+The slope (1 raw count = 0.1 C) comes from a 43->27 C sweep (R^2 = 0.986). The
+offset was originally fit as 33178 from that sweep, but live captures on
+2026-06-13 found decoded temperatures consistently read 1.0 C low versus the
+sensor's own display (4 data points, two different temperatures, across both
+frame types above) -- so the offset was corrected to 33168. Sign behavior
+below 0 C is unverified; the formula predicts raw keeps counting down, but no
+cold-point capture has confirmed this yet.
+
+The wire value is always Celsius-based regardless of the sensor's selected
+display unit. Toggling the on-device display between C and F (25.8 C <->
+78.5 F) produced identical decoded values (25.800 C) before and after the
+toggle, in both directions -- the C/F setting only affects the sensor's local
+display, not the transmitted payload, so no unit-aware handling is needed
+here.
+
+`battery_pct` tracks the sensor's bar-graph battery indicator: 100% (0x64) at
+full bars, 65% at 3 bars, 47% at 2 bars, and 20% at 1 bar, all observed live
+by running a set of batteries down. At 0 bars (critical), the sensor stopped
+transmitting RF entirely -- no frame with battery_pct near 0 was ever
+received. So `battery_ok = battery_pct > 0` is effectively always true for
+any frame this decoder actually sees; the real "low battery" signal is the
+sensor going silent, which is a job for rtl_433's downstream
+"not seen recently" handling, not this decoder. The placeholder is left as-is
+since there's no in-band low-battery state to detect.
+
+Other frames in this family (e.g. LL == 0x0c short poll/status, and the H5059
+leak-detector's own msg_class 0x01/0x02/0x11 telemetry) are not recognized by
+this decoder and are ignored; the H5059 decoder may report some of these as
+event "Unknown". The H5310 decoder runs at the default priority (before
+H5059's reduced priority, see govee_h5059.c) so it gets first access to
+frames in this family.
+*/
+static int govee_h5310_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    uint8_t frame[GOVEE_H5310_MAX_FRAME];
+    uint8_t dec[GOVEE_H5310_MAX_FRAME];
+
+    int row           = -1;
+    unsigned sync_pos = 0;
+
+    // Stage 1: find a row that contains either the native sync or the known skewed sync.
+    for (int r = 0; r < bitbuffer->num_rows; ++r) {
+        if (bitbuffer->bits_per_row[r] < 8 * GOVEE_H5310_MIN_FRAME) {
+            continue;
+        }
+
+        unsigned pos = bitbuffer_search(bitbuffer, r, 0, govee_h5310_sync, GOVEE_H5310_SYNC_LEN * 8);
+        if (pos < bitbuffer->bits_per_row[r]) {
+            row      = r;
+            sync_pos = pos;
+            break;
+        }
+
+        // The device preamble is MSB-first; depending on demod lock, bytes can
+        // arrive shifted by one bit, turning 2c 4c 4a into 16 26 25.
+        unsigned skew_pos = bitbuffer_search(bitbuffer, r, 0, govee_h5310_sync_skew1, GOVEE_H5310_SYNC_LEN * 8);
+        if (skew_pos < bitbuffer->bits_per_row[r]) {
+            row      = r;
+            sync_pos = skew_pos + 1;
+            break;
+        }
+    }
+
+    if (row < 0) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    // Stage 2: validate envelope and reject malformed messages before payload parsing.
+    sync_pos += GOVEE_H5310_SYNC_LEN * 8;
+
+    unsigned bits_after_sync = bitbuffer->bits_per_row[row] - sync_pos;
+    if (bits_after_sync < 8 * 4) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    unsigned bytes_after_sync = bits_after_sync / 8;
+    if (bytes_after_sync > GOVEE_H5310_MAX_FRAME) {
+        bytes_after_sync = GOVEE_H5310_MAX_FRAME;
+    }
+
+    bitbuffer_extract_bytes(bitbuffer, row, sync_pos, frame, bytes_after_sync * 8);
+
+    uint8_t outer_len = frame[0];
+
+    int is_temp_frame     = (outer_len == GOVEE_H5310_TEMP_OUTER_LEN);
+    int is_periodic_frame = (outer_len == GOVEE_H5310_PERIODIC_OUTER_LEN);
+    int is_status_frame   = (outer_len == GOVEE_H5310_STATUS_OUTER_LEN);
+    int is_ping_frame     = (outer_len == GOVEE_H5310_PING_OUTER_LEN);
+    // Only the temperature-update, periodic-update, status-reply, and ping
+    // frames have a fixed outer length we recognize; ignore all other frame
+    // types in the family (short poll, leak telemetry) without erroring.
+    if (!is_temp_frame && !is_periodic_frame && !is_status_frame && !is_ping_frame) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    if (bytes_after_sync < (unsigned)(1 + outer_len)) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    uint8_t seed      = frame[1];
+    unsigned enc_len  = outer_len - 3;
+    unsigned crc_offs = 2 + enc_len;
+
+    uint16_t crc_calc = crc16(&frame[2], enc_len, GOVEE_H5310_CRC_POLY, GOVEE_H5310_CRC_INIT);
+    uint16_t crc_recv = ((uint16_t)frame[crc_offs] << 8) | frame[crc_offs + 1];
+    if (crc_calc != crc_recv) {
+        return DECODE_FAIL_MIC;
+    }
+
+    for (unsigned i = 0; i < enc_len; ++i) {
+        dec[i] = frame[2 + i] ^ govee_h5310_key[(i + seed) % GOVEE_H5310_KEY_LEN];
+    }
+
+    // A CRC-valid frame should carry the marker matching its outer length;
+    // guard against any other message subtype that happens to share this length.
+    uint8_t expected_marker = is_temp_frame       ? GOVEE_H5310_TEMP_MARKER
+                              : is_periodic_frame ? GOVEE_H5310_PERIODIC_MARKER
+                              : is_status_frame   ? GOVEE_H5310_STATUS_MARKER
+                                                  : GOVEE_H5310_PING_MARKER;
+    if (dec[GOVEE_H5310_MARKER_OFFSET] != expected_marker) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    // Assemble the full 32-bit device ID to match the rest of the Govee family
+    // (govee_h5059): id_wire is the on-wire byte order, id is the same value
+    // with its two 16-bit words swapped (the app-facing form). The low 16 bits
+    // (9c b2) are shared family material; the device-distinguishing half is
+    // f8a7 (Pool) / 71b0 (Spa). The temperature-bearing frames carry the device
+    // ID at dec[1-2] and the shared material at dec[3-4]; the ping frame carries
+    // them in the opposite order, so reassemble it to the same id_wire.
+    uint32_t id_wire;
+    if (is_ping_frame) {
+        id_wire = ((uint32_t)dec[GOVEE_H5310_PING_ID_OFFSET] << 24) | ((uint32_t)dec[GOVEE_H5310_PING_ID_OFFSET + 1] << 16) | ((uint32_t)dec[GOVEE_H5310_ID_OFFSET] << 8) | dec[GOVEE_H5310_ID_OFFSET + 1];
+    }
+    else {
+        id_wire = ((uint32_t)dec[GOVEE_H5310_ID_OFFSET] << 24) | ((uint32_t)dec[GOVEE_H5310_ID_OFFSET + 1] << 16) | ((uint32_t)dec[GOVEE_H5310_ID_OFFSET + 2] << 8) | dec[GOVEE_H5310_ID_OFFSET + 3];
+    }
+    uint32_t id = ((id_wire & 0xffff) << 16) | ((id_wire >> 16) & 0xffff);
+
+    int battery_pct = 0;
+    uint16_t raw    = 0;
+    char const *event;
+    if (is_temp_frame) {
+        battery_pct = dec[GOVEE_H5310_TEMP_BATTERY_OFFSET];
+        raw         = dec[GOVEE_H5310_TEMP_LO_OFFSET] | ((uint16_t)dec[GOVEE_H5310_TEMP_HI_OFFSET] << 8);
+        event       = "Temperature Update";
+    }
+    else if (is_periodic_frame) {
+        battery_pct = dec[GOVEE_H5310_PERIODIC_BATTERY_OFFSET];
+        raw         = dec[GOVEE_H5310_PERIODIC_LO_OFFSET] | ((uint16_t)dec[GOVEE_H5310_PERIODIC_HI_OFFSET] << 8);
+        event       = "Periodic Update";
+    }
+    else if (is_status_frame) {
+        battery_pct = dec[GOVEE_H5310_STATUS_BATTERY_OFFSET];
+        raw         = dec[GOVEE_H5310_STATUS_LO_OFFSET] | ((uint16_t)dec[GOVEE_H5310_STATUS_HI_OFFSET] << 8);
+        event       = "Status";
+    }
+    else {
+        event = "Ping";
+    }
+
+    float temperature_c = ((float)raw - GOVEE_H5310_TEMP_OFFSET) / GOVEE_H5310_TEMP_SLOPE;
+
+    if (!is_ping_frame && (temperature_c < GOVEE_H5310_TEMP_MIN_C || temperature_c > GOVEE_H5310_TEMP_MAX_C)) {
+        return DECODE_FAIL_SANITY;
+    }
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",            "",             DATA_STRING, "Govee-H5310",
+            "id",               "",             DATA_FORMAT, "%08x", DATA_INT, id,
+            "id_wire",          "",             DATA_FORMAT, "%08x", DATA_INT, id_wire,
+            "event",            "",             DATA_STRING, event,
+            "battery_ok",       "Battery",      DATA_COND, !is_ping_frame, DATA_INT,    battery_pct > 0,
+            "battery_pct",      "Battery",      DATA_COND, !is_ping_frame, DATA_INT,    battery_pct,
+            "temperature_C",    "Temperature",  DATA_COND, !is_ping_frame, DATA_FORMAT, "%.1f C", DATA_DOUBLE, (double)temperature_c,
+            "mic",              "Integrity",    DATA_STRING, "CRC",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+/* Output fields for -F csv column order and optional field filtering. */
+static char const *const output_fields[] = {
+        "model",
+        "id",
+        "id_wire",
+        "event",
+        "battery_ok",
+        "battery_pct",
+        "temperature_C",
+        "mic",
+        NULL,
+};
+
+/* Device registration and demod timing profile. */
+r_device const govee_h5310 = {
+        .name        = "Govee Pool/Spa Thermometer H5310",
+        .modulation  = FSK_PULSE_PCM,
+        .short_width = 100,
+        .long_width  = 100,
+        .reset_limit = 2000,
+        .decode_fn   = &govee_h5310_decode,
+        .fields      = output_fields,
+};

--- a/src/devices/govee_h5310.c
+++ b/src/devices/govee_h5310.c
@@ -9,7 +9,7 @@
     128-byte XOR key, and the CRC-16/AUG-CCITT framing -- from a JTAG
     firmware dump of an H5059. This H5310 decoder reuses that protocol
     foundation and adds the LL=0x10 temperature-update, LL=0x3d
-    periodic-update, and LL=0x1c ping/connectivity payload layouts and the
+    periodic-update, and LL=0x1f status-reply payload layouts and the
     temperature conversion.
 
     This program is free software; you can redistribute it and/or modify
@@ -62,20 +62,8 @@
 #define GOVEE_H5310_STATUS_LO_OFFSET      6
 #define GOVEE_H5310_STATUS_HI_OFFSET      7
 
-// Ping/connectivity frame: outer length LL = 0x1c, decrypts to a 25-byte payload.
-// Carries no battery or temperature data; observed as a connectivity check-in
-// (e.g. "Network Test", unit-display change, "long battery life" toggle).
-// Unlike the temperature-bearing frames, the device ID and shared material
-// are swapped: shared material is at dec[1-2], device ID at dec[3-4].
-#define GOVEE_H5310_PING_OUTER_LEN     0x1c
-#define GOVEE_H5310_PING_DECRYPTED_LEN 25
-#define GOVEE_H5310_PING_MARKER        0x70
-#define GOVEE_H5310_PING_ID_OFFSET     3
 
-// Temperature formula: T_C = (raw - OFFSET) / SLOPE, raw = lo_byte | (hi_byte << 8).
-// Slope fit over a 43->27 C sweep (R^2 = 0.986); offset calibrated against live
-// decoded-vs-displayed readings (see file header); not yet confirmed below ~26 C
-// or below 0 C.
+// T_C = (raw - OFFSET) / SLOPE; raw is little-endian u16. Sign below 0 C unverified.
 #define GOVEE_H5310_TEMP_SLOPE  10.0
 #define GOVEE_H5310_TEMP_OFFSET 33168
 
@@ -118,11 +106,9 @@ Sensor uplink frame format:
 - ciphertext: encrypted payload bytes
 - CC CC: CRC-16/AUG-CCITT, poly=0x1021, init=0x1d0f
 
-This decoder handles four frame types. Three of them -- temperature-update,
-periodic-update, and status-reply -- share the same leading payload layout
-(device ID, shared ID material, battery, temperature), shifted by one byte
-between temperature-update and the other two; the ping frame shares only the
-device ID / shared material fields:
+This decoder handles three frame types, all sharing the same leading payload
+layout (device ID, shared ID material, battery, temperature), shifted by one
+byte between temperature-update and the other two:
 
 Temperature-update frame, LL == 0x10 (16), 13-byte decrypted payload. This
 frame appears to be triggered by a unit-change/forced-report action rather
@@ -182,31 +168,22 @@ by the H5059 decoder (same shared framing/key/CRC) but reported as model
 (this frame type has only been observed from H5310-family devices) and
 resolves that cross-model mislabeling.
 
-Ping/connectivity frame, LL == 0x1c (28), 25-byte decrypted payload. Carries
-no battery or temperature data. Observed correlating with app-side actions
-(Network Test, unit-display change, "long battery life" toggle on/off) for
-the Pool sensor, and also sent by the Spa; never observed from the H5059 leak
-detector, which only sends msg_class 0x11 telemetry:
+Ping/connectivity frame, LL == 0x1c (28), 25-byte decrypted payload. Observed
+correlating with app-side actions (Network Test, unit-display change, "long
+battery life" toggle). Not decoded: ping frames carry no battery or temperature
+data, and the 0x70 marker / LL=0x1c combination is shared with other Govee
+gateway devices (confirmed on H5112), making device attribution by frame
+structure alone impossible. These frames are silently ignored.
 
     byte:  0   1  2   3  4   5    6    7   8   9   10  11..24
     val :  70  9c b2  <id-2>  6a   2e  <varies, counter/nonce + flag>  00-padded
 
 - dec[0]: frame marker, constant 0x70
-- dec[1-2]: constant 9c b2 (shared device-ID material) -- note this is in the
-  opposite order from the temperature-bearing frames, where the shared
-  material follows the device ID
+- dec[1-2]: shared gateway material (reversed vs. temperature-bearing frames)
 - dec[3-4]: device ID (e.g. 71 b0 = Spa, f8 a7 = Pool)
-- dec[5]: constant 0x6a
-- dec[6]: constant 0x2e
-- dec[7-10]: varies between frames -- likely a counter/nonce plus a status
-  flag, not yet decoded
+- dec[5-6]: constants 0x6a 0x2e
+- dec[7-10]: counter/nonce + status flag, not decoded
 - dec[11-24]: zero padding
-
-Before this frame type was added, LL=0x1c frames were decrypted successfully
-by the H5059 decoder (same shared framing/key/CRC) but reported as model
-"Govee-H5059" with event "Unknown" -- claiming them here is both more accurate
-(this frame type has only been observed from H5310-family devices) and
-resolves that cross-model mislabeling.
 
 Device ID: the emitted `id_wire` is the full 32-bit on-wire ID (e.g.
 f8 a7 9c b2 -> 0xf8a79cb2) and `id` is the same value with its two 16-bit
@@ -308,11 +285,10 @@ static int govee_h5310_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int is_temp_frame     = (outer_len == GOVEE_H5310_TEMP_OUTER_LEN);
     int is_periodic_frame = (outer_len == GOVEE_H5310_PERIODIC_OUTER_LEN);
     int is_status_frame   = (outer_len == GOVEE_H5310_STATUS_OUTER_LEN);
-    int is_ping_frame     = (outer_len == GOVEE_H5310_PING_OUTER_LEN);
-    // Only the temperature-update, periodic-update, status-reply, and ping
-    // frames have a fixed outer length we recognize; ignore all other frame
-    // types in the family (short poll, leak telemetry) without erroring.
-    if (!is_temp_frame && !is_periodic_frame && !is_status_frame && !is_ping_frame) {
+    // Only the temperature-update, periodic-update, and status-reply frames
+    // have a fixed outer length we recognize; ignore all other frame types
+    // in the family (short poll, ping, leak telemetry) without erroring.
+    if (!is_temp_frame && !is_periodic_frame && !is_status_frame) {
         return DECODE_ABORT_EARLY;
     }
 
@@ -338,26 +314,12 @@ static int govee_h5310_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     // guard against any other message subtype that happens to share this length.
     uint8_t expected_marker = is_temp_frame       ? GOVEE_H5310_TEMP_MARKER
                               : is_periodic_frame ? GOVEE_H5310_PERIODIC_MARKER
-                              : is_status_frame   ? GOVEE_H5310_STATUS_MARKER
-                                                  : GOVEE_H5310_PING_MARKER;
+                                                  : GOVEE_H5310_STATUS_MARKER;
     if (dec[GOVEE_H5310_MARKER_OFFSET] != expected_marker) {
         return DECODE_ABORT_EARLY;
     }
 
-    // Assemble the full 32-bit device ID to match the rest of the Govee family
-    // (govee_h5059): id_wire is the on-wire byte order, id is the same value
-    // with its two 16-bit words swapped (the app-facing form). The low 16 bits
-    // (9c b2) are shared family material; the device-distinguishing half is
-    // f8a7 (Pool) / 71b0 (Spa). The temperature-bearing frames carry the device
-    // ID at dec[1-2] and the shared material at dec[3-4]; the ping frame carries
-    // them in the opposite order, so reassemble it to the same id_wire.
-    uint32_t id_wire;
-    if (is_ping_frame) {
-        id_wire = ((uint32_t)dec[GOVEE_H5310_PING_ID_OFFSET] << 24) | ((uint32_t)dec[GOVEE_H5310_PING_ID_OFFSET + 1] << 16) | ((uint32_t)dec[GOVEE_H5310_ID_OFFSET] << 8) | dec[GOVEE_H5310_ID_OFFSET + 1];
-    }
-    else {
-        id_wire = ((uint32_t)dec[GOVEE_H5310_ID_OFFSET] << 24) | ((uint32_t)dec[GOVEE_H5310_ID_OFFSET + 1] << 16) | ((uint32_t)dec[GOVEE_H5310_ID_OFFSET + 2] << 8) | dec[GOVEE_H5310_ID_OFFSET + 3];
-    }
+    uint32_t id_wire = ((uint32_t)dec[GOVEE_H5310_ID_OFFSET] << 24) | ((uint32_t)dec[GOVEE_H5310_ID_OFFSET + 1] << 16) | ((uint32_t)dec[GOVEE_H5310_ID_OFFSET + 2] << 8) | dec[GOVEE_H5310_ID_OFFSET + 3];
     uint32_t id = ((id_wire & 0xffff) << 16) | ((id_wire >> 16) & 0xffff);
 
     int battery_pct = 0;
@@ -373,18 +335,21 @@ static int govee_h5310_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         raw         = dec[GOVEE_H5310_PERIODIC_LO_OFFSET] | ((uint16_t)dec[GOVEE_H5310_PERIODIC_HI_OFFSET] << 8);
         event       = "Periodic Update";
     }
-    else if (is_status_frame) {
+    else {
+        // dec[9] is 0xFF in H5310 status frames (no humidity sensor); H5112
+        // status responses (msg_class 0x71, same outer_len) carry humidity at
+        // dec[9] with a maximum physical value of 0xFA (100% RH at 0.4/count).
+        if (dec[9] != 0xff) {
+            return DECODE_ABORT_EARLY;
+        }
         battery_pct = dec[GOVEE_H5310_STATUS_BATTERY_OFFSET];
         raw         = dec[GOVEE_H5310_STATUS_LO_OFFSET] | ((uint16_t)dec[GOVEE_H5310_STATUS_HI_OFFSET] << 8);
         event       = "Status";
     }
-    else {
-        event = "Ping";
-    }
 
     float temperature_c = ((float)raw - GOVEE_H5310_TEMP_OFFSET) / GOVEE_H5310_TEMP_SLOPE;
 
-    if (!is_ping_frame && (temperature_c < GOVEE_H5310_TEMP_MIN_C || temperature_c > GOVEE_H5310_TEMP_MAX_C)) {
+    if (temperature_c < GOVEE_H5310_TEMP_MIN_C || temperature_c > GOVEE_H5310_TEMP_MAX_C) {
         return DECODE_FAIL_SANITY;
     }
 
@@ -394,9 +359,9 @@ static int govee_h5310_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "id",               "",             DATA_FORMAT, "%08x", DATA_INT, id,
             "id_wire",          "",             DATA_FORMAT, "%08x", DATA_INT, id_wire,
             "event",            "",             DATA_STRING, event,
-            "battery_ok",       "Battery",      DATA_COND, !is_ping_frame, DATA_INT,    battery_pct > 0,
-            "battery_pct",      "Battery",      DATA_COND, !is_ping_frame, DATA_INT,    battery_pct,
-            "temperature_C",    "Temperature",  DATA_COND, !is_ping_frame, DATA_FORMAT, "%.1f C", DATA_DOUBLE, (double)temperature_c,
+            "battery_ok",       "Battery",      DATA_INT,    battery_pct > 0,
+            "battery_pct",      "Battery",      DATA_INT,    battery_pct,
+            "temperature_C",    "Temperature",  DATA_FORMAT, "%.1f C", DATA_DOUBLE, (double)temperature_c,
             "mic",              "Integrity",    DATA_STRING, "CRC",
             NULL);
     /* clang-format on */


### PR DESCRIPTION
## Summary

Adds a decoder for the Govee H5112 dual-probe thermometer, which transmits over the shared Govee FSK envelope (sync `2c4c4a`, XOR key, CRC-16/AUG-CCITT).

**Sensor encoding**: Both probe temperatures and humidity are packed into one 32-bit little-endian word (`dec[6..9]`) by the device's own firmware. Confirmed by dumping and disassembling the H5112's FR8016HA firmware: it contains a sensor-packing function with this exact symmetric layout — 11 bits each for probe1/probe2 (0.1°C/count, zero-anchored at -40°C) and 10 bits for humidity (0.1%/count). Probe2 is read directly as an absolute value, like probe1 — no per-device state, no wrap-count tracking, no cold-start dependency.

Validated two independent ways: (1) forward-encoding real app-displayed readings reproduces the actual RF bytes exactly across multiple frames/devices/temperature ranges; (2) decoding the in-frame history buffer (no app data involved) traces a smooth, physically continuous temperature curve through real 25.6°C band crossings.

**Frame types decoded:**
- `0x13` periodic sensor report (~10 min interval): full sensor data + 10-entry history buffer at ~1-minute intervals
- `0x71` triggered status response (reply to gateway poll): same sensor fields, no history

Also fixes a latent frame collision between the H5310 and H5112 decoders: H5310 status frames (dec[0]=0x71, dec[9]=0xFF) were being stolen from H5112 0x71 frames at certain probe temperatures. Fixed by adding a `dec[9] != 0xFF` guard in the H5310 status-frame path. Tightens H5059 decoder boundary (DECODE_ABORT_EARLY for unrecognised msg_class) and clarifies POST_ALARM (0x07) semantics.

## Test plan
- [x] Build passes (`make -j4`)
- [x] `ctest` passes (11/11 including style-check)
- [x] Three test captures in companion rtl_433_tests PR: two room-temp devices, one fridge/freezer device with history buffer
- [x] Verified against physical H5112 hardware at room temp, fridge (~2°C), and freezer (~-23°C)