### PR TITLE
Add flex decoder conf for Hampton Bay Ashby Park ceiling fan

### DIFF
--- a/conf/hamptonbay-ceilingfan.conf
+++ b/conf/hamptonbay-ceilingfan.conf
@@ -1,0 +1,56 @@
+# Hampton Bay "Ashby Park" 52" ceiling fan (and Bond Bridge, which controls
+# the same fixtures over the identical RF protocol).
+#
+# This fan's built-in RF receiver responds to a specific OOK_PWM protocol at
+# 304.25 MHz. Bond Bridge (Olibra BD-1000) was confirmed, by direct RF
+# capture comparison, to transmit bit-identical signals when controlling the
+# same fixture over its own local API - i.e. this is the fixture's own
+# receiver protocol, not tied to any one particular remote/switch product.
+#
+# Protocol: OOK_PWM. Reverse-engineered from live capture (not from a
+# datasheet/FCC filing) - short=744us, long=376us, reset/gap=900us,
+# tolerance=150us, no sync pulse. Every observed transmission is a fixed
+# 25-bit code with the first 3 bits always 0 (framing/padding, not
+# extracted).
+#
+# Packet layout (25 bits total, in transmission order):
+#
+#     Bit offset   0  1  2   3                          22  23 24
+#                  --------------------------------------------
+#     Field        |  pad  |          id (20 bits)         | ctr |
+#
+# - pad (3 bits): always observed as 0 across every code seen.
+# - id (20 bits): a combined address+function code identifying one specific
+#   paired remote/switch AND which button was pressed (fan speed / fan
+#   power / light). This code is unique per pairing and does not carry a
+#   further sub-structure we've confirmed (e.g. no independently-verified
+#   split between a device address and a button number) - treat it as an
+#   opaque per-installation identifier, similar in spirit to fan-11t.conf's
+#   dip-switch id, except we have no evidence this is a small user-settable
+#   space rather than a larger fixed pairing code.
+# - ctr (2 bits): a position counter, confirmed meaningful specifically for
+#   fan-speed codes: 0=33%, 1=66%, 2=100%, 3=off. For power/light codes
+#   this field's role is unconfirmed - we've only ever needed to match on
+#   `id` for those (they're pure toggle triggers, no target state to
+#   decode), so its value there was never examined.
+#
+# Bit offsets confirmed empirically (not just derived): captured real RF
+# from three known button presses/equivalent Bond actions and checked the
+# decoded `id`/`ctr` fields against independently-known values - fan power
+# (id 473), fan speed at 33/66/100% (id 511, ctr 0/1/2 respectively), and
+# light (id 505) - all matched.
+
+frequency 304.25M
+
+decoder {
+    name        = HamptonBay-CeilingFan,
+    modulation  = OOK_PWM,
+    short       = 744,
+    long        = 376,
+    reset       = 900,
+    gap         = 900,
+    tolerance   = 150,
+    bits        = 25,
+    get         = id:@3:{20},
+    get         = ctr:@23:{2}:[0:speed_33 1:speed_66 2:speed_100 3:speed_off],
+}


### PR DESCRIPTION
## Summary

Adds `conf/hamptonbay-ceilingfan.conf`, a flex-decoder config for the Hampton
Bay "Ashby Park" 52" ceiling fan's RF remote protocol (OOK_PWM, 304.25 MHz),
modeled on the existing `honeywell-fan.conf` / `fan-11t.conf` in this directory.

## How this was derived and verified

Reverse-engineered by live RF capture (no datasheet/FCC filing available for
the exact timing) while building a Home Assistant integration for these
fans. The fixture's own RF receiver was confirmed - by direct capture
comparison - to respond identically to its Bond Bridge (Olibra BD-1000)
smart-home controller, so the protocol documented here is the fixture's own
receiver protocol, independent of any specific remote/switch product.

Bit offsets in the `get =` field extraction were verified empirically, not
just derived: captured real RF from known commands (fan power, fan speed at
33/66/100%, light) and confirmed the decoded `id`/`ctr` fields matched
independently-known values in each case. Full detail in the file's own
header comment.

## Note on scope

`docs/CONTRIBUTING.md` documents the full C-decoder contribution path (with
test recordings submitted to `rtl_433_tests`) but doesn't mention `.conf`
files specifically, even though this directory already has ~80 similar
config-only device profiles. Happy to work toward a full C decoder + test
data submission instead if that's preferred for new contributions now -
just let me know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)