### PR TITLE
Fix https truncation on /events

### DIFF
--- a/src/http_server.c
+++ b/src/http_server.c
@@ -1324,32 +1324,13 @@ static void R_API_CALLCONV print_http_data(data_output_t *output, data_t *data, 
     UNUSED(format);
     data_output_http_t *http = (data_output_http_t *)output;
 
-    // collect well-known top level keys
-    data_t *data_model = NULL;
-    for (data_t *d = data; d; d = d->next) {
-        if (!strcmp(d->key, "model")) {
-            data_model = d;
-        }
+    char *buf = data_print_jsons_dup(data);
+    if (!buf) {
+        WARN_MALLOC("print_http_data()");
+        return; // NOTE: skip output on alloc failure.
     }
-
-    if (data_model) {
-        // "events"
-        char buf[2048]; // we expect the biggest strings to be around 500 bytes.
-        size_t len = data_print_jsons(data, buf, sizeof(buf));
-        http_broadcast_send(http->server, buf, len);
-    }
-    else {
-        // "states"
-        size_t buf_size = 20000; // state message need a large buffer
-        char *buf       = malloc(buf_size);
-        if (!buf) {
-            WARN_MALLOC("print_http_data()");
-            return; // NOTE: skip output on alloc failure.
-        }
-        size_t len = data_print_jsons(data, buf, buf_size);
-        http_broadcast_send(http->server, buf, len);
-        free(buf);
-    }
+    http_broadcast_send(http->server, buf, strlen(buf));
+    free(buf);
 }
 
 static void R_API_CALLCONV data_output_http_free(data_output_t *output)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,6 +74,13 @@ if(UNIX)
                 COMMAND ${BASH_PROGRAM}
                     ${CMAKE_CURRENT_SOURCE_DIR}/http-rtltcp-test.sh
                     $<TARGET_FILE:rtl_433>)
+            # Regression test for print_http_data() truncating a large stats
+            # report into invalid JSON (fixed-size buffer -> data_print_jsons_dup()).
+            add_test(
+                NAME http_server_stats_truncation
+                COMMAND ${BASH_PROGRAM}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/http-stats-truncation-test.sh
+                    $<TARGET_FILE:rtl_433>)
         else()
             message(STATUS "Skipping http_server_rtltcp test (need python3)")
         endif()

--- a/tests/http-stats-truncation-test.sh
+++ b/tests/http-stats-truncation-test.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+#
+# Regression test for the HTTP/WS "states" broadcast truncating a large stats
+# report into invalid JSON (print_http_data() in src/http_server.c).
+#
+# print_http_data() serializes every non-"model" data_t (e.g. the get_stats-
+# shaped report pushed on SIGINFO/level-3 stats) into a fixed-size buffer.
+# With ~335 decoders enabled by default, that report is comfortably larger
+# than the historical 20000-byte buffer, so a fixed buffer truncates it mid-
+# object -- the same abuf corruption pattern as the get_stats/get_protocols
+# RPC bug (see data-test.c's test_jsons_large_report). data_print_jsons_dup()
+# grows the buffer to fit instead.
+#
+# Like http-rtltcp-test.sh, this needs the *live* input path: process_sdr_frame()
+# (where the periodic stats check lives) only runs while IQ frames are flowing,
+# so a fake rtl_tcp source streams silence to keep rtl_433 in its live poll
+# loop. All default decoders stay enabled (no -R restriction) so the stats
+# report is big enough to exercise the bug; SIGINFO (signal 29) forces an
+# immediate level-3 report instead of waiting on the stats interval timer.
+#
+# Usage: http-stats-truncation-test.sh [path-to-rtl_433-binary]
+
+set -u
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+RTL_433=${1:-"$SCRIPT_DIR/../src/rtl_433"}
+HOST=127.0.0.1
+
+if [ ! -x "$RTL_433" ]; then
+    echo "ERROR: rtl_433 binary not found or not executable: $RTL_433" >&2
+    exit 99
+fi
+
+pick_port() {
+    python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' 2>/dev/null
+}
+HTTPPORT=${HTTPPORT:-$(pick_port)}
+TCPPORT=${TCPPORT:-$(pick_port)}
+HTTPPORT=${HTTPPORT:-18433}
+TCPPORT=${TCPPORT:-18533}
+BASE="http://$HOST:$HTTPPORT"
+
+SERVER_LOG=$(mktemp 2>/dev/null || echo /tmp/rtl_433_stats_test.$$.log)
+TCP_LOG=$(mktemp 2>/dev/null || echo /tmp/rtl_433_stats_srv.$$.log)
+RTL_PID=""
+TCP_PID=""
+
+cleanup() {
+    if [ -n "$RTL_PID" ] && kill -0 "$RTL_PID" 2>/dev/null; then
+        kill -TERM "$RTL_PID" 2>/dev/null
+        for _ in 1 2 3 4 5 6 7 8 9 10; do
+            kill -0 "$RTL_PID" 2>/dev/null || break
+            sleep 0.3
+        done
+        kill -0 "$RTL_PID" 2>/dev/null && kill -KILL "$RTL_PID" 2>/dev/null
+        wait "$RTL_PID" 2>/dev/null
+    fi
+    if [ -n "$TCP_PID" ] && kill -0 "$TCP_PID" 2>/dev/null; then
+        kill -TERM "$TCP_PID" 2>/dev/null
+        wait "$TCP_PID" 2>/dev/null
+    fi
+    rm -f "$SERVER_LOG" "$TCP_LOG"
+}
+trap cleanup EXIT INT TERM
+
+# --- start the fake rtl_tcp server (content is irrelevant; we only need a
+# continuous IQ stream to keep rtl_433's live poll loop -- and its periodic
+# stats-timer check -- running) ---
+echo "Starting fake rtl_tcp server on $HOST:$TCPPORT"
+python3 "$SCRIPT_DIR/rtl_tcp_serve.py" --port "$TCPPORT" --bits "0" \
+    >"$TCP_LOG" 2>&1 &
+TCP_PID=$!
+listening=0
+for _ in $(seq 1 50); do
+    if ! kill -0 "$TCP_PID" 2>/dev/null; then
+        echo "ERROR: rtl_tcp server exited during startup" >&2
+        cat "$TCP_LOG" >&2
+        exit 96
+    fi
+    grep -q "LISTENING" "$TCP_LOG" 2>/dev/null && { listening=1; break; }
+    sleep 0.1
+done
+if [ "$listening" != 1 ]; then
+    echo "ERROR: rtl_tcp server did not start listening" >&2
+    cat "$TCP_LOG" >&2
+    exit 96
+fi
+
+# --- start rtl_433 against it, all default decoders enabled (no -R) ---
+echo "Starting rtl_433: -d rtl_tcp:$HOST:$TCPPORT -F $BASE"
+"$RTL_433" -d "rtl_tcp:$HOST:$TCPPORT" -F "$BASE" >"$SERVER_LOG" 2>&1 &
+RTL_PID=$!
+
+ready=0
+for _ in $(seq 1 50); do
+    if ! kill -0 "$RTL_PID" 2>/dev/null; then
+        echo "ERROR: rtl_433 exited during startup" >&2
+        cat "$SERVER_LOG" >&2
+        exit 95
+    fi
+    if curl -s -o /dev/null --max-time 1 "$BASE/"; then
+        ready=1
+        break
+    fi
+    sleep 0.2
+done
+if [ "$ready" != 1 ]; then
+    echo "ERROR: HTTP server did not become ready on $BASE" >&2
+    cat "$SERVER_LOG" >&2
+    exit 94
+fi
+echo "HTTP server ready on $BASE (rtl_433 pid $RTL_PID)"
+
+# --- the actual assertion: SIGINFO forces a full stats report over the WS
+# API, and it must arrive as complete, valid JSON, not truncated ---
+echo "--- ws stats read-back ---"
+if python3 "$SCRIPT_DIR/ws-probe.py" "$HOST" "$HTTPPORT" 10 '"stats":[' "$RTL_PID" 29; then
+    echo "ok: full stats report round-tripped through the HTTP/WS API as valid JSON"
+    exit 0
+else
+    echo "NOT OK: stats report did not come back as valid JSON" >&2
+    cat "$SERVER_LOG" >&2
+    exit 1
+fi

