### PR TITLE
Update Vivint.c to include DW11 inputs

### DIFF
--- a/src/devices/vivint.c
+++ b/src/devices/vivint.c
@@ -493,7 +493,7 @@ static int vivint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int tamper_bit      = 0;    // Case open tamper
     int reed_bit        = 0;    // Primary use case for DW11
     int alarm_bit       = 0;    // Unknown meaning for DW11, copied from honeywell.c
-    int battery_low_bit = 0;    // Untested
+    int battery_low_bit = 0;    // Tested
     int heartbeat_bit   = 0;    // Unknown meaning for DW11, copied from honeywell.c
 
     if (event_type == 0x7a) {

--- a/src/devices/vivint.c
+++ b/src/devices/vivint.c
@@ -22,7 +22,7 @@
 /**
 Vivint Door/Window Sensors (345.0 MHz).
 
-Tested with the Vivint V-DW21R-345 door/window sensor.
+Tested with the Vivint V-DW21R-345 door/window sensor and Vivint V-DW11-345 Door Sensor.
 
 OOK Manchester (zerobit), 0xFFFE preamble, 96 bit (12 byte) packet. Decoded
 payload (80 data bits, 10 bytes) after the preamble:
@@ -488,14 +488,28 @@ static int vivint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     snprintf(id_str, sizeof(id_str), "%04u-%07u", (id >> 20) & 0xfff, id & 0xfffff);
 
     int has_contact  = 0;
-    int contact_open = 0;
+
+    int contact_bit     = 0;
+    int tamper_bit      = 0;
+    int reed_bit        = 0;
+    int alarm_bit       = 0;
+    int battery_low_bit = 0;
+    int heartbeat_bit   = 0;
     if (event_type == 0x7a) {
         vivint_seed_t *s = vivint_ctx_find((vivint_ctx_t *)decoder_user_data(decoder), id);
         if (s) {
             int c1 = vivint_seed_c1_at(s, (uint16_t)counter);
             if (c1 >= 0) {
                 has_contact  = 1;
-                contact_open = (flags ^ c1) & 0x80 ? 1 : 0;
+                /* Extract DW11 event bits (CTRABHUU layout):
+                   C=contact(7), T=tamper(6), R=reed(5), A=alarm(4),
+                   B=battery_low(3), H=heartbeat(2), U,U=unused(1,0) */
+                contact_bit     = (flags ^ c1) & 0x80 ? 1 : 0;
+                tamper_bit      = (flags ^ c1) & 0x40 ? 1 : 0;
+                reed_bit        = (flags ^ c1) & 0x20 ? 1 : 0;
+                alarm_bit       = (flags ^ c1) & 0x10 ? 1 : 0;
+                battery_low_bit = (flags ^ c1) & 0x08 ? 1 : 0;
+                heartbeat_bit   = (flags ^ c1) & 0x04 ? 1 : 0;
             }
         }
     }
@@ -513,8 +527,14 @@ static int vivint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "counter",      "",              DATA_FORMAT, "%04x", DATA_INT, counter,
             "flags",        "",              DATA_FORMAT, "%02x", DATA_INT, flags,
             "event_type",   "",              DATA_FORMAT, "%02x", DATA_INT, event_type,
-            "state",        "",              DATA_COND, has_contact,  DATA_STRING, contact_open ? "open" : "closed",
-            "contact_open", "",              DATA_COND, has_contact,  DATA_INT, contact_open,
+            "state",        "",              DATA_COND, has_contact,  DATA_STRING, contact_bit ? "open" : "closed",
+            "contact_open", "",              DATA_COND, has_contact,  DATA_INT, contact_bit,
+            /* DW11 event bits (CTRABHUU layout) */
+            "tamper",       "",              DATA_COND, has_contact,  DATA_INT,     tamper_bit,
+            "reed",         "",              DATA_COND, has_contact,  DATA_INT,     reed_bit,
+            "alarm",        "",              DATA_COND, has_contact,  DATA_INT,     alarm_bit,
+            "battery_low",  "Battery",       DATA_COND, has_contact,  DATA_INT,     battery_low_bit,
+            "heartbeat",    "",              DATA_COND, has_contact,  DATA_INT,     heartbeat_bit,
             "data",         "",              DATA_COND, !has_contact, DATA_STRING, payload,
             "mic",          "Integrity",     DATA_STRING, "CRC",
             NULL);
