### PR TITLE
Fix pulse_slicer_dmc missing bitbuffer_clear (closes #3492)

### DIFF
--- a/src/pulse_slicer.c
+++ b/src/pulse_slicer.c
@@ -589,6 +589,7 @@ int pulse_slicer_dmc(pulse_data_t const *pulses, r_device *device)
                 && bits.num_rows > 0) { // Only if data has been accumulated
             //END message ?
             events += account_event(device, &bits, __func__);
+            bitbuffer_clear(&bits);
         }
     }
 

--- a/src/pulse_slicer.c
+++ b/src/pulse_slicer.c
@@ -59,6 +59,9 @@ static int account_event(r_device *device, bitbuffer_t *bits, char const *demod_
         decoder_log_bitbuffer(device, ret > 0 ? 1 : 2, demod_name, bits, device->name);
     }
 
+    // always reset the bitbuffer after accounting, so every slicer starts the next message clean
+    bitbuffer_clear(bits);
+
     return ret;
 }
 
@@ -250,7 +253,6 @@ int pulse_slicer_pcm(pulse_data_t const *pulses, r_device *device)
                 && (bits.bits_per_row[0] > 0 || bits.num_rows > 1)) { // Only if data has been accumulated
 
             events += account_event(device, &bits, __func__);
-            bitbuffer_clear(&bits);
         }
     } // for
     return events;
@@ -329,7 +331,6 @@ int pulse_slicer_ppm(pulse_data_t const *pulses, r_device *device)
                 && (bits.bits_per_row[0] > 0 || bits.num_rows > 1)) { // Only if data has been accumulated
 
             events += account_event(device, &bits, __func__);
-            bitbuffer_clear(&bits);
         }
     } // for pulses
     return events;
@@ -437,7 +438,6 @@ int pulse_slicer_pwm(pulse_data_t const *pulses, r_device *device)
                     || (pulses->gap[n] > s_reset)) // Long silence (OOK)
                 && (bits.num_rows > 0)) {                        // Only if data has been accumulated
             events += account_event(device, &bits, __func__);
-            bitbuffer_clear(&bits);
         }
         else if (s_gap > 0 && pulses->gap[n] > s_gap
                 && bits.num_rows > 0 && bits.bits_per_row[bits.num_rows - 1] > 0) {
@@ -509,7 +509,6 @@ int pulse_slicer_manchester_zerobit(pulse_data_t const *pulses, r_device *device
                     || (pulses->gap[n] > s_reset)) // Long silence (OOK)
                 && (bits.num_rows > 0)) {                        // Only if data has been accumulated
             events += account_event(device, &bits, __func__);
-            bitbuffer_clear(&bits);
             bitbuffer_add_bit(&bits, 0); // Prepare for new message with hardcoded 0
             time_since_last = 0;
         }
@@ -589,7 +588,6 @@ int pulse_slicer_dmc(pulse_data_t const *pulses, r_device *device)
                 && bits.num_rows > 0) { // Only if data has been accumulated
             //END message ?
             events += account_event(device, &bits, __func__);
-            bitbuffer_clear(&bits);
         }
     }
 


### PR DESCRIPTION
Closes #3492.

`pulse_slicer_dmc()` calls `account_event()` when it hits a reset gap, but unlike every other slicer in this file it never clears the bitbuffer afterward. PCM, PPM, PWM, and manchester_zerobit all do `account_event()` then `bitbuffer_clear(&bits)` right after. DMC just keeps going, so the next message's bits get appended onto the row(s) from the message that was already reported. That matches what the issue reporter saw: the flex decoder output growing longer and repeating itself on every subsequent message instead of resetting.

The fix is one line, added right after the existing `account_event()` call, mirroring the other slicers exactly.

On the maintainer's comment about whether this could be intentional, to avoid splitting DMC into multiple rows on error: that row-splitting (the `bitbuffer_add_row` a few lines up, on a mid-message symbol error) happens before `account_event` is reached. It's unaffected by this change, the two are separate concerns. This clear only fires after a message has already been accounted for, so it just resets state for the next one, same as the sibling slicers.

I went through all the DMC-based device decoders (fordremote, funkbus, hideki, norgo, vaillant_vrt340f, wt450, plus flex.c for generic OOK_DMC use) to check none of them rely on bits persisting across separate messages. None do. They either index row 0 directly expecting one message per call, or iterate rows expecting the fixed repeat structure from a single capture. flex.c just reflects whatever's in the buffer, which is exactly why the growing output was so visible there.

One honest caveat: I don't have an OOK_DMC device on hand, so this is verified by reading the slicer code and the callers, not a live before/after capture. Running the sample .cu8 from the issue through this before merging would confirm it end to end. I'm confident in the read given how consistent the pattern is across the rest of the file, but that capture is the one thing I couldn't do myself.

Also worth flagging since it's visible in the issue thread already: piwm_raw, piwm_dc, and nrzs have the same missing clear. I kept this scoped to DMC since that's what's tracked here, but the same fix would apply to those.
