### PR TITLE
Add support for ThermoPro TX-2B to Thermopro-TX2C

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [242]* Baldr / RainPoint rain gauge.
     [243]  Celsia CZC1 Thermostat
     [244]  Fine Offset Electronics WS90 weather station
-    [245]* ThermoPro TX-2C Thermometer and Humidity sensor
+    [245]* ThermoPro TX-2C, TX-2B Thermometer and Humidity sensor
     [246]  TFA 30.3151 Weather Station
     [247]  Bresser water leakage
     [248]  Nissan TPMS

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -484,7 +484,7 @@ convert si
 # protocol 242 # Baldr / RainPoint rain gauge.
   protocol 243 # Celsia CZC1 Thermostat
   protocol 244 # Fine Offset Electronics WS90 weather station
-# protocol 245 # ThermoPro TX-2C Thermometer and Humidity sensor
+# protocol 245 # ThermoPro TX-2C, TX-2B Thermometer and Humidity sensor
   protocol 246 # TFA 30.3151 Weather Station
   protocol 247 # Bresser water leakage
   protocol 248 # Nissan TPMS

--- a/src/devices/thermopro_tx2c.c
+++ b/src/devices/thermopro_tx2c.c
@@ -1,8 +1,9 @@
 /** @file
-    ThermoPro TX-2C Outdoor Thermometer and humidity sensor.
+    ThermoPro TX-2C and TX-2B Outdoor Thermometer and humidity sensor.
 
     Copyright (C) 2023 igor@pele.tech.
     Copyright (C) 2023 maxime@werlen.fr.
+    Copyright (C) 2026 Philippe McLean
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -13,7 +14,13 @@
 #include "decoder.h"
 
 /**
-ThermoPro TX-2C Outdoor Thermometer.
+ThermoPro TX-2C Outdoor Thermometer, also ThermoPro TX-2B.
+
+The TX-2B is the 915 MHz (North America ISM band) variant of the TX-2C.
+It uses the same message layout and timing: fixed 452 us pulses with
+gaps of nominally 1950 us (short) and 3810-3920 us (long), and a packet
+gap of 8550 us. The long gap varies slightly between units, so the gap
+limit needs headroom above the longest observed value.
 
 Example data:
 
@@ -103,11 +110,11 @@ static char const *const output_fields[] = {
 };
 
 r_device const thermopro_tx2c = {
-        .name        = "ThermoPro TX-2C Thermometer and Humidity sensor",
+        .name        = "ThermoPro TX-2C, TX-2B Thermometer and Humidity sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 1958,
         .long_width  = 3825,
-        .gap_limit   = 3829,
+        .gap_limit   = 7000, // long gap varies up to 3920 us between units, packet gap is 8550 us
         .reset_limit = 8643,
         .decode_fn   = &thermopro_tx2c_decode,
         .fields      = output_fields,


### PR DESCRIPTION
The TX-2B is the 915 MHz (North America ISM band) variant of the TX-2C and is
protocol-identical to it, so this adds it to the existing decoder rather than
adding a second, near-duplicate one. There are no decoding logic changes.

### The bug

`gap_limit` was 3829 us, only 4 us above `long_width` 3825. Measured across
five units the long gap runs 3810-3920 us, so on units at the top of that
spread the long gaps were classified as row boundaries instead of data bits.
The transmission shatters into ~50 rows of 0-9 bits,
`bitbuffer_find_repeated_row(bitbuffer, 4, 36)` finds nothing, and the decode
fails silently — and only on some units, which is why this wasn't noticed.

Widening `gap_limit` to 7000 us clears the 3920 us worst case and stays well
below the ~8550 us packet gap and the unchanged `reset_limit` of 8643. It is
also the value `thermopro_tx2` already uses.

### Verification

- No TX-2C regression: the existing `tests/thermopro-tx2c` fixture (868 MHz)
  passes against the patched build, 2 records, 0 failed.
- The `thermopro-tx2` samples still decode only as Thermopro-TX2; no
  cross-decode.
- Running live, all five of my units decode simultaneously, including the one
  whose long gap motivated the change. Two of the IDs that decoded appear in
  none of the captures, so the fix generalises beyond the recorded samples.
- `maintainer_update.py` reproduces the two protocol 245 lines in `README.md`
  and `conf/rtl_433.example.conf` exactly as committed.

The hardware is a TX-2B: the case label reads `FCC ID: 2AATP-TX-2B` /
`Model No.: TX-2B`, photographed alongside the samples.

### Test signals

Companion fixtures: merbanan/rtl_433_tests#522

They require this change in order to decode, so they need to land after or
with it.

Supersedes #3418.
