### PR TITLE
Fix VS2019 arithmetic overflow warnings (C26451)

### DIFF
--- a/src/baseband.c
+++ b/src/baseband.c
@@ -86,7 +86,7 @@ float magnitude_true_cu8(uint8_t const *iq_buf, uint16_t *y_buf, uint32_t len)
     for (i = 0; i < len; i++) {
         int16_t x = iq_buf[2 * i] - 128;
         int16_t y = iq_buf[2 * i + 1] - 128;
-        y_buf[i]  = (uint16_t)(sqrt(x * x + y * y) * 128.0); // max 181, scaled 23170, fs 16384
+        y_buf[i]  = (uint16_t)(sqrtf((float)(x * x + y * y)) * 128.0f); // max 181, scaled 23170, fs 16384
         sum += y_buf[i];
     }
     return len > 0 && sum >= len ? MAG_TO_DB((float)sum / len) : MAG_TO_DB(1);
@@ -117,7 +117,7 @@ float magnitude_true_cs16(int16_t const *iq_buf, uint16_t *y_buf, uint32_t len)
     for (i = 0; i < len; i++) {
         int32_t x = iq_buf[2 * i];
         int32_t y = iq_buf[2 * i + 1];
-        y_buf[i]  = (int)sqrt(x * x + y * y) >> 1; // max 46341, scaled 23170, fs 16384
+        y_buf[i]  = (int)sqrtf((float)(x * x + y * y)) >> 1; // max 46341, scaled 23170, fs 16384
         sum += y_buf[i];
     }
     return len > 0 && sum >= len ? MAG_TO_DB((float)sum / len) : MAG_TO_DB(1);
@@ -221,7 +221,7 @@ void baseband_demod_FM(demodfm_state_t *state, uint8_t const *x_buf, int16_t *y_
             low_pass = 1e6f / low_pass / samp_rate;
         }
         print_logf(LOG_NOTICE, "Baseband", "FM low pass filter for %u Hz at cutoff %.0f Hz, %.1f us",
-                samp_rate, samp_rate * low_pass, 1e6 / (samp_rate * low_pass));
+                samp_rate, samp_rate * (double)low_pass, 1e6 / (samp_rate * (double)low_pass));
         double ita  = 1.0 / tan(M_PI_2 * low_pass);
         double gain = 1.0 / (1.0 + ita) / 2; // prescaled by div 2
         state->alp_16[0] = FIX(1.0);
@@ -314,7 +314,7 @@ void baseband_demod_FM_cs16(demodfm_state_t *state, int16_t const *x_buf, int16_
             low_pass = 1e6f / low_pass / samp_rate;
         }
         print_logf(LOG_NOTICE, "Baseband", "low pass filter for %u Hz at cutoff %.0f Hz, %.1f us",
-                samp_rate, samp_rate * low_pass, 1e6 / (samp_rate * low_pass));
+                samp_rate, samp_rate * (double)low_pass, 1e6 / (samp_rate * (double)low_pass));
         double ita  = 1.0 / tan(M_PI_2 * low_pass);
         double gain = 1.0 / (1.0 + ita);
         state->alp_32[0] = FIX32(1.0);

--- a/src/pulse_analyzer.c
+++ b/src/pulse_analyzer.c
@@ -341,8 +341,8 @@ void pulse_analyzer(pulse_data_t *data, int package_type, r_device* device)
             data->rssi_db, data->snr_db, data->noise_db);
     fprintf(stderr, "Frequency offsets [F1, F2]:  %6i, %6i\t(%+.1f kHz, %+.1f kHz)\n",
             data->fsk_f1_est, data->fsk_f2_est,
-            (float)data->fsk_f1_est / INT16_MAX * data->sample_rate / 2.0 / 1000.0,
-            (float)data->fsk_f2_est / INT16_MAX * data->sample_rate / 2.0 / 1000.0);
+            ((float)data->fsk_f1_est / INT16_MAX) * (data->sample_rate / 2.0 / 1000.0),
+            ((float)data->fsk_f2_est / INT16_MAX) * (data->sample_rate / 2.0 / 1000.0));
 
     fprintf(stderr, "Guessing modulation: ");
     device->name    = "Analyzer Device",


### PR DESCRIPTION
Based on PR #1877: MSVC /analyze flags int arithmetic that gets implicitly widened before a double/float use.

- magnitude_true_cu8/cs16: use sqrtf() instead of promoting the int sum-of-squares to double, per review feedback on #1877 that double math is undesirable in this hot path.
- baseband_demod_FM(_cs16): cast low_pass to double in the debug log line only, harmless since it's not per-sample code.
- pulse_analyzer: regroup the FSK offset calculation with explicit parens (no behavior change, same left-to-right eval order).

Drops the PR's S_CONST/S_CONST32 cast (no-op, doesn't fix anything) and the seven `.max + 1` -> `.max + 1.0` edits in pulse_analyzer.c, which reviewers flagged as false positives that shouldn't be fixed by turning int addition into double addition.