### PR TITLE
infactory: reject temperatures outside the sensor's rated range

### DIFF
--- a/src/devices/infactory.c
+++ b/src/devices/infactory.c
@@ -89,12 +89,17 @@ static int infactory_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     int battery_low = (b[1] >> 2) & 1;
     int temp_raw    = (b[2] << 4) | (b[3] >> 4);
     int humidity    = (b[3] & 0x0F) * 10 + (b[4] >> 4); // BCD, 'A0'=100%rH
+    float temp_f    = (temp_raw - 900) * 0.1f;
 
     if (humidity > 100) {
         return DECODE_FAIL_SANITY;
     }
 
-    float temp_f    = (temp_raw - 900) * 0.1f;
+    // Sensor family is rated -40 C to +70 C at the widest (NC-3982 manual and
+    // variants); anything outside cannot be a real reading.
+    if (temp_f < -40.0f || temp_f > 158.0f) {
+        return DECODE_FAIL_SANITY;
+    }
 
     /* clang-format off */
     data_t *data = data_make(


### PR DESCRIPTION
The inFactory decoder validates with only a 4-bit CRC, so roughly 1 in 16 arbitrary 40-bit rows pass. The remaining guards (channel != 0, humidity <= 100) are weak enough that unrelated 433.92 MHz traffic can produce a stable, repeatable false positive.

Observed in the field:

  {"model":"inFactory-TH","id":25,"channel":3,"battery_ok":1,"button":1,
   "temperature_F":200.400,"humidity":0,"mic":"CRC"}

This decodes to 200.4 F (93.6 C), which no NC-3982 can report. Pearl rates the sensor family at -20 to 60 C (NC-3982-675 manual, rev 6, 2025-09-12); other manuals in the family claim as wide as -40 to 70 C. Bound the decoder at the widest published figure, -40 to 158 F, so no legitimate reading is rejected.

Ref: https://microsites.pearl.de/storage/rel/52/254487.pdf