### PR TITLE
Add fixed format string flex decoder feature

### DIFF
--- a/src/devices/flex.c
+++ b/src/devices/flex.c
@@ -143,7 +143,12 @@ static void render_getters(data_t *data, uint8_t *bits, struct flex_params *para
         }
         if (!getter->map[m].val[0]) {
             char const *format = getter->format[0] ? getter->format : NULL;
-            data_int(data, getter->name, "", format, val);
+            if (format && format[0] == '%' && format[1] == '=') {
+                // expand special custom format of "%=FOO" to "FOO"
+                data_str(data, getter->name, "", NULL, &format[2]);
+            } else {
+                data_int(data, getter->name, "", format, val);
+            }
         }
     }
 }


### PR DESCRIPTION
As suggested in #1647 this adds a feature to the flex decoders:

- A flex getter format string of `%=foo` will be expanded to `"foo"` in the output.

E.g. use as an "else" case for a map like this

- `get = leak:@20:{12}:%=OFF:[0x404:ON],`
- `get = battery_level:@20:{12}:%=UNDEFINED:[0x39b:100 0x3bc:80 0x3c4:80 0x3b6:80 0x3e5:60 0x3e7:40],`

No for merge right now but to start a discussion if this is practical as syntax and solution.

We could also use a keyword like `ELSE` in the map. But the format string is already the current "else" for a map.