### PR TITLE
Add support for Fine Offset WN38 Black Globe Thermometer

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [218]  Microchip HCS200/HCS300 KeeLoq Hopping Encoder based remotes (FSK)
     [219]  Fine Offset Electronics WH45 air quality sensor
     [220]  Maverick XR-30 BBQ Sensor
-    [221]  Fine Offset Electronics WN34S/L/D and Froggit DP150/D35 temperature sensor
+    [221]  Fine Offset Electronics WN34S/L/D, WN38 and Froggit DP150/D35 temperature sensor
     [222]  Rubicson Pool Thermometer 48942
     [223]  Badger ORION water meter, 100kbps (-f 916.45M -s 1200k)
     [224]  GEO minim+ energy monitor

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -460,7 +460,7 @@ convert si
   protocol 218 # Microchip HCS200/HCS300 KeeLoq Hopping Encoder based remotes (FSK)
   protocol 219 # Fine Offset Electronics WH45 air quality sensor
   protocol 220 # Maverick XR-30 BBQ Sensor
-  protocol 221 # Fine Offset Electronics WN34S/L/D and Froggit DP150/D35 temperature sensor
+  protocol 221 # Fine Offset Electronics WN34S/L/D, WN38 and Froggit DP150/D35 temperature sensor
   protocol 222 # Rubicson Pool Thermometer 48942
   protocol 223 # Badger ORION water meter, 100kbps (-f 916.45M -s 1200k)
   protocol 224 # GEO minim+ energy monitor

--- a/src/devices/fineoffset_wn34.c
+++ b/src/devices/fineoffset_wn34.c
@@ -17,6 +17,7 @@ Fine Offset Electronics WN34 Temperature Sensor.
 - also Ecowitt WN34S (soil), WN34L (water), range is -40~60 °C (-40~140 °F)
 - also Ecowitt WN34D (water), range is -55~125 °C (-67~257 °F)
 - also Froggit DP150 (soil), DP35 (water)
+- also Ecowitt WN38 Black Globe Thermometer (family code 0x38)
 
 Preamble is aaaa aaaa, sync word is 2dd4.
 
@@ -25,11 +26,12 @@ Packet layout:
      0  1  2  3  4  5  6  7  8  9 10
     YY II II II ST TT BB XX AA ZZ ZZ
     34 00 29 65 02 85 44 66 f3 20 10
+    38 00 28 85 40 f5 41 4c a7
 
-- Y:{8}  fixed sensor type 0x34
+- Y:{8}  fixed sensor type, 0x34 = WN34, 0x38 = WN38
 - I:{24} device ID
-- S:{4}  sub type, 0 = WN34L, 0x4 = WN34D
-- T:{12} temperature, offset 40 (except WN34D), scale 10
+- S:{4}  sub type, 0 = WN34L, 0x4 = WN34D and WN38
+- T:{12} temperature, offset 40 (except sub type 4), scale 10
 - B:{7}  battery level (unit of 20 mV)
 - X:{8}  bit CRC
 - A:{8}  bit checksum
@@ -56,7 +58,7 @@ static int fineoffset_wn34_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     decoder_log_bitrow(decoder, 1, __func__, b, sizeof (b) * 8, "");
 
     // Verify family code
-    if (b[0] != 0x34) {
+    if (b[0] != 0x34 && b[0] != 0x38) {
         decoder_logf(decoder, 2, __func__, "Msg family unknown: %02x", b[0]);
         decoder_logf_bitbuffer(decoder, 2, __func__, bitbuffer, "Row length(bits_per_row[0]): %u", bitbuffer->bits_per_row[0]);
         return DECODE_ABORT_EARLY;
@@ -108,8 +110,9 @@ static int fineoffset_wn34_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     /* clang-format off */
     data = data_make(
-            "model",         "",                DATA_COND, sub_type != 4, DATA_STRING, "Fineoffset-WN34",
-            "model",         "",                DATA_COND, sub_type == 4, DATA_STRING, "Fineoffset-WN34D",
+            "model",         "",                DATA_COND, b[0] == 0x38, DATA_STRING, "Fineoffset-WN38",
+            "model",         "",                DATA_COND, b[0] == 0x34 && sub_type != 4, DATA_STRING, "Fineoffset-WN34",
+            "model",         "",                DATA_COND, b[0] == 0x34 && sub_type == 4, DATA_STRING, "Fineoffset-WN34D",
             "id",            "ID",              DATA_FORMAT, "%x",     DATA_INT,    id,
             "battery_ok",    "Battery level",   DATA_FORMAT, "%.1f",   DATA_DOUBLE, battery_ok,
             "battery_mV",    "Battery Voltage", DATA_FORMAT, "%d mV",  DATA_INT,    battery_mv,
@@ -133,7 +136,7 @@ static char const *const output_fields[] = {
 };
 
 r_device const fineoffset_wn34 = {
-        .name        = "Fine Offset Electronics WN34S/L/D and Froggit DP150/D35 temperature sensor",
+        .name        = "Fine Offset Electronics WN34S/L/D, WN38 and Froggit DP150/D35 temperature sensor",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 58,
         .long_width  = 58,


### PR DESCRIPTION
The Ecowitt WN38 Black Globe Thermometer ([product](https://shop.ecowitt.com/products/wn38), [manual](https://oss.ecowitt.net/uploads/20251128/WN38AN-UserManual.pdf)) transmits the WN34 packet layout with family code 0x38 and subtype 4 (temperature scale 10, no offset — same as the WN34D; matches its −40…125 °C spec range). Battery is 1× AA reported in 20 mV units. Its power-up LCD even shows "version 34", confirming the family kinship.

This PR extends the WN34 decoder to accept family code 0x38, reported as `model: Fineoffset-WN38`.

Verified against five captures from a real device (id 0x002885) at 24.5–31.0 °C; every decoded temperature matched the sensor's LCD exactly. Test samples (.cu8 + README + photos) are in a companion rtl_433_tests PR: merbanan/rtl_433_tests#507. Reference json/codes files will follow once this decoder merges.

Example: `rtl_433 -y "{137}aaaaaaaaaaa2dd43800288540f5414ca780"` → Fineoffset-WN38, id 2885, 24.5 °C, 1300 mV