### PR TITLE
Fix uint8_t offset wraparound in m_bus parse_payload

### DIFF
--- a/src/devices/m_bus.c
+++ b/src/devices/m_bus.c
@@ -762,7 +762,13 @@ static void parse_payload(data_t *data, const m_bus_block1_t *block1, const m_bu
 
     // process standard payload
 
-    uint8_t off = block1->block2.pl_offset;
+    // NOTE: off must not be a uint8_t. m_bus_decode_records() can return a
+    // "consumed" value up to 192 (LVAR variable-length field), and adding
+    // that to off several times can exceed 255. A uint8_t accumulator would
+    // wrap around, and the wrapped (small) value can still satisfy
+    // "off < block1->L", making the parser jump backward and re-process
+    // already consumed bytes instead of terminating.
+    unsigned off = block1->block2.pl_offset;
     const uint8_t *b = out->data;
 
     // Data Record Header DRH, contains Data Information Block DIB and Value Information Block VIB
@@ -782,7 +788,7 @@ static void parse_payload(data_t *data, const m_bus_block1_t *block1, const m_bu
 //[02 65] b408 [42 65] a008 [8201 65] 6408 [22 65] 9608 [12 65] ac08 [62 65] 2808 [52 65] 920802fb1a470142fb1a4a018201fb1a550122fb1a4a0112fb1a4a0162fb1a3c0152fb1a6c01066dbb3197902100
 
     /* Payload must start with a DIF */
-    while (off < block1->L) {
+    while (off < block1->L && off < out->length) {
         uint8_t dif;
         uint8_t dife_array[10] = {0};
         uint8_t dife_cnt;


### PR DESCRIPTION
`parse_payload()` in `src/devices/m_bus.c` walks the M-Bus data records using
a running offset `off`, declared as `uint8_t`:

```c
uint8_t off = block1->block2.pl_offset;
...
while (off < block1->L) {
    ...
    int consumed = m_bus_decode_records(&data, &b[off], ...);
    ...
    off += consumed;
}
```

`m_bus_decode_records()` can return a `consumed` value up to 192 for the
LVAR (variable-length) DIF coding, taken directly from a byte in the
telegram (`m_bus_decode_val()`: `if (b[0] <= 0xbf) return b[0] + 1;`). After
a couple of records the running `off += consumed` overflows the `uint8_t`
accumulator and wraps modulo 256. The wrapped value can still be smaller
than `block1->L` (also a `uint8_t`, max 255), so the loop condition
`off < block1->L` doesn't catch it - the parser jumps backward into bytes
it already processed and starts reinterpreting them as a new DIF/VIF
record.

I worked through the arithmetic on a crafted example (L=250, off starting
around 198, constant per-record consumption of 192): the offset cycles
through a fixed set of residues mod 256 and only escapes the loop when it
happens to land on one of a handful of values >= L. An attacker who can
place the same DIF/VIF/LVAR-style record at the right repeating offsets in
a telegram with valid per-block CRC (public, computable offline) can make
the offset walk cycle for a long time, or indefinitely, instead of
terminating - a hang against an unattended M-Bus gateway.

`out->data` is a fixed 512-byte buffer and `block1->L` tops out at 255, so
this doesn't corrupt memory - it's a parser desync / DoS, not an
out-of-bounds read or write.

This is a different bug from the one fixed for #1310 (that one was a
`consumed == 0` case, already fixed by making DIF/VIF byte consumption
unconditional). That fix didn't touch `off`'s type, so the large-`consumed`
wraparound is still there.

Fix: widen `off` to `unsigned` so the running total can't wrap, and also
bound the loop against `out->length` (the number of bytes actually copied
into `out->data`), not just `block1->L`. For Format B telegrams
`out->length` is a few bytes smaller than `block1->L`, so this is also a
slightly tighter, more correct bound on its own, not just insurance against
the overflow case. This matches the "don't trust a length taken from the
air without bounding it" approach already used elsewhere in the codebase
(Arexx-ML, GridStream).

Not memory-unsafe, so no crash/ASan repro to attach, just the arithmetic.
I didn't have cmake available to build the full project, but I compiled
`m_bus.c` directly against the project's `-Wall -Wextra -Wsign-compare`
flags with no new warnings, and verified the fix with a small standalone
program reproducing the exact offset walk before and after the type
change.
