### PR TITLE
Add Anime-Lightbox Remote decoder (PT2262/EV1527 family)

### DIFF
--- a/conf/EV1527-anime_lightbox_remote.conf
+++ b/conf/EV1527-anime_lightbox_remote.conf
@@ -1,0 +1,31 @@
+# Anime Lightbox Remote
+#
+# Remote used to control anime lightboxes sold at https://myanimelightbox.com/
+#
+# Generic EV1527 OOK PWM protocol (also matched by generic_remote).
+# This flex decoder adds command descriptions for the specific buttons on the
+# lightbox remote and sets the pulse widths measured across several remotes with measured
+# values across multiple commercialized remotes.
+#
+# The lightbox receiver does not seem to use the address bits in any way as demonstrated 
+# by spoofing tests with a CC1101 module: only the command is parsed
+#
+# Data layout (25 bits, MSB first):
+# - bits  1-16: remote address / ID
+# - bits 17-24: command byte        (only low 5 bits used, high 3 are always 0)
+# - bit     25: stop bit            (constant 1)
+#
+
+decoder {
+    n=Anime-Lightbox-Remote,
+    m=OOK_PWM,
+    s=400,
+    l=1200,
+    r=1500,
+    t=200,
+    bits=25,
+    invert,
+    unique,
+    get=@0:{16}:id,
+    get=@16:{8}:cmd:[5:MODE+ 7:SPEED- 8:DEMO 9:SPEED+ 10:COLOR+ 11:MODE- 12:BRIGHT+ 13:COLOR- 14:WHITE 15:BRIGHT- 16:RED 17:GREEN 18:BLUE 19:YELLOW 20:LIGHT_BLUE 21:PINK]
+}


### PR DESCRIPTION
Add a flex decoder for the remote shipped with anime lightboxes sold at https://myanimelightbox.com/.

The protocol is the same PT2262/EV1527 OOK-PWM family. This flex decoder provides the command byte into named commands (WHITE, BLUE, SPEED+, MODE-, etc).

**Sample output:**
```
$rtl_433 -c conf/EV1527-anime_lightbox_remote.conf
rtl_433 version 25.12-144-gf6b135d4 branch anime_lightbox at 202607072353 inputs file rtl_tcp RTL-SDR with TLS
Found Rafael Micro R820T tuner
[SDR] Using device 0: Realtek, RTL2838UHIDIR, SN: 00000001, "Generic RTL2832U OEM"
Exact sample rate is: 250000.000414 Hz
[R82XX] PLL not locked!
Allocating 15 zero-copy buffers
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
time      : 2026-07-08 21:54:09
model     : Generic-Remote                         House Code: 43027
Command   : 18           Tri-State : XXX00Z010Z0X
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
time      : 2026-07-08 21:54:11
model     : Anime-Lightbox-Remote                  count     : 1             num_rows  : 1             len       : 25
data      : a813150      id        : 43027
cmd       : PINK
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ __
...
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
time      : 2026-07-08 21:54:12
model     : Anime-Lightbox-Remote                  count     : 1             num_rows  : 1             len       : 25
data      : a813140      id        : 43027
cmd       : LIGHT_BLUE
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
time      : 2026-07-08 21:54:12
model     : Anime-Lightbox-Remote                  count     : 1             num_rows  : 1             len       : 25
data      : a813140      id        : 43027
cmd       : LIGHT_BLUE
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
```
