### PR TITLE
vevor_7in1: document US 915 MHz YT60234 variant and radio parameters

### DIFF
--- a/src/devices/vevor_7in1.c
+++ b/src/devices/vevor_7in1.c
@@ -19,10 +19,17 @@ Vevor Wireless Weather Station 7-in-1.
 Manufacturer : Fujian Youtong Industries Co., Ltd. rebrand under Vevor name.
 Reference:
 
-- YT60231, Vevor Weather Station 7-in-1
+- YT60231, Vevor Weather Station 7-in-1, 868 MHz (EU)
+- YT60234, Vevor Weather Station 7-in-1, 915 MHz (US)
 - R53 / R56 Fujian Youtong Industries , FCC ID : https://fccid.io/2AQBD-R53, https://fccid.io/2AQBD-R56
 
-S.a. issue #3020
+S.a. issue #3020 and issue #3591
+
+Radio parameters, US 915 MHz YT60234 (measured, issue #3591):
+
+- 2-FSK, +-37 kHz deviation, ~11.26 kbaud, one ~85 ms burst every 20.000 s, all sensors in every frame.
+- Measured center 915.031 MHz on one unit (nominal 915.000 MHz), so allow for a small frequency offset.
+- Same protocol and checksum as the 868 MHz EU YT60231; decoded by this decoder unchanged.
 
 Data Layout:
 


### PR DESCRIPTION
Documentation-only update to the vevor_7in1 decoder header, as requested in #3591:

- Note the frequency per model: YT60231 = 868 MHz (EU), YT60234 = 915 MHz (US)
- Reference issue #3591 (US 915 MHz variant confirmed working with this decoder unchanged) alongside #3020
- Add measured radio parameters for the US variant: 2-FSK, +-37 kHz deviation, ~11.26 kbaud, one ~85 ms burst every 20.000 s, measured center 915.031 MHz on my unit (nominal 915.000)

No code changes.