### PR TITLE
Add data_new to create an empty data list head

### DIFF
--- a/include/data.h
+++ b/include/data.h
@@ -43,6 +43,7 @@
 #include <stdint.h>
 
 typedef enum {
+    DATA_EMPTY,  /**< no data is stored, skip while printing */
     DATA_DATA,   /**< pointer to data is stored */
     DATA_INT,    /**< pointer to integer is stored */
     DATA_DOUBLE, /**< pointer to a double is stored */
@@ -115,6 +116,12 @@ R_API data_t *data_make(const char *key, const char *pretty_key, ...);
     @see data_make()
 */
 R_API data_t *data_prepend(data_t *tail, data_t *head);
+
+/** Creates a new structured data object list by creating an empty head object.
+
+    Type-safe alternative to `data_make()` and `data_append()`.
+*/
+R_API data_t *data_new(void);
 
 /** Adds to a structured data object, by appending `int` data.
 

--- a/src/data.c
+++ b/src/data.c
@@ -55,6 +55,13 @@ typedef struct {
 } data_meta_type_t;
 
 static data_meta_type_t dmt[DATA_COUNT] = {
+    //  DATA_EMPTY
+    { .array_element_size       = 0,
+      .array_is_boxed           = false,
+      .array_elementwise_import = NULL,
+      .array_element_release    = NULL,
+      .value_release            = NULL },
+
     //  DATA_DATA
     { .array_element_size       = sizeof(data_t*),
       .array_is_boxed           = true,
@@ -312,6 +319,16 @@ R_API data_t *data_prepend(data_t *tail, data_t *head)
     return head;
 }
 
+R_API data_t *data_new(void)
+{
+    data_t *empty = calloc(1, sizeof(*empty));
+    if (!empty) {
+        FATAL_CALLOC("data_new()"); // we must always return a list head
+    }
+    empty->type = DATA_EMPTY;
+    return empty;
+}
+
 // Wrappers for now, should be refactored.
 R_API data_t *data_int(data_t *first, char const *key, char const *pretty_key, char const *format, int val)
 {
@@ -431,6 +448,9 @@ R_API void data_output_free(data_output_t *output)
 R_API void print_value(data_output_t *output, data_type_t type, data_value_t value, char const *format)
 {
     switch (type) {
+    case DATA_EMPTY:
+        // skip empty elements
+        break;
     case DATA_FORMAT:
     case DATA_COUNT:
     case DATA_COND:
@@ -497,6 +517,9 @@ static void R_API_CALLCONV format_jsons_object(data_output_t *output, data_t *da
     bool separator = false;
     abuf_cat(&jsons->msg, "{");
     for (; data; data = data->next) {
+        if (!data->key) {
+            continue;
+        }
         if (separator)
             abuf_cat(&jsons->msg, ",");
         output->print_string(output, data->key, NULL);

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -1327,6 +1327,9 @@ static void R_API_CALLCONV print_http_data(data_output_t *output, data_t *data, 
     // collect well-known top level keys
     data_t *data_model = NULL;
     for (data_t *d = data; d; d = d->next) {
+        if (!d->key) {
+            continue;
+        }
         if (!strcmp(d->key, "model")) {
             data_model = d;
         }

--- a/src/output_file.c
+++ b/src/output_file.c
@@ -51,6 +51,9 @@ static void R_API_CALLCONV print_json_data(data_output_t *output, data_t *data, 
     bool separator = false;
     fputc('{', json->file);
     for (; data; data = data->next) {
+        if (!data->key) {
+            continue;
+        }
         if (separator)
             fprintf(json->file, ", ");
         output->print_string(output, data->key, NULL);
@@ -245,6 +248,9 @@ static void R_API_CALLCONV print_kv_data(data_output_t *output, data_t *data, ch
         data_t *data_lvl  = NULL;
         data_t *data_msg  = NULL;
         for (data_t *d = data; d; d = d->next) {
+            if (!d->key) {
+                continue;
+            }
             if (!strcmp(d->key, "src"))
                 data_src = d;
             else if (!strcmp(d->key, "lvl"))
@@ -327,6 +333,9 @@ static void R_API_CALLCONV print_kv_data(data_output_t *output, data_t *data, ch
 
     ++kv->data_recursion;
     for (; data; data = data->next) {
+        if (!data->key) {
+            continue;
+        }
         // skip logging keys
         if (is_log && (!strcmp(data->key, "time") || !strcmp(data->key, "src") || !strcmp(data->key, "lvl")
                 || !strcmp(data->key, "msg") || !strcmp(data->key, "num_rows"))) {
@@ -500,6 +509,9 @@ static void R_API_CALLCONV print_csv_data(data_output_t *output, data_t *data, c
 
     fputc('{', csv->file);
     for (bool separator = false; data; data = data->next) {
+        if (!data->key) {
+            continue;
+        }
         if (separator)
             fprintf(csv->file, "; "); // NOTE: distinct from csv->separator
         output->print_string(output, data->key, NULL);
@@ -643,6 +655,9 @@ static void R_API_CALLCONV data_output_csv_print(data_output_t *output, data_t *
 
     int regular = 0; // skip "states" output
     for (data_t *d = data; d; d = d->next) {
+        if (!d->key) {
+            continue;
+        }
         if (!strcmp(d->key, "msg") || !strcmp(d->key, "codes") || !strcmp(d->key, "model")) {
             regular = 1;
             break;
@@ -657,6 +672,9 @@ static void R_API_CALLCONV data_output_csv_print(data_output_t *output, data_t *
         if (i)
             fprintf(csv->file, "%s", csv->separator);
         for (data_t *iter = data; !found && iter; iter = iter->next) {
+            if (!iter->key) {
+                continue;
+            }
             if (strcmp(iter->key, key) == 0)
                 found = iter;
         }

--- a/src/output_influx.c
+++ b/src/output_influx.c
@@ -336,6 +336,9 @@ static void R_API_CALLCONV print_influx_data(data_output_t *output, data_t *data
     data_t *data_model = NULL;
     data_t *data_time = NULL;
     for (data_t *d = data; d; d = d->next) {
+        if (!d->key) {
+            continue;
+        }
         if (!strcmp(d->key, "model"))
             data_model = d;
         if (!strcmp(d->key, "time"))
@@ -365,6 +368,9 @@ static void R_API_CALLCONV print_influx_data(data_output_t *output, data_t *data
 
     // write tags
     for (; data; data = data->next) {
+        if (!data->key) {
+            continue;
+        }
         if ((!strcmp(data->key, "model") && strstr(influx->metric_format, "[model"))
             || (!strcmp(data->key, "type") && strstr(influx->metric_format, "[type"))
             || (!strcmp(data->key, "subtype") && strstr(influx->metric_format, "[subtype"))
@@ -402,6 +408,9 @@ static void R_API_CALLCONV print_influx_data(data_output_t *output, data_t *data
     // write fields
     data = data_org;
     for (; data; data = data->next) {
+        if (!data->key) {
+            continue;
+        }
         if (!strcmp(data->key, "model")
                 || !strcmp(data->key, "time")) {
             // skip

--- a/src/output_log.c
+++ b/src/output_log.c
@@ -91,6 +91,9 @@ static void R_API_CALLCONV data_output_log_print(data_output_t *output, data_t *
     data_t *data_lvl = NULL;
     data_t *data_msg = NULL;
     for (data_t *d = data; d; d = d->next) {
+        if (!d->key) {
+            continue;
+        }
         if (!strcmp(d->key, "src"))
             data_src = d;
         else if (!strcmp(d->key, "lvl"))
@@ -117,6 +120,9 @@ static void R_API_CALLCONV data_output_log_print(data_output_t *output, data_t *
 
     for (; data; data = data->next) {
         // skip logging keys
+        if (!data->key) {
+            continue;
+        }
         if (!strcmp(data->key, "time")
                 || !strcmp(data->key, "src")
                 || !strcmp(data->key, "lvl")

--- a/src/output_mqtt.c
+++ b/src/output_mqtt.c
@@ -499,6 +499,9 @@ static void R_API_CALLCONV print_mqtt_data(data_output_t *output, data_t *data, 
         // collect well-known top level keys
         data_t *data_model = NULL;
         for (data_t *d = data; d; d = d->next) {
+            if (!d->key) {
+                continue;
+            }
             if (!strcmp(d->key, "model"))
                 data_model = d;
         }
@@ -539,6 +542,9 @@ static void R_API_CALLCONV print_mqtt_data(data_output_t *output, data_t *data, 
     }
 
     for (; data; data = data->next) {
+        if (!data->key) {
+            continue;
+        }
         if (!strcmp(data->key, "type")
                 || !strcmp(data->key, "model")
                 || !strcmp(data->key, "subtype")) {

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -632,6 +632,9 @@ void data_acquired_handler(r_device *r_dev, data_t *data)
     for (data_t *d = data; d; d = d->next) {
         int found = 0;
         for (char const *const *p = r_dev->fields; *p; ++p) {
+            if (!d->key) {
+                continue;
+            }
             if (!strcmp(d->key, *p)) {
                 found = 1;
                 break;

--- a/src/string_expand.c
+++ b/src/string_expand.c
@@ -44,6 +44,9 @@ char *expand_topic_string(char *topic, char const *format, data_t *data, char co
     data_t *data_id      = NULL;
     data_t *data_protocol = NULL;
     for (data_t *d = data; d; d = d->next) {
+        if (!d->key) {
+            continue;
+        }
         if (!strcmp(d->key, "type"))
             data_type = d;
         else if (!strcmp(d->key, "model"))


### PR DESCRIPTION
Adds a `DATA_EMPTY` type and `data_new()` function to create a fixed head element for structured data object lists.

This will improve the data output ergonomics, esp. with #3137 to e.g.
```
data_t *data = data_new();
data_str(data, "model", ...);
data_int(data, "id", ...);
…
```
I.e. the `data` var is created once and stays fixed. It could arguably also be written as
```
data_t *data = data_str(NULL "model", ...);
data_int(data, "id", ...);
…
```
but that feels awkward and won't work as well with sub data lists with no obvious first/head element.