### PR TITLE
typhur_sync_gold: fix WT10 temperature/battery scaling, add variant detection

### DIFF
--- a/src/devices/typhur_sync_gold.c
+++ b/src/devices/typhur_sync_gold.c
@@ -13,7 +13,7 @@
 #include <math.h>
 
 /**
-Typhur Sync Gold / Thermomaven WT10 meat thermometer probe.
+Typhur Sync Gold / ThermoMaven G1 / WT10 meat thermometer probe.
 
 Reverse engineered in issue #3138 by \@hakong and \@kevin-david, with
 guidance from \@zuckschwerdt. FSK_PCM at 12.5 us/bit, long 0xaa
@@ -25,19 +25,19 @@ preamble, 16 bit sync word `0x5754`, 24 byte payload:
 - ID: 24 bit, one per physical probe
 - STATUS: bit 3 set when the probe is seated in its charging base
 - VARIANT (byte 5): model/firmware tag, constant per model. 0x1d =
-  Thermomaven WT10, 0x57 = Typhur Sync Gold. See below.
+  ThermoMaven G1 / WT10, 0x57 = Typhur Sync Gold. See below.
 - T1-T5: probe temperature sensors, little-endian
 - AMBIENT: little-endian, separate thermistor
-- BATTERY: little-endian; scale is per-model (Typhur 0.01 V, WT10
+- BATTERY: little-endian; scale is per-model (Typhur 0.01 V, G1/WT10
   0.01/3 V)
 - COUNTER: little-endian, increments every transmission
 - CRC: CRC-16 poly 0x8005 init 0x0000 over the preceding 22 bytes
 
 Temperature encoding differs by model, selected by the byte-5 variant
 tag (constant per model, distinct between models -- confirmed against
-CRC-valid captures from two Typhur units and one WT10 unit).
+CRC-valid captures from two Typhur units and one G1/WT10 unit).
 
-Thermomaven WT10 (variant 0x1d): each 16-bit field is the raw ADC code
+ThermoMaven G1 / WT10 (variant 0x1d): each 16-bit field is the raw ADC code
 of an NTC thermistor read through a voltage divider, not a scaled
 temperature (the code decreases as temperature rises). Recover the
 resistance as R = code / (N - code) (the series resistor folds into
@@ -47,7 +47,7 @@ the constants) and apply Steinhart-Hart:
 
 The probe channels and the ambient sensor use different thermistors,
 so each has its own constants, reverse engineered for unit id 913719
-by capturing raw codes alongside the Thermomaven app. Probes were
+by capturing raw codes alongside the ThermoMaven app. Probes were
 fitted across an ice bath (~0 C), room (~25-28 C), mid-range points
 (~48-57 C) and a rolling boil (~98 C): worst-case residual 0.25 C over
 0-98 C (the ln(R)^2 term is unused, C == 0), monotonic but uncalibrated
@@ -64,10 +64,10 @@ and masks the spurious ambient bit when the flag is set (when clear,
 bit 0x8000 is a legitimate cold-end magnitude bit).
 
 Typhur Sync Gold (variant 0x57): uses a different thermistor whose raw
-codes do NOT fit the WT10 curve, and no app ground truth was available.
+codes do NOT fit the G1/WT10 curve, and no app ground truth was available.
 Its fields are reported with the original issue-#3138 linear scale
 (probes * 0.01 C, ambient * 0.1 C). NOTE: that scale is almost
-certainly wrong -- the fields are raw NTC codes, same as the WT10 --
+certainly wrong -- the fields are raw NTC codes, same as the G1/WT10 --
 but it is retained until Typhur app ground truth allows a proper
 Steinhart-Hart fit. Treat Typhur temperatures as unverified.
 */
