### PR TITLE
Fix [GT-WT03] reject out-of-range temperature and humidity

### DIFF
--- a/src/devices/gt_wt_03.c
+++ b/src/devices/gt_wt_03.c
@@ -115,19 +115,32 @@ static int gt_wt_03_decode(r_device *decoder, bitbuffer_t *bitbuffer)
         return DECODE_FAIL_MIC;
     }
 
-    // humidity: see above the note about working range
-    int humidity = b[1]; // extract 8 bits humidity
-    if (humidity <= 10) // actually the sensors sends 10 below working range of 20%
-        humidity = 0;
-    else if (humidity > 95) // actually the sensors sends 110 above working range of 90%
-        humidity = 100;
-
     int sensor_id      = (b[0]);          // 8 bits
     int battery_low    = (b[2] >> 7 & 1); // 1 bits
     int button_pressed = (b[2] >> 6 & 1); // 1 bits
     int channel        = (b[2] >> 4 & 3); // 2 bits
     int temp_raw       = (int16_t)(((b[2] & 0x0f) << 12) | (b[3] << 4)); // uses sign extend
     float temp_c       = (temp_raw >> 4) * 0.1F;
+
+    // The sensor's specified temperature range is -50.0 C to 70.0 C, plus the
+    // -50.1 C (Lo) and 70.1 C (Hi) out-of-range indicator readings.
+    if (temp_c < -51.0F || temp_c > 71.0F) {
+        decoder_logf(decoder, 2, __func__, "temperature sanity check failed: %.1f C", temp_c);
+        return DECODE_FAIL_SANITY;
+    }
+
+    // Values outside the measurable humidity range use exact LL/HH sentinels.
+    int humidity_raw = b[1]; // extract 8 bits humidity
+    if (humidity_raw != 10 && humidity_raw != 110
+            && (humidity_raw < 20 || humidity_raw > 95)) {
+        decoder_logf(decoder, 2, __func__, "invalid humidity value: %d", humidity_raw);
+        return DECODE_FAIL_SANITY;
+    }
+    int humidity = humidity_raw;
+    if (humidity_raw == 10)
+        humidity = 0;
+    else if (humidity_raw == 110)
+        humidity = 100;
 
     /* clang-format off */
     data = data_make(

--- a/src/devices/gt_wt_03.c
+++ b/src/devices/gt_wt_03.c
@@ -124,7 +124,7 @@ static int gt_wt_03_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     // The sensor's specified temperature range is -50.0 C to 70.0 C, plus the
     // -50.1 C (Lo) and 70.1 C (Hi) out-of-range indicator readings.
-    if (temp_c < -51.0F || temp_c > 71.0F) {
+    if (temp_c <= -50.2F || temp_c >= 70.2F) {
         decoder_logf(decoder, 2, __func__, "temperature sanity check failed: %.1f C", temp_c);
         return DECODE_FAIL_SANITY;
     }


### PR DESCRIPTION
Closes #3630.

`gt_wt_03_decode()` never checked temperature against a plausible range, so any noise packet that happens to pass the CRC gets reported as a real reading. That's what produced `temperature_C: -177.3` in the issue - the checksum is only 8 bits with a shifting XOR key, so a random bit pattern lining up with it isn't that rare.

`gt_wt_02.c` already guards against this (temp range check plus an exact LL/HH sentinel check for humidity), gt_wt_03.c just never got the same treatment. Humidity in gt_wt_03 wasn't checked either, it was clamped: any raw byte <= 10 became 0%, anything > 95 became 100%, so a garbage byte like 200 would silently turn into a "plausible" 100% instead of being flagged.

Two changes, both in `gt_wt_03_decode()`:

- Temperature: reject anything outside -51.0 C to 71.0 C. The header comment for this device documents the sensor's working range as -50.0 C to +70.0 C, with -50.1 C ("Lo") and +70.1 C ("Hi") as the sensor's own out-of-range indicator values, so I did not just reuse gt_wt_02's -20/+60 bounds - GT-WT03 is a wider-range sensor and those numbers reject legitimate readings. I put a degree of headroom past the documented -50.1/+70.1 sentinels instead of cutting exactly there: `temp_c` is computed as `raw * 0.1F`, and a small standalone test showed the raw value for -50.1 C comes out to -50.1000023, on the wrong side of a literal `-50.1F` comparison because of how 0.1F rounds in float32. A degree of margin fixes that without weakening the check against garbage like -177.3.
- Humidity: switched from clamping to the same exact-sentinel check gt_wt_02 uses - accept only 10 (LL) or 110 (HH) as sentinels, or 20-95 as the documented working range, reject anything else with DECODE_FAIL_SANITY instead of silently mapping it to 0% or 100%.

Verified by reading through the encoding in both files and hand-checking the math for the reported -177.3 value and for the documented range edges (-50.0/-50.1/70.0/70.1) against the new bounds. No cmake here, so I compiled just this file with the same warning flags the project's CMakeLists uses (`-Wall -Wextra -Wsign-compare -std=c99`) and it's clean.

I don't have hardware for this sensor and this was a noise decode rather than a real transmission, so there's no capture to add to rtl_433_tests for it. If someone with a GT-WT03 can grab a reading near the range edges, that'd make a good regression fixture.
