### PR TITLE
Fix [Truck] reject all-zero payload

### DIFF
--- a/src/devices/tpms_truck.c
+++ b/src/devices/tpms_truck.c
@@ -61,6 +61,11 @@ static int tpms_truck_decode(r_device *decoder, bitbuffer_t *bitbuffer, unsigned
     uint8_t b[9] = {0};
     bitbuffer_extract_bytes(&packet_bits, 0, 4, b, 72);
 
+    // reject all-zero data, the XOR checksum can't catch it
+    if (!b[0] && !b[1] && !b[2] && !b[3]) {
+        return 0; // DECODE_FAIL_SANITY;
+    }
+
     int chk = xor_bytes(b, 9);
     if (chk != 0) {
         return 0; // DECODE_FAIL_MIC;


### PR DESCRIPTION
The phantom in #3633 needs no real signal. The MIC is an XOR over all 9 bytes so an all-zero packet passes it. The packet is Manchester coded and a plain 0x55 fill decodes to all zeros. Any long run of the preamble's own alternating pattern with one 0x56 in it becomes a valid looking report.

Repro on current master:

```
$ src/rtl_433 -R 201 -y "{424}5555555555555555555555555555555555555555555555555555555556555555555555555555555555555555555555555555555555"
model     : Truck
type      : TPMS
id        : 00000000
wheel     : 0
Pressure  : 0 kPa
Temperature: 0 C
Battery Ok: 0
Flag?     : 0
Integrity : CHECKSUM
```

Same all-zero record as the one pasted in #3633.

The fix rejects a zero ID before the checksum. Same guard as `schraeder.c` and `ert_scm.c`. All-0xff already fails the XOR since the 9th byte does not cancel.

The row above is now rejected and both sample rows from the doc comment still decode:

```
$ src/rtl_433 -R 201 -y "{401}555555555555555555555555555555555555555555555555555555555699556695569a59955655595a55555556a9969aaaff80"
model     : Truck
type      : TPMS
id        : 0581b281
wheel     : 2
Pressure  : 0 kPa
Temperature: 30 C
Battery Ok: 1
Flag?     : 3
Integrity : CHECKSUM
```

`node .github/actions/style-check/index.js` passes.

Should the model rename from #3633 (Truck to SolarTPMS) go in here too? It changes output for downstream consumers so I left it alone for now. Thanks.
