### PR TITLE
Fix crash decoding DeltaDore X3D sensor messages

### DIFF
--- a/src/devices/deltadore_x3d.c
+++ b/src/devices/deltadore_x3d.c
@@ -157,6 +157,7 @@ To get raw data:
 #define DELTADORE_X3D_HEADER_TEMP_OUTDOOR     0x01
 
 #define DELTADORE_X3D_MAX_PKT_LEN             (64U)
+#define DELTADORE_X3D_STANDARD_PAYLOAD_LEN    (12U)
 
 struct deltadore_x3d_message_header {
     uint8_t number;
@@ -246,7 +247,7 @@ static uint8_t deltadore_x3d_parse_message_payload(uint8_t *buffer, struct delta
     out->register_high = *buffer++;
     out->register_low  = *buffer++;
     out->target_ack    = deltadore_x3d_read_le_u16(&buffer);
-    return 12;
+    return DELTADORE_X3D_STANDARD_PAYLOAD_LEN;
 }
 
 static int deltadore_x3d_decode(r_device *decoder, bitbuffer_t *bitbuffer)
@@ -285,8 +286,8 @@ static int deltadore_x3d_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     // dewhite length
     ccitt_whitening(&len, 1);
 
-    if (len > DELTADORE_X3D_MAX_PKT_LEN) {
-        decoder_logf(decoder, 1, __func__, "packet too large (%u bytes), dropping it\n", len);
+    if (len < 2 || len > DELTADORE_X3D_MAX_PKT_LEN) {
+        decoder_logf(decoder, 1, __func__, "invalid packet length (%u bytes), dropping it\n", len);
         return DECODE_ABORT_LENGTH;
     }
 
@@ -310,6 +311,14 @@ static int deltadore_x3d_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     struct deltadore_x3d_message_header head = {0};
     uint8_t bytes_read                       = 2; // step over length and FF field
     bytes_read += deltadore_x3d_parse_message_header(&frame[bytes_read], &head);
+
+    if (head.type == DELTADORE_X3D_MSGTYPE_STANDARD
+            && !(head.header_flags & DELTADORE_X3D_HEADER_FLAG_NO_PAYLOAD)
+            && len < bytes_read + DELTADORE_X3D_STANDARD_PAYLOAD_LEN + 2) {
+        decoder_logf(decoder, 1, __func__, "standard message payload truncated\n");
+        return DECODE_ABORT_LENGTH;
+    }
+
     const char *class, *wnd_stat, *temp_type;
 
     /* clang-format off */
@@ -362,7 +371,7 @@ static int deltadore_x3d_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             data = data_str(data, "wnd_stat", "Window Status", NULL, wnd_stat);
         }
     }
-    else {
+    else if (head.type == DELTADORE_X3D_MSGTYPE_STANDARD) {
         struct deltadore_x3d_message_payload body = {0};
         bytes_read += deltadore_x3d_parse_message_payload(&frame[bytes_read], &body);
 


### PR DESCRIPTION
## Summary

Fix a segmentation fault in the DeltaDore X3D decoder when decoding
sensor messages (type 0x00).

The decoder previously parsed every message with a payload as a
standard message (type 0x01). The standard payload parser consumes
12 bytes unconditionally.

For shorter sensor frames this advanced `bytes_read` past the end of
the frame. The resulting `len - bytes_read - 2` underflow was then
passed to `data_hex()`, causing an out-of-bounds read and a crash.

A valid 20-byte X3D sensor frame (type 0x00) triggered the issue.

For this frame, bytes_read is 16 before attempting to parse the
12-byte standard payload, which advances it past the 20-byte frame.
The subsequent raw payload length calculation underflows and causes
an out-of-bounds read.

## Fix

- Parse the standard payload only for `DELTADORE_X3D_MSGTYPE_STANDARD`
  messages.
- Validate that enough bytes remain before parsing a standard payload.
- Keep valid sensor messages partially decoded instead of rejecting them.
