### PR TITLE
Add Neptune r900bcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [339]  Florabest FB-TH-1 BBQ Thermometer
     [340]  Holman Industries iWeather WS5029 weather station (older PWM, OOK), BIOWIN 270208
     [341]  Esun EN2053 two-channel BBQ thermometer
-    [342]  Vivint Door/Window Sensor, V-DW21R-345
+    [342]  Vivint Door/Window Sensor, V-DW21R-345/V-DW11-345
     [343]  SmarTire TPMS sensor, Aston Martin/Vantage DB9 protocol
     [344]* Dickert MAHS433-01 garage door remote control
     [345]  FSL Cricket Scoreboard Controller
@@ -478,6 +478,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [382]* Cotech 36-7900 rain gauge
     [383]  Silver Spring Networks mesh endpoint (-s 1600k)
     [384]  Bresser SmartHome Garden soil moisture and water timer valve (Baldr Homgar, RainPoint)
+    [385]  Neptune R900 BCD flow meters
 
 * Disabled by default, use -R n or a conf file to enable
 

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -624,6 +624,7 @@ convert si
 # protocol 382 # Cotech 36-7900 rain gauge
   protocol 383 # Silver Spring Networks mesh endpoint (-s 1600k)
   protocol 384 # Bresser SmartHome Garden soil moisture and water timer valve (Baldr Homgar, RainPoint)
+  protocol 385 # Neptune R900 BCD flow meters
 
 ## Flex devices (command line option "-X")
 

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -392,6 +392,7 @@
     DECL(cotech_36_7900) \
     DECL(silver_spring_mesh) \
     DECL(bresser_garden) \
+    DECL(neptune_r900bcd) \
     /* Add new decoders here. */
 
 #define DECL(name) extern r_device const name;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -236,6 +236,7 @@ add_library(r_433 STATIC
     devices/missil_ml0757.c
     devices/mueller_hotrod.c
     devices/neptune_r900.c
+    devices/neptune_r900bcd.c
     devices/netatmo_thw.c
     devices/new_template.c
     devices/newkaku.c

