### PR TITLE
Set autolevel to be on by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Changed pulse detector `autolevel` to be enabled by default, BREAKING behavioral change to the minimum detection level: it now tracks estimated noise instead of a fixed -12 dB floor; use `-Y autolevel=0` (`no`/`off` also accepted) to restore the previous fixed floor
+
 ## Release 25.12 (2025-12-12)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Changed
-
-- Changed pulse detector `autolevel` to be enabled by default, BREAKING behavioral change to the minimum detection level: it now tracks estimated noise instead of a fixed -12 dB floor; use `-Y autolevel=0` (`no`/`off` also accepted) to restore the previous fixed floor
-
 ## Release 25.12 (2025-12-12)
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
   [-X <spec> | help] Add a general purpose decoder (prepend -R 0 to disable all decoders)
   [-Y auto | classic | minmax] FSK pulse detector mode.
   [-Y level=<dB level>] Manual detection level used to determine pulses (-1.0 to -30.0) (0=auto).
-  [-Y minlevel=<dB level>] Manual minimum detection level used to determine pulses (-1.0 to -99.0).
+  [-Y minlevel=<dB level>] Manual minimum detection level used to determine pulses (-1.0 to -99.0) (disables autolevel).
   [-Y minsnr=<dB level>] Minimum SNR to determine pulses (1.0 to 99.0).
-  [-Y autolevel] Set minlevel automatically based on average estimated noise (default: on, use 0|no|off|false to disable).
+  [-Y autolevel] Set minlevel automatically based on average estimated noise (default: on, 0 disables).
   [-Y squelch] Skip frames below estimated noise level to reduce cpu load (default: off).
   [-Y ampest | magest] Choose amplitude or magnitude level estimator.
   [-Y filter=<value>] Manual FM low-pass filter cutoff to separate simultaneous transmissions: us (1-9999, e.g. 20), Hz (10000+), or ratio of sample rate (0.0-1.0).

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
   [-Y level=<dB level>] Manual detection level used to determine pulses (-1.0 to -30.0) (0=auto).
   [-Y minlevel=<dB level>] Manual minimum detection level used to determine pulses (-1.0 to -99.0).
   [-Y minsnr=<dB level>] Minimum SNR to determine pulses (1.0 to 99.0).
-  [-Y autolevel] Set minlevel automatically based on average estimated noise.
-  [-Y squelch] Skip frames below estimated noise level to reduce cpu load.
+  [-Y autolevel] Set minlevel automatically based on average estimated noise (default: on, use 0|no|off to disable).
+  [-Y squelch] Skip frames below estimated noise level to reduce cpu load (use 0|no|off to disable).
   [-Y ampest | magest] Choose amplitude or magnitude level estimator.
   [-Y filter=<value>] Manual FM low-pass filter cutoff to separate simultaneous transmissions: us (1-9999, e.g. 20), Hz (10000+), or ratio of sample rate (0.0-1.0).
 		= Analyze/Debug options =

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
   [-Y level=<dB level>] Manual detection level used to determine pulses (-1.0 to -30.0) (0=auto).
   [-Y minlevel=<dB level>] Manual minimum detection level used to determine pulses (-1.0 to -99.0).
   [-Y minsnr=<dB level>] Minimum SNR to determine pulses (1.0 to 99.0).
-  [-Y autolevel] Set minlevel automatically based on average estimated noise (default: on, use 0|no|off to disable).
-  [-Y squelch] Skip frames below estimated noise level to reduce cpu load (use 0|no|off to disable).
+  [-Y autolevel] Set minlevel automatically based on average estimated noise (default: on, use 0|no|off|false to disable).
+  [-Y squelch] Skip frames below estimated noise level to reduce cpu load (default: off).
   [-Y ampest | magest] Choose amplitude or magnitude level estimator.
   [-Y filter=<value>] Manual FM low-pass filter cutoff to separate simultaneous transmissions: us (1-9999, e.g. 20), Hz (10000+), or ratio of sample rate (0.0-1.0).
 		= Analyze/Debug options =

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -103,7 +103,8 @@
 
 # as command line option:
 #   [-Y autolevel] Set minlevel automatically based on average estimated noise.
-# This is now the default; kept enabled here for clarity, use "pulse_detect autolevel=0" to disable.
+# This is now the default; kept enabled here for clarity.
+# Use "pulse_detect autolevel=0" ("no", "off", "false" and "disable" also work) to disable.
 pulse_detect autolevel
 
 # as command line option:

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -94,7 +94,7 @@
 #pulse_detect level=0
 
 # as command line option:
-#   [-Y minlevel=<dB level>] Manual minimum detection level used to determine pulses (-1.0 to -99.0).
+#   [-Y minlevel=<dB level>] Manual minimum detection level used to determine pulses (-1.0 to -99.0) (disables autolevel).
 #pulse_detect minlevel=-12
 
 # as command line option:
@@ -102,13 +102,11 @@
 #pulse_detect minsnr=9
 
 # as command line option:
-#   [-Y autolevel] Set minlevel automatically based on average estimated noise.
-# This is now the default; kept enabled here for clarity.
-# Use "pulse_detect autolevel=0" ("no", "off", "false" and "disable" also work) to disable.
+#   [-Y autolevel] Set minlevel automatically based on average estimated noise (default: on, 0 disables).
 pulse_detect autolevel
 
 # as command line option:
-#   [-Y squelch] Skip frames below estimated noise level to lower cpu load.
+#   [-Y squelch] Skip frames below estimated noise level to reduce cpu load (default: off).
 pulse_detect squelch
 
 # as command line option:

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -103,6 +103,7 @@
 
 # as command line option:
 #   [-Y autolevel] Set minlevel automatically based on average estimated noise.
+# This is now the default; kept enabled here for clarity, use "pulse_detect autolevel=0" to disable.
 pulse_detect autolevel
 
 # as command line option:

--- a/docs/STARTING.md
+++ b/docs/STARTING.md
@@ -199,17 +199,25 @@ for higher frequencies like `868M` the `minmax` pulse detector is used by defaul
 
 Use `-Y classic` or `-Y minmax` to force the use of a FSK pulse detector.
 
-Use `-Y autolevel` to automatically adjust the minimum detection level based on average estimated noise. Recommended.
+### Detection levels
 
