### PR TITLE
Refactor to add proper package flush

### DIFF
--- a/include/r_flow.h
+++ b/include/r_flow.h
@@ -16,7 +16,7 @@
 
 struct r_cfg;
 
-void flush_sdr_flow(struct r_cfg *cfg);
+int flush_sdr_flow(struct r_cfg *cfg);
 
 void reset_sdr_flow(struct r_cfg *cfg);
 

--- a/src/pulse_detect.c
+++ b/src/pulse_detect.c
@@ -198,9 +198,88 @@ static void print_att_hist(char const *s, int att_hist[])
 /// Demodulate On/Off Keying (OOK) and Frequency Shift Keying (FSK) from an envelope signal
 int pulse_detect_package(pulse_detect_t *pulse_detect, int16_t const *envelope_data, int16_t const *fm_data, int len, uint32_t samp_rate, uint64_t sample_offset, pulse_data_t *pulses, pulse_data_t *fsk_pulses, unsigned fpdm)
 {
+    pulse_detect_t *s = pulse_detect;
+
+    // Special case: flush any partial package
+    if (len == 0) {
+
+        switch (s->ook_state) {
+        case PD_OOK_STATE_IDLE:
+            break;
+        case PD_OOK_STATE_PULSE:
+            // Check for spurious short pulses
+            if (s->pulse_length < PD_MIN_PULSE_SAMPLES) {
+                if (pulses->num_pulses <= 1) {
+                    // if this was the first pulse go back to idle
+                    s->ook_state = PD_OOK_STATE_IDLE;
+                    break;
+                }
+                else {
+                    // otherwise emit a package, which then goes back to idle
+                    s->ook_state = PD_OOK_STATE_GAP;
+                }
+            }
+            else {
+                // Continue with OOK decoding
+                pulses->pulse[pulses->num_pulses] = s->pulse_length;                    // Store pulse width
+                s->max_pulse                      = MAX(s->pulse_length, s->max_pulse); // Find largest pulse
+                s->pulse_length                   = 0;
+                s->ook_state                      = PD_OOK_STATE_GAP_START;
+            }
+            // intentional fallthrough
+#if defined __has_attribute
+#if __has_attribute(fallthrough)
+            __attribute__((fallthrough));
+#endif
+#endif
+
+        case PD_OOK_STATE_GAP_START:
+            s->ook_state = PD_OOK_STATE_GAP;
+            // Determine if FSK modulation is detected
+            if (fsk_pulses->num_pulses > PD_MIN_PULSES) {
+                // Store last pulse/gap
+                if (fpdm == FSK_PULSE_DETECT_OLD) {
+                    pulse_detect_fsk_wrap_up(&s->pulse_detect_fsk, fsk_pulses);
+                }
+                // Store estimates
+                fsk_pulses->fsk_f1_est        = s->pulse_detect_fsk.fm_f1_est;
+                fsk_pulses->fsk_f2_est        = s->pulse_detect_fsk.fm_f2_est;
+                fsk_pulses->ook_low_estimate  = s->ook_low_estimate;
+                fsk_pulses->ook_high_estimate = s->ook_high_estimate;
+                pulses->end_ago               = len - s->data_counter;
+                fsk_pulses->end_ago           = len - s->data_counter;
+                s->ook_state                  = PD_OOK_STATE_IDLE; // Ensure everything is reset
+
+                return PULSE_DATA_FSK;
+            }
+
+            // intentional fallthrough
+#if defined __has_attribute
+#if __has_attribute(fallthrough)
+            __attribute__((fallthrough));
+#endif
+#endif
+
+        case PD_OOK_STATE_GAP:
+            pulses->gap[pulses->num_pulses] = s->pulse_length; // Store gap width
+            pulses->num_pulses += 1;                           // Store last pulse
+            s->ook_state = PD_OOK_STATE_IDLE;
+            // Store estimates
+            pulses->ook_low_estimate  = s->ook_low_estimate;
+            pulses->ook_high_estimate = s->ook_high_estimate;
+            pulses->end_ago           = len - s->data_counter;
+
+            return PULSE_DATA_OOK;
+
+        default:
+            fprintf(stderr, "demod_OOK(): Unknown state!!\n");
+            s->ook_state = PD_OOK_STATE_IDLE;
+        }
+    }
+
     int att_hist[37] = {0};
     int const samples_per_ms = samp_rate / 1000;
-    pulse_detect_t *s = pulse_detect;
+
     s->ook_high_estimate = MAX(s->ook_high_estimate, pulse_detect->ook_min_high_level);    // Be sure to set initial minimum level
 
     if (s->data_counter == 0) {

--- a/src/r_flow.c
+++ b/src/r_flow.c
@@ -66,13 +66,11 @@ static void calc_rssi_snr(struct dm_state const *demod, pulse_data_t *pulse_data
 /**
 Flush the SDR IQ data frame processing, e.g. on the end of a input file.
 
-Note: this should flush pulse_detect_package() but is not implemented.
-You need to mocked this by feeding empty I/Q frames.
+@return Count of successful decoding events
 */
-void flush_sdr_flow(r_cfg_t *cfg)
+int flush_sdr_flow(r_cfg_t *cfg)
 {
-    (void)cfg;
-    // should flush pulse_detect_package() someday
+    return push_sdr_flow(cfg, NULL, 0);
 }
 
 /**
@@ -108,12 +106,21 @@ int push_sdr_flow(r_cfg_t *cfg, unsigned char *iq_buf, uint32_t len)
     //fprintf(stderr, "push_sdr_flow... %u\n", len);
     struct dm_state *demod = cfg->demod;
     char time_str[LOCAL_TIME_BUFLEN];
-    unsigned long n_samples;
 
     if (!demod) {
         // might happen when the demod closed and we get a last data frame
         return 0; // ignore the data
     }
+
+    unsigned long n_samples = len / demod->sample_size;
+    if (n_samples * demod->sample_size != len) {
+        print_log(LOG_WARNING, __func__, "Sample buffer length not aligned to sample size!");
+    }
+
+    int process_frame = 1;
+
+    // Process new frame data if available
+    if (len) {
 
     // Feed data to all raw outputs (e.g. rtl_tcp)
     // do this here and not in sdr_handler so realtime replay can use rtl_tcp output
@@ -125,15 +132,6 @@ int push_sdr_flow(r_cfg_t *cfg, unsigned char *iq_buf, uint32_t len)
     // save last frame time to see if a new second started
     time_t last_frame_sec = demod->now.tv_sec;
     get_time_now(&demod->now);
-
-    n_samples = len / demod->sample_size;
-    if (n_samples * demod->sample_size != len) {
-        print_log(LOG_WARNING, __func__, "Sample buffer length not aligned to sample size!");
-    }
-    if (!n_samples) {
-        print_log(LOG_WARNING, __func__, "Sample buffer too short!");
-        return 0; // no error, keep running
-    }
 
     // age the frame position if there is one
     if (demod->frame_start_ago) {
@@ -173,7 +171,7 @@ int push_sdr_flow(r_cfg_t *cfg, unsigned char *iq_buf, uint32_t len)
     }
     int noise_only = avg_db < demod->noise_level + 3.0f; // or demod->min_level_auto?
     // always process frames if loader, dumper, or analyzers are in use, otherwise skip silent frames
-    int process_frame = demod->squelch_offset <= 0 || !noise_only || demod->load_info.format || demod->analyze_pulses || demod->dumper.len || demod->samp_grab;
+    process_frame = demod->squelch_offset <= 0 || !noise_only || demod->load_info.format || demod->analyze_pulses || demod->dumper.len || demod->samp_grab;
     demod->total_frames_count += 1;
     if (noise_only) {
         demod->total_frames_squelch += 1;
@@ -225,6 +223,8 @@ int push_sdr_flow(r_cfg_t *cfg, unsigned char *iq_buf, uint32_t len)
         memcpy(demod->buf.fm, iq_buf, len);
     }
 
+    }
+
     // Run a pulse discriminator and pass packages to all configured slicers
     int d_events = 0; // Sensor events successfully detected
     if (demod->r_devs.len || demod->analyze_pulses || demod->dumper.len || demod->samp_grab) {
@@ -259,7 +259,7 @@ int push_sdr_flow(r_cfg_t *cfg, unsigned char *iq_buf, uint32_t len)
                 p_events += run_ook_demods(&demod->r_devs, &demod->pulse_data);
                 demod->total_frames_ook += 1;
                 demod->total_frames_events += p_events > 0;
-                demod->frames_ook +=1;
+                demod->frames_ook += 1;
                 demod->frames_events += p_events > 0;
 
                 // Dump pulse data for this complete package
@@ -292,7 +292,6 @@ int push_sdr_flow(r_cfg_t *cfg, unsigned char *iq_buf, uint32_t len)
                     int p_quality   = pulse_analyzer_check(&demod->pulse_data, package_type, &device);
                     demod->frame_quality = p_quality > demod->frame_quality ? p_quality : demod->frame_quality;
                 }
-
             }
             else if (package_type == PULSE_DATA_FSK) {
                 calc_rssi_snr(demod, &demod->fsk_pulse_data);
@@ -301,7 +300,7 @@ int push_sdr_flow(r_cfg_t *cfg, unsigned char *iq_buf, uint32_t len)
                 }
 
                 p_events += run_fsk_demods(&demod->r_devs, &demod->fsk_pulse_data);
-                demod->total_frames_fsk +=1;
+                demod->total_frames_fsk += 1;
                 demod->total_frames_events += p_events > 0;
                 demod->frames_fsk += 1;
                 demod->frames_events += p_events > 0;
@@ -371,6 +370,11 @@ int push_sdr_flow(r_cfg_t *cfg, unsigned char *iq_buf, uint32_t len)
                 break;
             }
         }
+    }
+
+    // End processing if no new frame data
+    if (!len) {
+        return d_events;
     }
 
     // Run the AM analyzer (deprecated)

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1105,15 +1105,23 @@ static void process_sdr_frame(r_cfg_t *cfg, unsigned char *iq_buf, uint32_t len)
     // Setup variable demod parameters
     cfg->demod->raw_handler           = &cfg->raw_handler;
     cfg->demod->fsk_pulse_detect_mode = fpdm; // cfg->fsk_pulse_detect_mode;
-    cfg->demod->center_frequency      = cfg->center_frequency;
-    cfg->demod->samp_rate             = cfg->samp_rate;
     cfg->demod->report_noise          = cfg->report_noise;
     cfg->demod->verbosity             = cfg->verbosity;
     cfg->demod->raw_mode              = cfg->raw_mode;
     cfg->demod->grab_mode             = cfg->grab_mode;
 
+    int events = 0;
+
+    if (cfg->demod->center_frequency != cfg->center_frequency || cfg->demod->samp_rate != cfg->samp_rate) {
+        // Flush if stream parameters changed
+        events += flush_sdr_flow(cfg);
+    }
+
+    cfg->demod->center_frequency = cfg->center_frequency;
+    cfg->demod->samp_rate        = cfg->samp_rate;
+
     // Send frame data to processing
-    int events = push_sdr_flow(cfg, iq_buf, len);
+    events += push_sdr_flow(cfg, iq_buf, len);
 
     // Exit on errors
     if (events < 0) {
@@ -1826,26 +1834,15 @@ int main(int argc, char **argv) {
                     }
                 }
                 if (n_read == 0) {
-                    break;  // push_sdr_flow() will Segmentation Fault with len=0
+                    break;  // push_sdr_flow() must not be called with len=0
                 }
                 demod->sample_file_pos = ((float)n_blocks * DEFAULT_BUF_LENGTH + n_read) / cfg->samp_rate / demod->sample_size;
                 n_blocks++; // this assumes n_read == DEFAULT_BUF_LENGTH
                 process_sdr_frame(cfg, test_mode_buf, n_read);
             } while (n_read != 0 && !cfg->exit_async);
 
-            flush_sdr_flow(cfg); // this is just a placeholder for now
-            // Call a last time with cleared samples to ensure EOP detection
-            if (demod->sample_size == 2) { // CU8
-                memset(test_mode_buf, 128, DEFAULT_BUF_LENGTH); // 128 is 0 in unsigned data
-                // or is 127.5 a better 0 in cu8 data?
-                //for (unsigned long n = 0; n < DEFAULT_BUF_LENGTH/2; n++)
-                //    ((uint16_t *)test_mode_buf)[n] = 0x807f;
-            }
-            else { // CF32, CS16
-                    memset(test_mode_buf, 0, DEFAULT_BUF_LENGTH);
-            }
-            demod->sample_file_pos = ((float)n_blocks + 1) * DEFAULT_BUF_LENGTH / cfg->samp_rate / demod->sample_size;
-            process_sdr_frame(cfg, test_mode_buf, DEFAULT_BUF_LENGTH);
+            // Flush to ensure EOP detection
+            flush_sdr_flow(cfg);
 
             //Always classify a signal at the end of the file
             if (demod->am_analyze) {


### PR DESCRIPTION
This adds proper on-demand flushing of the demod (discriminator actually).

E.g. on parameter change (freq or rate) and on input file change any currently unfinished packet will be emitted.

This replaces our old workaround of pushing two empty frames through the demod.