### PR TITLE
Fix [secplus_v2] doc comment had order/inversion nibbles swapped

### DIFF
--- a/src/devices/secplus_v2.c
+++ b/src/devices/secplus_v2.c
@@ -28,12 +28,12 @@ Data comes in two bursts/packets.
 
 Layout:
 
-    bits = `AA BB IIII OOOO X*30`
+    bits = `AA BB OOOO IIII X*30`
 
 - AA = payload type  (2 bits 00 or 01)
 - BB = FrameID (2 bits always 00)
-- IIII = inversion indicator (4 bits)
-- OOOO = Order indicator (4 bits).
+- OOOO = Order indicator (4 bits)
+- IIII = inversion indicator (4 bits).
 - XXXX....  = data (30 bits)
 
 ---


### PR DESCRIPTION
Closes #3557.

The header comment for the Security+ 2.0 decoder lists the two 4-bit
indicator fields in the wrong order. It currently reads:

    bits = `AA BB IIII OOOO X*30`
    - IIII = inversion indicator (4 bits)
    - OOOO = Order indicator (4 bits).

but the decode function pulls order from the high nibble and inversion
from the low nibble of that byte:

    order = buffy[0] >> 4;
    invert = buffy[0] & 0x0f;

so in actual transmission order it's order first, then inversion. I
checked this against argilo/secplus (the reference implementation this
decoder is based on, linked at the top of the file) and it extracts the
indicator byte the same way: high nibble picks the reorder permutation,
low nibble picks the inversion pattern. So the code's right, the comment
has the two fields backwards.

Swapped the layout string and field descriptions to match what the code
actually does. No functional change, comment only.
