### PR TITLE
Fix warnings about size_t being cast to a narrower type

### DIFF
--- a/include/bitbuffer.h
+++ b/include/bitbuffer.h
@@ -13,6 +13,7 @@
 #define INCLUDE_BITBUFFER_H_
 
 #include <stdint.h>
+#include <stddef.h>
 
 // NOTE: Wireless mbus protocol needs at least ((256+16*2+3)*12)/8 => 437 bytes
 //       which fits even if RTL_433_REDUCE_STACK_USE is defined because of row spilling
@@ -92,7 +93,7 @@ void bitrow_debug(uint8_t const *bitrow, unsigned bit_len);
 /// @param size the size of @p str
 ///
 /// @return the number of characters printed (not including the trailing `\0`).
-int bitrow_snprint(uint8_t const *bitrow, unsigned bit_len, char *str, unsigned size);
+int bitrow_snprint(uint8_t const *bitrow, unsigned bit_len, char *str, size_t size);
 
 /// Parse a string into a bitbuffer.
 ///

--- a/src/bitbuffer.c
+++ b/src/bitbuffer.c
@@ -401,7 +401,7 @@ void bitrow_debug(uint8_t const *bitrow, unsigned bit_len)
     print_bitrow(bitrow, bit_len, 0, 1);
 }
 
