### PR TITLE
Add protocols help listing as json

### DIFF
--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -170,20 +170,31 @@ static void usage(int exit_code)
 _Noreturn
 static void help_protocols(r_device *devices, unsigned num_devices, int exit_code)
 {
-    unsigned i;
-    char disabledc;
-
     if (devices) {
         FILE *fp = exit_code ? stderr : stdout;
         term_help_fprintf(fp,
                 "\t\t= Supported device protocols =\n");
-        for (i = 0; i < num_devices; i++) {
-            disabledc = devices[i].disabled ? '*' : ' ';
+        for (unsigned i = 0; i < num_devices; i++) {
+            char disabledc = devices[i].disabled ? '*' : ' ';
             if (devices[i].disabled <= 2) { // if not hidden
                 fprintf(fp, "    [%02u]%c %s\n", i + 1, disabledc, devices[i].name);
             }
         }
         fprintf(fp, "\n* Disabled by default, use -R n or a conf file to enable\n");
+    }
+    exit(exit_code);
+}
+
+_Noreturn static void help_protocols_json(r_device *devices, unsigned num_devices, int exit_code)
+{
+    if (devices) {
+        FILE *fp = exit_code ? stderr : stdout;
+        fprintf(fp, "[");
+        for (unsigned i = 0; i < num_devices; i++) {
+            if (devices[i].disabled <= 2) { // if not hidden
+                fprintf(fp, "{\"num\":%u,\"dis\":%u,\"desc\":\"%s\"}%s\n", i + 1, devices[i].disabled, devices[i].name, i + 1 < num_devices ? "," : "]");
+            }
+        }
     }
     exit(exit_code);
 }
@@ -791,6 +802,11 @@ static void parse_conf_option(r_cfg_t *cfg, int opt, char *arg)
     case 'R':
         if (!arg) {
             help_protocols(cfg->devices, cfg->num_r_devices, 0);
+        }
+
+        // use arg of 'json' for machine-readable info
+        if (!strcasecmp(arg, "json")) {
+            help_protocols_json(cfg->devices, cfg->num_r_devices, 0);
         }
 
         // use arg of 'v', 'vv', 'vvv' as global device verbosity


### PR DESCRIPTION
Adds an option `-R json` to the protocol help listing that outputs json, e.g.
```
[{"num":1,"dis":0,"desc":"Silvercrest Remote Control"},
{"num":2,"dis":0,"desc":"Rubicson, TFA 30.3197 or InFactory PT-310 Temperature Sensor"},
…
{"num":363,"dis":0,"desc":"Oregon Scientific WMR500 weather station"}]
```