### PR TITLE
Change timers to monotonic time

### DIFF
--- a/include/r_private.h
+++ b/include/r_private.h
@@ -71,7 +71,8 @@ struct dm_state {
     list_t *raw_handler;
 
     /* global stats */
-    time_t running_since;          ///< program start time statistic
+    time_t running_start;          ///< program start wall clock time statistic
+    time_t running_since;          ///< program start monotonic time statistic
     unsigned total_frames_count;   ///< total frames recieved statistic
     unsigned total_frames_squelch; ///< total frames with noise only statistic
     unsigned total_frames_ook;     ///< total frames with ook demod statistic

--- a/include/rtl_433.h
+++ b/include/rtl_433.h
@@ -82,7 +82,7 @@ typedef struct r_cfg {
     int hop_time[MAX_FREQS];
     time_t hop_start_time;
     int duration;
-    time_t stop_time;
+    time_t start_time; ///< Program startup time
     int after_successful_events_flag;
     uint32_t samp_rate;
     uint32_t bytes_to_read;
@@ -116,7 +116,8 @@ typedef struct r_cfg {
     int sr_execopen;
     int watchdog; ///< SDR acquire stall watchdog
     /* sdr stats */
-    time_t sdr_since; ///< time of last SDR connect statistic
+    time_t sdr_start; ///< wall clock time of last SDR connect statistic
+    time_t sdr_since; ///< monotonic time of last SDR connect statistic
     struct mg_mgr *mgr;
 } r_cfg_t;
 

--- a/include/timer.h
+++ b/include/timer.h
@@ -12,9 +12,26 @@
 #ifndef INCLUDE_TIMER_H_
 #define INCLUDE_TIMER_H_
 
-#include "compat_time.h"
+#ifdef _WIN32
 
-typedef struct timeval interval_timer_t;
+typedef struct unsigned long interval_timer_t;
+
+#else
+
+#include <time.h>
+typedef struct timespec interval_timer_t;
+
+#endif
+
+/// Number of seconds that have elapsed since some arbitrary time in the past.
+///
+/// Might wrap, use `monotonic_time_diff()` to calculate elapsed time.
+time_t monotonic_time(void);
+
+/// Number of seconds that have elapsed between `time0` and `time1`.
+///
+/// Accounts for possible wrap around.
+time_t monotonic_time_diff(time_t time1, time_t time0);
 
 void interval_timer_init(interval_timer_t *interval_timer);
 

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -101,6 +101,7 @@ or `(echo "GET /stream HTTP/1.0\n"; sleep 600) | socat - tcp:127.0.0.1:8433`
 #include "r_private.h" // used for protocols
 #include "r_util.h"
 #include "optparse.h"
+#include "timer.h"
 #include "abuf.h"
 #include "list.h" // used for protocols
 #include "jsmn.h"
@@ -787,8 +788,7 @@ static void handle_openmetrics(struct mg_connection *nc, struct http_message *hm
     struct http_server_context *ctx = nc->user_data;
     r_cfg_t *cfg = ctx->cfg;
 
-    time_t now;
-    time(&now);
+    time_t now = monotonic_time();
 
     char buf[2000];
     int len = snprintf(buf, sizeof(buf),
@@ -827,10 +827,10 @@ static void handle_openmetrics(struct mg_connection *nc, struct http_message *hm
             "input_event_frames_total %u\n"
             "# EOF\n",
             (float)(now - cfg->demod->running_since), // uptime_seconds_total,
-            (float)cfg->demod->running_since,         // uptime_seconds_created,
+            (float)cfg->demod->running_start,         // uptime_seconds_created,
             (unsigned)cfg->demod->r_devs.len,         // decoder_enabled,
             (float)(now - cfg->sdr_since),            // input_uptime_seconds_total,
-            (float)cfg->sdr_since,                    // input_uptime_seconds_created,
+            (float)cfg->sdr_start,                    // input_uptime_seconds_created,
             cfg->demod->total_frames_count,           // input_count_frames_total,
             cfg->demod->total_frames_squelch,         // input_squelch_frames_total,
             cfg->demod->total_frames_ook,             // input_ook_frames_total,

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -40,6 +40,7 @@
 #include "sigmf.h"
 #include "mongoose.h"
 #include "compat_time.h"
+#include "timer.h"
 #include "logger.h"
 #include "fatal.h"
 #include "http_server.h"
@@ -126,6 +127,9 @@ void r_init_cfg(r_cfg_t *cfg)
     // abnormal messages and LOG_CRITICAL information.
     cfg->verbosity = LOG_WARNING;
 
+    cfg->start_time = monotonic_time();
+    cfg->hop_start_time = monotonic_time();
+
     list_ensure_size(&cfg->in_files, 100);
     list_ensure_size(&cfg->output_handler, 16);
 
@@ -161,8 +165,9 @@ void r_init_cfg(r_cfg_t *cfg)
     // initialize tables
     baseband_init();
 
-    time(&cfg->demod->running_since);
-    time(&cfg->demod->frames_since);
+    cfg->demod->running_start = time(NULL);
+    cfg->demod->running_since = monotonic_time();
+    cfg->demod->frames_since = monotonic_time();
     get_time_now(&cfg->demod->now);
 
     list_ensure_size(&cfg->demod->r_devs, 100);
@@ -902,7 +907,7 @@ void flush_report_data(r_cfg_t *cfg)
 {
     list_t *r_devs = &cfg->demod->r_devs;
 
-    time(&cfg->demod->frames_since);
+    cfg->demod->frames_since = monotonic_time();
     cfg->demod->frames_ook = 0;
     cfg->demod->frames_fsk = 0;
     cfg->demod->frames_events = 0;

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -784,8 +784,7 @@ static void parse_conf_option(r_cfg_t *cfg, int opt, char *arg)
             char *p = arg_param(arg);
             cfg->report_stats = atoiv(p, 1);
             cfg->stats_interval = atoiv(arg_param(p), 600); // atoi_time_default()
-            time(&cfg->stats_time);
-            cfg->stats_time += cfg->stats_interval;
+            cfg->stats_time = monotonic_time();
         }
         else if (!strncasecmp(arg, "replay", 6)) {
             cfg->in_replay = atobv(arg_param(arg), 1);
@@ -1143,21 +1142,18 @@ static void process_sdr_frame(r_cfg_t *cfg, unsigned char *iq_buf, uint32_t len)
     }
 
     // Check for timer actions
-    time_t rawtime;
-    time(&rawtime);
+    time_t rawtime = monotonic_time();
 
     // Check for maximum run duration
-    if (cfg->duration > 0 && rawtime >= cfg->stop_time) {
+    if (cfg->duration > 0 && monotonic_time_diff(rawtime, cfg->start_time) > cfg->duration) {
         cfg->exit_async = 1;
         print_log(LOG_CRITICAL, __func__, "Time expired, exiting!");
     }
     // Check for interval stats printing
-    if (cfg->stats_now || (cfg->report_stats && cfg->stats_interval && rawtime >= cfg->stats_time)) {
+    if (cfg->stats_now || (cfg->report_stats && cfg->stats_interval && monotonic_time_diff(rawtime, cfg->stats_time) >= cfg->stats_interval)) {
         event_occurred_handler(cfg, create_report_data(cfg, cfg->stats_now ? 3 : cfg->report_stats));
         flush_report_data(cfg);
-        if (rawtime >= cfg->stats_time) {
-            cfg->stats_time += cfg->stats_interval;
-        }
+        cfg->stats_time = rawtime;
         if (cfg->stats_now) {
             cfg->stats_now--;
         }
@@ -1165,13 +1161,13 @@ static void process_sdr_frame(r_cfg_t *cfg, unsigned char *iq_buf, uint32_t len)
     // Check for hopping timer
     // choose hop_index as frequency_index, if there are too few hop_times use the last one
     int hop_index = cfg->hop_times > cfg->frequency_index ? cfg->frequency_index : cfg->hop_times - 1;
-    if (cfg->hop_times > 0 && cfg->frequencies > 1 && difftime(rawtime, cfg->hop_start_time) >= cfg->hop_time[hop_index]) {
+    if (cfg->hop_times > 0 && cfg->frequencies > 1 && monotonic_time_diff(rawtime, cfg->hop_start_time) >= cfg->hop_time[hop_index]) {
         cfg->hop_now = 1;
     }
     // Apply hopping, might be set by timer, successful decode event, or signal handler
     if (cfg->hop_now && !cfg->exit_async) {
         cfg->hop_now = 0;
-        time(&cfg->hop_start_time);
+        cfg->hop_start_time  = rawtime;
         cfg->frequency_index = (cfg->frequency_index + 1) % cfg->frequencies;
         sdr_set_center_freq(cfg->dev, cfg->frequency[cfg->frequency_index], 1);
     }
@@ -1371,7 +1367,8 @@ static void timer_handler(struct mg_connection *nc, int ev, void *ev_data)
             if (cfg->dev_state == DEVICE_STATE_STARTING
                     || cfg->dev_state == DEVICE_STATE_GRACE) {
                 cfg->dev_state = DEVICE_STATE_STARTED;
-                time(&cfg->sdr_since);
+                cfg->sdr_start = time(NULL);
+                cfg->sdr_since = monotonic_time();
             }
             cfg->watchdog = 0;
             break;
@@ -1695,11 +1692,6 @@ int main(int argc, char **argv) {
             FATAL_MALLOC("test_mode_float_buf");
         }
 
-        if (cfg->duration > 0) {
-            time(&cfg->stop_time);
-            cfg->stop_time += cfg->duration;
-        }
-
         for (void **iter = cfg->in_files.elems; iter && *iter; ++iter) {
             cfg->in_filename = *iter;
 
@@ -1801,7 +1793,7 @@ int main(int argc, char **argv) {
             do {
                 // Replay in realtime if requested
                 if (cfg->in_replay) {
-                    // per block delay
+                    // per block interval
                     unsigned interval_us = (unsigned)(1000000llu * DEFAULT_BUF_LENGTH / cfg->samp_rate / demod->sample_size / cfg->in_replay);
                     if (demod->load_info.format == CF32_IQ) {
                         interval_us /= 2; // adjust for float only reading half as many samples
@@ -1896,13 +1888,6 @@ int main(int argc, char **argv) {
             exit(2);
         }
     }
-
-    if (cfg->duration > 0) {
-        time(&cfg->stop_time);
-        cfg->stop_time += cfg->duration;
-    }
-
-    time(&cfg->hop_start_time);
 
     // add dummy socket to receive timer broadcasts
     struct mg_add_sock_opts opts = {.user_data = cfg};

--- a/src/timer.c
+++ b/src/timer.c
@@ -23,35 +23,93 @@
 #define usleep(us) Sleep((us) / 1000)
 #endif
 
+#ifdef _WIN32
+
+static void _get_monotonic_time(interval_timer_t *interval_timer)
+{
+    *interval_timer = GetTickCount(); // number of milliseconds that have elapsed since the system was started, wraps every 49.7 days.
+}
+
+time_t monotonic_time()
+{
+    // if we had C11 atomics (https://en.cppreference.com/c/language/atomic) we could increment an overflow counter on each (atomic) wrap around.
+    // e.g.
+    // static atomic_ulong last_tick = ATOMIC_VAR_INIT(0);
+    // static unsigned long wrap_around = 0;
+
+    // number of milliseconds that have elapsed since the system was started, wraps every 49.7 days.
+    // note that 64-bit Windows is LLP64 and not LP64 as 64-bit unix-like systems.
+    unsigned long t = GetTickCount();
+
+    // unsigned long p = atomic_exchange_explicit(&last_tick, t, memory_order_relaxed);
+    // if (p > t) {
+    //     wrap_around += 1;
+    // }
+
+    // return ((unsigned long long)t + (unsigned long long)wrap_around * (ULONG_MAX + 1)) / 1000;
+    return t / 1000;
+}
+
+time_t monotonic_time_diff(time_t time1, time_t time0)
+{
+    unsigned long time0_ms = time0 * 1000; // expand to fit the wrap around
+    unsigned long time1_ms = time1 * 1000; // expand to fit the wrap around
+    unsigned long d_ms = time1_ms - time0_ms;
+    return d_ms / 1000;
+}
+
+#else
+
+static void _get_monotonic_time(interval_timer_t *interval_timer)
+{
+    int r = clock_gettime(CLOCK_MONOTONIC, interval_timer);
+    if (r) {
+        perror("clock_gettime(CLOCK_MONOTONIC)");
+    }
+}
+
+time_t monotonic_time(void)
+{
+    struct timespec t;
+    int r = clock_gettime(CLOCK_MONOTONIC, &t);
+    if (r) {
+        perror("clock_gettime(CLOCK_MONOTONIC)");
+    }
+    return t.tv_sec; // number of seconds that have elapsed since some arbitrary time.
+}
+
+time_t monotonic_time_diff(time_t time1, time_t time0)
+{
+    return time1 - time0;
+}
+
+#endif
+
 void interval_timer_init(interval_timer_t *interval_timer)
 {
-    // set to current wall clock
-    int ret = gettimeofday(interval_timer, NULL);
-    if (ret) {
-        perror("gettimeofday");
-    }
+    _get_monotonic_time(interval_timer);
 }
 
 void interval_timer_wait(interval_timer_t *interval_timer, unsigned interval_us)
 {
     // sync to wall clock
-    struct timeval now_tv;
-    int ret = gettimeofday(&now_tv, NULL);
-    if (ret) {
-        perror("gettimeofday");
-    }
+    interval_timer_t now_tv;
+    _get_monotonic_time(&now_tv);
 
     time_t elapsed_s  = now_tv.tv_sec - interval_timer->tv_sec;
-    time_t elapsed_us = 1000000 * elapsed_s + now_tv.tv_usec - interval_timer->tv_usec;
+    time_t elapsed_ns = 1000000000 * elapsed_s + now_tv.tv_nsec - interval_timer->tv_nsec;
 
+    //time_t diff = elapsed_ns / interval_us; // TODO: finish skip logic
+    //time_t skip = diff * interval_us;       // TODO: finish skip logic
     // set next wanted start time
-    interval_timer->tv_usec += interval_us;
-    while (interval_timer->tv_usec > 1000000) {
-        interval_timer->tv_usec -= 1000000;
+    interval_timer->tv_nsec += interval_us * 1000;
+    while (interval_timer->tv_nsec > 1000000000) {
+        interval_timer->tv_nsec -= 1000000000;
         interval_timer->tv_sec += 1;
     }
 
-    if ((time_t)interval_us > elapsed_us) {
-        usleep(interval_us - elapsed_us);
+    // sleep the remaining time to interval_us
+    if ((time_t)interval_us * 1000 > elapsed_ns) {
+        usleep(interval_us - elapsed_ns / 1000);
     }
 }


### PR DESCRIPTION
A first draft to change timers to monotonic time.

Interval timers will work with µs precision (ms on Win32) and regular task timers (`monotonic_time()`, `monotonic_time_diff()`) with second precision.