### PR TITLE
Fix flex decoder getter bugs introduced by commit dd28f8a for #3351

### DIFF
--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -142,7 +142,8 @@ static void render_getters(data_t *data, uint8_t *bits, struct flex_params *para
             }
         }
         if (!getter->map[m].val[0]) {
-            data_int(data, getter->name, "", getter->format, val);
+            char const *format = getter->format[0] ? getter->format : NULL;
+            data_int(data, getter->name, "", format, val);
         }
     }
 }
@@ -590,11 +591,13 @@ static const char *parse_map(const char *arg, struct flex_get *getter)
         // then parse a string
         const char *e = c;
         while (*e && *e != ' ' && *e != ']') e++;
-        size_t map_len = (size_t)(e - c);
-        strncpy(getter->map[i].val, c, FLEX_GET_STR_LEN - 1);
-        getter->map[i].val[FLEX_GET_STR_LEN - 1] = '\0';
-        if (map_len >= FLEX_GET_STR_LEN)
-            fprintf(stderr, "Warning: flex map value truncated at %d chars.\n", FLEX_GET_STR_LEN - 1);
+        size_t map_val_buffer_len = (size_t)(e - c + 1);
+        if (map_val_buffer_len > FLEX_GET_STR_LEN) {
+            fprintf(stderr, "Warning: flex map value (%s) truncated at %d chars.\n", c, FLEX_GET_STR_LEN - 1);
+            map_val_buffer_len = FLEX_GET_STR_LEN;
+        }
+        strncpy(getter->map[i].val, c, map_val_buffer_len - 1);
+        getter->map[i].val[map_val_buffer_len - 1] = '\0';
         c = e;
 
         // store result


### PR DESCRIPTION
Fix flex decoder getter bugs introduced by commit dd28f8a for #3351

**Problem:** On commit dd28f8a, when you run:
```
build/src/rtl_433 -r rtl_433_tests/tests/dsc/01/gfile001.cu8 -R 23 -X 'n=DSC,m=OOK_RZ,s=250,l=500,r=5000,get=@4:{8}:status:%d,get=@10:{1}:closed,get=@8:{1}:Battery:[0:1 1:0]'
```

you get the following (noting that DSC flex parser is missing data for `closed` and has erroneous output for `Battery`):
```
rtl_433 version 25.12-112-gdd28f8ac branch testing at 202607022243 inputs file rtl_tcp RTL-SDR SoapySDR with TLS
[Input] Test mode active. Reading samples from file: rtl_433_tests/tests/dsc/01/gfile001.cu8
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
time      : @0.196524s
model     : DSC-Security id        : 2407880
closed    : 0            event     : 1             tamper    : 0             Battery   : 1             xactivity : 0             xtamper1  : 0             xtamper2  : 0             exception : 0
esn       : 24bdc8       status    : 129           status_hex: 81            Integrity : CRC
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
time      : @0.196524s
model     : DSC          count     : 1             num_rows  : 1             rows      : 
len       : 56           data      : f81926f7915c00 status    : 129          closed    :               Battery   : 1 1:0]
codes     : {56}f81926f7915c00
```

**Solution:** The commit contained herein has two discrete bug fixes in `flex.c` to address above.

**Testing:** Reran the same command  and got expected output for `closed` and `Battery`:
```
build/src/rtl_433 -r rtl_433_tests/tests/dsc/01/gfile001.cu8 -R 23 -X 'n=DSC,m=OOK_RZ,s=250,l=500,r=5000,get=@4:{8}:status:%d,get=@10:{1}:closed,get=@8:{1}:Battery:[0:1 1:0]'
rtl_433 version 25.12-113-gef1c3575 branch pr_3351_bugfix at 202607022059 inputs file rtl_tcp RTL-SDR SoapySDR with TLS
[Input] Test mode active. Reading samples from file: rtl_433_tests/tests/dsc/01/gfile001.cu8
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
time      : @0.196524s
model     : DSC-Security id        : 2407880
closed    : 0            event     : 1             tamper    : 0             Battery   : 1             xactivity : 0             xtamper1  : 0             xtamper2  : 0             exception : 0
esn       : 24bdc8       status    : 129           status_hex: 81            Integrity : CRC
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
time      : @0.196524s
model     : DSC          count     : 1             num_rows  : 1             rows      : 
len       : 56           data      : f81926f7915c00 status    : 129          closed    : 0             Battery   : 1
```