--- a/src/devices/neptune_r900bcd.c
+++ b/src/devices/neptune_r900bcd.c
@@ -1,7 +1,7 @@
 /** @file
     Neptune R900 BCD flow meter decoder.
 
-    Copyright (C) 2024 the rtl_433 authors
+    Copyright (C) 2026 the rtl_433 authors
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/devices/neptune_r900bcd.c
+++ b/src/devices/neptune_r900bcd.c
@@ -1,0 +1,261 @@
+/** @file
+    Neptune R900 BCD flow meter decoder.
+
+    Copyright (C) 2024 Your Name
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+ */
+
+#include "decoder.h"
+
+/** @fn int neptune_r900bcd_decode(r_device *decoder, bitbuffer_t * bitbuffer)
+Neptune R900 BCD flow meter decoder.
+
+The device uses PPM encoding,
+- 1 is encoded as 30 us pulse.
+- 0 is encoded as 30 us gap.
+
+A gap longer than 320 us is considered the end of the transmission.
+
+The device sends a transmission every xx seconds.
+
+A transmission starts with a preamble of 0xAA,0xAA,0xAA,0xAB,0x52,0xCC,0xD2
+But, it is "zero" based, so if you insert a zero bit to the beginning of the bitstream,
+the preamble is:
+- 0x55,0x55,0x55,0x55,0xA9,0x66,0x69,0x65
+
+It should be sufficient to find the start of the data after 0x55,0x55,0x55,0xA9,0x66,0x69,0x65.
+
+Once the payload is decoded, the message is as follows:
+(from https://github.com/bemasher/rtlamr/wiki/Protocol#r900-consumption-message)
+- ID - 32 bits
+- Unkn1 - 8 bits
+- NoUse - 6 bits
+- BackFlow - 6 bits    // found this to be 2 bits in my case ???
+- Consumption - 24 bits
+- Unkn3 - 2 bits
+- Leak - 4 bits
+- LeakNow - 2 bits
+
+This version handles BCD (Binary Coded Decimal) decoding of the consumption field.
+
+After decoding the bitstream into 168 bits of payload, the layout appears to be:
+
+Data layout:
+
+    IIIIIIII IIIIIIII IIIIIIII IIIIIIII UUUUMMMM ???NNNBB CCCCCCCC CCCCCCCC CCCCCCCC WWWTTTLL EEEEEEEE EEEEEEEE EEEEEEEE
+
+- I: 32-bit little-endian id
+- U:  4-bit Unknown1
+- M:  4-bit Meter Type
+- N:  6-bit NoUse (3 bits)
+- B:  2-bit backflow flag
+- C: 24-bit Consumption Data, in BCD format
+- W:  3-bit Wrap, high bits of Consumption on Non-BCD meters, consumption = (WRAP << 24 | CONSUMPTION) / 10
+- T:  4-bit days of leak mapping (3 bits)
+- L:  2-bit leak flag type
+- E: 24-bit extra data???
+
+*/
+int const bcd_map16to6[16] = { -1, -1, -1, 0, -1, 1, 2, -1, -1, 5, 4, -1, 3, -1, -1, -1 };
+
+static void bcd_decode_5to8(bitbuffer_t *bytes, uint8_t *base6_dec)
+{
+    // is there a better way to convert groups of 5 bits to groups of 8 bits?
+    for (int i=0; i < 21; i++) {
+        uint8_t data = base6_dec[i];
+        bitbuffer_add_bit(bytes, data >> 4 & 0x01);
+        bitbuffer_add_bit(bytes, data >> 3 & 0x01);
+        bitbuffer_add_bit(bytes, data >> 2 & 0x01);
+        bitbuffer_add_bit(bytes, data >> 1 & 0x01);
+        bitbuffer_add_bit(bytes, data >> 0 & 0x01);
+    }
+}
+
+static int neptune_r900bcd_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    // partial preamble and sync word shifted by 1 bit
+    uint8_t const preamble[] = {0x55, 0x55, 0x55, 0xa9, 0x66, 0x69, 0x65};
+    int const preamble_length = sizeof(preamble) * 8;
+
+    if (bitbuffer->num_rows != 1) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    // Search for preamble and sync-word
+    unsigned start_pos = bitbuffer_search(bitbuffer, 0, 0, preamble, preamble_length);
+
+    // check that (bitbuffer->bits_per_row[0]) greater than (start_pos+sizeof(preamble)*8+168)
+    if (start_pos + preamble_length + 168 > bitbuffer->bits_per_row[0])
+        return DECODE_ABORT_LENGTH;
+
+    // No preamble detected
+    if (start_pos == bitbuffer->bits_per_row[0])
+        return DECODE_ABORT_EARLY;
+
+    decoder_logf(decoder, 1, __func__, "Neptune R900 BCD detected, buffer is %d bits length", bitbuffer->bits_per_row[0]);
+
+    // Remove preamble and sync word, keep whole payload
+    uint8_t bits[21]; // 168 bits
+    bitbuffer_extract_bytes(bitbuffer, 0, start_pos + preamble_length, bits, 21 * 8);
+
+    uint8_t *bb = bitbuffer->bb[0];
+    bitbuffer_t bytes = {0};
+    uint8_t base6_dec[21] = {0};
+    int count = 0;
+
+    /*
+     * Each group of four of these chips must be interpreted as a digit in base 6
+     *             according to the following mapping:
+     * 0011 -> 0
+     * 0101 -> 1
+     * 0110 -> 2
+     * 1100 -> 3
+     * 1010 -> 4
+     * 1001 -> 5
+    */
+    // create a pair of char bit array of '0' and '1' for each base6 byte
+    for (uint8_t k = start_pos+preamble_length; k < start_pos + preamble_length + 168; k=k+8) {
+        uint8_t byte = bitrow_get_byte(bb, k);
+        int highNibble = bcd_map16to6[(byte >> 4 & 0xF)];
+        int lowNibble = bcd_map16to6[(byte & 0xF)];
+
+        if (highNibble < 0 || lowNibble < 0)
+            return DECODE_ABORT_EARLY;
+
+        base6_dec[count] = (6 * highNibble) + lowNibble;
+        count++;
+    }
+
+    // convert the base6 integers above into binary bits for decoding data
+    // this reduces the 168 bits to 105 bits (104 bits??)
+    // the first 80 bits are used in this decoder, the last 24 bits are decoded as extra
+    bcd_decode_5to8(&bytes, base6_dec);
+    uint8_t b[13]; // 104 bits
+    bitbuffer_extract_bytes(&bytes, 0, 0, b, sizeof(b)*8);
+
+    // decode the data
+
+    // meter_id 32 bits
+    uint32_t meter_id = ((uint32_t)b[0] << 24) | (b[1] << 16) | (b[2] << 8) | (b[3]);
+    //Unkn1 4 bits
+    int unkn1 = b[4] >> 4;
+    //MeterType 4 bits
+    int metertype = b[4]&0x0F;
+    //Unkn2 3 bits
+    int unkn2 = b[5] >> 5;
+    //NoUse 3 bits
+    // 0 = 0 days
+    // 1 = 1-2 days
+    // 2 = 3-7 days
+    // 3 = 8-14 days
+    // 4 = 15-21 days
+    // 5 = 22-34 days
+    // 6 = 35+ days
+    int nouse = ((b[5] >> 1)&0x0F) >> 1;
+    //BackFlow 2 bits
+    // During the last 35 days
+    // 0 = none
+    // 1 = low
+    // 2 = high
+    int backflow = b[5]&0x03;
+    //Consumption 24 bits + 3-bit Wrap on Non-BCD meters
+    int consumption = ((b[9] >> 5) << 24) | (b[6] << 16) | (b[7] << 8) | (b[8]);
+    //Leak 3 bits
+    // 0 = 0 days
+    // 1 = 1-2 days
+    // 2 = 3-7 days
+    // 3 = 8-14 days
+    // 4 = 15-21 days
+    // 5 = 22-34 days
+    // 6 = 35+ days
+    int leak = ((b[9] >> 1)&0x0F) >> 1;
+    //LeakNow 2 bits
+    // During the last 24 hours
+    // 0 = none
+    // 1 = low (intermittent leak) water used for at least 50 of the 96 15-minute intervals
+    // 2 = high (continuous leak) water use in every 15-min interval for the last 24 hours
+    int leaknow = b[9]&0x03;
+    // extra 24 bits ???
+    char extra[7];
+    snprintf(extra, sizeof(extra),"%02x%02x%02x", b[10], b[11], b[12]);
+
+    // Convert BCD consumption to decimal
+    // In BCD format, each nibble represents a decimal digit
+    int bcd_consumption = consumption;
+    int decimal_consumption = 0;
+    int multiplier = 1;
+
+    // Extract each digit from BCD and convert to decimal
+    // We have 24 bits (6 nibbles) to process
+    for (int i = 0; i < 6; i++) {  // 6 digits for 24 bits
+        int digit = bcd_consumption & 0x0F;
+        if (digit > 9) {
+            // Invalid BCD digit - this should not happen in valid data
+            decimal_consumption = -1;  // Invalid value
+            return DECODE_ABORT_EARLY;
+        }
+        decimal_consumption += digit * multiplier;
+        multiplier *= 10;
+        bcd_consumption >>= 4;
+    }
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",       "",    DATA_STRING, "Neptune-R900BCD",
+            "id",          "",    DATA_INT,    meter_id,
+            "unkn1",       "",    DATA_INT,    unkn1,
+            "metertype",   "",    DATA_INT,    metertype,
+            "unkn2",       "",    DATA_INT,    unkn2,
+            "nouse",       "",    DATA_INT,    nouse,
+            "backflow",    "",    DATA_INT,    backflow,
+            "consumption", "",    DATA_INT,    decimal_consumption,
+            "leak",        "",    DATA_INT,    leak,
+            "leaknow",     "",    DATA_INT,    leaknow,
+            "extra",       "",    DATA_STRING, extra,
+            NULL);
+    /* clang-format on */
+    decoder_output_data(decoder, data);
+
+    // Return 1 if message successfully decoded
+    return 1;
+}
+
+/*
+ * List of fields that may appear in the output
+ *
+ * Used to determine what fields will be output in what
+ * order for this device when using -F csv.
+ *
+ */
+static char const *const output_fields[] = {
+        "model",
+        "id",
+        "unkn1",
+        "metertype",
+        "unkn2",
+        "nouse",
+        "backflow",
+        "consumption_bcd",
+        "consumption",
+        "leak",
+        "leaknow",
+        "extra",
+        NULL,
+};
+
+/*
+ * r_device - registers device/callback. see rtl_433_devices.h
+ */
+r_device const neptune_r900bcd = {
+        .name        = "Neptune R900 BCD flow meters",
+        .modulation  = OOK_PULSE_PCM,
+        .short_width = 30,
+        .long_width  = 30,
+        .reset_limit = 320, // a bit longer than packet gap
+        .decode_fn   = &neptune_r900bcd_decode,
+        .fields      = output_fields,
+};