@@ -532,13 +552,19 @@ static char const *const output_fields[] = {
         "event_type",
         "state",
         "contact_open",
+        /* DW11 event bits (CTRABHUU layout) */
+        "tamper",
+        "reed",
+        "alarm",
+        "battery_low",
+        "heartbeat",
         "data",
         "mic",
         NULL,
 };
 
 r_device const vivint = {
-        .name        = "Vivint Door/Window Sensor, V-DW21R-345",
+        .name        = "Vivint Door/Window Sensor, V-DW21R-345/V-DW11-345",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 150,
         .long_width  = 0,

--- a/src/devices/vivint.c
+++ b/src/devices/vivint.c
@@ -489,12 +489,13 @@ static int vivint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     int has_contact  = 0;
 
-    int contact_bit     = 0;
-    int tamper_bit      = 0;
-    int reed_bit        = 0;
-    int alarm_bit       = 0;
-    int battery_low_bit = 0;
-    int heartbeat_bit   = 0;
+    int contact_bit     = 0;    // External contact open/closed state
+    int tamper_bit      = 0;    // Case open tamper
+    int reed_bit        = 0;    // Primary use case for DW11
+    int alarm_bit       = 0;    // Unknown meaning for DW11, copied from honweywell.c
+    int battery_low_bit = 0;    // Untested
+    int heartbeat_bit   = 0;    // Unknown meaning for DW11, copied from honweywell.c
+    
     if (event_type == 0x7a) {
         vivint_seed_t *s = vivint_ctx_find((vivint_ctx_t *)decoder_user_data(decoder), id);
         if (s) {
@@ -528,8 +529,7 @@ static int vivint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "flags",        "",              DATA_FORMAT, "%02x", DATA_INT, flags,
             "event_type",   "",              DATA_FORMAT, "%02x", DATA_INT, event_type,
             "state",        "",              DATA_COND, has_contact,  DATA_STRING, contact_bit ? "open" : "closed",
-            "contact_open", "",              DATA_COND, has_contact,  DATA_INT, contact_bit,
-            /* DW11 event bits (CTRABHUU layout) */
+            "contact_open", "",              DATA_COND, has_contact,  DATA_INT,     contact_bit,
             "tamper",       "",              DATA_COND, has_contact,  DATA_INT,     tamper_bit,
             "reed",         "",              DATA_COND, has_contact,  DATA_INT,     reed_bit,
             "alarm",        "",              DATA_COND, has_contact,  DATA_INT,     alarm_bit,
@@ -552,7 +552,6 @@ static char const *const output_fields[] = {
         "event_type",
         "state",
         "contact_open",
-        /* DW11 event bits (CTRABHUU layout) */
         "tamper",
         "reed",
         "alarm",

--- a/src/devices/vivint.c
+++ b/src/devices/vivint.c
@@ -492,10 +492,10 @@ static int vivint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int contact_bit     = 0;    // External contact open/closed state
     int tamper_bit      = 0;    // Case open tamper
     int reed_bit        = 0;    // Primary use case for DW11
-    int alarm_bit       = 0;    // Unknown meaning for DW11, copied from honweywell.c
+    int alarm_bit       = 0;    // Unknown meaning for DW11, copied from honeywell.c
     int battery_low_bit = 0;    // Untested
-    int heartbeat_bit   = 0;    // Unknown meaning for DW11, copied from honweywell.c
-    
+    int heartbeat_bit   = 0;    // Unknown meaning for DW11, copied from honeywell.c
+
     if (event_type == 0x7a) {
         vivint_seed_t *s = vivint_ctx_find((vivint_ctx_t *)decoder_user_data(decoder), id);
         if (s) {


### PR DESCRIPTION
Adds

Reed Sensor ( Primary on the DW11 )
Tamper Sensor ( Detects open unit )
Alarm - Unknown - copied from honeywell.c
Battery Low - Tested - copied from honeywell.c - Updated, I found a unit with a low battery and it showed a 1 for low battery
Heartbeat - Unknown - copied from honeywell.c

Just a small comment, what is the value of the `state` field?  On a DW11 it is a secondary use case as it requires connecting some wires to a contact sensor and the reed switch is primary.  Is it needed or required ?

Expands on issue #1504

Testing with my two devices, and opening/closing the reed switch
```
~/Code/rtl_433/build/src/rtl_433 -f 345M -R 342:0016-0357157=e4d8,0016-0345744=1e35 -F log
rtl_433 version 25.12-343-g308fd14e branch master at 202607272035 inputs file rtl_tcp RTL-SDR with TLS
Reading conf from "/Users/sgracey/.config/rtl_433/rtl_433.conf".
MQTT: Publishing MQTT data to 192.168.1.11 port 1883
MQTT: Publishing availability to MQTT topic "rtl_433/Pinkman/availability".
MQTT: Publishing device info to MQTT topic "rtl_433/Pinkman/devices[/type][/model][/subtype][/channel][/id]".
MQTT: Publishing events info to MQTT topic "rtl_433/Pinkman/events".
MQTT: Publishing states info to MQTT topic "rtl_433/Pinkman/states".
Found Rafael Micro R820T tuner
SDR: Using device 0: Realtek, RTL2838UHIDIR, SN: 00000001, "Generic RTL2832U OEM"
Exact sample rate is: 250000.000414 Hz
[R82XX] PLL not locked!
{"time" : "2026-07-28 22:19:40", "model" : "Vivint-Security", "id" : "0016-0357157", "counter" : 49, "flags" : 148, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 1, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:41", "model" : "Vivint-Security", "id" : "0016-0357157", "counter" : 49, "flags" : 148, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 1, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:42", "model" : "Vivint-Security", "id" : "0016-0357157", "counter" : 49, "flags" : 148, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 1, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:43", "model" : "Vivint-Security", "id" : "0016-0357157", "counter" : 49, "flags" : 148, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 1, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:46", "model" : "Vivint-Security", "id" : "0016-0345744", "counter" : 62, "flags" : 248, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 0, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:47", "model" : "Vivint-Security", "id" : "0016-0345744", "counter" : 62, "flags" : 248, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 0, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:48", "model" : "Vivint-Security", "id" : "0016-0345744", "counter" : 62, "flags" : 248, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 0, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:49", "model" : "Vivint-Security", "id" : "0016-0345744", "counter" : 62, "flags" : 248, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 0, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:49", "model" : "Vivint-Security", "id" : "0016-0357157", "counter" : 50, "flags" : 32, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 0, "alarm" : 0, "battery_low" : 0, "heartbeat" : 0, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:50", "model" : "Vivint-Security", "id" : "0016-0357157", "counter" : 50, "flags" : 32, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 0, "alarm" : 0, "battery_low" : 0, "heartbeat" : 0, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:52", "model" : "Vivint-Security", "id" : "0016-0357157", "counter" : 50, "flags" : 32, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 0, "alarm" : 0, "battery_low" : 0, "heartbeat" : 0, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:53", "model" : "Vivint-Security", "id" : "0016-0345744", "counter" : 63, "flags" : 176, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 0, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 1, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:54", "model" : "Vivint-Security", "id" : "0016-0345744", "counter" : 63, "flags" : 176, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 0, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 1, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:55", "model" : "Vivint-Security", "id" : "0016-0345744", "counter" : 63, "flags" : 240, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 1, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:56", "model" : "Vivint-Security", "id" : "0016-0345744", "counter" : 63, "flags" : 240, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 1, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:57", "model" : "Vivint-Security", "id" : "0016-0357157", "counter" : 51, "flags" : 60, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 0, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:57", "model" : "Vivint-Security", "id" : "0016-0345744", "counter" : 63, "flags" : 240, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 1, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:57", "model" : "Vivint-Security", "id" : "0016-0357157", "counter" : 51, "flags" : 60, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 0, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:57", "model" : "Vivint-Security", "id" : "0016-0345744", "counter" : 63, "flags" : 240, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 1, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:58", "model" : "Vivint-Security", "id" : "0016-0357157", "counter" : 51, "flags" : 60, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 0, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:58", "model" : "Vivint-Security", "id" : "0016-0345744", "counter" : 63, "flags" : 240, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 1, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:58", "model" : "Vivint-Security", "id" : "0016-0345744", "counter" : 64, "flags" : 140, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 0, "alarm" : 0, "battery_low" : 0, "heartbeat" : 1, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:59", "model" : "Vivint-Security", "id" : "0016-0345744", "counter" : 64, "flags" : 140, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 0, "alarm" : 0, "battery_low" : 0, "heartbeat" : 1, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:59", "model" : "Vivint-Security", "id" : "0016-0357157", "counter" : 51, "flags" : 60, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 0, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:59", "model" : "Vivint-Security", "id" : "0016-0345744", "counter" : 64, "flags" : 140, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 0, "alarm" : 0, "battery_low" : 0, "heartbeat" : 1, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:59", "model" : "Vivint-Security", "id" : "0016-0357157", "counter" : 51, "flags" : 60, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 0, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:59", "model" : "Vivint-Security", "id" : "0016-0345744", "counter" : 64, "flags" : 140, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 0, "alarm" : 0, "battery_low" : 0, "heartbeat" : 1, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:59", "model" : "Vivint-Security", "id" : "0016-0357157", "counter" : 51, "flags" : 60, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 0, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:59", "model" : "Vivint-Security", "id" : "0016-0345744", "counter" : 64, "flags" : 140, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 0, "alarm" : 0, "battery_low" : 0, "heartbeat" : 1, "mic" : "CRC"}
{"time" : "2026-07-28 22:19:59", "model" : "Vivint-Security", "id" : "0016-0357157", "counter" : 51, "flags" : 60, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 1, "alarm" : 0, "battery_low" : 0, "heartbeat" : 0, "mic" : "CRC"}
{"time" : "2026-07-28 22:20:00", "model" : "Vivint-Security", "id" : "0016-0357157", "counter" : 52, "flags" : 148, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 0, "alarm" : 0, "battery_low" : 0, "heartbeat" : 0, "mic" : "CRC"}
{"time" : "2026-07-28 22:20:01", "model" : "Vivint-Security", "id" : "0016-0345744", "counter" : 64, "flags" : 140, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 0, "alarm" : 0, "battery_low" : 0, "heartbeat" : 1, "mic" : "CRC"}
{"time" : "2026-07-28 22:20:02", "model" : "Vivint-Security", "id" : "0016-0345744", "counter" : 64, "flags" : 140, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 0, "alarm" : 0, "battery_low" : 0, "heartbeat" : 1, "mic" : "CRC"}
{"time" : "2026-07-28 22:20:02", "model" : "Vivint-Security", "id" : "0016-0357157", "counter" : 52, "flags" : 148, "event_type" : 122, "state" : "open", "contact_open" : 1, "tamper" : 1, "reed" : 0, "alarm" : 0, "battery_low" : 0, "heartbeat" : 0, "mic" : "CRC"}
```