-int bitrow_snprint(uint8_t const *bitrow, unsigned bit_len, char *str, unsigned size)
+int bitrow_snprint(uint8_t const *bitrow, unsigned bit_len, char *str, size_t size)
 {
     if (bit_len == 0 && size > 0) {
         str[0] = '\0';

--- a/src/confparse.c
+++ b/src/confparse.c
@@ -74,9 +74,9 @@ char *readconf(char const *path)
         return NULL;
     }
 
-    off_t n_read = fread(conf, sizeof(char), file_size, fp);
+    size_t n_read = fread(conf, sizeof(char), file_size, fp);
     fclose(fp);
-    if (n_read != file_size) {
+    if (n_read != (size_t)file_size) {
         fprintf(stderr, "Failed to read \"%s\"\n", path);
         free(conf);
         return NULL;

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -327,7 +327,7 @@ static data_t *protocols_data(r_cfg_t *cfg)
     }
 
     data_t *data = data_make(
-            "protocols", "", DATA_ARRAY, data_array(devs.len, DATA_DATA, devs.elems),
+            "protocols", "", DATA_ARRAY, data_array((int)devs.len, DATA_DATA, devs.elems),
             NULL);
     list_free_elems(&devs, NULL);
     return data;

--- a/src/output_mqtt.c
+++ b/src/output_mqtt.c
@@ -759,9 +759,9 @@ struct data_output *data_output_mqtt_create(struct mg_mgr *mgr, char *param, cha
     //fprintf(stderr, "Hostname: %s\n", hostname);
 
     // generate a short deterministic client_id to identify this input device on restart
-    uint16_t host_crc = crc16((uint8_t *)mqtt->hostname, strlen(mqtt->hostname), 0x1021, 0xffff);
-    uint16_t devq_crc = crc16((uint8_t *)dev_hint, dev_hint ? strlen(dev_hint) : 0, 0x1021, 0xffff);
-    uint16_t parm_crc = crc16((uint8_t *)param, param ? strlen(param) : 0, 0x1021, 0xffff);
+    uint16_t host_crc = crc16((uint8_t *)mqtt->hostname, (unsigned int)strlen(mqtt->hostname), 0x1021, 0xffff);
+    uint16_t devq_crc = crc16((uint8_t *)dev_hint, dev_hint ? (unsigned int)strlen(dev_hint) : 0, 0x1021, 0xffff);
+    uint16_t parm_crc = crc16((uint8_t *)param, param ? (unsigned int)strlen(param) : 0, 0x1021, 0xffff);
     char client_id[21];
     /// MQTT 3.1.1 specifies that the broker MUST accept clients id's between 1 and 23 characters
     snprintf(client_id, sizeof(client_id), "rtl_433-%04x%04x%04x", host_crc, devq_crc, parm_crc);

--- a/src/output_rtltcp.c
+++ b/src/output_rtltcp.c
@@ -405,7 +405,7 @@ static int rtltcp_server_start(rtltcp_server_t *srv, char const *host, char cons
         if (sock >= 0) {
             memset(&srv->addr, 0, sizeof(srv->addr));
             memcpy(&srv->addr, res->ai_addr, res->ai_addrlen);
-            srv->addr_len = res->ai_addrlen;
+            srv->addr_len = (socklen_t)res->ai_addrlen;
             break; // success
         }
     }

--- a/src/output_udp.c
+++ b/src/output_udp.c
@@ -109,7 +109,7 @@ static int datagram_client_open(datagram_client_t *client, const char *host, con
             client->sock = sock;
             memset(&client->addr, 0, sizeof(client->addr));
             memcpy(&client->addr, res->ai_addr, res->ai_addrlen);
-            client->addr_len = res->ai_addrlen;
+            client->addr_len = (socklen_t)res->ai_addrlen;
             break; // success
         }
     }

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -429,7 +429,7 @@ char const **determine_csv_fields(r_cfg_t *cfg, char const *const *well_known, i
     convert_csv_fields(cfg, (char const **)field_list.elems);
 
     if (num_fields)
-        *num_fields = field_list.len;
+        *num_fields = (int)field_list.len;
     return (char const **)field_list.elems;
 }
 
@@ -875,7 +875,7 @@ data_t *create_report_data(r_cfg_t *cfg, int level)
             "enabled",          "", DATA_INT, r_devs->len,
             "since",            "", DATA_STRING, since_str,
             "frames",           "", DATA_DATA, data,
-            "stats",            "", DATA_ARRAY, data_array(dev_data_list.len, DATA_DATA, dev_data_list.elems),
+            "stats",            "", DATA_ARRAY, data_array((int)dev_data_list.len, DATA_DATA, dev_data_list.elems),
             NULL);
 
     list_free_elems(&dev_data_list, NULL);

--- a/src/r_util.c
+++ b/src/r_util.c
@@ -220,8 +220,8 @@ bool str_endswith(char const *restrict str, char const *restrict suffix)
     if (!str) {
         return false;
     }
-    int str_len = strlen(str);
-    int suffix_len = strlen(suffix);
+    size_t str_len = strlen(str);
+    size_t suffix_len = strlen(suffix);
 
     return (str_len >= suffix_len) &&
            (0 == strcmp(str + (str_len - suffix_len), suffix));
@@ -236,8 +236,8 @@ char *str_replace(char const *orig, char const *rep, char const *with)
     char *result;  // the return string
     char const *ins; // the next insert point
     char *tmp;     // varies
-    int len_rep;   // length of rep (the string to remove)
-    int len_with;  // length of with (the string to replace rep with)
+    size_t len_rep;  // length of rep (the string to remove)
+    size_t len_with; // length of with (the string to replace rep with)
     int len_front; // distance between rep and end of last rep
     int count;     // number of replacements
 

--- a/src/sdr.c
+++ b/src/sdr.c
@@ -174,7 +174,7 @@ static int rtltcp_open(sdr_dev_t **out_dev, char const *dev_query, int verbose)
     for (res = res0; res; res = res->ai_next) {
         sock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
         if (sock >= 0) {
-            ret = connect(sock, res->ai_addr, res->ai_addrlen);
+            ret = connect(sock, res->ai_addr, (int)res->ai_addrlen);
             if (ret == -1) {
                 perror("connect");
                 closesocket(sock);


### PR DESCRIPTION
Based on PR #1875: several size_t values (from strlen(), fread(), list_t.len, struct addrinfo::ai_addrlen) were implicitly narrowed to int/unsigned/socklen_t, which triggers MSVC C4267 warnings on x64 Windows builds. Adds explicit casts and widens a few parameter/local types to size_t where that is the semantically correct type.

Excludes the original PR's mongoose-related mg_send() casts, and drops two hunks (flex.c, honeywell_cm921.c) that no longer apply since the affected code was refactored away since 2021.