### PR TITLE
Change logf length limit from 60 to 80 chars

### DIFF
--- a/include/decoder_util.h
+++ b/include/decoder_util.h
@@ -44,7 +44,7 @@ void decoder_output_data(r_device *decoder, data_t *data);
 /// Output log.
 void decoder_output_log(r_device *decoder, int level, data_t *data);
 
-// be terse, a maximum msg length of 60 characters is supported on the decoder_log_ functions
+// be terse, a maximum msg length of 80 characters is supported on the decoder_log_ functions
 // e.g. "FoobarCorp-XY3000: unexpected type code %02x"
 
 /// Get the current verbosity level for the decoder.
@@ -56,6 +56,8 @@ int decoder_verbose(r_device *decoder);
 void decoder_log(r_device *decoder, int level, char const *func, char const *msg);
 
 /// Output a formatted log message.
+///
+/// Be terse, a maximum msg length of 80 characters is supported.
 void decoder_logf(r_device *decoder, int level, char const *func, _Printf_format_string_ const char *format, ...)
 #if defined(__GNUC__) || defined(__clang__)
         __attribute__((format(printf, 4, 5)))
@@ -66,6 +68,8 @@ void decoder_logf(r_device *decoder, int level, char const *func, _Printf_format
 void decoder_log_bitbuffer(r_device *decoder, int level, char const *func, const bitbuffer_t *bitbuffer, char const *msg);
 
 /// Output a formatted log message with the content of the bitbuffer.
+///
+/// Be terse, a maximum msg length of 80 characters is supported.
 void decoder_logf_bitbuffer(r_device *decoder, int level, char const *func, const bitbuffer_t *bitbuffer, _Printf_format_string_ const char *format, ...)
 #if defined(__GNUC__) || defined(__clang__)
         __attribute__((format(printf, 5, 6)))
@@ -76,6 +80,8 @@ void decoder_logf_bitbuffer(r_device *decoder, int level, char const *func, cons
 void decoder_log_bitrow(r_device *decoder, int level, char const *func, uint8_t const *bitrow, unsigned bit_len, char const *msg);
 
 /// Output a formatted log message with the content of a bit row (byte buffer).
+///
+/// Be terse, a maximum msg length of 80 characters is supported.
 void decoder_logf_bitrow(r_device *decoder, int level, char const *func, uint8_t const *bitrow, unsigned bit_len, _Printf_format_string_ const char *format, ...)
 #if defined(__GNUC__) || defined(__clang__)
         __attribute__((format(printf, 6, 7)))

--- a/src/decoder_util.c
+++ b/src/decoder_util.c
@@ -143,12 +143,15 @@ void decoder_log(r_device *decoder, int level, char const *func, char const *msg
 void decoder_logf(r_device *decoder, int level, char const *func, _Printf_format_string_ const char *format, ...)
 {
     if (decoder->verbose >= level) {
-        char msg[60]; // fixed length limit
+        char msg[80]; // fixed length limit
         va_list ap;
         va_start(ap, format);
-        vsnprintf(msg, sizeof(msg), format, ap);
+        int len = vsnprintf(msg, sizeof(msg), format, ap);
         va_end(ap);
 
+        if (len >= (int)sizeof(msg)) {
+            decoder_log(decoder, 0, __func__, "Truncating log message");
+        }
         decoder_log(decoder, level, func, msg);
     }
 }
@@ -198,12 +201,15 @@ void decoder_logf_bitbuffer(r_device *decoder, int level, char const *func, cons
 {
     // TODO: pass to interested outputs
     if (decoder->verbose >= level) {
-        char msg[60]; // fixed length limit
+        char msg[80]; // fixed length limit
         va_list ap;
         va_start(ap, format);
-        vsnprintf(msg, sizeof(msg), format, ap);
+        int len = vsnprintf(msg, sizeof(msg), format, ap);
         va_end(ap);
 
+        if (len >= (int)sizeof(msg)) {
+            decoder_log(decoder, 0, __func__, "Truncating log message");
+        }
         decoder_log_bitbuffer(decoder, level, func, bitbuffer, msg);
     }
 }
@@ -243,12 +249,15 @@ void decoder_log_bitrow(r_device *decoder, int level, char const *func, uint8_t 
 void decoder_logf_bitrow(r_device *decoder, int level, char const *func, uint8_t const *bitrow, unsigned bit_len, _Printf_format_string_ const char *format, ...)
 {
     if (decoder->verbose >= level) {
-        char msg[60]; // fixed length limit
+        char msg[80]; // fixed length limit
         va_list ap;
         va_start(ap, format);
-        vsnprintf(msg, sizeof(msg), format, ap);
+        int len = vsnprintf(msg, sizeof(msg), format, ap);
         va_end(ap);
 
+        if (len >= (int)sizeof(msg)) {
+            decoder_log(decoder, 0, __func__, "Truncating log message");
+        }
         decoder_log_bitrow(decoder, level, func, bitrow, bit_len, msg);
     }
 }

--- a/src/devices/companion_wtr001.c
+++ b/src/devices/companion_wtr001.c
@@ -67,13 +67,13 @@ static int companion_wtr001_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // Make sure bit 5 is not set
     if ((b[0] & 0x04) == 0x04) {
-        decoder_log(decoder, 2, __func__, "companion_wtr001: Fixed Bit set (and it shouldn't be)");
+        decoder_log(decoder, 2, __func__, "Fixed Bit set (and it shouldn't be)");
         return DECODE_FAIL_SANITY;
     }
 
     /* Parity check (must be ODD) */
     if (!parity_bytes(b, 2)) {
-        decoder_log(decoder, 2, __func__, "companion_wtr001: parity check failed (should be ODD)");
+        decoder_log(decoder, 2, __func__, "parity check failed (should be ODD)");
         return DECODE_FAIL_MIC;
     }
 
@@ -83,13 +83,13 @@ static int companion_wtr001_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     if (temp_tenth_raw < 0x0a) {
         // Value is too low
-        decoder_logf(decoder, 2, __func__, "companion_wtr001: Temperature Degree Tenth too low (%d - 10 is less than 0", temp_tenth_raw);
+        decoder_logf(decoder, 2, __func__, "Temperature Degree Tenth too low (%d - 10 is less than 0)", temp_tenth_raw);
         return DECODE_FAIL_SANITY;
     }
 
     if (temp_tenth_raw > 0x13) {
         // Value is too high
-        decoder_logf(decoder, 2, __func__, "companion_wtr001: Temperature Degree Tenth too high (%d - 10 is greater than 9", temp_tenth_raw);
+        decoder_logf(decoder, 2, __func__, "Temperature Degree Tenth too high (%d - 10 is greater than 9)", temp_tenth_raw);
         return DECODE_FAIL_SANITY;
     }
 
@@ -101,13 +101,13 @@ static int companion_wtr001_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     if (temp_whole_raw < 11) {
         // Value is too low (outside published specs)
-        decoder_logf(decoder, 2, __func__, "companion_wtr001: Whole part of Temperature is too low (%d - 41 is less than -30)", temp_whole_raw);
+        decoder_logf(decoder, 2, __func__, "Whole part of Temperature is too low (%d - 41 is less than -30)", temp_whole_raw);
         return DECODE_FAIL_SANITY;
     }
 
     if (temp_whole_raw > 111) {
         // Value is too high (outside published specs)
-        decoder_logf(decoder, 2, __func__, "companion_wtr001: Whole part of Temperature is too high (%d - 41 is greater than 70)", temp_whole_raw);
+        decoder_logf(decoder, 2, __func__, "Whole part of Temperature is too high (%d - 41 is greater than 70)", temp_whole_raw);
         return DECODE_FAIL_SANITY;
     }
 

--- a/src/devices/fineoffset_ws85.c
+++ b/src/devices/fineoffset_ws85.c
@@ -66,7 +66,7 @@ static int fineoffset_ws85_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // Validate package, WS85 nominal size is 345 bit periods
     if (bitbuffer->bits_per_row[0] < 168 || bitbuffer->bits_per_row[0] > 500) {
-        decoder_logf_bitbuffer(decoder, 2, __func__, bitbuffer, "abort length" );
+        decoder_logf_bitbuffer(decoder, 2, __func__, bitbuffer, "abort length");
         return DECODE_ABORT_LENGTH;
     }
 

--- a/src/devices/fineoffset_ws90.c
+++ b/src/devices/fineoffset_ws90.c
@@ -71,7 +71,7 @@ static int fineoffset_ws90_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // Validate package, WS90 nominal size is 345 bit periods
     if (bitbuffer->bits_per_row[0] < 168 || bitbuffer->bits_per_row[0] > 500) {
-        decoder_logf_bitbuffer(decoder, 2, __func__, bitbuffer, "abort length" );
+        decoder_logf_bitbuffer(decoder, 2, __func__, bitbuffer, "abort length");
         return DECODE_ABORT_LENGTH;
     }
 

--- a/src/devices/ikea_sparsnas.c
+++ b/src/devices/ikea_sparsnas.c
@@ -172,7 +172,7 @@ static int ikea_sparsnas_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         decoder_log(decoder, 2, __func__, "No sensor ID configured. Brute forcing encryption.");
         ikea_sparsnas_sensor_id = ikea_sparsnas_brute_force_encryption(buffer);
         if (ikea_sparsnas_sensor_id) {
-            decoder_logf(decoder, 2, __func__, "Found valid sensor ID %06u. If reported values does not make sense, this might be incorrect.", ikea_sparsnas_sensor_id);
+            decoder_logf(decoder, 2, __func__, "Found valid sensor ID %06u. Might be invalid if values are incorrect.", ikea_sparsnas_sensor_id);
         } else {
             decoder_log(decoder, 2, __func__, "No valid sensor ID found.");
         }
@@ -205,7 +205,7 @@ static int ikea_sparsnas_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     decoder_logf(decoder, 2, __func__, "Received sensor id: %06u", rcv_sensor_id);
 
     if (rcv_sensor_id != ikea_sparsnas_sensor_id) {
-        decoder_logf(decoder, 2, __func__, "Malformed package, or wrong sensor id. Received sensor id (%06u) not the same as sender (%d)", rcv_sensor_id, ikea_sparsnas_sensor_id);
+        decoder_logf(decoder, 2, __func__, "Malformed package or wrong sensor id. Sensor id (%06u) but sender (%d).", rcv_sensor_id, ikea_sparsnas_sensor_id);
     }
 
     if ((!ikea_sparsnas_sensor_id) || (rcv_sensor_id != ikea_sparsnas_sensor_id)) {

--- a/src/devices/maverick_et73x.c
+++ b/src/devices/maverick_et73x.c
@@ -86,8 +86,8 @@ static int maverick_et73x_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     //digest is used to represent a session. This means, we get a new id if a reset or battery exchange is done.
     int id = lfsr_digest16(chk, 3, 0x8810, 0xdd38) ^ digest;
 
-    decoder_logf(decoder, 1, __func__, "pre %03x, flags %x, t1 %d, t2 %d, digest %04x, chk_data %02x%02x%02x, digest xor'ed: %04x",
-                pre, flags, temp1, temp2, digest, chk[0], chk[1], chk[2], id);
+    decoder_logf(decoder, 1, __func__, "pre %03x, flags %x, t1 %d, t2 %d", pre, flags, temp1, temp2);
+    decoder_logf(decoder, 1, __func__, "digest %04x, chk_data %02x%02x%02x, digest xor'ed: %04x", digest, chk[0], chk[1], chk[2], id);
 
     /* clang-format off */
     data = data_make(

--- a/src/devices/maverick_xr30.c
+++ b/src/devices/maverick_xr30.c
@@ -76,8 +76,8 @@ static int maverick_xr30_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     //digest is used to represent a session. This means, we get a new id if a reset or battery exchange is done.
     int id = lfsr_digest16(&b[7], 3, 0x8810, 0x0d42) ^ digest;
 
-    decoder_logf(decoder, 1, __func__, "sync %08x, flags %x, t1 %d, t2 %d, digest %04x, chk_data %02x%02x%02x, digest xor'ed: %04x",
-                sync, flags, temp1, temp2, digest, b[7], b[8], b[9], id);
+    decoder_logf(decoder, 1, __func__, "sync %08x, flags %x, t1 %d, t2 %d", sync, flags, temp1, temp2);
+    decoder_logf(decoder, 1, __func__, "digest %04x, chk_data %02x%02x%02x, digest xor'ed: %04x", digest, b[7], b[8], b[9], id);
 
     /* clang-format off */
     data = data_make(

--- a/src/devices/oregon_scientific.c
+++ b/src/devices/oregon_scientific.c
@@ -831,7 +831,7 @@ static int oregon_scientific_v3_decode(r_device *decoder, bitbuffer_t *bitbuffer
 
         // Sanity check values
         if (gustWindspeed < 0 || gustWindspeed > 56 || avgWindspeed < 0 || avgWindspeed > 56) {
-            decoder_logf(decoder, 1, __func__, "WGR800 failed value sanity check: wind_max_m_s %.1f wind_avg_m_s %.1f wind_dir_deg %.1f.", gustWindspeed, avgWindspeed, quadrant);
+            decoder_logf(decoder, 1, __func__, "WGR800 failed value sanity check: wind_max_m_s %.1f wind_avg_m_s %.1f.", gustWindspeed, avgWindspeed);
             return DECODE_FAIL_SANITY;
         }
 

--- a/src/devices/secplus_v1.c
+++ b/src/devices/secplus_v1.c
@@ -359,7 +359,6 @@ static int secplus_v1_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     char fixed_str[16]; // should be 10 chars max
     snprintf(fixed_str, sizeof(fixed_str), "%u", fixed);
 
-    // decoder_logf(decoder, 0, __func__,  "# Security+:  rolling=2320615320  fixed=1846948897  (id1=2 id0=0 switch=1 remote_id=68405514 button=left)");
     /* clang-format off */
     data_t *data = data_make(
             "model",        "",             DATA_STRING, "Secplus-v1",

--- a/src/devices/x10_sec.c
+++ b/src/devices/x10_sec.c
@@ -81,7 +81,7 @@ static int x10_sec_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* validate what we received */
     if ((b[0] ^ b[1]) != 0x0f || (b[2] ^ b[3]) != 0xff) {
-        decoder_logf(decoder, 1, __func__, "DECODE_FAIL_SANITY, b0=%02x b1=%02x b2=%02x b3=%02x", b[0], b[1], b[2], b[3]);
+        decoder_logf(decoder, 1, __func__, "DECODE_FAIL_SANITY, %02x %02x %02x %02x", b[0], b[1], b[2], b[3]);
         return DECODE_FAIL_SANITY;
     }
 
@@ -91,7 +91,7 @@ static int x10_sec_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     parity = (parity >> 2) ^ (parity & 0x3);                   // fold to 2 bits
     parity = (parity >> 1) ^ (parity & 0x1);                   // fold to 1 bit
     if (parity) {                                              // even parity - parity should be zero
-        decoder_logf(decoder, 1, __func__, "DECODE_FAIL_MIC CRC Fail, b0=%02x b1=%02x b2=%02x b3=%02x b4=%02x b5-CRC-bit=%02x", b[0], b[1], b[2], b[3], b[4], (b[5] & 0x80));
+        decoder_logf(decoder, 1, __func__, "DECODE_FAIL_MIC CRC Fail, %02x %02x %02x %02x %02x %02x", b[0], b[1], b[2], b[3], b[4], (b[5] & 0x80));
         return DECODE_FAIL_MIC;
     }
 


### PR DESCRIPTION
Shorten some overly long logf messages and raise the limit to fit all others.