-Use `-Y squelch` to skip frames below estimated noise level to reduce cpu load. Recommended.
+Note `-Y auto` above (the FSK pulse detector's slicer mode, alongside `classic`/`minmax`) is unrelated to `-Y autolevel` below despite the similar name -- `-Y auto` picks how FSK edges are sliced, `-Y autolevel` controls the detection floor described here.
+
+The pulse detector ignores any signal below a minimum detection level (`-Y minlevel`, fixed at -12 dB by default) before any decoder gets a chance to run. Since a typical noise floor is well below that, e.g. around -30 dB, a fixed floor silently discards a wide band of otherwise receivable signal.
+
+Use `-Y autolevel` to track the detection floor to the estimated noise instead of using a fixed value. This is now the **default**, since field testing recovered reception of weak signals that the fixed floor discarded, without a measurable increase in false decodes. Disable it with `-Y autolevel=0` (`no` and `off` are also accepted) to restore the previous fixed `-Y minlevel` behavior.
+
+`-Y minlevel=<dB level>` still matters with autolevel on: it sets the *initial* detection level, and it is the level the tracked noise must fall at least 3 dB below before autolevel starts lowering the floor further -- it is not a lower bound on how far autolevel can track down. To prevent the tracked floor from drifting arbitrarily low on a quiet band (and pulling in more CPU-costly false candidates), autolevel's own adjustment is clamped to a built-in lower bound of -30 dB, regardless of `-Y minlevel`.
+
+Use `-Y squelch` to skip frames below estimated noise level to reduce cpu load. Squelch decides per received sample frame (the SDR callback buffer, about 1 second at the default 250k sample rate) using that frame's *average* level, so a short weak-signal burst can raise the average too little to change the frame's classification -- the whole frame, burst included, gets discarded. Making squelch evaluate noise-only status within a frame instead of across it (sub-frame squelch) is potential future work to make it safe to enable by default; until then it works best where signals stay strong for most of each frame.
 
 :::tip
     [-Y auto | classic | minmax] FSK pulse detector mode.
     [-Y level=<dB level>] Manual detection level used to determine pulses (-1.0 to -30.0) (0=auto).
     [-Y minlevel=<dB level>] Manual minimum detection level used to determine pulses (-1.0 to -99.0).
     [-Y minsnr=<dB level>] Minimum SNR to determine pulses (1.0 to 99.0).
-    [-Y autolevel] Set minlevel automatically based on average estimated noise.
-    [-Y squelch] Skip frames below estimated noise level to reduce cpu load.
+    [-Y autolevel] Set minlevel automatically based on average estimated noise (default: on, use 0|no|off to disable).
+    [-Y squelch] Skip frames below estimated noise level to reduce cpu load (use 0|no|off to disable).
     [-Y ampest | magest] Choose amplitude or magnitude level estimator.
 :::
 

--- a/docs/STARTING.md
+++ b/docs/STARTING.md
@@ -205,9 +205,9 @@ Note `-Y auto` above (the FSK pulse detector's slicer mode, alongside `classic`/
 
 The pulse detector ignores any signal below a minimum detection level (`-Y minlevel`, fixed at -12 dB by default) before any decoder gets a chance to run. Since a typical noise floor is well below that, e.g. around -30 dB, a fixed floor silently discards a wide band of otherwise receivable signal.
 
-Use `-Y autolevel` to track the detection floor to the estimated noise instead of using a fixed value. This is now the **default**, since field testing recovered reception of weak signals that the fixed floor discarded, without a measurable increase in false decodes. Disable it with `-Y autolevel=0` (`no` and `off` are also accepted) to restore the previous fixed `-Y minlevel` behavior.
+Use `-Y autolevel` to track the detection floor to the estimated noise instead of using a fixed value. This is now the **default**, since field testing recovered reception of weak signals that the fixed floor discarded, without a measurable increase in false decodes. Disable it with `-Y autolevel=0` (`no`, `off`, `false` and `disable` are also accepted) to restore the previous fixed `-Y minlevel` behavior.
 
-`-Y minlevel=<dB level>` still matters with autolevel on: it sets the *initial* detection level, and it is the level the tracked noise must fall at least 3 dB below before autolevel starts lowering the floor further -- it is not a lower bound on how far autolevel can track down. To prevent the tracked floor from drifting arbitrarily low on a quiet band (and pulling in more CPU-costly false candidates), autolevel's own adjustment is clamped to a built-in lower bound of -30 dB, regardless of `-Y minlevel`.
+`-Y minlevel=<dB level>` still matters with autolevel on: it sets the *initial* detection level, and it is the level the tracked noise must fall at least 3 dB below before autolevel starts lowering the floor further -- it is not a lower bound on how far autolevel can track down. To prevent the tracked floor from drifting arbitrarily low on a quiet band (and pulling in more CPU-costly false candidates), autolevel's own adjustment is clamped to a built-in lower bound of -30 dB. Setting `-Y minlevel` *below* -30 dB lowers that clamp to match, so an explicitly requested sensitivity is never raised back up by the default.
 
 Use `-Y squelch` to skip frames below estimated noise level to reduce cpu load. Squelch decides per received sample frame (the SDR callback buffer, about 1 second at the default 250k sample rate) using that frame's *average* level, so a short weak-signal burst can raise the average too little to change the frame's classification -- the whole frame, burst included, gets discarded.
 
@@ -216,8 +216,8 @@ Use `-Y squelch` to skip frames below estimated noise level to reduce cpu load. 
     [-Y level=<dB level>] Manual detection level used to determine pulses (-1.0 to -30.0) (0=auto).
     [-Y minlevel=<dB level>] Manual minimum detection level used to determine pulses (-1.0 to -99.0).
     [-Y minsnr=<dB level>] Minimum SNR to determine pulses (1.0 to 99.0).
-    [-Y autolevel] Set minlevel automatically based on average estimated noise (default: on, use 0|no|off to disable).
-    [-Y squelch] Skip frames below estimated noise level to reduce cpu load (use 0|no|off to disable).
+    [-Y autolevel] Set minlevel automatically based on average estimated noise (default: on, use 0|no|off|false to disable).
+    [-Y squelch] Skip frames below estimated noise level to reduce cpu load (default: off).
     [-Y ampest | magest] Choose amplitude or magnitude level estimator.
 :::
 

--- a/docs/STARTING.md
+++ b/docs/STARTING.md
@@ -209,7 +209,7 @@ Use `-Y autolevel` to track the detection floor to the estimated noise instead o
 
 `-Y minlevel=<dB level>` still matters with autolevel on: it sets the *initial* detection level, and it is the level the tracked noise must fall at least 3 dB below before autolevel starts lowering the floor further -- it is not a lower bound on how far autolevel can track down. To prevent the tracked floor from drifting arbitrarily low on a quiet band (and pulling in more CPU-costly false candidates), autolevel's own adjustment is clamped to a built-in lower bound of -30 dB. Setting `-Y minlevel` *below* -30 dB lowers that clamp to match, so an explicitly requested sensitivity is never raised back up by the default.
 
-Use `-Y squelch` to skip frames below estimated noise level to reduce cpu load. Squelch decides per received sample frame (the SDR callback buffer, about 1 second at the default 250k sample rate) using that frame's *average* level, so a short weak-signal burst can raise the average too little to change the frame's classification -- the whole frame, burst included, gets discarded.
+Use `-Y squelch` to skip frames below estimated noise level to reduce cpu load. Squelch decides per received sample frame (the SDR callback buffer, 256 kB — 128k samples, about half a second at the default 250k sample rate, or ~0.13 s at the 1000k rate used for 868M) using that frame’s average level using that frame's *average* level, so a short weak-signal burst can raise the average too little to change the frame's classification -- the whole frame, burst included, gets discarded.
 
 :::tip
     [-Y auto | classic | minmax] FSK pulse detector mode.

--- a/docs/STARTING.md
+++ b/docs/STARTING.md
@@ -209,7 +209,7 @@ Use `-Y autolevel` to track the detection floor to the estimated noise instead o
 
 `-Y minlevel=<dB level>` still matters with autolevel on: it sets the *initial* detection level, and it is the level the tracked noise must fall at least 3 dB below before autolevel starts lowering the floor further -- it is not a lower bound on how far autolevel can track down. To prevent the tracked floor from drifting arbitrarily low on a quiet band (and pulling in more CPU-costly false candidates), autolevel's own adjustment is clamped to a built-in lower bound of -30 dB, regardless of `-Y minlevel`.
 
-Use `-Y squelch` to skip frames below estimated noise level to reduce cpu load. Squelch decides per received sample frame (the SDR callback buffer, about 1 second at the default 250k sample rate) using that frame's *average* level, so a short weak-signal burst can raise the average too little to change the frame's classification -- the whole frame, burst included, gets discarded. Making squelch evaluate noise-only status within a frame instead of across it (sub-frame squelch) is potential future work to make it safe to enable by default; until then it works best where signals stay strong for most of each frame.
+Use `-Y squelch` to skip frames below estimated noise level to reduce cpu load. Squelch decides per received sample frame (the SDR callback buffer, about 1 second at the default 250k sample rate) using that frame's *average* level, so a short weak-signal burst can raise the average too little to change the frame's classification -- the whole frame, burst included, gets discarded.
 
 :::tip
     [-Y auto | classic | minmax] FSK pulse detector mode.

--- a/docs/STARTING.md
+++ b/docs/STARTING.md
@@ -207,16 +207,18 @@ The pulse detector ignores any signal below a minimum detection level (`-Y minle
 
 Use `-Y autolevel` to track the detection floor to the estimated noise instead of using a fixed value. This is now the **default**, since field testing recovered reception of weak signals that the fixed floor discarded, without a measurable increase in false decodes. Disable it with `-Y autolevel=0` (`no`, `off`, `false` and `disable` are also accepted) to restore the previous fixed `-Y minlevel` behavior.
 
-`-Y minlevel=<dB level>` still matters with autolevel on: it sets the *initial* detection level, and it is the level the tracked noise must fall at least 3 dB below before autolevel starts lowering the floor further -- it is not a lower bound on how far autolevel can track down. To prevent the tracked floor from drifting arbitrarily low on a quiet band (and pulling in more CPU-costly false candidates), autolevel's own adjustment is clamped to a built-in lower bound of -30 dB. Setting `-Y minlevel` *below* -30 dB lowers that clamp to match, so an explicitly requested sensitivity is never raised back up by the default.
+Giving `-Y minlevel=<dB level>` turns the autolevel default off, since it asks for a specific detection level and a tracked floor would walk away from it. Add `-Y autolevel` alongside it to get both; order does not matter.
 
-Use `-Y squelch` to skip frames below estimated noise level to reduce cpu load. Squelch decides per received sample frame (the SDR callback buffer, 256 kB — 128k samples, about half a second at the default 250k sample rate, or ~0.13 s at the 1000k rate used for 868M) using that frame’s average level using that frame's *average* level, so a short weak-signal burst can raise the average too little to change the frame's classification -- the whole frame, burst included, gets discarded.
+With autolevel on, `-Y minlevel` sets the *initial* detection level, and it is the level the tracked noise must fall at least 3 dB below before autolevel starts lowering the floor further -- it is not a lower bound on how far autolevel can track down. Note this means a *higher* `-Y minlevel` makes autolevel engage sooner, which is why an explicit setting turns the default off rather than layering on top of it. To prevent the tracked floor from drifting arbitrarily low on a quiet band (and pulling in more CPU-costly false candidates), autolevel's own adjustment is clamped to a built-in lower bound of -30 dB. Setting `-Y minlevel` *below* -30 dB lowers that clamp to match, so an explicitly requested sensitivity is never raised back up.
+
+Use `-Y squelch` to skip frames below estimated noise level to reduce cpu load. Squelch decides per received sample frame (the SDR callback buffer, 256 kB -- 128k samples, about half a second at the default 250k sample rate, or about 0.13 s at the 1000k rate used for `868M`) using that frame's *average* level, so a short weak-signal burst can raise the average too little to change the frame's classification -- the whole frame, burst included, gets discarded.
 
 :::tip
     [-Y auto | classic | minmax] FSK pulse detector mode.
     [-Y level=<dB level>] Manual detection level used to determine pulses (-1.0 to -30.0) (0=auto).
-    [-Y minlevel=<dB level>] Manual minimum detection level used to determine pulses (-1.0 to -99.0).
+    [-Y minlevel=<dB level>] Manual minimum detection level used to determine pulses (-1.0 to -99.0) (disables autolevel).
     [-Y minsnr=<dB level>] Minimum SNR to determine pulses (1.0 to 99.0).
-    [-Y autolevel] Set minlevel automatically based on average estimated noise (default: on, use 0|no|off|false to disable).
+    [-Y autolevel] Set minlevel automatically based on average estimated noise (default: on, 0 disables).
     [-Y squelch] Skip frames below estimated noise level to reduce cpu load (default: off).
     [-Y ampest | magest] Choose amplitude or magnitude level estimator.
 :::

--- a/include/auto_level.h
+++ b/include/auto_level.h
@@ -1,7 +1,7 @@
 /** @file
     Auto-tracked detection floor for the pulse detector.
 
-    Copyright (C) 2026 Christian W. Zuckschwerdt <zany@triq.net>
+    Copyright (C) 2026 Andrew Berry <andrew@furrypaws.ca>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -29,7 +29,8 @@
 /// Decide whether the auto-tracked detection floor should move.
 ///
 /// The floor tracks @p noise_level plus ::AUTO_LEVEL_HEADROOM_DB, clamped to
-/// ::MIN_LEVEL_AUTO_FLOOR. It only moves when the estimated noise sits at least
+/// ::MIN_LEVEL_AUTO_FLOOR, or to @p min_level when that was configured lower
+/// still. It only moves when the estimated noise sits at least
 /// ::AUTO_LEVEL_HEADROOM_DB below @p min_level and the move is larger than
 /// ::AUTO_LEVEL_HYSTERESIS_DB.
 ///

--- a/include/auto_level.h
+++ b/include/auto_level.h
@@ -1,0 +1,47 @@
+/** @file
+    Auto-tracked detection floor for the pulse detector.
+
+    Copyright (C) 2026 Christian W. Zuckschwerdt <zany@triq.net>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#ifndef INCLUDE_AUTO_LEVEL_H_
+#define INCLUDE_AUTO_LEVEL_H_
+
+/// Lower bound for the auto-tracked detection floor.
+///
+/// Measured on real hardware: letting the tracked floor fall below -30 dB
+/// raises CPU usage sharply (~3.9x at -35 dB vs -30 dB) for negligible
+/// additional decode benefit, so auto-level tracking is clamped here.
+#define MIN_LEVEL_AUTO_FLOOR -30.0f
+
+/// Headroom the estimated noise must sit below the minimum detection level
+/// before the floor is tracked down, and the offset the floor is placed at.
+#define AUTO_LEVEL_HEADROOM_DB 3.0f
+
+/// Smallest floor movement worth applying, to avoid thrashing on noise jitter.
+#define AUTO_LEVEL_HYSTERESIS_DB 1.0f
+
+/// Decide whether the auto-tracked detection floor should move.
+///
+/// The floor tracks @p noise_level plus ::AUTO_LEVEL_HEADROOM_DB, clamped to
+/// ::MIN_LEVEL_AUTO_FLOOR. It only moves when the estimated noise sits at least
+/// ::AUTO_LEVEL_HEADROOM_DB below @p min_level and the move is larger than
+/// ::AUTO_LEVEL_HYSTERESIS_DB.
+///
+/// Comparing against the clamped target, rather than the unclamped
+/// noise_level + headroom, is what stops the floor re-adjusting on every frame
+/// once the clamp is reached.
+///
+/// @param noise_level current estimated noise level in dB
+/// @param min_level configured minimum detection level in dB
+/// @param current currently applied auto-tracked floor in dB
+/// @param[out] out receives the new floor in dB, only written when 1 is returned
+/// @return 1 if the floor should be adjusted, 0 to leave it unchanged
+int auto_level_next(float noise_level, float min_level, float current, float *out);
+
+#endif /* INCLUDE_AUTO_LEVEL_H_ */

--- a/include/r_private.h
+++ b/include/r_private.h
@@ -18,6 +18,7 @@
 
 struct dm_state {
     float auto_level;
+    int auto_level_set; // set to 1 if autolevel was explicitly requested (CLI or conf file), 0 if only the default
     float squelch_offset;
     float level_limit;
     float noise_level;

--- a/include/r_private.h
+++ b/include/r_private.h
@@ -19,6 +19,7 @@
 struct dm_state {
     float auto_level;
     int auto_level_set; // set to 1 if autolevel was explicitly requested (CLI or conf file), 0 if only the default
+    int min_level_set;  // set to 1 if minlevel was explicitly given (CLI or conf file), 0 if only the default
     float squelch_offset;
     float level_limit;
     float noise_level;

--- a/man/man1/rtl_433.1
+++ b/man/man1/rtl_433.1
@@ -98,10 +98,10 @@ Manual minimum detection level used to determine pulses (\-1.0 to \-99.0).
 Minimum SNR to determine pulses (1.0 to 99.0).
 .TP
 [ \fB\-Y\fI autolevel\fP ]
-Set minlevel automatically based on average estimated noise.
+Set minlevel automatically based on average estimated noise (default: on, use 0|no|off to disable).
 .TP
 [ \fB\-Y\fI squelch\fP ]
-Skip frames below estimated noise level to reduce cpu load.
+Skip frames below estimated noise level to reduce cpu load (use 0|no|off to disable).
 .TP
 [ \fB\-Y\fI ampest | magest\fP ]
 Choose amplitude or magnitude level estimator.

--- a/man/man1/rtl_433.1
+++ b/man/man1/rtl_433.1
@@ -98,10 +98,10 @@ Manual minimum detection level used to determine pulses (\-1.0 to \-99.0).
 Minimum SNR to determine pulses (1.0 to 99.0).
 .TP
 [ \fB\-Y\fI autolevel\fP ]
-Set minlevel automatically based on average estimated noise (default: on, use 0|no|off to disable).
+Set minlevel automatically based on average estimated noise (default: on, use 0|no|off|false to disable).
 .TP
 [ \fB\-Y\fI squelch\fP ]
-Skip frames below estimated noise level to reduce cpu load (use 0|no|off to disable).
+Skip frames below estimated noise level to reduce cpu load (default: off).
 .TP
 [ \fB\-Y\fI ampest | magest\fP ]
 Choose amplitude or magnitude level estimator.

--- a/man/man1/rtl_433.1
+++ b/man/man1/rtl_433.1
@@ -92,13 +92,13 @@ FSK pulse detector mode.
 Manual detection level used to determine pulses (\-1.0 to \-30.0) (0=auto).
 .TP
 [ \fB\-Y\fI minlevel=<dB level>\fP ]
-Manual minimum detection level used to determine pulses (\-1.0 to \-99.0).
+Manual minimum detection level used to determine pulses (\-1.0 to \-99.0) (disables autolevel).
 .TP
 [ \fB\-Y\fI minsnr=<dB level>\fP ]
 Minimum SNR to determine pulses (1.0 to 99.0).
 .TP
 [ \fB\-Y\fI autolevel\fP ]
-Set minlevel automatically based on average estimated noise (default: on, use 0|no|off|false to disable).
+Set minlevel automatically based on average estimated noise (default: on, 0 disables).
 .TP
 [ \fB\-Y\fI squelch\fP ]
 Skip frames below estimated noise level to reduce cpu load (default: off).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@
 add_library(r_433 STATIC
     abuf.c
     am_analyze.c
+    auto_level.c
     baseband.c
     bit_util.c
     bitbuffer.c

--- a/src/auto_level.c
+++ b/src/auto_level.c
@@ -1,7 +1,7 @@
 /** @file
     Auto-tracked detection floor for the pulse detector.
 
-    Copyright (C) 2026 Christian W. Zuckschwerdt <zany@triq.net>
+    Copyright (C) 2026 Andrew Berry <andrew@furrypaws.ca>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -13,10 +13,17 @@
 
 int auto_level_next(float noise_level, float min_level, float current, float *out)
 {
-    // track the noise, but never below the clamp
+    // Track the noise, but never below the clamp. A minimum level configured
+    // below the clamp is an explicit request for that sensitivity, so it wins:
+    // the clamp is there to stop the floor drifting down on its own, not to
+    // overrule what was asked for.
+    float clamp = MIN_LEVEL_AUTO_FLOOR;
+    if (min_level < clamp) {
+        clamp = min_level;
+    }
     float target = noise_level + AUTO_LEVEL_HEADROOM_DB;
-    if (target < MIN_LEVEL_AUTO_FLOOR) {
-        target = MIN_LEVEL_AUTO_FLOOR;
+    if (target < clamp) {
+        target = clamp;
     }
 
     // only track down when the noise is well below the configured minimum level
@@ -111,6 +118,13 @@ int main(void)
     ASSERT_ADJUSTS(-99.0f, def_min, -22.0f, MIN_LEVEL_AUTO_FLOOR);
     // the last value that is not clamped
     ASSERT_ADJUSTS(-33.0f, def_min, -22.0f, MIN_LEVEL_AUTO_FLOOR);
+    // A minimum level configured below the clamp must not be overruled by it:
+    // -Y minlevel=-35 asks for -35 dB and must not be raised back to -30 dB.
+    ASSERT_ADJUSTS(-40.0f, -35.0f, -32.0f, -35.0f);
+    // and the floor still may not pass that lower clamp
+    ASSERT_ADJUSTS(-99.0f, -35.0f, -32.0f, -35.0f);
+    // a minimum level above the clamp leaves the clamp in charge
+    ASSERT_ADJUSTS(-40.0f, -20.0f, -25.0f, MIN_LEVEL_AUTO_FLOOR);
 
     fprintf(stderr, "auto_level::convergence:\n");
     // Regression: once the floor is clamped, a noise level that keeps

--- a/src/auto_level.c
+++ b/src/auto_level.c
@@ -1,0 +1,165 @@
+/** @file
+    Auto-tracked detection floor for the pulse detector.
+
+    Copyright (C) 2026 Christian W. Zuckschwerdt <zany@triq.net>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#include "auto_level.h"
+
+int auto_level_next(float noise_level, float min_level, float current, float *out)
+{
+    // track the noise, but never below the clamp
+    float target = noise_level + AUTO_LEVEL_HEADROOM_DB;
+    if (target < MIN_LEVEL_AUTO_FLOOR) {
+        target = MIN_LEVEL_AUTO_FLOOR;
+    }
+
+    // only track down when the noise is well below the configured minimum level
+    if (noise_level >= min_level - AUTO_LEVEL_HEADROOM_DB) {
+        return 0;
+    }
+
+    // ignore movements too small to be worth re-arming the pulse detector
+    float delta = current - target;
+    if (delta < 0.0f) {
+        delta = -delta;
+    }
+    if (delta <= AUTO_LEVEL_HYSTERESIS_DB) {
+        return 0;
+    }
+
+    *out = target;
+    return 1;
+}
+
+#ifdef _TEST
+#include <stdio.h>
+
+#define ASSERT_ADJUSTS(noise, min_level, current, expected) \
+    do { \
+        float out_ = 0.0f; \
+        int r_      = auto_level_next((noise), (min_level), (current), &out_); \
+        if (r_ == 1 && out_ == (float)(expected)) \
+            ++passed; \
+        else { \
+            ++failed; \
+            fprintf(stderr, "FAIL: auto_level_next(%.2f, %.2f, %.2f) = %d, %.2f, want 1, %.2f\n", \
+                    (double)(noise), (double)(min_level), (double)(current), r_, (double)out_, (double)(expected)); \
+        } \
+    } while (0)
+
+#define ASSERT_HOLDS(noise, min_level, current) \
+    do { \
+        float out_ = 0.0f; \
+        int r_      = auto_level_next((noise), (min_level), (current), &out_); \
+        if (r_ == 0) \
+            ++passed; \
+        else { \
+            ++failed; \
+            fprintf(stderr, "FAIL: auto_level_next(%.2f, %.2f, %.2f) = 1, %.2f, want 0\n", \
+                    (double)(noise), (double)(min_level), (double)(current), (double)out_); \
+        } \
+    } while (0)
+
+int main(void)
+{
+    unsigned passed = 0;
+    unsigned failed = 0;
+
+    // the default minimum detection level, i.e. what -Y minlevel starts at
+    float const def_min = -12.1442f;
+
+    fprintf(stderr, "auto_level:: test\n");
+
+    fprintf(stderr, "auto_level::tracking:\n");
+    // noise well below the minimum level tracks to noise + 3 dB
+    ASSERT_ADJUSTS(-25.0f, def_min, def_min, -22.0f);
+    // a rising noise floor tracks back up just the same
+    ASSERT_ADJUSTS(-18.0f, def_min, -22.0f, -15.0f);
+
+    fprintf(stderr, "auto_level::gate:\n");
+    // noise not far enough below the minimum level, leave the floor alone
+    ASSERT_HOLDS(-14.0f, def_min, def_min);
+    // noise above the minimum level entirely
+    ASSERT_HOLDS(-5.0f, def_min, def_min);
+    // exactly at the gate is not "well below", the comparison is strict
+    ASSERT_HOLDS(def_min - AUTO_LEVEL_HEADROOM_DB, def_min, def_min);
+    // Just past the gate the target is still within hysteresis of the starting
+    // floor, so nothing moves: from a standing start the noise has to drop
+    // roughly a full hysteresis step past the gate before the floor tracks.
+    ASSERT_HOLDS(-16.0f, def_min, def_min);
+    // far enough past the gate to clear hysteresis too
+    ASSERT_ADJUSTS(-16.5f, def_min, def_min, -13.5f);
+
+    fprintf(stderr, "auto_level::hysteresis:\n");
+    // a 0.5 dB move is not worth re-arming the detector for
+    ASSERT_HOLDS(-25.5f, def_min, -22.0f);
+    // exactly at the hysteresis limit still holds, the comparison is inclusive
+    ASSERT_HOLDS(-26.0f, def_min, -22.0f);
+    // just past it adjusts
+    ASSERT_ADJUSTS(-26.5f, def_min, -22.0f, -23.5f);
+
+    fprintf(stderr, "auto_level::clamp:\n");
+    // a quiet band would target -37 dB, the clamp holds it at -30 dB
+    ASSERT_ADJUSTS(-40.0f, def_min, -22.0f, MIN_LEVEL_AUTO_FLOOR);
+    // an absurdly quiet band clamps to the same place
+    ASSERT_ADJUSTS(-99.0f, def_min, -22.0f, MIN_LEVEL_AUTO_FLOOR);
+    // the last value that is not clamped
+    ASSERT_ADJUSTS(-33.0f, def_min, -22.0f, MIN_LEVEL_AUTO_FLOOR);
+
+    fprintf(stderr, "auto_level::convergence:\n");
+    // Regression: once the floor is clamped, a noise level that keeps
+    // targeting below the clamp must not re-adjust on every single frame.
+    // Comparing against the unclamped noise + 3 dB made this loop forever,
+    // re-arming the pulse detector and logging a warning per frame.
+    {
+        float level = def_min;
+        float out   = 0.0f;
+        int adjusts = 0;
+        for (int i = 0; i < 100; ++i) {
+            if (auto_level_next(-50.0f, def_min, level, &out)) {
+                level = out;
+                ++adjusts;
+            }
+        }
+        if (adjusts == 1 && level == MIN_LEVEL_AUTO_FLOOR)
+            ++passed;
+        else {
+            ++failed;
+            fprintf(stderr, "FAIL: steady -50.0 dB noise adjusted %d times to %.2f, want 1 to %.2f\n",
+                    adjusts, (double)level, (double)MIN_LEVEL_AUTO_FLOOR);
+        }
+    }
+
+    // The same must hold for an unclamped level, hysteresis alone settles it.
+    {
+        float level = def_min;
+        float out   = 0.0f;
+        int adjusts = 0;
+        for (int i = 0; i < 100; ++i) {
+            if (auto_level_next(-25.0f, def_min, level, &out)) {
+                level = out;
+                ++adjusts;
+            }
+        }
+        if (adjusts == 1 && level == -22.0f)
+            ++passed;
+        else {
+            ++failed;
+            fprintf(stderr, "FAIL: steady -25.0 dB noise adjusted %d times to %.2f, want 1 to -22.00\n",
+                    adjusts, (double)level);
+        }
+    }
+
+    // ------------- add test above this line -----------------------------------------------------
+    // Show result of the tests, this line must stay the last line before return failed;
+    fprintf(stderr, "auto_level:: test (%u/%u) passed, (%u) failed.\n", passed, passed + failed, failed);
+
+    return failed;
+}
+#endif /* _TEST */

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -151,6 +151,7 @@ void r_init_cfg(r_cfg_t *cfg)
         FATAL_CALLOC("r_init_cfg()");
 
     cfg->demod->level_limit = 0.0f;
+    cfg->demod->auto_level = 1;
     cfg->demod->min_level = -12.1442f;
     cfg->demod->min_snr = 9.0f;
     // Pulse detect will only print LOG_NOTICE and lower.

--- a/src/r_flow.c
+++ b/src/r_flow.c
@@ -183,9 +183,10 @@ int push_sdr_flow(r_cfg_t *cfg, unsigned char *iq_buf, uint32_t len)
         demod->total_frames_squelch += 1;
         demod->noise_level = (demod->noise_level * 7 + avg_db) / 8; // fast fall over 8 frames
         // If auto_level and noise level well below min_level and significant change in noise level
+        float min_level_auto_target = fmaxf(demod->noise_level + 3.0f, MIN_LEVEL_AUTO_FLOOR);
         if (demod->auto_level > 0 && demod->noise_level < demod->min_level - 3.0f
-                && fabsf(demod->min_level_auto - demod->noise_level - 3.0f) > 1.0f) {
-            demod->min_level_auto = fmaxf(demod->noise_level + 3.0f, MIN_LEVEL_AUTO_FLOOR);
+                && fabsf(demod->min_level_auto - min_level_auto_target) > 1.0f) {
+            demod->min_level_auto = min_level_auto_target;
             print_logf(LOG_WARNING, "Auto Level", "Estimated noise level is %.1f dB, adjusting minimum detection level to %.1f dB",
                     demod->noise_level, demod->min_level_auto);
             pulse_detect_set_levels(demod->pulse_detect, demod->use_mag_est, demod->level_limit, demod->min_level_auto, demod->min_snr, demod->detect_verbosity);

--- a/src/r_flow.c
+++ b/src/r_flow.c
@@ -29,14 +29,9 @@
 #include "raw_output.h"
 #include "r_util.h"
 #include "am_analyze.h"
+#include "auto_level.h"
 #include "logger.h"
 #include "fatal.h"
-
-// Lower bound for the auto-tracked detection floor (min_level_auto).
-// Measured on real hardware: letting the tracked floor fall below -30 dB
-// raises CPU usage sharply (~3.9x at -35 dB vs -30 dB) for negligible
-// additional decode benefit, so auto-level tracking is clamped here.
-#define MIN_LEVEL_AUTO_FLOOR -30.0f
 
 static void calc_rssi_snr(struct dm_state const *demod, pulse_data_t *pulse_data)
 {
@@ -183,10 +178,10 @@ int push_sdr_flow(r_cfg_t *cfg, unsigned char *iq_buf, uint32_t len)
         demod->total_frames_squelch += 1;
         demod->noise_level = (demod->noise_level * 7 + avg_db) / 8; // fast fall over 8 frames
         // If auto_level and noise level well below min_level and significant change in noise level
-        float min_level_auto_target = fmaxf(demod->noise_level + 3.0f, MIN_LEVEL_AUTO_FLOOR);
-        if (demod->auto_level > 0 && demod->noise_level < demod->min_level - 3.0f
-                && fabsf(demod->min_level_auto - min_level_auto_target) > 1.0f) {
-            demod->min_level_auto = min_level_auto_target;
+        float min_level_auto_next = 0.0f;
+        if (demod->auto_level > 0
+                && auto_level_next(demod->noise_level, demod->min_level, demod->min_level_auto, &min_level_auto_next)) {
+            demod->min_level_auto = min_level_auto_next;
             print_logf(LOG_WARNING, "Auto Level", "Estimated noise level is %.1f dB, adjusting minimum detection level to %.1f dB",
                     demod->noise_level, demod->min_level_auto);
             pulse_detect_set_levels(demod->pulse_detect, demod->use_mag_est, demod->level_limit, demod->min_level_auto, demod->min_snr, demod->detect_verbosity);

--- a/src/r_flow.c
+++ b/src/r_flow.c
@@ -32,6 +32,12 @@
 #include "logger.h"
 #include "fatal.h"
 
+// Lower bound for the auto-tracked detection floor (min_level_auto).
+// Measured on real hardware: letting the tracked floor fall below -30 dB
+// raises CPU usage sharply (~3.9x at -35 dB vs -30 dB) for negligible
+// additional decode benefit, so auto-level tracking is clamped here.
+#define MIN_LEVEL_AUTO_FLOOR -30.0f
+
 static void calc_rssi_snr(struct dm_state const *demod, pulse_data_t *pulse_data)
 {
     float ook_high_estimate      = pulse_data->ook_high_estimate > 0 ? pulse_data->ook_high_estimate : 1;
@@ -179,7 +185,7 @@ int push_sdr_flow(r_cfg_t *cfg, unsigned char *iq_buf, uint32_t len)
         // If auto_level and noise level well below min_level and significant change in noise level
         if (demod->auto_level > 0 && demod->noise_level < demod->min_level - 3.0f
                 && fabsf(demod->min_level_auto - demod->noise_level - 3.0f) > 1.0f) {
-            demod->min_level_auto = demod->noise_level + 3.0f;
+            demod->min_level_auto = fmaxf(demod->noise_level + 3.0f, MIN_LEVEL_AUTO_FLOOR);
             print_logf(LOG_WARNING, "Auto Level", "Estimated noise level is %.1f dB, adjusting minimum detection level to %.1f dB",
                     demod->noise_level, demod->min_level_auto);
             pulse_detect_set_levels(demod->pulse_detect, demod->use_mag_est, demod->level_limit, demod->min_level_auto, demod->min_snr, demod->detect_verbosity);

--- a/src/r_flow.c
+++ b/src/r_flow.c
@@ -95,6 +95,11 @@ void reset_sdr_flow(r_cfg_t *cfg)
     baseband_demod_FM_reset(&demod->demod_FM_state);
 
     pulse_detect_reset(demod->pulse_detect);
+    // Put the configured level back too. Clearing min_level_auto above only
+    // resets what we track; without this the detector keeps the floor auto
+    // level left it at, so a tracked floor would leak from one input file into
+    // the next and decoding a file would depend on what preceded it.
+    pulse_detect_set_levels(demod->pulse_detect, demod->use_mag_est, demod->level_limit, demod->min_level, demod->min_snr, demod->detect_verbosity);
 }
 
 /**

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1460,6 +1460,12 @@ int main(int argc, char **argv) {
     }
 
     parse_conf_args(cfg, argc, argv);
+
+    // notify once if autolevel is active only because of the new default, not an explicit request
+    if (demod->auto_level > 0 && !demod->auto_level_set) {
+        fprintf(stderr, "\nAuto Level is now enabled by default, use \"-Y autolevel=0\" for the previous fixed -12 dB minimum level\n\n");
+    }
+
     // apply hop defaults and set first frequency
     if (cfg->frequencies == 0) {
         cfg->frequency[0] = DEFAULT_FREQUENCY;

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -138,8 +138,8 @@ static void usage(int exit_code)
             "  [-Y level=<dB level>] Manual detection level used to determine pulses (-1.0 to -30.0) (0=auto).\n"
             "  [-Y minlevel=<dB level>] Manual minimum detection level used to determine pulses (-1.0 to -99.0).\n"
             "  [-Y minsnr=<dB level>] Minimum SNR to determine pulses (1.0 to 99.0).\n"
-            "  [-Y autolevel] Set minlevel automatically based on average estimated noise (default: on, use 0|no|off to disable).\n"
-            "  [-Y squelch] Skip frames below estimated noise level to reduce cpu load (use 0|no|off to disable).\n"
+            "  [-Y autolevel] Set minlevel automatically based on average estimated noise (default: on, use 0|no|off|false to disable).\n"
+            "  [-Y squelch] Skip frames below estimated noise level to reduce cpu load (default: off).\n"
             "  [-Y ampest | magest] Choose amplitude or magnitude level estimator.\n"
             "  [-Y filter=<value>] Manual FM low-pass filter cutoff to separate simultaneous transmissions: us (1-9999, e.g. 20), Hz (10000+), or ratio of sample rate (0.0-1.0).\n"
             "\t\t= Analyze/Debug options =\n"
@@ -942,25 +942,15 @@ static void parse_conf_option(r_cfg_t *cfg, int opt, char *arg)
         while (p && *p) {
             char const *val = NULL;
             if (kwargs_match(p, "autolevel", &val)) {
-                // autolevel  autolevel:1  autolevel:on  autolevel:yes
-                // autolevel:0  autolevel:off  autolevel:no
-                if (val && (!strncasecmp(val, "0", 1) || !strncasecmp(val, "no", 2) || !strncasecmp(val, "off", 3))) {
-                    cfg->demod->auto_level = 0;
-                }
-                else {
-                    cfg->demod->auto_level = atoiv(val, 1); // arg_float_default(p + 9, "-Y autolevel: ");
-                }
+                // autolevel  autolevel:1  autolevel:on  autolevel:yes  autolevel:true  autolevel:enable
+                // autolevel:0  autolevel:off  autolevel:no  autolevel:false  autolevel:disable
+                cfg->demod->auto_level     = atobv(val, 1);
                 cfg->demod->auto_level_set = 1;
             }
             else if (kwargs_match(p, "squelch", &val)) {
-                // squelch  squelch:1  squelch:on  squelch:yes
-                // squelch:0  squelch:off  squelch:no
-                if (val && (!strncasecmp(val, "0", 1) || !strncasecmp(val, "no", 2) || !strncasecmp(val, "off", 3))) {
-                    cfg->demod->squelch_offset = 0;
-                }
-                else {
-                    cfg->demod->squelch_offset = atoiv(val, 1); // arg_float_default(p + 7, "-Y squelch: ");
-                }
+                // squelch  squelch:1  squelch:on  squelch:yes  squelch:true  squelch:enable
+                // squelch:0  squelch:off  squelch:no  squelch:false  squelch:disable
+                cfg->demod->squelch_offset = atobv(val, 1); // arg_float_default(p + 7, "-Y squelch: ");
             }
             else if (kwargs_match(p, "auto", &val)) {
                 cfg->fsk_pulse_detect_mode = FSK_PULSE_DETECT_AUTO;

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -138,8 +138,8 @@ static void usage(int exit_code)
             "  [-Y level=<dB level>] Manual detection level used to determine pulses (-1.0 to -30.0) (0=auto).\n"
             "  [-Y minlevel=<dB level>] Manual minimum detection level used to determine pulses (-1.0 to -99.0).\n"
             "  [-Y minsnr=<dB level>] Minimum SNR to determine pulses (1.0 to 99.0).\n"
-            "  [-Y autolevel] Set minlevel automatically based on average estimated noise.\n"
-            "  [-Y squelch] Skip frames below estimated noise level to reduce cpu load.\n"
+            "  [-Y autolevel] Set minlevel automatically based on average estimated noise (default: on, use 0|no|off to disable).\n"
+            "  [-Y squelch] Skip frames below estimated noise level to reduce cpu load (use 0|no|off to disable).\n"
             "  [-Y ampest | magest] Choose amplitude or magnitude level estimator.\n"
             "  [-Y filter=<value>] Manual FM low-pass filter cutoff to separate simultaneous transmissions: us (1-9999, e.g. 20), Hz (10000+), or ratio of sample rate (0.0-1.0).\n"
             "\t\t= Analyze/Debug options =\n"
@@ -942,10 +942,25 @@ static void parse_conf_option(r_cfg_t *cfg, int opt, char *arg)
         while (p && *p) {
             char const *val = NULL;
             if (kwargs_match(p, "autolevel", &val)) {
-                cfg->demod->auto_level = atoiv(val, 1); // arg_float_default(p + 9, "-Y autolevel: ");
+                // autolevel  autolevel:1  autolevel:on  autolevel:yes
+                // autolevel:0  autolevel:off  autolevel:no
+                if (val && (!strncasecmp(val, "0", 1) || !strncasecmp(val, "no", 2) || !strncasecmp(val, "off", 3))) {
+                    cfg->demod->auto_level = 0;
+                }
+                else {
+                    cfg->demod->auto_level = atoiv(val, 1); // arg_float_default(p + 9, "-Y autolevel: ");
+                }
+                cfg->demod->auto_level_set = 1;
             }
             else if (kwargs_match(p, "squelch", &val)) {
-                cfg->demod->squelch_offset = atoiv(val, 1); // arg_float_default(p + 7, "-Y squelch: ");
+                // squelch  squelch:1  squelch:on  squelch:yes
+                // squelch:0  squelch:off  squelch:no
+                if (val && (!strncasecmp(val, "0", 1) || !strncasecmp(val, "no", 2) || !strncasecmp(val, "off", 3))) {
+                    cfg->demod->squelch_offset = 0;
+                }
+                else {
+                    cfg->demod->squelch_offset = atoiv(val, 1); // arg_float_default(p + 7, "-Y squelch: ");
+                }
             }
             else if (kwargs_match(p, "auto", &val)) {
                 cfg->fsk_pulse_detect_mode = FSK_PULSE_DETECT_AUTO;

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -136,9 +136,9 @@ static void usage(int exit_code)
             "  [-X <spec> | help] Add a general purpose decoder (prepend -R 0 to disable all decoders)\n"
             "  [-Y auto | classic | minmax] FSK pulse detector mode.\n"
             "  [-Y level=<dB level>] Manual detection level used to determine pulses (-1.0 to -30.0) (0=auto).\n"
-            "  [-Y minlevel=<dB level>] Manual minimum detection level used to determine pulses (-1.0 to -99.0).\n"
+            "  [-Y minlevel=<dB level>] Manual minimum detection level used to determine pulses (-1.0 to -99.0) (disables autolevel).\n"
             "  [-Y minsnr=<dB level>] Minimum SNR to determine pulses (1.0 to 99.0).\n"
-            "  [-Y autolevel] Set minlevel automatically based on average estimated noise (default: on, use 0|no|off|false to disable).\n"
+            "  [-Y autolevel] Set minlevel automatically based on average estimated noise (default: on, 0 disables).\n"
             "  [-Y squelch] Skip frames below estimated noise level to reduce cpu load (default: off).\n"
             "  [-Y ampest | magest] Choose amplitude or magnitude level estimator.\n"
             "  [-Y filter=<value>] Manual FM low-pass filter cutoff to separate simultaneous transmissions: us (1-9999, e.g. 20), Hz (10000+), or ratio of sample rate (0.0-1.0).\n"
@@ -974,7 +974,8 @@ static void parse_conf_option(r_cfg_t *cfg, int opt, char *arg)
                 cfg->demod->level_limit = arg_float(val, "-Y level: ");
             }
             else if (kwargs_match(p, "minlevel", &val)) {
-                cfg->demod->min_level = arg_float(val, "-Y minlevel: ");
+                cfg->demod->min_level     = arg_float(val, "-Y minlevel: ");
+                cfg->demod->min_level_set = 1;
             }
             else if (kwargs_match(p, "minsnr", &val)) {
                 cfg->demod->min_snr = arg_float(val, "-Y minsnr: ");
@@ -1450,6 +1451,16 @@ int main(int argc, char **argv) {
     }
 
     parse_conf_args(cfg, argc, argv);
+
+    // An explicit minlevel is a request for that detection level, so it turns
+    // off the new autolevel default: otherwise the tracked floor would walk
+    // away from the level that was asked for. Note the tracking starts once the
+    // noise is 3 dB below minlevel, so raising minlevel to reduce load would
+    // otherwise make autolevel engage sooner and end up lower than the default.
+    // An explicit autolevel still wins, in either direction.
+    if (demod->min_level_set && !demod->auto_level_set) {
+        demod->auto_level = 0;
+    }
 
     // notify once if autolevel is active only because of the new default, not an explicit request
     if (demod->auto_level > 0 && !demod->auto_level_set) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 ########################################################################
 # target_compile_definitions was only added in CMake 2.8.11
 add_definitions(-D_TEST)
-foreach(testSrc bitbuffer.c fileformat.c optparse.c bit_util.c r_util.c abuf.c)
+foreach(testSrc bitbuffer.c fileformat.c optparse.c bit_util.c r_util.c abuf.c auto_level.c)
     get_filename_component(testName ${testSrc} NAME_WE)
 
     # Note that r_util.c needs compat_time.c shims
@@ -59,6 +59,20 @@ if(UNIX)
     find_program(BASH_PROGRAM sh)
     find_program(CURL_PROGRAM curl)
     find_program(PYTHON3_PROGRAM python3)
+    # Black-box test of the pulse detector auto level, which is on by default.
+    # Checks every documented spelling of -Y autolevel and the conf file
+    # equivalent, then runs generated noise-only samples to confirm the tracked
+    # detection floor moves, stays inside its clamp, and settles. Needs python3
+    # to generate the samples.
+    if(BASH_PROGRAM AND PYTHON3_PROGRAM)
+        add_test(
+            NAME autolevel
+            COMMAND ${BASH_PROGRAM}
+                ${CMAKE_CURRENT_SOURCE_DIR}/autolevel-test.sh
+                $<TARGET_FILE:rtl_433>)
+    else()
+        message(STATUS "Skipping autolevel test (need sh and python3)")
+    endif()
     if(BASH_PROGRAM AND CURL_PROGRAM)
         add_test(
             NAME http_server_integration

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,6 +70,9 @@ if(UNIX)
             COMMAND ${BASH_PROGRAM}
                 ${CMAKE_CURRENT_SOURCE_DIR}/autolevel-test.sh
                 $<TARGET_FILE:rtl_433>)
+        # The script exits 77 when it cannot generate its samples, e.g. python3
+        # was found at configure time but is gone at test time.
+        set_tests_properties(autolevel PROPERTIES SKIP_RETURN_CODE 77)
     else()
         message(STATUS "Skipping autolevel test (need sh and python3)")
     endif()

--- a/tests/autolevel-test.sh
+++ b/tests/autolevel-test.sh
@@ -1,0 +1,169 @@
+#!/bin/sh
+#
+# Black-box test for the pulse detector auto level, which is on by default.
+#
+# Two things are checked. First, that every documented spelling of
+# "-Y autolevel" and its conf file equivalent turns the feature on or off as
+# advertised. Second, that the auto-tracked detection floor actually moves,
+# stays inside its clamp, and settles instead of re-adjusting forever.
+#
+# The behavioural half runs rtl_433 over generated cu8 files. A "quiet" file of
+# low-amplitude samples lets the tracked floor walk down; a "silent" file of
+# dead-centre samples drives it into the -30 dB clamp. Both are noise-only, so
+# no decoder ever fires and the test is not tied to any device.
+#
+# Usage: autolevel-test.sh [path-to-rtl_433-binary]
+#   Defaults to ../src/rtl_433 relative to this script.
+
+set -u
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+RTL_433=${1:-"$SCRIPT_DIR/../src/rtl_433"}
+
+if [ ! -x "$RTL_433" ]; then
+    echo "ERROR: rtl_433 binary not found or not executable: $RTL_433" >&2
+    exit 99
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "SKIP: python3 not found, cannot generate sample files" >&2
+    exit 77
+fi
+
+WORK_DIR=$(mktemp -d 2>/dev/null || echo /tmp/rtl_433_autolevel_test.$$)
+mkdir -p "$WORK_DIR" || exit 98
+FAILED=0
+PASSED=0
+
+cleanup() { rm -rf "$WORK_DIR"; }
+trap cleanup EXIT INT TERM
+
+fail() { echo "  NOT OK: $1" >&2; FAILED=$((FAILED + 1)); }
+pass() { echo "  ok: $1"; PASSED=$((PASSED + 1)); }
+
+EMPTY_CU8="$WORK_DIR/empty.cu8"
+QUIET_CU8="$WORK_DIR/quiet.cu8"
+SILENT_CU8="$WORK_DIR/silent.cu8"
+CONF_ON="$WORK_DIR/autolevel-on.conf"
+CONF_OFF="$WORK_DIR/autolevel-off.conf"
+
+: > "$EMPTY_CU8"
+
+# cu8 is complex unsigned 8-bit centred on 128. A tight spread around the
+# centre is a quiet band well below the -12 dB default minimum level; dead
+# centre is quieter still and drives the tracked floor into its clamp.
+python3 - "$QUIET_CU8" "$SILENT_CU8" <<'EOF' || exit 98
+import random, sys
+random.seed(1)
+quiet = bytearray()
+for _ in range(2_000_000):
+    quiet.append(128 + random.randint(-2, 2))
+    quiet.append(128 + random.randint(-2, 2))
+open(sys.argv[1], 'wb').write(bytes(quiet))
+open(sys.argv[2], 'wb').write(bytes(bytearray([128]) * 8_000_000))
+EOF
+
+printf 'pulse_detect autolevel\n'   > "$CONF_ON"
+printf 'pulse_detect autolevel=0\n' > "$CONF_OFF"
+
+NOTICE='Auto Level is now enabled by default'
+ADJUST='adjusting minimum detection level'
+
+# Mind the streams: the one-time notice is written straight to stderr, matching
+# the older "New defaults active" notice, while every print_logf() message goes
+# to stdout. So the two counters below deliberately read different streams.
+
+# count_notice ARGS... -- how many times the new-default notice was printed
+count_notice() {
+    "$RTL_433" "$@" -r "$EMPTY_CU8" 2>&1 >/dev/null | grep -c "$NOTICE"
+}
+
+# count_adjust FILE ARGS... -- how many times the floor was adjusted.
+# Needs -vv: the adjustment is logged at a level the default verbosity hides.
+count_adjust() {
+    file=$1; shift
+    "$RTL_433" -vv "$@" -r "$file" 2>/dev/null | grep -c "$ADJUST"
+}
+
+# adjust_log ARGS... -- the floor adjustment lines for the silent sample
+adjust_log() {
+    "$RTL_433" -vv -r "$SILENT_CU8" 2>/dev/null | grep "$ADJUST"
+}
+
+# expect_notice DESC WANT ARGS...
+expect_notice() {
+    desc=$1; want=$2; shift 2
+    got=$(count_notice "$@")
+    [ "$got" = "$want" ] && pass "$desc" || fail "$desc: expected $want notice(s), got $got"
+}
+
+# expect_enabled DESC ARGS... -- auto level on means the floor tracks down
+expect_enabled() {
+    desc=$1; shift
+    got=$(count_adjust "$QUIET_CU8" "$@")
+    [ "$got" -gt 0 ] && pass "$desc" || fail "$desc: expected the floor to track, got $got adjustments"
+}
+
+# expect_disabled DESC ARGS... -- auto level off means the floor never moves
+expect_disabled() {
+    desc=$1; shift
+    got=$(count_adjust "$QUIET_CU8" "$@")
+    [ "$got" = 0 ] && pass "$desc" || fail "$desc: expected a fixed floor, got $got adjustments"
+}
+
+echo "Testing auto level with $RTL_433"
+
+# The one-time notice tells apart "on because of the new default" from "on
+# because the user asked", so it is the observable for auto_level_set. Users of
+# the shipped example conf have asked explicitly and must not be nagged.
+echo "autolevel::notice:"
+expect_notice "no option prints the notice"            1
+expect_notice "-Y autolevel is explicit, no notice"    0 -Y autolevel
+expect_notice "-Y autolevel=0 is explicit, no notice"  0 -Y autolevel=0
+expect_notice "-Y autolevel=1 is explicit, no notice"  0 -Y autolevel=1
+expect_notice "conf file autolevel, no notice"         0 -c "$CONF_ON"
+expect_notice "conf file autolevel=0, no notice"       0 -c "$CONF_OFF"
+
+# Every spelling the usage text and docs promise. The off words are matched
+# case-insensitively, so check a capitalised one too.
+echo "autolevel::spellings:"
+expect_enabled  "on by default"
+expect_enabled  "-Y autolevel"          -Y autolevel
+expect_enabled  "-Y autolevel=1"        -Y autolevel=1
+expect_disabled "-Y autolevel=0"        -Y autolevel=0
+expect_disabled "-Y autolevel=no"       -Y autolevel=no
+expect_disabled "-Y autolevel=off"      -Y autolevel=off
+expect_disabled "-Y autolevel=OFF"      -Y autolevel=OFF
+expect_disabled "-Y autolevel=No"       -Y autolevel=No
+expect_enabled  "conf file autolevel"   -c "$CONF_ON"
+expect_disabled "conf file autolevel=0" -c "$CONF_OFF"
+
+# The floor must stop at the built-in clamp no matter how quiet the band is,
+# and having stopped there it must not keep re-adjusting. Re-adjusting on every
+# frame is a real regression this catches: it re-arms the pulse detector and
+# logs a warning per frame for as long as rtl_433 runs.
+echo "autolevel::clamp:"
+clamped=$(adjust_log | tail -1)
+case "$clamped" in
+    *"detection level to -30.0 dB"*) pass "a silent band settles at the -30.0 dB clamp" ;;
+    *) fail "expected the floor to settle at -30.0 dB, last adjustment was: ${clamped:-none}" ;;
+esac
+
+at_clamp=$(adjust_log | grep -c "detection level to -30.0 dB")
+[ "$at_clamp" = 1 ] \
+    && pass "the clamped floor is applied once, not re-adjusted per frame" \
+    || fail "expected 1 adjustment to the clamp, got $at_clamp"
+
+# Noise estimation keeps falling past the clamp, so a floor that ignored the
+# clamp would have gone below -30 dB here.
+below=$(adjust_log \
+    | sed -n "s/.*detection level to \(-[0-9]*\)\..* dB.*/\1/p" \
+    | awk '$1 < -30 { n++ } END { print n + 0 }')
+[ "$below" = 0 ] \
+    && pass "the floor never goes below the clamp" \
+    || fail "expected no adjustment below -30 dB, got $below"
+
+echo
+echo "auto level: $PASSED passed, $FAILED failed."
+[ "$FAILED" -eq 0 ] || exit 1
+exit 0

--- a/tests/autolevel-test.sh
+++ b/tests/autolevel-test.sh
@@ -188,6 +188,20 @@ expect_disabled "conf file autolevel=0"   -c "$CONF_OFF"
 # and having stopped there it must not keep re-adjusting. Re-adjusting on every
 # frame is a real regression this catches: it re-arms the pulse detector and
 # logs a warning per frame for as long as rtl_433 runs.
+# An explicit -Y minlevel is a request for that detection level, so it turns the
+# new default off rather than letting the tracked floor walk away from it. The
+# trigger is "noise 3 dB below minlevel", so without this a user raising
+# minlevel to cut load would make autolevel engage sooner and settle lower than
+# the -12 dB default they were trying to get away from. An explicit -Y autolevel
+# still wins in either direction.
+echo "autolevel::minlevel:"
+expect_disabled "-Y minlevel alone turns the default off"      $NO_CONF -Y minlevel=-10
+expect_enabled  "-Y minlevel with explicit autolevel tracks"   $NO_CONF -Y minlevel=-10 -Y autolevel
+expect_enabled  "order does not matter, autolevel first"       $NO_CONF -Y autolevel -Y minlevel=-10
+expect_disabled "-Y minlevel with explicit autolevel=0"        $NO_CONF -Y minlevel=-10 -Y autolevel=0
+expect_enabled  "no minlevel still gets the default"           $NO_CONF
+expect_notice   "-Y minlevel suppresses the notice too"      0 $NO_CONF -Y minlevel=-10
+
 echo "autolevel::clamp:"
 clamped=$(adjust_log | tail -1)
 case "$clamped" in
@@ -216,7 +230,9 @@ below=$(adjust_log \
 # have the floor quietly raised to the -30 dB clamp and lose 5 dB of the
 # sensitivity they explicitly configured. Nothing may move the floor above the
 # configured level; tracking it no further down is fine.
-raised=$("$RTL_433" -vv $NO_CONF -Y minlevel=-35 -r "$SILENT_CU8" 2>/dev/null \
+# -Y autolevel is explicit here on purpose: minlevel alone now turns tracking
+# off, which would make this case pass without ever exercising the clamp.
+raised=$("$RTL_433" -vv $NO_CONF -Y minlevel=-35 -Y autolevel -r "$SILENT_CU8" 2>/dev/null \
     | sed -n "s/.*detection level to \(-\{0,1\}[0-9]\{1,\}\.[0-9]\{1,\}\) dB.*/\1/p" \
     | awk '$1 > -35.0 { n++ } END { print n + 0 }')
 [ "$raised" = 0 ] \

--- a/tests/autolevel-test.sh
+++ b/tests/autolevel-test.sh
@@ -72,43 +72,80 @@ ADJUST='adjusting minimum detection level'
 # Mind the streams: the one-time notice is written straight to stderr, matching
 # the older "New defaults active" notice, while every print_logf() message goes
 # to stdout. So the two counters below deliberately read different streams.
+#
+# Every run passes -c /dev/null unless the case is about a conf file. Without it
+# rtl_433 searches ./rtl_433.conf, $XDG_CONFIG_HOME/rtl_433/rtl_433.conf and
+# $SYSCONFDIR/rtl_433/rtl_433.conf, and the shipped example conf has an active
+# "pulse_detect autolevel" line, so an installed conf would decide the result
+# instead of the option under test.
+NO_CONF="-c /dev/null"
+
+# RC carries the exit status of the last count_* run, so callers can tell "the
+# floor did not move" apart from "rtl_433 refused to start". Without that an
+# option that fatally exits looks exactly like an option that works.
+RC=0
 
 # count_notice ARGS... -- how many times the new-default notice was printed
 count_notice() {
-    "$RTL_433" "$@" -r "$EMPTY_CU8" 2>&1 >/dev/null | grep -c "$NOTICE"
+    out=$("$RTL_433" "$@" -r "$EMPTY_CU8" 2>&1 >/dev/null)
+    RC=$?
+    printf '%s\n' "$out" | grep -c "$NOTICE"
 }
 
 # count_adjust FILE ARGS... -- how many times the floor was adjusted.
 # Needs -vv: the adjustment is logged at a level the default verbosity hides.
 count_adjust() {
     file=$1; shift
-    "$RTL_433" -vv "$@" -r "$file" 2>/dev/null | grep -c "$ADJUST"
+    out=$("$RTL_433" -vv "$@" -r "$file" 2>/dev/null)
+    RC=$?
+    printf '%s\n' "$out" | grep -c "$ADJUST"
 }
 
-# adjust_log ARGS... -- the floor adjustment lines for the silent sample
+# adjust_log -- the floor adjustment lines for the silent sample
 adjust_log() {
-    "$RTL_433" -vv -r "$SILENT_CU8" 2>/dev/null | grep "$ADJUST"
+    "$RTL_433" -vv $NO_CONF -r "$SILENT_CU8" 2>/dev/null | grep "$ADJUST"
 }
 
 # expect_notice DESC WANT ARGS...
 expect_notice() {
     desc=$1; want=$2; shift 2
     got=$(count_notice "$@")
-    [ "$got" = "$want" ] && pass "$desc" || fail "$desc: expected $want notice(s), got $got"
+    if [ "$RC" != 0 ]; then
+        fail "$desc: rtl_433 exited $RC"
+    elif [ "$got" = "$want" ]; then
+        pass "$desc"
+    else
+        fail "$desc: expected $want notice(s), got $got"
+    fi
 }
 
 # expect_enabled DESC ARGS... -- auto level on means the floor tracks down
 expect_enabled() {
     desc=$1; shift
     got=$(count_adjust "$QUIET_CU8" "$@")
-    [ "$got" -gt 0 ] && pass "$desc" || fail "$desc: expected the floor to track, got $got adjustments"
+    if [ "$RC" != 0 ]; then
+        fail "$desc: rtl_433 exited $RC"
+    elif [ "$got" -gt 0 ]; then
+        pass "$desc"
+    else
+        fail "$desc: expected the floor to track, got $got adjustments"
+    fi
 }
 
-# expect_disabled DESC ARGS... -- auto level off means the floor never moves
+# expect_disabled DESC ARGS... -- auto level off means the floor never moves.
+# The exit status check is the point here: a fatal exit also produces no
+# adjustments, and without it every off-spelling case would pass on a binary
+# that rejects the option outright.
 expect_disabled() {
     desc=$1; shift
     got=$(count_adjust "$QUIET_CU8" "$@")
-    [ "$got" = 0 ] && pass "$desc" || fail "$desc: expected a fixed floor, got $got adjustments"
+    if [ "$RC" != 0 ]; then
+        fail "$desc: rtl_433 exited $RC"
+    elif [ "$got" = 0 ]; then
+        pass "$desc"
+    else
+        fail "$desc: expected a fixed floor, got $got adjustments"
+    fi
 }
 
 echo "Testing auto level with $RTL_433"
@@ -117,26 +154,35 @@ echo "Testing auto level with $RTL_433"
 # because the user asked", so it is the observable for auto_level_set. Users of
 # the shipped example conf have asked explicitly and must not be nagged.
 echo "autolevel::notice:"
-expect_notice "no option prints the notice"            1
-expect_notice "-Y autolevel is explicit, no notice"    0 -Y autolevel
-expect_notice "-Y autolevel=0 is explicit, no notice"  0 -Y autolevel=0
-expect_notice "-Y autolevel=1 is explicit, no notice"  0 -Y autolevel=1
+expect_notice "no option prints the notice"            1 $NO_CONF
+expect_notice "-Y autolevel is explicit, no notice"    0 $NO_CONF -Y autolevel
+expect_notice "-Y autolevel=0 is explicit, no notice"  0 $NO_CONF -Y autolevel=0
+expect_notice "-Y autolevel=1 is explicit, no notice"  0 $NO_CONF -Y autolevel=1
 expect_notice "conf file autolevel, no notice"         0 -c "$CONF_ON"
 expect_notice "conf file autolevel=0, no notice"       0 -c "$CONF_OFF"
 
-# Every spelling the usage text and docs promise. The off words are matched
-# case-insensitively, so check a capitalised one too.
+# Every spelling atobv() accepts, in both directions. The words are matched
+# case-insensitively, so check a capitalised one too. The false/disable/n cases
+# are the ones that matter most: they are what a user reaching for an opt-out
+# is likely to type, and parsing that silently treats an unrecognised word as
+# "on" would turn the feature ON for someone trying to turn it off.
 echo "autolevel::spellings:"
-expect_enabled  "on by default"
-expect_enabled  "-Y autolevel"          -Y autolevel
-expect_enabled  "-Y autolevel=1"        -Y autolevel=1
-expect_disabled "-Y autolevel=0"        -Y autolevel=0
-expect_disabled "-Y autolevel=no"       -Y autolevel=no
-expect_disabled "-Y autolevel=off"      -Y autolevel=off
-expect_disabled "-Y autolevel=OFF"      -Y autolevel=OFF
-expect_disabled "-Y autolevel=No"       -Y autolevel=No
-expect_enabled  "conf file autolevel"   -c "$CONF_ON"
-expect_disabled "conf file autolevel=0" -c "$CONF_OFF"
+expect_enabled  "on by default"           $NO_CONF
+expect_enabled  "-Y autolevel"            $NO_CONF -Y autolevel
+expect_enabled  "-Y autolevel=1"          $NO_CONF -Y autolevel=1
+expect_enabled  "-Y autolevel=on"         $NO_CONF -Y autolevel=on
+expect_enabled  "-Y autolevel=yes"        $NO_CONF -Y autolevel=yes
+expect_enabled  "-Y autolevel=true"       $NO_CONF -Y autolevel=true
+expect_enabled  "-Y autolevel=enable"     $NO_CONF -Y autolevel=enable
+expect_disabled "-Y autolevel=0"          $NO_CONF -Y autolevel=0
+expect_disabled "-Y autolevel=no"         $NO_CONF -Y autolevel=no
+expect_disabled "-Y autolevel=off"        $NO_CONF -Y autolevel=off
+expect_disabled "-Y autolevel=OFF"        $NO_CONF -Y autolevel=OFF
+expect_disabled "-Y autolevel=No"         $NO_CONF -Y autolevel=No
+expect_disabled "-Y autolevel=false"      $NO_CONF -Y autolevel=false
+expect_disabled "-Y autolevel=disable"    $NO_CONF -Y autolevel=disable
+expect_enabled  "conf file autolevel"     -c "$CONF_ON"
+expect_disabled "conf file autolevel=0"   -c "$CONF_OFF"
 
 # The floor must stop at the built-in clamp no matter how quiet the band is,
 # and having stopped there it must not keep re-adjusting. Re-adjusting on every
@@ -155,13 +201,27 @@ at_clamp=$(adjust_log | grep -c "detection level to -30.0 dB")
     || fail "expected 1 adjustment to the clamp, got $at_clamp"
 
 # Noise estimation keeps falling past the clamp, so a floor that ignored the
-# clamp would have gone below -30 dB here.
+# clamp would have gone below -30 dB here. Compare the whole number, fraction
+# included: truncating to the integer part would let anything from -30.1 to
+# -30.9 dB through and only catch a breakage of a full dB or more.
 below=$(adjust_log \
-    | sed -n "s/.*detection level to \(-[0-9]*\)\..* dB.*/\1/p" \
+    | sed -n "s/.*detection level to \(-\{0,1\}[0-9]\{1,\}\.[0-9]\{1,\}\) dB.*/\1/p" \
     | awk '$1 < -30 { n++ } END { print n + 0 }')
 [ "$below" = 0 ] \
     && pass "the floor never goes below the clamp" \
     || fail "expected no adjustment below -30 dB, got $below"
+
+# A minimum level configured below the clamp must win over it. Autolevel is on
+# by default now, so without this a user who asked for -Y minlevel=-35 would
+# have the floor quietly raised to the -30 dB clamp and lose 5 dB of the
+# sensitivity they explicitly configured. Nothing may move the floor above the
+# configured level; tracking it no further down is fine.
+raised=$("$RTL_433" -vv $NO_CONF -Y minlevel=-35 -r "$SILENT_CU8" 2>/dev/null \
+    | sed -n "s/.*detection level to \(-\{0,1\}[0-9]\{1,\}\.[0-9]\{1,\}\) dB.*/\1/p" \
+    | awk '$1 > -35.0 { n++ } END { print n + 0 }')
+[ "$raised" = 0 ] \
+    && pass "-Y minlevel below the clamp is not raised back up to it" \
+    || fail "expected -Y minlevel=-35 to be honored, but the floor was raised $raised time(s)"
 
 echo
 echo "auto level: $PASSED passed, $FAILED failed."


### PR DESCRIPTION
Following up from discussion in #3623.

This PR changes the pulse detector to be set to autolevel by default. A few notes:

- We support the same types of settings flags as other flags (0 / no / off) at the cost of a bit more code.
- This _doesn’t_ enable squelch by default. I’m open to changing that, but it seems to me that for new users missing signals is worse than high CPU use.
- The “measured on real hardware” is my own setup for WH51 sensors. Totally open to testing other values if if it makes sense.

Test run locally has the same results as master:

|      |records|failures|
|------|-------|--------|
|BEFORE|5545   |71      |
|AFTER |5545   |71      |

82 captures also trigger the tracking, moving the floor from -12 dB to -24.7.

IMO this closes #1785 and partially addresses #1784 .