### PR TITLE
Add support for Grill Thermometer (RF-T0912)

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [328]  Schrader TPMS MRXBC5A4 (BMW)
     [329]  Microchip HCS362 KeeLoq PWM
     [330]  Microchip HCS362 KeeLoq MC
+    [331]  RF-T0912 Grill Thermometer
 
 * Disabled by default, use -R n or a conf file to enable
 

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -569,6 +569,7 @@ convert si
   protocol 328 # Schrader TPMS MRXBC5A4 (BMW)
   protocol 329 # Microchip HCS362 KeeLoq PWM
   protocol 330 # Microchip HCS362 KeeLoq MC
+  protocol 331 # RF-T0912 Grill Thermometer
 
 ## Flex devices (command line option "-X")
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -338,6 +338,8 @@
     DECL(schrader_MRXBC5A4) \
     DECL(hcs362_pwm) \
     DECL(hcs362_mc) \
+    DECL(grill_thermometer) \
+
     /* Add new decoders here. */
 
 #define DECL(name) extern r_device const name;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -159,6 +159,7 @@ add_library(r_433 STATIC
     devices/govee.c
     devices/govee_h5059.c
     devices/gridstream.c
+    devices/grill_thermometer.c
     devices/gt_tmbbq05.c
     devices/gt_wt_02.c
     devices/gt_wt_03.c

--- a/src/devices/grill_thermometer.c
+++ b/src/devices/grill_thermometer.c
@@ -1,0 +1,108 @@
+/** @file
+    Remote Grill Thermometer temperature sensor.
+
+    Copyright (C) 2023 Ethan Halsall
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#include "decoder.h"
+
+/**
+Remote Grill Thermometer -- Generic wireless thermometer with probe.
+
+This is a meat thermometer with no brand / model identification except the FCC ID.
+
+Manufacturer:
+- Yangzhou Fupond Electronic Technology Corp., Ltd
+
+Supported Models:
+- RF-T0912 (FCC ID TXRFPT0912)
+
+9 - 415 F, frequency 434.052 MHz
+
+Data structure:
+
+10 repetitions of the same 24 bit payload.
+
+    AAAAAAAA AAAAAAAA BBBBBBBB
+
+- A: 16 bit temperature in Fahrenheit. Big Endian.
+- B: Checksum of A
+
+*/
+static int grill_thermometer_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    int temp_f       = 0;
+    int overload     = 0;
+    int repeats      = 0;
+    uint8_t checksum = 0;
+
+    bitbuffer_invert(bitbuffer);
+
+    // use the most recent "valid" data that repeats more than once
+    for (int row = 0; row < bitbuffer->num_rows; row++) {
+        uint8_t *row_data = bitbuffer->bb[row];
+        checksum          = row_data[0] + row_data[1];
+
+        if (bitbuffer->bits_per_row[row] != 24 ||
+                checksum != row_data[2] ||
+                checksum == 0) {
+            continue;
+        }
+
+        int current_value = (int16_t)((row_data[0] << 8) | row_data[1]); // uses sign-extend
+
+        if (temp_f != current_value) {
+            temp_f  = current_value;
+            repeats = 0;
+        }
+        else {
+            repeats++;
+        }
+    }
+
+    if (repeats < 1) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    if (temp_f == -1029) {
+        overload = 1;
+    }
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",            "",             DATA_STRING, "RF-T0912",
+            "temperature_F",    "Temperature",  DATA_COND, !overload, DATA_FORMAT, "%.0f F", DATA_DOUBLE, (double)temp_f,
+            "overload",         "Overload",     DATA_INT, overload,
+            "mic",              "Integrity",    DATA_STRING, "CHECKSUM",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+    return 1;
+}
+
+static char const *const output_fields[] = {
+        "model",
+        "temperature_F",
+        "overload",
+        "mic",
+        NULL,
+};
+
+r_device const grill_thermometer = {
+        .name        = "RF-T0912 Grill Thermometer",
+        .modulation  = OOK_PULSE_PWM,
+        .short_width = 252,
+        .long_width  = 736,
+        .gap_limit   = 5000,
+        .reset_limit = 8068,
+        .sync_width  = 980,
+        .priority    = 10, // lower decode priority due to potential false positives
+        .decode_fn   = &grill_thermometer_decode,
+        .fields      = output_fields,
+};


### PR DESCRIPTION
Remote Grill Thermometer with probe (FCC ID TXRFPT0912), sold under the RF-T0912 model number. Decodes a 16-bit Fahrenheit temperature with an 8-bit checksum, repeated across multiple rows for reliable detection, and reports an overload condition.