### PR TITLE
Fix [WT450] reject implausible temperature and humidity

### DIFF
--- a/src/devices/wt450.c
+++ b/src/devices/wt450.c
@@ -99,6 +99,17 @@ static int wt450_callback(r_device *decoder, bitbuffer_t *bitbuffer)
     temp          = (temp_whole - 50.0f) + (temp_fraction / 16.0f);
     seq           = (b[4] >> 6);
 
+    // Only 2 parity bits gate this frame; sanity-check the decoded values.
+    // WT450H range is -30 to 70 C, so reject well outside it and humidity > 100%.
+    if (humidity > 100) {
+        decoder_logf(decoder, 1, __func__, "implausible humidity: %u %%", humidity);
+        return DECODE_FAIL_SANITY;
+    }
+    if (temp < -35.0f || temp > 75.0f) {
+        decoder_logf(decoder, 1, __func__, "implausible temperature: %.2f C", temp);
+        return DECODE_FAIL_SANITY;
+    }
+
     /* clang-format off */
     data = data_make(
             "model",            "",             DATA_STRING, "WT450-TH",


### PR DESCRIPTION
`wt450_callback()` never range-checks what it decodes. The only integrity check on this frame is 2 bits of parity, so roughly 1 in 4 possible trailing bytes satisfy it for any given data bits. That's much weaker than the checksum in `gt_wt_03`. Humidity is a raw 7-bit field with no ceiling at 100, and temperature is a full 8-bit whole-degree field offset by -50, so noise that happens to match the preamble nibble and pass parity gets reported as a real reading — 127% humidity, 205.0 C.

`gt_wt_02.c` and `gt_wt_03.c` already guard against exactly this. `wt450.c` never got the same treatment, and it's enabled by default.

Rejecting humidity over 100% and temperature outside -35 to 75 C. The WT450H is documented -30 to 70 C in its Clas Ohlson manual, so that leaves a few degrees of headroom either side.

No cmake on this machine, so I pulled the real unmodified `wt450.c` into a small standalone program via `#include` (the callback is `static`) and linked it against the project's own `bit_util.c`, `decoder_util.c`, `data.c` and `abuf.c`, so `data_make()` and the output path behave as they do in the real binary.

Feeding it a crafted 36-bit frame `C0 07 FF F0 01`, which matches the preamble and passes parity, on current `master`:

```
DECODER ACCEPTED FRAME, output fields:
  temperature_C    = 205
  humidity         = 127
wt450_callback() return value: 1
```

With this change, the same frame:

```
wt450_callback() return value: -4   (DECODE_FAIL_SANITY)
```

And a plausible reading, `C0 03 74 88 03`, still decodes fine after the change:

```
  temperature_C    = 22.5
  humidity         = 55
wt450_callback() return value: 1
```

Compiles clean under `-Wall -Wextra -Wsign-compare -std=c99`.

I don't have this sensor, so there's no capture to add to rtl_433_tests. If someone with a WT450, WT260H or WT405H can grab a reading near the range edges, that'd make a good regression fixture.
