### PR TITLE
tpms_renault_0435r: report mic as CHECKSUM, not CRC

### DIFF
--- a/src/devices/tpms_renault_0435r.c
+++ b/src/devices/tpms_renault_0435r.c
@@ -122,7 +122,7 @@ static int tpms_renault_0435r_decode(r_device *decoder, bitbuffer_t *bitbuffer, 
             "pressure_kPa",    "Pressure",                 DATA_FORMAT, "%.1f kPa",  DATA_DOUBLE, (double)pressure_kpa,
             "temperature_C",   "Temperature",              DATA_FORMAT, "%.0f C",    DATA_DOUBLE, (double)temp_c,
             "centrifugal_acc", "Centrifugal Acceleration", DATA_FORMAT, "%.0f m/s2", DATA_DOUBLE, (double)rad_acc,
-            "mic",             "",                         DATA_STRING, "CRC",
+            "mic",             "",                         DATA_STRING, "CHECKSUM",
             "has_tick",        "",                         DATA_INT,    has_tick,
             "tick",            "",                         DATA_INT,    tick - 0x80*(1-has_tick), //set to negative value when has_tick == 0 (invert bit 7)
             NULL);


### PR DESCRIPTION
`tpms_renault_0435r` reports its integrity check as `CRC`, but computes an 8-bit XOR:

- line 85: `int chk = xor_bytes(b, 9);`
- line 125: `"mic", "", DATA_STRING, "CRC",`

The file's own header says so too — line 2: *"FSK 9 byte Manchester encoded TPMS with xor checksum, 0435R"*, and line 84's comment is `// check checksum (checksum8 xor)`.

Every other TPMS decoder is self-consistent on this: those computing `xor_bytes` report `CHECKSUM` (`tpms_truck`, `tpms_citroen`, `tpms_ford`, `tpms_abarth124`), and those reporting `CRC` compute `crc8` (`tpms_toyota`, `tpms_renault`, `tpms_elantra2012`). As far as I can tell this is the only TPMS decoder where the declared and computed MIC disagree.

Noting it because the `mic` field is load-bearing for the integrity-level work in #3622 — any level derived from it would inherit the error here, and an XOR-8 decoder presenting as CRC is the case most likely to be trusted more than it should be.

No functional change; the `mic` string only.