--- a/tests/ws-probe.py
+++ b/tests/ws-probe.py
@@ -9,10 +9,16 @@ and reads the reply. This exercises the server's WebSocket code paths
 
 Pure standard library so it runs in CI without extra packages.
 
-Usage: ws-probe.py HOST PORT [timeout_seconds] [expect_substring]
+Usage: ws-probe.py HOST PORT [timeout_seconds] [expect_substring] [signal_pid] [signal_num]
 If expect_substring is given, the probe also asserts that a pushed frame (the
 history the server replays on connect, or a live broadcast) contains it -- used
 to confirm a decoded event is retrievable over the WS API.
+
+If signal_pid/signal_num are also given, the probe sends that signal to that
+PID right after the meta frame arrives (e.g. SIGINFO/29 to make rtl_433 push a
+full-level stats report), then additionally requires the matched frame to
+parse as valid JSON -- catching a truncated/corrupted broadcast that a plain
+substring match would miss.
 Exit 0 on success, non-zero otherwise; received text frames go to stdout.
 """
 import base64
@@ -121,6 +127,8 @@ def main():
     port = int(sys.argv[2])
     timeout = float(sys.argv[3]) if len(sys.argv) > 3 else 10.0
     expect = sys.argv[4] if len(sys.argv) > 4 else None
+    signal_pid = int(sys.argv[5]) if len(sys.argv) > 5 else None
+    signal_num = int(sys.argv[6]) if len(sys.argv) > 6 else None
 
     sock = socket.create_connection((host, port), timeout=timeout)
     sock.settimeout(timeout)
@@ -132,13 +140,24 @@ def main():
             print("FAIL: never received a meta frame with 'center_frequency'", file=sys.stderr)
             return 1
 
+        if signal_pid is not None:
+            os.kill(signal_pid, signal_num)
+
         # If asked, confirm a decoded event is retrievable over the WS API: the
         # server replays its history ring on connect, so a decode that already
         # happened arrives as a pushed frame (a live broadcast also matches).
         if expect is not None:
-            if read_until_contains(sock, expect, max_frames=200) is None:
+            frame = read_until_contains(sock, expect, max_frames=200)
+            if frame is None:
                 print("FAIL: never received a frame containing %r" % expect, file=sys.stderr)
                 return 1
+            if signal_pid is not None:
+                try:
+                    json.loads(frame)
+                except ValueError as e:
+                    print("FAIL: matched frame (%d bytes) is not valid JSON: %s" % (len(frame), e),
+                          file=sys.stderr)
+                    return 1
 
         # The WebSocket RPC uses the simple {"cmd": ...} form (json_parse),
         # NOT the JSON-RPC envelope the /jsonrpc HTTP endpoint expects.


### PR DESCRIPTION
This fixes another corrupt JSON issue over the http server. Nearly all the code is adding tests, and the actual production code is just calling a previously introduced function.