--- a/src/devices/neptune_r900bcd.c
+++ b/src/devices/neptune_r900bcd.c
@@ -62,12 +62,12 @@ Data layout:
 - E: 24-bit extra data???
 
 */
-int const bcd_map16to6[16] = { -1, -1, -1, 0, -1, 1, 2, -1, -1, 5, 4, -1, 3, -1, -1, -1 };
+int const bcd_map16to6[16] = {-1, -1, -1, 0, -1, 1, 2, -1, -1, 5, 4, -1, 3, -1, -1, -1};
 
 static void bcd_decode_5to8(bitbuffer_t *bytes, uint8_t *base6_dec)
 {
     // is there a better way to convert groups of 5 bits to groups of 8 bits?
-    for (int i=0; i < 21; i++) {
+    for (int i = 0; i < 21; i++) {
         uint8_t data = base6_dec[i];
         bitbuffer_add_bit(bytes, data >> 4 & 0x01);
         bitbuffer_add_bit(bytes, data >> 3 & 0x01);
@@ -80,7 +80,7 @@ static void bcd_decode_5to8(bitbuffer_t *bytes, uint8_t *base6_dec)
 static int neptune_r900bcd_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     // partial preamble and sync word shifted by 1 bit
-    uint8_t const preamble[] = {0x55, 0x55, 0x55, 0xa9, 0x66, 0x69, 0x65};
+    uint8_t const preamble[]  = {0x55, 0x55, 0x55, 0xa9, 0x66, 0x69, 0x65};
     int const preamble_length = sizeof(preamble) * 8;
 
     if (bitbuffer->num_rows != 1) {
@@ -104,10 +104,10 @@ static int neptune_r900bcd_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     uint8_t bits[21]; // 168 bits
     bitbuffer_extract_bytes(bitbuffer, 0, start_pos + preamble_length, bits, 21 * 8);
 
-    uint8_t *bb = bitbuffer->bb[0];
-    bitbuffer_t bytes = {0};
+    uint8_t *bb           = bitbuffer->bb[0];
+    bitbuffer_t bytes     = {0};
     uint8_t base6_dec[21] = {0};
-    int count = 0;
+    int count             = 0;
 
     /*
      * Each group of four of these chips must be interpreted as a digit in base 6
@@ -118,12 +118,12 @@ static int neptune_r900bcd_decode(r_device *decoder, bitbuffer_t *bitbuffer)
      * 1100 -> 3
      * 1010 -> 4
      * 1001 -> 5
-    */
+     */
     // create a pair of char bit array of '0' and '1' for each base6 byte
-    for (uint8_t k = start_pos+preamble_length; k < start_pos + preamble_length + 168; k=k+8) {
-        uint8_t byte = bitrow_get_byte(bb, k);
+    for (uint8_t k = start_pos + preamble_length; k < start_pos + preamble_length + 168; k = k + 8) {
+        uint8_t byte   = bitrow_get_byte(bb, k);
         int highNibble = bcd_map16to6[(byte >> 4 & 0xF)];
-        int lowNibble = bcd_map16to6[(byte & 0xF)];
+        int lowNibble  = bcd_map16to6[(byte & 0xF)];
 
         if (highNibble < 0 || lowNibble < 0)
             return DECODE_ABORT_EARLY;
@@ -137,67 +137,67 @@ static int neptune_r900bcd_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     // the first 80 bits are used in this decoder, the last 24 bits are decoded as extra
     bcd_decode_5to8(&bytes, base6_dec);
     uint8_t b[13]; // 104 bits
-    bitbuffer_extract_bytes(&bytes, 0, 0, b, sizeof(b)*8);
+    bitbuffer_extract_bytes(&bytes, 0, 0, b, sizeof(b) * 8);
 
     // decode the data
 
     // meter_id 32 bits
     uint32_t meter_id = ((uint32_t)b[0] << 24) | (b[1] << 16) | (b[2] << 8) | (b[3]);
-    //Unkn1 4 bits
+    // Unkn1 4 bits
     int unkn1 = b[4] >> 4;
-    //MeterType 4 bits
-    int metertype = b[4]&0x0F;
-    //Unkn2 3 bits
+    // MeterType 4 bits
+    int metertype = b[4] & 0x0F;
+    // Unkn2 3 bits
     int unkn2 = b[5] >> 5;
-    //NoUse 3 bits
-    // 0 = 0 days
-    // 1 = 1-2 days
-    // 2 = 3-7 days
-    // 3 = 8-14 days
-    // 4 = 15-21 days
-    // 5 = 22-34 days
-    // 6 = 35+ days
-    int nouse = ((b[5] >> 1)&0x0F) >> 1;
-    //BackFlow 2 bits
-    // During the last 35 days
-    // 0 = none
-    // 1 = low
-    // 2 = high
-    int backflow = b[5]&0x03;
-    //Consumption 24 bits + 3-bit Wrap on Non-BCD meters
+    // NoUse 3 bits
+    //  0 = 0 days
+    //  1 = 1-2 days
+    //  2 = 3-7 days
+    //  3 = 8-14 days
+    //  4 = 15-21 days
+    //  5 = 22-34 days
+    //  6 = 35+ days
+    int nouse = ((b[5] >> 1) & 0x0F) >> 1;
+    // BackFlow 2 bits
+    //  During the last 35 days
+    //  0 = none
+    //  1 = low
+    //  2 = high
+    int backflow = b[5] & 0x03;
+    // Consumption 24 bits + 3-bit Wrap on Non-BCD meters
     int consumption = ((b[9] >> 5) << 24) | (b[6] << 16) | (b[7] << 8) | (b[8]);
-    //Leak 3 bits
-    // 0 = 0 days
-    // 1 = 1-2 days
-    // 2 = 3-7 days
-    // 3 = 8-14 days
-    // 4 = 15-21 days
-    // 5 = 22-34 days
-    // 6 = 35+ days
-    int leak = ((b[9] >> 1)&0x0F) >> 1;
-    //LeakNow 2 bits
-    // During the last 24 hours
-    // 0 = none
-    // 1 = low (intermittent leak) water used for at least 50 of the 96 15-minute intervals
-    // 2 = high (continuous leak) water use in every 15-min interval for the last 24 hours
-    int leaknow = b[9]&0x03;
+    // Leak 3 bits
+    //  0 = 0 days
+    //  1 = 1-2 days
+    //  2 = 3-7 days
+    //  3 = 8-14 days
+    //  4 = 15-21 days
+    //  5 = 22-34 days
+    //  6 = 35+ days
+    int leak = ((b[9] >> 1) & 0x0F) >> 1;
+    // LeakNow 2 bits
+    //  During the last 24 hours
+    //  0 = none
+    //  1 = low (intermittent leak) water used for at least 50 of the 96 15-minute intervals
+    //  2 = high (continuous leak) water use in every 15-min interval for the last 24 hours
+    int leaknow = b[9] & 0x03;
     // extra 24 bits ???
     char extra[7];
-    snprintf(extra, sizeof(extra),"%02x%02x%02x", b[10], b[11], b[12]);
+    snprintf(extra, sizeof(extra), "%02x%02x%02x", b[10], b[11], b[12]);
 
     // Convert BCD consumption to decimal
     // In BCD format, each nibble represents a decimal digit
-    int bcd_consumption = consumption;
+    int bcd_consumption     = consumption;
     int decimal_consumption = 0;
-    int multiplier = 1;
+    int multiplier          = 1;
 
     // Extract each digit from BCD and convert to decimal
     // We have 24 bits (6 nibbles) to process
-    for (int i = 0; i < 6; i++) {  // 6 digits for 24 bits
+    for (int i = 0; i < 6; i++) { // 6 digits for 24 bits
         int digit = bcd_consumption & 0x0F;
         if (digit > 9) {
             // Invalid BCD digit - this should not happen in valid data
-            decimal_consumption = -1;  // Invalid value
+            decimal_consumption = -1; // Invalid value
             return DECODE_ABORT_EARLY;
         }
         decimal_consumption += digit * multiplier;

--- a/src/devices/neptune_r900bcd.c
+++ b/src/devices/neptune_r900bcd.c
@@ -1,7 +1,7 @@
 /** @file
     Neptune R900 BCD flow meter decoder.
 
-    Copyright (C) 2024 Your Name
+    Copyright (C) 2024 the rtl_433 authors
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -13,6 +13,8 @@
 
 /** @fn int neptune_r900bcd_decode(r_device *decoder, bitbuffer_t * bitbuffer)
 Neptune R900 BCD flow meter decoder.
+
+Tested with Neptune T-10 meter.
 
 The device uses PPM encoding,
 - 1 is encoded as 30 us pulse.
@@ -40,7 +42,7 @@ Once the payload is decoded, the message is as follows:
 - Leak - 4 bits
 - LeakNow - 2 bits
 
-This version handles BCD (Binary Coded Decimal) decoding of the consumption field.
+This version handles BCD (Binary Coded Decimal) decoding of the consumption field.  Same as device in rtlamr: https://github.com/bemasher/rtlamr/blob/master/r900bcd/r900bcd.go
 
 After decoding the bitstream into 168 bits of payload, the layout appears to be:
 


### PR DESCRIPTION
Some Neptune meters report consumption in BCD.  Copied existing neptune_r900 device and added BCD decoding.  Aborts early if it detects it is not BCD encoded.

Referenced Neptune BCD device in rtlamr.