### PR TITLE
Improve WH52 battery and conductivity reporting

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -284,7 +284,7 @@ mappings = {
         }
     },
 
-    "conductivity": {
+    "conductivity_uS_cm": {
         "device_type": "sensor",
         "object_suffix": "EC",
         "config": {

--- a/src/devices/fineoffset_wh52.c
+++ b/src/devices/fineoffset_wh52.c
@@ -47,8 +47,8 @@ Preamble: aa aa aa 2d d4
 - Byte 9: EC bits 15..8
 - Byte 10: EC bits 7..0; ec_raw = ((b8 & 0x0F) << 16) | (b9 << 8) | b10 (20-bit); conductivity_uS = ec_raw / 25.6 (empirical; 25.6 = 256/10)
 - Byte 11: coarse EC / range indicator (redundant, low nibble fixed 0x6)
-- Byte 15: battery voltage; battery_mV ~= b15 * 20 - 60 (0.02 V/LSB, -0.06 V offset; empirical, fit from 4 field units reading 1.56/1.58/1.58/1.62 V vs bytes 0x51/0x52/0x52/0x54; scale approximate pending a wider range). Reported as battery_ok (low below 1.4 V) + battery_pct + battery_mV.
-- Bytes 12-14, 16-21: per-unit fixed data (factory serial / calibration), constant per unit, differ between units. Not decoded.
+- Byte 20: battery voltage; battery_mV ~= b20 * 20 (0.02 V/LSB, no offset; empirical. Reported as battery_ok_b (low below 1.4 V) + battery_pct + battery_mV.
+- Bytes 12-19, 21: per-unit fixed data (factory serial / calibration), constant per unit, differ between units. Not decoded.
 - Byte 22: CRC-8, poly 0x31, init 0x00, over bytes 0..21
 - Byte 23: checksum = sum(bytes 0..22) & 0xFF
 
@@ -101,31 +101,35 @@ static int fineoffset_wh52_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int moisture   = b[6];
     int ec_raw     = ((b[8] & 0x0f) << 16) | (b[9] << 8) | b[10];
     float ec_uscm  = ec_raw / 25.6f;  // empirical calibration, see notes above
-    int battery_mv = b[15] * 20 - 60; // 0.02 V/LSB, -0.06 V offset (empirical, see notes above)
+    int battery_mv = b[20] * 20; // 0.02 V/LSB, no offset (empirical, see notes above)
 
-    // Battery reported as an OK flag + a percentage of the usable ~1.3-1.6 V range
-    // (WH51 sibling breakpoints), following the standard battery convention.
-    float batt_lvl = (battery_mv - 1300) * (1.0f / 300.0f);
-    if (batt_lvl < 0.0f) {
-        batt_lvl = 0.0f;
+    // We have no data yet for the battery depletion curve / remaining percentage.
+    // Assuming similarity to the WH51 sensor and reusing its mapping for a start.
+    // Review and correct when more ground data is available.
+    float battery_level;
+    if (battery_mv >= 1600) {
+      battery_level = 1.0;
+    } else if (battery_mv >= 1500) {
+      battery_level = 0.9;
+    } else if (battery_mv >= 1400) {
+      battery_level = 0.5;
+    } else if (battery_mv >= 1300) {
+      battery_level = 0.1;
+    } else {
+      battery_level = 0.0;
     }
-    if (batt_lvl > 1.0f) {
-        batt_lvl = 1.0f;
-    }
-    int battery_ok = battery_mv >= 1400;
 
     /* clang-format off */
     data_t *data = data_make(
-            "model",            "",                     DATA_STRING, "Fineoffset-WH52",
-            "id",               "ID",                   DATA_STRING, id,
-            "temperature_C",    "Temperature",          DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
-            "moisture",         "Moisture",             DATA_FORMAT, "%u %%",  DATA_INT,    moisture,
-            "conductivity",     "Conductivity",         DATA_FORMAT, "%.0f uS/cm", DATA_DOUBLE, ec_uscm,
-            "battery_ok",       "Battery",              DATA_INT,    battery_ok,
-            "battery_pct",      "Battery level",        DATA_DOUBLE, 100.0f * batt_lvl, // Note: this might change with #3103
-            "battery_mV",       "Battery",              DATA_FORMAT, "%d mV",      DATA_INT,    battery_mv,
-            "boost",            "Transmission boost",   DATA_INT,    boost,
-            "mic",              "Integrity",            DATA_STRING, "CRC",
+            "model",                "",                     DATA_STRING, "Fineoffset-WH52",
+            "id",                   "ID",                   DATA_STRING, id,
+            "temperature_C",        "Temperature",          DATA_FORMAT, "%.1f C", DATA_DOUBLE, temp_c,
+            "moisture",             "Moisture",             DATA_FORMAT, "%u %%",  DATA_INT,    moisture,
+            "conductivity_uS_cm",   "Conductivity",         DATA_FORMAT, "%.0f uS/cm", DATA_DOUBLE, ec_uscm,
+            "battery_ok",           "Battery level",        DATA_DOUBLE, battery_level,
+            "battery_mV",           "Battery",              DATA_FORMAT, "%d mV",      DATA_INT,    battery_mv,
+            "boost",                "Transmission boost",   DATA_INT,    boost,
+            "mic",                  "Integrity",            DATA_STRING, "CRC",
             NULL);
     /* clang-format on */
 
@@ -138,9 +142,8 @@ static char const *const output_fields_wh52[] = {
         "id",
         "temperature_C",
         "moisture",
-        "conductivity",
+        "conductivity_uS_cm",
         "battery_ok",
-        "battery_pct",
         "battery_mV",
         "boost",
         "mic",


### PR DESCRIPTION
WH52 battery voltage calculated from byte 20, not byte 15 (based on empirical observations).
Harmonized battery percent reporting with the WH51 sensor.
Renamed `conductivity` to `conductivity_uS_cm` for consistency and clarity.

The multiplier / scale factor is based on 7 measurements x 2 physical devices in the 1.282...1.617 voltage range, rounded to the nearest plausible values (20mV scale, no offset):

<img width="1506" height="818" alt="image" src="https://github.com/user-attachments/assets/e1b4ca19-03a0-46e7-9bd8-bbe42b3c128a" />