@@ -96,7 +96,7 @@ typedef struct {
 } typhur_variant_t;
 
 static typhur_variant_t const typhur_variants[] = {
-        {0x1d, "Thermomaven-WT10", TYPHUR_CONV_STEINHART,
+        {0x1d, "Thermomaven-G1-WT10", TYPHUR_CONV_STEINHART,
                 39740.0f, 3.336648967e-03f, 2.907677078e-04f, 0.0f, -8.446529470e-07f,
                 48420.0f, 3.273739948e-03f, 3.237830150e-04f, 5.655028386e-05f, 1.257351231e-05f,
                 0.0f, 0.0f, 0.01f / 3.0f},
@@ -236,7 +236,7 @@ static char const *const output_fields[] = {
 };
 
 r_device const typhur_sync_gold = {
-        .name        = "Typhur Sync Gold / Thermomaven WT10 meat thermometer probe",
+        .name        = "Typhur Sync Gold / ThermoMaven G1 / WT10 meat thermometer probe",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 13,
         .long_width  = 13,

--- a/src/devices/typhur_sync_gold.c
+++ b/src/devices/typhur_sync_gold.c
@@ -10,37 +10,124 @@
 */
 
 #include "decoder.h"
+#include <math.h>
 
 /**
-Typhur Sync Gold meat thermometer probe (Dual/Quad variants).
+Typhur Sync Gold / Thermomaven WT10 meat thermometer probe.
 
 Reverse engineered in issue #3138 by \@hakong and \@kevin-david, with
 guidance from \@zuckschwerdt. FSK_PCM at 12.5 us/bit, long 0xaa
 preamble, 16 bit sync word `0x5754`, 24 byte payload:
 
-    ID:24h ?:8h STATUS:8h ?:8h T1:16h T2:16h T3:16h T4:16h T5:16h
+    ID:24h ?:8h STATUS:8h VARIANT:8h T1:16h T2:16h T3:16h T4:16h T5:16h
     AMBIENT:16h BATTERY:16h COUNTER:16h CRC:16h
 
 - ID: 24 bit, one per physical probe
 - STATUS: bit 3 set when the probe is seated in its charging base
-- T1-T5: probe temperature sensors, little-endian, scale 0.01 C
-- AMBIENT: little-endian, scale 0.1 C (coarser resolution than T1-T5)
-- BATTERY: little-endian, scale 0.01 V
+- VARIANT (byte 5): model/firmware tag, constant per model. 0x1d =
+  Thermomaven WT10, 0x57 = Typhur Sync Gold. See below.
+- T1-T5: probe temperature sensors, little-endian
+- AMBIENT: little-endian, separate thermistor
+- BATTERY: little-endian; scale is per-model (Typhur 0.01 V, WT10
+  0.01/3 V)
 - COUNTER: little-endian, increments every transmission
 - CRC: CRC-16 poly 0x8005 init 0x0000 over the preceding 22 bytes
 
-Independently verified against 19 real captures across two physical
-probes (issue #3138's attached zip): CRC valid on all 19, and the
-decoded values are physically sane -- T1-T5 cluster in a narrow range
-per probe (matching the reporter's own "~140-165 F" note), AMBIENT
-matches the reporter's "~210-230 F" note, battery voltage is stable
-per probe, and COUNTER increments monotonically per probe ID across
-the capture sequence.
+Temperature encoding differs by model, selected by the byte-5 variant
+tag (constant per model, distinct between models -- confirmed against
+CRC-valid captures from two Typhur units and one WT10 unit).
+
+Thermomaven WT10 (variant 0x1d): each 16-bit field is the raw ADC code
+of an NTC thermistor read through a voltage divider, not a scaled
+temperature (the code decreases as temperature rises). Recover the
+resistance as R = code / (N - code) (the series resistor folds into
+the constants) and apply Steinhart-Hart:
+
+    1/T[K] = A + B*ln(R) + C*ln(R)^3
+
+The probe channels and the ambient sensor use different thermistors,
+so each has its own constants, reverse engineered for unit id 913719
+by capturing raw codes alongside the Thermomaven app. Probes were
+fitted across an ice bath (~0 C), room (~25-28 C), a mid-range point
+(~48-51 C) and a rolling boil (~98 C): worst-case residual 0.25 C over
+0-98 C, monotonic but uncalibrated extrapolation above ~98 C. Ambient
+additionally used two grill points (~125 C): <=0.35 C over 0-125 C,
+extrapolation (tends to overshoot) above ~125 C.
+
+Ambient/battery status flag: a per-frame flag rides in bit 0x0800 of
+the battery field. When set it also forces bit 0x8000 of the ambient
+field high, which otherwise rolls a high ambient reading over to a
+bogus cold value. The decoder strips the flag from the battery field
+and masks the spurious ambient bit when the flag is set (when clear,
+bit 0x8000 is a legitimate cold-end magnitude bit).
+
+Typhur Sync Gold (variant 0x57): uses a different thermistor whose raw
+codes do NOT fit the WT10 curve, and no app ground truth was available.
+Its fields are reported with the original issue-#3138 linear scale
+(probes * 0.01 C, ambient * 0.1 C). NOTE: that scale is almost
+certainly wrong -- the fields are raw NTC codes, same as the WT10 --
+but it is retained until Typhur app ground truth allows a proper
+Steinhart-Hart fit. Treat Typhur temperatures as unverified.
 */
 
 #define TYPHUR_SYNC_GOLD_PAYLOAD_LEN 24
 
+typedef enum {
+    TYPHUR_CONV_STEINHART, // NTC divider + Steinhart-Hart (calibrated)
+    TYPHUR_CONV_LINEAR,    // legacy raw * scale (unverified)
+} typhur_conv_t;
+
+typedef struct {
+    uint8_t variant; // byte-5 tag
+    char const *model;
+    typhur_conv_t conv;
+    // Steinhart-Hart + voltage-divider constants (probe, then ambient).
+    float probe_n, probe_a, probe_b, probe_c;
+    float amb_n, amb_a, amb_b, amb_c;
+    // Linear scale (probe, ambient) for TYPHUR_CONV_LINEAR.
+    float probe_scale, amb_scale;
+    // Battery voltage scale (the raw field is scaled differently per model).
+    float battery_scale;
+} typhur_variant_t;
+
+static typhur_variant_t const typhur_variants[] = {
+        {0x1d, "Thermomaven-WT10", TYPHUR_CONV_STEINHART,
+                39820.0f, 3.337914614e-03f, 2.918389929e-04f, -9.998324687e-07f,
+                40140.0f, 3.182108432e-03f, 2.309766424e-04f, 2.744203041e-06f,
+                0.0f, 0.0f, 0.01f / 3.0f},
+        {0x57, "Typhur-SyncGold", TYPHUR_CONV_LINEAR,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0.01f, 0.1f, 0.01f},
+};
+
 static uint8_t const typhur_sync_gold_sync[2] = {0x57, 0x54};
+
+/// Convert a raw NTC ADC code to degrees Celsius via divider + Steinhart-Hart.
+static float typhur_sync_gold_steinhart(int code, float n, float a, float b, float c)
+{
+    // Guard the divider/log domain: code must stay within (0, N).
+    if (code < 1) {
+        code = 1;
+    }
+    if ((float)code > n - 1.0f) {
+        code = (int)(n - 1.0f);
+    }
+    float lr  = logf((float)code / (n - (float)code));
+    float t_k = 1.0f / (a + b * lr + c * lr * lr * lr);
+    return t_k - 273.15f;
+}
+
+/// Convert a raw field to degrees Celsius using the variant's model.
+static float typhur_sync_gold_temp_c(typhur_variant_t const *v, int code, int is_ambient)
+{
+    if (v->conv == TYPHUR_CONV_LINEAR) {
+        return code * (is_ambient ? v->amb_scale : v->probe_scale);
+    }
+    if (is_ambient) {
+        return typhur_sync_gold_steinhart(code, v->amb_n, v->amb_a, v->amb_b, v->amb_c);
+    }
+    return typhur_sync_gold_steinhart(code, v->probe_n, v->probe_a, v->probe_b, v->probe_c);
+}
 
 static int typhur_sync_gold_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
@@ -65,20 +152,47 @@ static int typhur_sync_gold_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             continue;
         }
 
+        // Identify the model from the byte-5 variant tag.
+        typhur_variant_t const *v = NULL;
+        for (unsigned i = 0; i < sizeof(typhur_variants) / sizeof(typhur_variants[0]); i++) {
+            if (typhur_variants[i].variant == b[5]) {
+                v = &typhur_variants[i];
+                break;
+            }
+        }
+        if (!v) {
+            decoder_logf(decoder, 1, __func__, "unknown variant tag %02x", b[5]);
+            continue;
+        }
+
         uint32_t id = ((uint32_t)b[0] << 16) | (b[1] << 8) | b[2];
         int in_base = (b[4] & 0x08) != 0;
-        float temp_1_c   = (b[6] | (b[7] << 8)) * 0.01f;
-        float temp_2_c   = (b[8] | (b[9] << 8)) * 0.01f;
-        float temp_3_c   = (b[10] | (b[11] << 8)) * 0.01f;
-        float temp_4_c   = (b[12] | (b[13] << 8)) * 0.01f;
-        float temp_5_c   = (b[14] | (b[15] << 8)) * 0.01f;
-        float ambient_c  = (b[16] | (b[17] << 8)) * 0.1f;
-        float battery_v  = (b[18] | (b[19] << 8)) * 0.01f;
-        int counter       = b[20] | (b[21] << 8);
+
+        // A per-frame status flag rides in bit 0x0800 of the battery field.
+        // When set it also forces bit 0x8000 of the ambient field high,
+        // which otherwise rolls the ambient reading over (e.g. 3052 -> 35820,
+        // decoding a ~115 C grill temp as -2.5 C). Strip the flag from the
+        // battery field, and mask the spurious ambient bit when it is set --
+        // when clear, bit 0x8000 is a legitimate part of a cold-end code.
+        int flag        = (b[19] & 0x08) != 0;
+        int amb_code    = b[16] | (b[17] << 8);
+        if (flag) {
+            amb_code &= 0x7fff;
+        }
+        int batt_raw = (b[18] | (b[19] << 8)) & ~0x0800;
+
+        float temp_1_c  = typhur_sync_gold_temp_c(v, b[6] | (b[7] << 8), 0);
+        float temp_2_c  = typhur_sync_gold_temp_c(v, b[8] | (b[9] << 8), 0);
+        float temp_3_c  = typhur_sync_gold_temp_c(v, b[10] | (b[11] << 8), 0);
+        float temp_4_c  = typhur_sync_gold_temp_c(v, b[12] | (b[13] << 8), 0);
+        float temp_5_c  = typhur_sync_gold_temp_c(v, b[14] | (b[15] << 8), 0);
+        float ambient_c = typhur_sync_gold_temp_c(v, amb_code, 1);
+        float battery_v = batt_raw * v->battery_scale;
+        int counter     = b[20] | (b[21] << 8);
 
         /* clang-format off */
         data_t *data = data_make(
-                "model",        "",             DATA_STRING, "Typhur-SyncGold",
+                "model",        "",             DATA_STRING, v->model,
                 "id",           "",             DATA_FORMAT, "%06x", DATA_INT, id,
                 "in_base",      "In base",      DATA_INT,    in_base,
                 "counter",      "Counter",      DATA_INT,    counter,
@@ -117,7 +231,7 @@ static char const *const output_fields[] = {
 };
 
 r_device const typhur_sync_gold = {
-        .name        = "Typhur Sync Gold meat thermometer probe",
+        .name        = "Typhur Sync Gold / Thermomaven WT10 meat thermometer probe",
         .modulation  = FSK_PULSE_PCM,
         .short_width = 13,
         .long_width  = 13,

--- a/src/devices/typhur_sync_gold.c
+++ b/src/devices/typhur_sync_gold.c
@@ -43,16 +43,18 @@ temperature (the code decreases as temperature rises). Recover the
 resistance as R = code / (N - code) (the series resistor folds into
 the constants) and apply Steinhart-Hart:
 
-    1/T[K] = A + B*ln(R) + C*ln(R)^3
+    1/T[K] = A + B*ln(R) + C*ln(R)^2 + D*ln(R)^3
 
 The probe channels and the ambient sensor use different thermistors,
 so each has its own constants, reverse engineered for unit id 913719
 by capturing raw codes alongside the Thermomaven app. Probes were
-fitted across an ice bath (~0 C), room (~25-28 C), a mid-range point
-(~48-51 C) and a rolling boil (~98 C): worst-case residual 0.25 C over
-0-98 C, monotonic but uncalibrated extrapolation above ~98 C. Ambient
-additionally used two grill points (~125 C): <=0.35 C over 0-125 C,
-extrapolation (tends to overshoot) above ~125 C.
+fitted across an ice bath (~0 C), room (~25-28 C), mid-range points
+(~48-57 C) and a rolling boil (~98 C): worst-case residual 0.25 C over
+0-98 C (the ln(R)^2 term is unused, C == 0), monotonic but uncalibrated
+extrapolation above ~98 C. Ambient additionally used a ~61 C and two
+~125 C grill points and needs the full four-term fit: worst-case
+residual 0.4 C over 0-125 C, extrapolation (tends to overshoot) above
+~125 C.
 
 Ambient/battery status flag: a per-frame flag rides in bit 0x0800 of
 the battery field. When set it also forces bit 0x8000 of the ambient
@@ -81,9 +83,12 @@ typedef struct {
     uint8_t variant; // byte-5 tag
     char const *model;
     typhur_conv_t conv;
-    // Steinhart-Hart + voltage-divider constants (probe, then ambient).
-    float probe_n, probe_a, probe_b, probe_c;
-    float amb_n, amb_a, amb_b, amb_c;
+    // Voltage-divider full-scale + Steinhart-Hart coefficients for the
+    // 1, ln(R), ln(R)^2 and ln(R)^3 terms (probe, then ambient). The probe
+    // needs only three terms (c == 0); ambient needs the ln(R)^2 term to
+    // span its wider 0-125 C range.
+    float probe_n, probe_a, probe_b, probe_c, probe_d;
+    float amb_n, amb_a, amb_b, amb_c, amb_d;
     // Linear scale (probe, ambient) for TYPHUR_CONV_LINEAR.
     float probe_scale, amb_scale;
     // Battery voltage scale (the raw field is scaled differently per model).
@@ -92,18 +97,18 @@ typedef struct {
 
 static typhur_variant_t const typhur_variants[] = {
         {0x1d, "Thermomaven-WT10", TYPHUR_CONV_STEINHART,
-                39820.0f, 3.337914614e-03f, 2.918389929e-04f, -9.998324687e-07f,
-                40140.0f, 3.182108432e-03f, 2.309766424e-04f, 2.744203041e-06f,
+                39740.0f, 3.336648967e-03f, 2.907677078e-04f, 0.0f, -8.446529470e-07f,
+                48420.0f, 3.273739948e-03f, 3.237830150e-04f, 5.655028386e-05f, 1.257351231e-05f,
                 0.0f, 0.0f, 0.01f / 3.0f},
         {0x57, "Typhur-SyncGold", TYPHUR_CONV_LINEAR,
-                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 0.01f, 0.1f, 0.01f},
 };
 
 static uint8_t const typhur_sync_gold_sync[2] = {0x57, 0x54};
 
 /// Convert a raw NTC ADC code to degrees Celsius via divider + Steinhart-Hart.
-static float typhur_sync_gold_steinhart(int code, float n, float a, float b, float c)
+static float typhur_sync_gold_steinhart(int code, float n, float a, float b, float c, float d)
 {
     // Guard the divider/log domain: code must stay within (0, N).
     if (code < 1) {
@@ -113,7 +118,7 @@ static float typhur_sync_gold_steinhart(int code, float n, float a, float b, flo
         code = (int)(n - 1.0f);
     }
     float lr  = logf((float)code / (n - (float)code));
-    float t_k = 1.0f / (a + b * lr + c * lr * lr * lr);
+    float t_k = 1.0f / (a + b * lr + c * lr * lr + d * lr * lr * lr);
     return t_k - 273.15f;
 }
 
@@ -124,9 +129,9 @@ static float typhur_sync_gold_temp_c(typhur_variant_t const *v, int code, int is
         return code * (is_ambient ? v->amb_scale : v->probe_scale);
     }
     if (is_ambient) {
-        return typhur_sync_gold_steinhart(code, v->amb_n, v->amb_a, v->amb_b, v->amb_c);
+        return typhur_sync_gold_steinhart(code, v->amb_n, v->amb_a, v->amb_b, v->amb_c, v->amb_d);
     }
-    return typhur_sync_gold_steinhart(code, v->probe_n, v->probe_a, v->probe_b, v->probe_c);
+    return typhur_sync_gold_steinhart(code, v->probe_n, v->probe_a, v->probe_b, v->probe_c, v->probe_d);
 }
 
 static int typhur_sync_gold_decode(r_device *decoder, bitbuffer_t *bitbuffer)


### PR DESCRIPTION
Modify the temperature decode logic in the `typhur_sync_gold` decoder to add support for raw NTC value temperature data, adding support for the ThermoMaven G1 / WT10 rebrand. See #3627 for the full analysis and data.

### Problem

The 16-bit temperature fields in some 2BC6K-WTP4000 probe variants are raw NTC thermistor ADC codes (read through a voltage divider), not hundredths of a degree. The existing `* 0.01` / `* 0.1` scaling reported ~205 °C for a probe at room temperature, and values dropped as the probe warmed.

The ThermoMaven G1 / WT10 (same device, two names) transmits the identical frame (same `0x5754` sync, 24-byte layout, CRC-16/0x8005) but uses a different thermistor. It is distinguishable from the Typhur by a per-model tag in byte 5 (`0x1d` G1/WT10, `0x57` Typhur), constant within a model and distinct between models across CRC-valid captures from three units.

### Change

- Detect the model from the byte-5 variant tag and report the correct model name (the G1/WT10 is emitted as `Thermomaven-G1-WT10`). Unknown variant tags are rejected.
- **ThermoMaven G1 / WT10 (`0x1d`):** convert with an NTC divider + Steinhart-Hart model, `R = code / (N - code)`, `1/T = A + B·ln(R) + C·ln(R)² + D·ln(R)³`, with separate probe and ambient thermistor constants. Calibrated against vendor-app ground truth: probe channels use the three-term form (`C = 0`) fitted across an ice bath, room, a mid-range (~48–57 °C) and a rolling boil (≤0.25 °C over 0–98 °C); the ambient sensor uses the full four-term form to span room, ~61 °C and ~125 °C grill points (≤0.4 °C over 0–125 °C).
- **Status flag / high-temp rollover:** a per-frame status flag rides in bit `0x0800` of the battery field, and when set it also forces bit `0x8000` of the ambient field high — which otherwise rolls a high-temperature ambient reading over to a bogus cold value (e.g. a ~115 °C grill reading decoding as −2.5 °C). The decoder strips the flag from the battery field and masks the spurious ambient bit when the flag is set (when clear, bit `0x8000` is a legitimate cold-end magnitude bit).
- **Battery** is scaled per-model: the G1/WT10 reads 3× the Typhur for the same voltage. A per-variant battery scale (G1/WT10 `0.01/3`, Typhur `0.01`) brings both to a sane ~2.5–2.7 V single-cell reading; applying either scale to the other model gives implausible values (G1/WT10 7.69 V, or Typhur 0.9 V).
- **Typhur Sync Gold (`0x57`):** retains the original linear scale (no app ground truth available to fit a curve), documented as unverified.

### Verification

Decoded G1/WT10 captures vs the vendor app (Celsius):

| point | probes decoder | probes app | ambient dec / app |
|-------|----------------|------------|-------------------|
| ice   | 4.05 … 0.20    | 4.18 … 0.17 | 0.3 / 0.3 |
| room  | ~24.9          | ~24.8       | 24.8 / 24.8 |
| ~56 °C | 55.50 … 53.10 | 55.56 … 53.08 | 50.2 / 49.8 |
| boil  | 98.06 … 97.35  | 98.31 … 97.35 | 98.4 / 98.4 |
| grill | —              | —           | 124.5–125.6 / 124.8–125.2 |

Worst-case residual ≤0.25 °C (probes, 0–98 °C) and ≤0.4 °C (ambient, 0–125 °C). Typhur sample frames still decode to the original linear values (no regression).

### Caveats

- G1/WT10 constants were fitted from a single unit; other units may vary by thermistor tolerance.
- G1/WT10 probe readings above ~98 °C and ambient readings above ~125 °C are monotonic but uncalibrated extrapolation (no ground truth beyond those points was available).
- Typhur temperatures remain unverified pending app ground truth for a proper fit.

The Typhur curve is still uncalibrated, and the G1/WT10 constants are from one unit. Unfortunately I don't have access to the Typhur variant, as it doesn't appear to be sold in the US.
