### PR TITLE
m_bus: widen pl_offset to avoid uint8_t wraparound

### DIFF
--- a/src/devices/m_bus.c
+++ b/src/devices/m_bus.c
@@ -148,7 +148,7 @@ typedef struct {
     uint8_t     AC;         // Access number
     uint8_t     ST;
     uint16_t    CW;         // Configuration word
-    uint8_t     pl_offset;  // Payload offset
+    unsigned    pl_offset;  // Payload offset
     /* Extended Link Layer (EN 13757-4), when the frame has one: this
        wraps the actual Transport/Application Layer CI above, which is
        parsed from just after it once found not to be encrypted. */


### PR DESCRIPTION
`m_bus_block2_t.pl_offset` is a `uint8_t`, but `m_bus_parse_ci()` sets it to
`pl_base` plus the header size, and `pl_base` grows through the AFL sub-header
recursion:

```c
m_bus_parse_ci(b + 2 + afl_len, remaining - 2 - afl_len, pl_base + 2 + afl_len, b2);
```

`afl_len` is a byte off the wire and the only thing bounding it is
`remaining < 2 + afl_len`. On Mode C `remaining` runs to roughly 375, so one AFL
is enough to take the offset past 255. The uint8_t keeps the low 8 bits and
`parse_payload()` walks DIF/VIF from there. Same shape as #3597, one field over.

## Reproducer

A valid maximum length Mode C Format A frame carrying CI=0x90 with afl_len=243
and a short TPL header behind it. `pl_base` lands on 10 + 2 + 243 = 255, the
0x7A header takes it to 260, and 260 in a uint8_t is 4. Offset 4 is the address
field in block 1.

```
rtl_433 -R 104 -F json -y "{2352}543d54cdff442d2c0c1367452301431a90f30000000000000000000000000000fa2d00000000000000000000000000000000ffff00000000000000000000000000000000ffff00000000000000000000000000000000ffff00000000000000000000000000000000ffff00000000000000000000000000000000ffff00000000000000000000000000000000ffff00000000000000000000000000000000ffff00000000000000000000000000000000ffff00000000000000000000000000000000ffff00000000000000000000000000000000ffff00000000000000000000000000000000ffff00000000000000000000000000000000ffff00000000000000000000007a2b0000002cd100000000000000000000000000000000ffff000000000000ffff"
```

Before, `time` and `data` trimmed:

```
{"model": "Wireless-MBus", "mode": "C", "M": "KAM", "id": 45671312, "version": 35, "type": 1, "type_string": "Oil", "C": 68, "CI": 122, "AC": 43, "ST": 0, "CW": 0, "inst_volume_0": "1234.567 m3", "max_energy_wh_6": "0.000 Wh", "inst_energy_wh_0": "0.000 Wh", "min_energy_wh_0": "0.000 Wh", "mic": "CRC"}
```

That 1234.567 m3 is the meter address decoded as a DIF/VIF record. The plain
text output carries 119 more fabricated Energy records behind it.

After:

```
{"model": "Wireless-MBus", "mode": "C", "M": "KAM", "id": 45671312, "version": 35, "type": 1, "type_string": "Oil", "C": 68, "CI": 122, "AC": 43, "ST": 0, "CW": 0, "mic": "CRC"}
```

260 is past `block1->L`, so the walk never starts and the frame reports its
header and raw hex only.

The other use sites are fine as they are: line 787 already copies it into an
`unsigned`, and 1187 and 1202 only test it for zero.

## Checks

`tests/m-bus` from rtl_433_tests gives 42 records and 0 failures on both
builds, with identical logs. I also pushed 3000 randomly generated Mode C frames
(mixed CI 0x72/0x7A/0x78, ELL, short AFL, some with a flipped bit) through both
builds with 104/105/106/238 enabled. 5042 events, byte identical output. ctest
is 16/16 both ways. Build warning count is unchanged at 1, the pre-existing
`-Wanalyzer-out-of-bounds` in proflame2.c.

The frame is synthetic and fed through `-y`. I have no capture of a real meter
sending an AFL that long.

One thing I left out on purpose. `m_bus_parse_ci()` could also decline to set
`pl_offset` when `pl_base` plus the header size runs past the destination
buffer. That would cover the `if (b[off] == 0x2F) off++;` peek at the top of
`parse_payload()`, which reads before the loop bounds check.

I walked the reachable offsets per caller before deciding to leave it out. Mode
C tops out near 399. Mode T and Mode R near 271. Mode S cannot chain an AFL
because everything past the manchester decode is zero. RADIAN's own length byte
caps it at 268. All of those sit inside the 512 byte buffer, so the widening
holds up on its own. Want the guard in this PR as well?
