### PR TITLE
Add La Crosse TX63U-IT wind sensor support

### DIFF
--- a/examples/rtl_433_mqtt_hass.py
+++ b/examples/rtl_433_mqtt_hass.py
@@ -463,6 +463,17 @@ mappings = {
         }
     },
 
+    "wind_max_dir_deg": {
+        "device_type": "sensor",
+        "object_suffix": "GWD",
+        "config": {
+            "name": "Gust Direction",
+            "unit_of_measurement": "°",
+            "value_template": "{{ value|float }}",
+            "state_class": "measurement"
+        }
+    },
+
     "rain_mm": {
         "device_type": "sensor",
         "object_suffix": "RT",

--- a/include/psk_demod.h
+++ b/include/psk_demod.h
@@ -1,0 +1,37 @@
+#ifndef INCLUDE_PSK_DEMOD_H_
+#define INCLUDE_PSK_DEMOD_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "bitbuffer.h"
+
+typedef struct {
+    double offset_s;
+    double signature_db;
+    double carrier_offset_hz;
+    double symbol_rate_hint;
+} psk_candidate_t;
+
+typedef int (*psk_validate_fn)(
+        bitbuffer_t *bitbuffer,
+        void *context);
+
+int psk_find_candidate(
+        uint8_t const *iq_buf,
+        size_t sample_count,
+        unsigned sample_size,
+        unsigned sample_rate,
+        psk_candidate_t *candidate);
+
+int psk_demod_candidate(
+        uint8_t const *iq_buf,
+        size_t sample_count,
+        unsigned sample_size,
+        unsigned sample_rate,
+        psk_candidate_t const *candidate,
+        psk_validate_fn validate_fn,
+        void *validate_context,
+        bitbuffer_t *bitbuffer);
+
+#endif /* INCLUDE_PSK_DEMOD_H_ */

--- a/include/psk_stream.h
+++ b/include/psk_stream.h
@@ -1,0 +1,20 @@
+/** @file
+    Streaming raw-IQ support for PSK demodulation.
+*/
+
+#ifndef INCLUDE_PSK_STREAM_H_
+#define INCLUDE_PSK_STREAM_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "rtl_433.h"
+
+void psk_stream_reset(r_cfg_t *cfg);
+
+int psk_stream_push(
+        r_cfg_t *cfg,
+        uint8_t const *iq_buf,
+        size_t sample_count);
+
+#endif /* INCLUDE_PSK_STREAM_H_ */

--- a/include/r_device.h
+++ b/include/r_device.h
@@ -33,10 +33,15 @@ enum modulation_types {
     OOK_PULSE_PWM_OSV1           = 10, ///< OOK Modulation, Pulse Width Coding. Oregon Scientific v1.
     OOK_PULSE_NRZS               = 12, ///< OOK Modulation, NRZS Coding
     OOK_PULSE_RZI                = 13, ///< OOK Modulation, Return-to-Zero inverted coding, Pulse = 1, No pulse = 0.
+
     FSK_DEMOD_MIN_VAL            = 16, ///< Dummy. FSK demodulation must start at this value.
     FSK_PULSE_PCM                = 16, ///< FSK Modulation, Non-Return-to-Zero coding, Pulse = 1, No pulse = 0.
     FSK_PULSE_PWM                = 17, ///< FSK Modulation, Pulse Width Coding. Short pulses = 1, Long = 0.
     FSK_PULSE_MANCHESTER_ZEROBIT = 18, ///< FSK Modulation, Manchester coding.
+    FSK_DEMOD_MAX_VAL            = 31, ///< Dummy. Highest value reserved for FSK demodulation.
+
+    PSK_DEMOD_MIN_VAL            = 32, ///< Dummy. PSK demodulation must start at this value.
+    PSK_PULSE_DBPSK              = 32, ///< PSK Modulation, differentially encoded BPSK.
 };
 
 /** Decoders should return n>0 for n packets successfully decoded,
@@ -69,6 +74,14 @@ typedef struct r_device {
     float sync_width;   ///< sync symbol nominal width in microseconds (us)
     float tolerance;    ///< maximum allowed deviation from nominal symbol widths in microseconds (us)
     int (*decode_fn)(struct r_device *decoder, struct bitbuffer *bitbuffer);
+
+    /*
+     * Optional pure protocol validator used by demodulators that must test
+     * multiple signal hypotheses before selecting a bitbuffer. The validator
+     * must not emit output or update decoder statistics.
+     */
+    int (*validate_fn)(struct bitbuffer *bitbuffer, void *context);
+
     struct r_device *(*create_fn)(char const *args);
     unsigned priority; ///< Run later and only if no previous events were produced
     unsigned disabled; ///< 0: default enabled, 1: default disabled, 2: disabled, 3: disabled and hidden

--- a/include/r_private.h
+++ b/include/r_private.h
@@ -5,8 +5,10 @@
 #ifndef INCLUDE_R_PRIVATE_H_
 #define INCLUDE_R_PRIVATE_H_
 
+#include <stddef.h>
 #include <stdint.h>
 #include <time.h>
+
 #include "list.h"
 #include "baseband.h"
 #include "pulse_detect.h"
@@ -28,19 +30,43 @@ struct dm_state {
     int use_mag_est;
     int detect_verbosity;
 
-    int16_t am_buf[MAXIMAL_BUF_LENGTH];  // AM demodulated signal (for OOK decoding)
+    int16_t am_buf[MAXIMAL_BUF_LENGTH]; // AM demodulated signal (for OOK decoding)
     union {
         // These buffers aren't used at the same time, so let's use a union to save some memory
-        int16_t fm[MAXIMAL_BUF_LENGTH];  // FM demodulated signal (for FSK decoding)
-        uint16_t temp[MAXIMAL_BUF_LENGTH];  // Temporary buffer (to be optimized out..)
+        int16_t fm[MAXIMAL_BUF_LENGTH];   // FM demodulated signal (for FSK decoding)
+        uint16_t temp[MAXIMAL_BUF_LENGTH]; // Temporary buffer (to be optimized out..)
     } buf;
+
     uint8_t u8_buf[MAXIMAL_BUF_LENGTH]; // format conversion buffer
-    float f32_buf[MAXIMAL_BUF_LENGTH]; // format conversion buffer
+    float f32_buf[MAXIMAL_BUF_LENGTH];   // format conversion buffer
+
     int sample_size; // CU8: 2, CS16: 4
+
     pulse_detect_t *pulse_detect;
     filter_state_t lowpass_filter_state;
     demodfm_state_t demod_FM_state;
+
     int enable_FM_demod;
+    int enable_PSK_demod;
+
+    /*
+     * Rolling raw-IQ buffer for PSK demodulation.
+     *
+     * The current PSK implementation has been validated for CU8 input only.
+     * psk_iq_start_pos is the absolute sample position corresponding to the
+     * first sample currently stored in psk_iq_buf.
+     */
+    uint8_t psk_iq_buf[262144];
+    size_t psk_iq_len;
+    uint64_t psk_iq_start_pos;
+
+    /*
+     * Last successfully decoded PSK candidate position.
+     * Used to suppress duplicate decoding caused by overlapping PSK windows.
+     */
+    uint64_t psk_last_event_pos;
+    int psk_have_last_event;
+
     samp_grab_t *samp_grab;
     am_analyze_t *am_analyze;
     int analyze_pulses;
@@ -50,8 +76,9 @@ struct dm_state {
     /* Protocol states */
     list_t r_devs;
 
-    pulse_data_t    pulse_data;
-    pulse_data_t    fsk_pulse_data;
+    pulse_data_t pulse_data;
+    pulse_data_t fsk_pulse_data;
+
     uint64_t input_pos;
     unsigned frame_event_count;
     int frame_quality;
@@ -60,12 +87,12 @@ struct dm_state {
     struct timeval now;
     float sample_file_pos;
 
-    /* parameters copied in for each frame  */
+    /* parameters copied in for each frame */
     uint32_t center_frequency;
     uint32_t samp_rate;
     int fsk_pulse_detect_mode;
     int grab_mode; ///< Signal grabber mode: 0=off, 1=all, 2=unknown, 3=known, 4=undecoded
-    int raw_mode; ///< Raw pulses printing mode: 0=off, 1=all, 2=unknown, 3=known
+    int raw_mode;  ///< Raw pulses printing mode: 0=off, 1=all, 2=unknown, 3=known
     int verbosity; ///< 0=normal, 1=verbose, 2=verbose decoders, 3=debug decoders, 4=trace decoding.
     int report_noise;
     list_t *raw_handler;
@@ -74,15 +101,17 @@ struct dm_state {
     time_t running_since;          ///< program start time statistic
     unsigned total_frames_count;   ///< total frames recieved statistic
     unsigned total_frames_squelch; ///< total frames with noise only statistic
-    unsigned total_frames_ook;     ///< total frames with ook demod statistic
-    unsigned total_frames_fsk;     ///< total frames with fsk demod statistic
+    unsigned total_frames_ook;     ///< total frames with OOK demod statistic
+    unsigned total_frames_fsk;     ///< total frames with FSK demod statistic
+    unsigned total_frames_psk;     ///< total frames with PSK demod statistic
     unsigned total_frames_events;  ///< total frames with decoder events statistic
 
     /* per report interval stats */
-    time_t frames_since;    ///< time at start of report interval statistic
-    unsigned frames_ook;    ///< counter of ook demods for report interval statistic
-    unsigned frames_fsk;    ///< counter of fsk demods for report interval statistic
-    unsigned frames_events; ///< counter of decoder events for report interval statistic
+    time_t frames_since;      ///< time at start of report interval statistic
+    unsigned frames_ook;      ///< counter of OOK demods for report interval statistic
+    unsigned frames_fsk;      ///< counter of FSK demods for report interval statistic
+    unsigned frames_psk;      ///< counter of PSK demods for report interval statistic
+    unsigned frames_events;   ///< counter of decoder events for report interval statistic
 };
 
 #endif /* INCLUDE_R_PRIVATE_H_ */

--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -84,6 +84,7 @@
     DECL(acurite_00275rm) \
     DECL(lacrosse_tx35) \
     DECL(lacrosse_tx29) \
+    DECL(lacrosse_tx63) \
     DECL(vaillant_vrt340f) \
     DECL(fineoffset_WH25) \
     DECL(fineoffset_WH0530) \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -121,6 +121,7 @@ add_library(r_433 STATIC
     pulse_detect.c
     pulse_detect_fsk.c
     psk_demod.c
+    psk_stream.c
     pulse_slicer.c
     r_api.c
     r_flow.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,12 +116,12 @@ add_library(r_433 STATIC
     output_rtltcp.c
     output_trigger.c
     output_udp.c
+    psk_demod.c
+    psk_stream.c
     pulse_analyzer.c
     pulse_data.c
     pulse_detect.c
     pulse_detect_fsk.c
-    psk_demod.c
-    psk_stream.c
     pulse_slicer.c
     r_api.c
     r_flow.c
@@ -303,6 +303,7 @@ add_library(r_433 STATIC
     devices/lacrosse_tx31u.c
     devices/lacrosse_tx34.c
     devices/lacrosse_tx35.c
+    devices/lacrosse_tx63.c
     devices/lacrosse_wr1.c
     devices/lacrosse_ws6868.c
     devices/lacrosse_ws7000.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -120,6 +120,7 @@ add_library(r_433 STATIC
     pulse_data.c
     pulse_detect.c
     pulse_detect_fsk.c
+    psk_demod.c
     pulse_slicer.c
     r_api.c
     r_flow.c

--- a/src/devices/lacrosse_tx63.c
+++ b/src/devices/lacrosse_tx63.c
@@ -1,0 +1,353 @@
+/** @file
+    La Crosse TX63U-IT solar wind sensor.
+
+    Copyright (C) 2026
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+/**
+La Crosse TX63U-IT solar wind sensor.
+
+FCC ID: OMO-M-12
+Frequency: approximately 924 MHz.
+
+The RF modulation is differential phase encoded and is recovered by the
+rtl_433 PSK demodulator before this decoder is called.
+
+Recovered bit stream:
+
+- HDLC-style 0x7e opening and closing flags
+- zero-bit stuffing after five consecutive one bits
+- payload bytes transmitted least-significant bit first
+- 9-byte de-stuffed frame
+
+Known frame layout:
+
+    3C C0 D0 D1 D2 D3 38 CRClo CRChi
+
+The meanings of bytes 0x3c, 0xc0, and 0x38 are not yet known. They have
+been constant in all verified captures and are therefore currently used
+as protocol-family validation bytes.
+
+Fields:
+
+    D0 high nibble: average wind direction, 0..15
+    D0 low nibble + D1: average wind speed, 0.1 m/s units
+    D2 high nibble: gust direction, 0..15
+    D2 low nibble + D3: gust speed, 0.1 m/s units
+
+Direction encoding:
+
+     0 N       1 NNE     2 NE      3 ENE
+     4 E       5 ESE     6 SE      7 SSE
+     8 S       9 SSW    10 SW     11 WSW
+    12 W      13 WNW    14 NW     15 NNW
+
+CRC:
+
+    CRC-16/X-25 / CRC-16/IBM-SDLC
+    polynomial 0x1021, reflected polynomial 0x8408
+    initial value 0xffff
+    reflected input/output
+    xorout 0xffff
+
+No unique sensor ID has been identified.
+*/
+
+#include "decoder.h"
+
+#include <stdint.h>
+#include <string.h>
+
+#define TX63_FRAME_BYTES 9
+#define TX63_FRAME_BITS 72
+
+static int tx63_flag_at(
+        uint8_t const *row,
+        unsigned bit_count,
+        unsigned pos)
+{
+    static uint8_t const flag[8] = {
+            0, 1, 1, 1, 1, 1, 1, 0};
+    unsigned i;
+
+    if (pos + 8 > bit_count) {
+        return 0;
+    }
+
+    for (i = 0; i < 8; ++i) {
+        if (bitrow_get_bit(row, pos + i) != flag[i]) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+static uint16_t tx63_crc16_x25(
+        uint8_t const *data,
+        unsigned len)
+{
+    uint16_t crc = 0xffff;
+    unsigned i;
+
+    for (i = 0; i < len; ++i) {
+        unsigned bit;
+
+        crc ^= data[i];
+
+        for (bit = 0; bit < 8; ++bit) {
+            if (crc & 1) {
+                crc = (uint16_t)((crc >> 1) ^ 0x8408);
+            }
+            else {
+                crc >>= 1;
+            }
+        }
+    }
+
+    return (uint16_t)(crc ^ 0xffff);
+}
+
+static int tx63_destuff_frame(
+        uint8_t const *row,
+        unsigned start,
+        unsigned end,
+        uint8_t frame[TX63_FRAME_BYTES])
+{
+    uint8_t bits[TX63_FRAME_BITS];
+    unsigned bit_count = 0;
+    unsigned ones = 0;
+    unsigned i;
+
+    memset(frame, 0, TX63_FRAME_BYTES);
+
+    for (i = start; i < end; ++i) {
+        uint8_t bit = bitrow_get_bit(row, i);
+
+        /*
+         * HDLC inserts a zero following five consecutive one bits.
+         * Remove that stuffed zero before reconstructing the payload.
+         */
+        if (ones == 5) {
+            if (bit != 0) {
+                return 0;
+            }
+
+            ones = 0;
+            continue;
+        }
+
+        if (bit_count >= TX63_FRAME_BITS) {
+            return 0;
+        }
+
+        bits[bit_count++] = bit;
+
+        if (bit) {
+            ++ones;
+        }
+        else {
+            ones = 0;
+        }
+    }
+
+    if (bit_count != TX63_FRAME_BITS) {
+        return 0;
+    }
+
+    /*
+     * Payload bytes are transmitted LSB first.
+     */
+    for (i = 0; i < TX63_FRAME_BITS; ++i) {
+        if (bits[i]) {
+            frame[i / 8] |= (uint8_t)(1U << (i % 8));
+        }
+    }
+
+    return 1;
+}
+
+static int tx63_find_frame(
+        bitbuffer_t const *bitbuffer,
+        uint8_t frame[TX63_FRAME_BYTES])
+{
+    uint8_t const *row;
+    unsigned bit_count;
+    unsigned start_flag;
+
+    if (!bitbuffer || bitbuffer->num_rows != 1) {
+        return 0;
+    }
+
+    row = bitbuffer->bb[0];
+    bit_count = bitbuffer->bits_per_row[0];
+
+    for (start_flag = 0;
+            start_flag + 8 <= bit_count;
+            ++start_flag) {
+        unsigned end_flag;
+
+        if (!tx63_flag_at(row, bit_count, start_flag)) {
+            continue;
+        }
+
+        /*
+         * Verified captures place the closing flag 75 to 110
+         * recovered bits after the opening flag.
+         */
+        for (end_flag = start_flag + 75;
+                end_flag <= start_flag + 110 &&
+                end_flag + 8 <= bit_count;
+                ++end_flag) {
+            uint16_t received_crc;
+            uint16_t calculated_crc;
+
+            if (!tx63_flag_at(row, bit_count, end_flag)) {
+                continue;
+            }
+
+            if (!tx63_destuff_frame(
+                        row,
+                        start_flag + 8,
+                        end_flag,
+                        frame)) {
+                continue;
+            }
+
+            /*
+             * Fixed values observed in every verified TX63 capture.
+             * Their precise semantic meaning is not yet known.
+             */
+            if (frame[0] != 0x3c ||
+                    frame[1] != 0xc0 ||
+                    frame[6] != 0x38) {
+                continue;
+            }
+
+            received_crc =
+                    (uint16_t)frame[7] |
+                    ((uint16_t)frame[8] << 8);
+
+            calculated_crc =
+                    tx63_crc16_x25(frame, 7);
+
+            if (received_crc != calculated_crc) {
+                continue;
+            }
+
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+/*
+ * Pure protocol validator for PSK rate/phase/polarity hypothesis testing.
+ *
+ * This routine deliberately produces no rtl_433 output and does not modify
+ * decoder statistics. The normal decode function is called only after the
+ * PSK layer has selected a valid bitbuffer.
+ */
+int lacrosse_tx63_validate(
+        bitbuffer_t *bitbuffer,
+        void *context)
+{
+    uint8_t frame[TX63_FRAME_BYTES];
+
+    (void)context;
+
+    return tx63_find_frame(bitbuffer, frame);
+}
+
+static int lacrosse_tx63_decode(
+        r_device *decoder,
+        bitbuffer_t *bitbuffer)
+{
+    uint8_t frame[TX63_FRAME_BYTES];
+    unsigned direction_code;
+    unsigned wind_raw;
+    unsigned gust_direction_code;
+    unsigned gust_raw;
+    double wind_direction_deg;
+    double gust_direction_deg;
+    double wind_speed_m_s;
+    double gust_speed_m_s;
+    data_t *data;
+
+    if (!bitbuffer || bitbuffer->num_rows != 1) {
+        return DECODE_ABORT_EARLY;
+    }
+
+    if (bitbuffer->bits_per_row[0] < 90) {
+        return DECODE_ABORT_LENGTH;
+    }
+
+    if (!tx63_find_frame(bitbuffer, frame)) {
+        return DECODE_FAIL_MIC;
+    }
+
+    direction_code =
+            (frame[2] >> 4) & 0x0f;
+
+    wind_raw =
+            ((unsigned)(frame[2] & 0x0f) << 8) |
+            frame[3];
+
+    gust_direction_code =
+            (frame[4] >> 4) & 0x0f;
+
+    gust_raw =
+            ((unsigned)(frame[4] & 0x0f) << 8) |
+            frame[5];
+
+    wind_direction_deg =
+            direction_code * 22.5;
+
+    gust_direction_deg =
+            gust_direction_code * 22.5;
+
+    wind_speed_m_s =
+            wind_raw * 0.1;
+
+    gust_speed_m_s =
+            gust_raw * 0.1;
+
+    /* clang-format off */
+    data = data_make(
+            "model",            "",                 DATA_STRING, "LaCrosse-TX63U-IT",
+            "wind_avg_m_s",     "Wind speed",       DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, wind_speed_m_s,
+            "wind_max_m_s",     "Wind gust",        DATA_FORMAT, "%.1f m/s", DATA_DOUBLE, gust_speed_m_s,
+            "wind_dir_deg",     "Wind direction",   DATA_FORMAT, "%.1f", DATA_DOUBLE, wind_direction_deg,
+            "wind_max_dir_deg", "Gust direction",   DATA_FORMAT, "%.1f", DATA_DOUBLE, gust_direction_deg,
+            "mic",              "Integrity",        DATA_STRING, "CRC",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+
+    return 1;
+}
+
+static char const *const output_fields[] = {
+        "model",
+        "wind_avg_m_s",
+        "wind_max_m_s",
+        "wind_dir_deg",
+        "wind_max_dir_deg",
+        "mic",
+        NULL,
+};
+
+r_device const lacrosse_tx63 = {
+        .name        = "La Crosse TX63U-IT solar wind sensor",
+        .modulation  = PSK_PULSE_DBPSK,
+        .decode_fn   = &lacrosse_tx63_decode,
+        .validate_fn = &lacrosse_tx63_validate,
+        .fields      = output_fields,
+};

--- a/src/psk_demod.c
+++ b/src/psk_demod.c
@@ -31,6 +31,12 @@ static cpx_t c_mul(cpx_t a, cpx_t b)
     return r;
 }
 
+static cpx_t c_conj(cpx_t a)
+{
+    cpx_t r = {a.re, -a.im};
+    return r;
+}
+
 static cpx_t c_scale(cpx_t a, double s)
 {
     cpx_t r = {a.re * s, a.im * s};
@@ -357,20 +363,354 @@ int psk_find_candidate(
     return found;
 }
 
+static int demod_bits(
+        cpx_t const *iq,
+        size_t count,
+        unsigned sample_rate,
+        double symbol_rate,
+        double carrier_offset_hz,
+        double phase_samples,
+        uint8_t **bits_out,
+        size_t *nbits_out)
+{
+    cpx_t *mixed;
+    cpx_t *cumulative;
+    cpx_t *symbols;
+    cpx_t *diff;
+    double *magnitudes;
+    double samples_per_symbol;
+    size_t symbol_count;
+    size_t i;
+    double threshold;
+    cpx_t sq_sum = {0.0, 0.0};
+    double residual_phase;
+    cpx_t correction;
+    uint8_t *bits;
+
+    if (!iq || !bits_out || !nbits_out || !sample_rate ||
+            symbol_rate <= 0.0) {
+        return 0;
+    }
+
+    samples_per_symbol = (double)sample_rate / symbol_rate;
+    if ((double)count <= phase_samples + samples_per_symbol * 102.0) {
+        return 0;
+    }
+
+    symbol_count = (size_t)(((double)count - phase_samples) /
+                            samples_per_symbol) - 1;
+    if (symbol_count < 100) {
+        return 0;
+    }
+
+    mixed = malloc(count * sizeof(*mixed));
+    if (!mixed) {
+        return 0;
+    }
+
+    cumulative = malloc((count + 1) * sizeof(*cumulative));
+    if (!cumulative) {
+        free(mixed);
+        return 0;
+    }
+
+    symbols = malloc(symbol_count * sizeof(*symbols));
+    if (!symbols) {
+        free(mixed);
+        free(cumulative);
+        return 0;
+    }
+
+    diff = malloc((symbol_count - 1) * sizeof(*diff));
+    if (!diff) {
+        free(mixed);
+        free(cumulative);
+        free(symbols);
+        return 0;
+    }
+
+    magnitudes = malloc((symbol_count - 1) * sizeof(*magnitudes));
+    if (!magnitudes) {
+        free(mixed);
+        free(cumulative);
+        free(symbols);
+        free(diff);
+        return 0;
+    }
+
+    bits = malloc((symbol_count - 1) * sizeof(*bits));
+    if (!bits) {
+        free(mixed);
+        free(cumulative);
+        free(symbols);
+        free(diff);
+        free(magnitudes);
+        return 0;
+    }
+
+    for (i = 0; i < count; i++) {
+        double phase = -2.0 * M_PI * carrier_offset_hz *
+                (double)i / (double)sample_rate;
+        mixed[i] = c_mul(iq[i], c_expj(phase));
+    }
+
+    cumulative[0].re = 0.0;
+    cumulative[0].im = 0.0;
+    for (i = 0; i < count; i++) {
+        cumulative[i + 1] = c_add(cumulative[i], mixed[i]);
+    }
+
+    for (i = 0; i < symbol_count; i++) {
+        long start = lround(phase_samples +
+                (double)i * samples_per_symbol);
+        long end = lround(phase_samples +
+                (double)(i + 1) * samples_per_symbol);
+        long width;
+
+        if (start < 0) {
+            start = 0;
+        }
+        if (end > (long)count) {
+            end = (long)count;
+        }
+
+        width = end - start;
+        if (width <= 0) {
+            free(mixed);
+            free(cumulative);
+            free(symbols);
+            free(diff);
+            free(magnitudes);
+            free(bits);
+            return 0;
+        }
+
+        symbols[i] = c_scale(
+                c_sub(cumulative[(size_t)end],
+                        cumulative[(size_t)start]),
+                1.0 / (double)width);
+    }
+
+    for (i = 0; i + 1 < symbol_count; i++) {
+        diff[i] = c_mul(symbols[i + 1], c_conj(symbols[i]));
+        magnitudes[i] = sqrt(c_abs2(diff[i]));
+    }
+
+    {
+        double *sorted;
+        size_t diff_count = symbol_count - 1;
+        size_t idx;
+
+        sorted = malloc(diff_count * sizeof(*sorted));
+        if (!sorted) {
+            free(mixed);
+            free(cumulative);
+            free(symbols);
+            free(diff);
+            free(magnitudes);
+            free(bits);
+            return 0;
+        }
+
+        memcpy(sorted, magnitudes, diff_count * sizeof(*sorted));
+        qsort(sorted, diff_count, sizeof(*sorted), cmp_double);
+        idx = (size_t)(0.20 * (double)diff_count);
+        if (idx >= diff_count) {
+            idx = diff_count - 1;
+        }
+        threshold = sorted[idx];
+        free(sorted);
+    }
+
+    for (i = 0; i + 1 < symbol_count; i++) {
+        double mag = magnitudes[i];
+
+        if (mag > threshold && mag > 0.0) {
+            cpx_t normalized = c_scale(diff[i], 1.0 / mag);
+            sq_sum = c_add(sq_sum, c_mul(normalized, normalized));
+        }
+    }
+
+    if (c_abs2(sq_sum) <= 0.0) {
+        free(mixed);
+        free(cumulative);
+        free(symbols);
+        free(diff);
+        free(magnitudes);
+        free(bits);
+        return 0;
+    }
+
+    residual_phase = 0.5 * atan2(sq_sum.im, sq_sum.re);
+    correction = c_expj(-residual_phase);
+
+    for (i = 0; i + 1 < symbol_count; i++) {
+        cpx_t corrected = c_mul(diff[i], correction);
+        bits[i] = corrected.re >= 0.0 ? 1 : 0;
+    }
+
+    *bits_out = bits;
+    *nbits_out = symbol_count - 1;
+
+    free(mixed);
+    free(cumulative);
+    free(symbols);
+    free(diff);
+    free(magnitudes);
+
+    return 1;
+}
+
+static int validate_bits(
+        uint8_t const *bits,
+        size_t nbits,
+        int invert,
+        psk_validate_fn validate_fn,
+        void *validate_context,
+        bitbuffer_t *bitbuffer)
+{
+    size_t i;
+
+    if (!bits || !nbits || !validate_fn || !bitbuffer) {
+        return 0;
+    }
+
+    bitbuffer_clear(bitbuffer);
+
+    for (i = 0; i < nbits; i++) {
+        bitbuffer_add_bit(bitbuffer,
+                invert ? (uint8_t)!bits[i] : bits[i]);
+    }
+
+    if (validate_fn(bitbuffer, validate_context) > 0) {
+        return 1;
+    }
+
+    bitbuffer_clear(bitbuffer);
+    return 0;
+}
+
 int psk_demod_candidate(
         uint8_t const *iq_buf,
         size_t sample_count,
         unsigned sample_size,
         unsigned sample_rate,
         psk_candidate_t const *candidate,
+        psk_validate_fn validate_fn,
+        void *validate_context,
         bitbuffer_t *bitbuffer)
 {
-    (void)iq_buf;
-    (void)sample_count;
-    (void)sample_size;
-    (void)sample_rate;
-    (void)candidate;
-    (void)bitbuffer;
+    size_t center;
+    size_t half;
+    size_t start;
+    size_t end;
+    size_t candidate_count;
+    cpx_t *iq;
+    double rates[41];
+    int rate_count = 0;
+    int delta;
+    int r;
+    size_t i;
+
+    if (!iq_buf || !candidate || !validate_fn ||
+            !bitbuffer || !sample_rate) {
+        return 0;
+    }
+
+    if (sample_size != 2) {
+        return 0;
+    }
+
+    center = (size_t)llround(candidate->offset_s *
+            (double)sample_rate);
+    if (center > sample_count) {
+        center = sample_count;
+    }
+
+    half = (size_t)(0.012 * (double)sample_rate);
+    start = center > half ? center - half : 0;
+    end = center + half < sample_count ? center + half : sample_count;
+
+    if (end <= start ||
+            end - start < (size_t)(0.015 * (double)sample_rate)) {
+        return 0;
+    }
+
+    candidate_count = end - start;
+
+    iq = malloc(candidate_count * sizeof(*iq));
+    if (!iq) {
+        return 0;
+    }
+
+    for (i = 0; i < candidate_count; i++) {
+        iq[i] = cu8_sample(iq_buf, start + i);
+    }
+
+    rates[rate_count++] = candidate->symbol_rate_hint;
+    for (delta = 50; delta <= 1000; delta += 50) {
+        rates[rate_count++] = candidate->symbol_rate_hint - (double)delta;
+        rates[rate_count++] = candidate->symbol_rate_hint + (double)delta;
+    }
+
+    for (r = 0; r < rate_count; r++) {
+        double symbol_rate = rates[r];
+        double samples_per_symbol;
+        int p;
+
+        if (symbol_rate < 35000.0 || symbol_rate > 37000.0) {
+            continue;
+        }
+
+        samples_per_symbol = (double)sample_rate / symbol_rate;
+
+        for (p = 0; p < 16; p++) {
+            double phase = samples_per_symbol * (double)p / 16.0;
+            uint8_t *bits = NULL;
+            size_t nbits = 0;
+
+            if (!demod_bits(
+                        iq,
+                        candidate_count,
+                        sample_rate,
+                        symbol_rate,
+                        candidate->carrier_offset_hz,
+                        phase,
+                        &bits,
+                        &nbits)) {
+                continue;
+            }
+
+            if (validate_bits(
+                        bits,
+                        nbits,
+                        0,
+                        validate_fn,
+                        validate_context,
+                        bitbuffer)) {
+                free(bits);
+                free(iq);
+                return 1;
+            }
+
+            if (validate_bits(
+                        bits,
+                        nbits,
+                        1,
+                        validate_fn,
+                        validate_context,
+                        bitbuffer)) {
+                free(bits);
+                free(iq);
+                return 1;
+            }
+
+            free(bits);
+        }
+    }
+
+    free(iq);
+    bitbuffer_clear(bitbuffer);
 
     return 0;
 }

--- a/src/psk_demod.c
+++ b/src/psk_demod.c
@@ -1,0 +1,376 @@
+#include "psk_demod.h"
+
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+typedef struct {
+    double re;
+    double im;
+} cpx_t;
+
+static cpx_t c_add(cpx_t a, cpx_t b)
+{
+    cpx_t r = {a.re + b.re, a.im + b.im};
+    return r;
+}
+
+static cpx_t c_sub(cpx_t a, cpx_t b)
+{
+    cpx_t r = {a.re - b.re, a.im - b.im};
+    return r;
+}
+
+static cpx_t c_mul(cpx_t a, cpx_t b)
+{
+    cpx_t r = {a.re * b.re - a.im * b.im, a.re * b.im + a.im * b.re};
+    return r;
+}
+
+static cpx_t c_scale(cpx_t a, double s)
+{
+    cpx_t r = {a.re * s, a.im * s};
+    return r;
+}
+
+static double c_abs2(cpx_t a)
+{
+    return a.re * a.re + a.im * a.im;
+}
+
+static cpx_t c_expj(double phase)
+{
+    cpx_t r = {cos(phase), sin(phase)};
+    return r;
+}
+
+static void fft_inplace(cpx_t *a, size_t n)
+{
+    size_t i;
+    size_t j;
+    size_t len;
+
+    for (i = 1, j = 0; i < n; i++) {
+        size_t bit = n >> 1;
+
+        for (; j & bit; bit >>= 1) {
+            j ^= bit;
+        }
+        j ^= bit;
+
+        if (i < j) {
+            cpx_t t = a[i];
+            a[i] = a[j];
+            a[j] = t;
+        }
+    }
+
+    for (len = 2; len <= n; len <<= 1) {
+        double ang = -2.0 * M_PI / (double)len;
+        cpx_t wlen = c_expj(ang);
+
+        for (i = 0; i < n; i += len) {
+            cpx_t w = {1.0, 0.0};
+            size_t half = len >> 1;
+
+            for (j = 0; j < half; j++) {
+                cpx_t u = a[i + j];
+                cpx_t v = c_mul(a[i + j + half], w);
+
+                a[i + j] = c_add(u, v);
+                a[i + j + half] = c_sub(u, v);
+                w = c_mul(w, wlen);
+            }
+        }
+    }
+}
+
+static int cmp_double(void const *pa, void const *pb)
+{
+    double a = *(double const *)pa;
+    double b = *(double const *)pb;
+
+    return (a > b) - (a < b);
+}
+
+static double median_copy(double const *v, size_t n)
+{
+    double *tmp;
+    double result;
+
+    if (!n) {
+        return 0.0;
+    }
+
+    tmp = malloc(n * sizeof(*tmp));
+    if (!tmp) {
+        return 0.0;
+    }
+
+    memcpy(tmp, v, n * sizeof(*tmp));
+    qsort(tmp, n, sizeof(*tmp), cmp_double);
+
+    if (n & 1) {
+        result = tmp[n / 2];
+    }
+    else {
+        result = 0.5 * (tmp[n / 2 - 1] + tmp[n / 2]);
+    }
+
+    free(tmp);
+    return result;
+}
+
+static double fft_bin_freq(size_t bin, size_t nfft, double sample_rate)
+{
+    if (bin <= nfft / 2) {
+        return (double)bin * sample_rate / (double)nfft;
+    }
+
+    return ((double)bin - (double)nfft) * sample_rate / (double)nfft;
+}
+
+static cpx_t cu8_sample(uint8_t const *iq_buf, size_t sample)
+{
+    cpx_t value = {
+            (double)iq_buf[sample * 2] - 127.5,
+            (double)iq_buf[sample * 2 + 1] - 127.5};
+
+    return value;
+}
+
+int psk_find_candidate(
+        uint8_t const *iq_buf,
+        size_t sample_count,
+        unsigned sample_size,
+        unsigned sample_rate,
+        psk_candidate_t *candidate)
+{
+    size_t window_samples;
+    size_t rows;
+    size_t nfft = 1;
+    size_t row;
+    int found = 0;
+    psk_candidate_t global_best = {0};
+
+    if (!iq_buf || !candidate || !sample_rate) {
+        return 0;
+    }
+
+    /* Currently validated for unsigned 8-bit interleaved I/Q only. */
+    if (sample_size != 2) {
+        return 0;
+    }
+
+    window_samples = (size_t)((double)sample_rate * 0.004);
+    if (window_samples < 256) {
+        window_samples = 256;
+    }
+
+    rows = sample_count / window_samples;
+    if (!rows) {
+        return 0;
+    }
+
+    while (nfft < window_samples) {
+        nfft <<= 1;
+    }
+
+    for (row = 0; row < rows; row++) {
+        cpx_t *buf;
+        double *bg;
+        size_t bg_count = 0;
+        size_t k;
+        size_t top_bins[16] = {0};
+        double top_power[16] = {0};
+        cpx_t mean = {0.0, 0.0};
+        double bg_hi;
+        double background;
+        double row_best_score = 0.0;
+        double row_best_midpoint = 0.0;
+        double row_best_sep = 0.0;
+
+        buf = calloc(nfft, sizeof(*buf));
+        if (!buf) {
+            return 0;
+        }
+
+        bg = malloc(nfft * sizeof(*bg));
+        if (!bg) {
+            free(buf);
+            return 0;
+        }
+
+        for (k = 0; k < window_samples; k++) {
+            mean = c_add(mean, cu8_sample(iq_buf, row * window_samples + k));
+        }
+        mean = c_scale(mean, 1.0 / (double)window_samples);
+
+        for (k = 0; k < window_samples; k++) {
+            double w = 0.5 - 0.5 * cos(
+                                         2.0 * M_PI * (double)k /
+                                         (double)(window_samples - 1));
+            cpx_t sample = cu8_sample(iq_buf, row * window_samples + k);
+
+            buf[k] = c_scale(c_sub(sample, mean), w);
+        }
+
+        fft_inplace(buf, nfft);
+
+        bg_hi = (double)sample_rate / 2.0 * 0.90;
+        if (bg_hi > 110000.0) {
+            bg_hi = 110000.0;
+        }
+
+        for (k = 0; k < nfft; k++) {
+            double f = fft_bin_freq(k, nfft, (double)sample_rate);
+            double af = fabs(f);
+            double p = c_abs2(buf[k]);
+
+            if (af > 2000.0 && af < 60000.0) {
+                int slot;
+
+                for (slot = 0; slot < 16; slot++) {
+                    if (p > top_power[slot]) {
+                        int s;
+
+                        for (s = 15; s > slot; s--) {
+                            top_power[s] = top_power[s - 1];
+                            top_bins[s] = top_bins[s - 1];
+                        }
+
+                        top_power[slot] = p;
+                        top_bins[slot] = k;
+                        break;
+                    }
+                }
+            }
+
+            if (af > 60000.0 && af < bg_hi) {
+                bg[bg_count++] = p;
+            }
+        }
+
+        if (bg_count < 5) {
+            bg_count = 0;
+
+            for (k = 0; k < nfft; k++) {
+                double f = fft_bin_freq(k, nfft, (double)sample_rate);
+                double af = fabs(f);
+
+                if (af > 40000.0 &&
+                        af < (double)sample_rate / 2.0 * 0.90) {
+                    bg[bg_count++] = c_abs2(buf[k]);
+                }
+            }
+        }
+
+        if (bg_count >= 5) {
+            int a;
+            int b;
+
+            background = median_copy(bg, bg_count) + 1e-12;
+
+            for (a = 0; a < 16; a++) {
+                if (top_power[a] <= 0.0) {
+                    continue;
+                }
+
+                for (b = a + 1; b < 16; b++) {
+                    double fi;
+                    double fj;
+                    double sep;
+                    double midpoint;
+                    double score;
+
+                    if (top_power[b] <= 0.0) {
+                        continue;
+                    }
+
+                    fi = fft_bin_freq(
+                            top_bins[a], nfft, (double)sample_rate);
+                    fj = fft_bin_freq(
+                            top_bins[b], nfft, (double)sample_rate);
+
+                    if (fj < fi) {
+                        double t = fi;
+                        fi = fj;
+                        fj = t;
+                    }
+
+                    sep = fj - fi;
+                    midpoint = (fi + fj) / 2.0;
+
+                    if (sep >= 34500.0 &&
+                            sep <= 37500.0 &&
+                            fabs(midpoint) <= 22000.0) {
+                        double weaker =
+                                top_power[a] < top_power[b] ?
+                                        top_power[a] :
+                                        top_power[b];
+
+                        score = weaker / background;
+
+                        if (score > row_best_score) {
+                            row_best_score = score;
+                            row_best_midpoint = midpoint;
+                            row_best_sep = sep;
+                        }
+                    }
+                }
+            }
+
+            if (row_best_score > 20.0) {
+                psk_candidate_t detected;
+
+                detected.offset_s =
+                        (double)(row * window_samples) /
+                        (double)sample_rate;
+                detected.signature_db =
+                        10.0 * log10(row_best_score);
+                detected.carrier_offset_hz =
+                        row_best_midpoint;
+                detected.symbol_rate_hint =
+                        row_best_sep;
+
+                if (!found ||
+                        detected.signature_db >
+                                global_best.signature_db) {
+                    global_best = detected;
+                    found = 1;
+                }
+            }
+        }
+
+        free(buf);
+        free(bg);
+    }
+
+    if (found) {
+        *candidate = global_best;
+    }
+
+    return found;
+}
+
+int psk_demod_candidate(
+        uint8_t const *iq_buf,
+        size_t sample_count,
+        unsigned sample_size,
+        unsigned sample_rate,
+        psk_candidate_t const *candidate,
+        bitbuffer_t *bitbuffer)
+{
+    (void)iq_buf;
+    (void)sample_count;
+    (void)sample_size;
+    (void)sample_rate;
+    (void)candidate;
+    (void)bitbuffer;
+
+    return 0;
+}

--- a/src/psk_stream.c
+++ b/src/psk_stream.c
@@ -30,10 +30,10 @@
  * as one continuous IQ region.
  *
  * The existing candidate decoder extracts +/-12 ms around the detected
- * signature. A 48 ms window with 24 ms overlap therefore provides ample
+ * signature. A 64 ms window with 24 ms overlap therefore provides ample
  * context around a TX63 transmission while keeping the FFT work bounded.
  */
-#define PSK_STREAM_WINDOW_MS 48
+#define PSK_STREAM_WINDOW_MS 64
 #define PSK_STREAM_OVERLAP_MS 24
 
 /*

--- a/src/psk_stream.c
+++ b/src/psk_stream.c
@@ -1,0 +1,455 @@
+/** @file
+    Streaming raw-IQ support for PSK demodulation.
+
+    Copyright (C) 2026
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#include "psk_stream.h"
+
+#include "bitbuffer.h"
+#include "decoder_util.h"
+#include "logger.h"
+#include "psk_demod.h"
+#include "r_device.h"
+#include "r_private.h"
+
+#include <limits.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * The PSK detector operates on overlapping rolling windows so a transmission
+ * crossing an SDR input-buffer boundary is still presented to the detector
+ * as one continuous IQ region.
+ *
+ * The existing candidate decoder extracts +/-12 ms around the detected
+ * signature. A 48 ms window with 24 ms overlap therefore provides ample
+ * context around a TX63 transmission while keeping the FFT work bounded.
+ */
+#define PSK_STREAM_WINDOW_MS 48
+#define PSK_STREAM_OVERLAP_MS 24
+
+/*
+ * The same RF burst may be present in two adjacent overlapping windows.
+ * Candidate positions within 12 ms of the last successfully decoded burst
+ * are treated as the same burst.
+ */
+#define PSK_DUPLICATE_MS 12
+
+/*
+ * psk_demod_candidate() requires at least 15 ms of candidate IQ. At EOF,
+ * attempt a final partial window only when at least 20 ms remains.
+ */
+#define PSK_FLUSH_MIN_MS 20
+
+static int account_psk_event(
+        r_device *device,
+        bitbuffer_t *bits)
+{
+    int ret = 0;
+    unsigned max_bits = 0;
+
+    if (device->decode_fn) {
+        ret = device->decode_fn(device, bits);
+    }
+
+    device->decode_events += 1;
+
+    if (ret > 0) {
+        device->decode_ok += 1;
+        device->decode_messages += ret;
+    }
+    else if (ret >= DECODE_FAIL_SANITY) {
+        device->decode_fails[-ret] += 1;
+        ret = 0;
+    }
+    else {
+        print_logf(
+                LOG_ERROR,
+                "PSK",
+                "Decoder \"%s\" gave invalid return value %d: notify maintainer",
+                device->name,
+                ret);
+        exit(1);
+    }
+
+    for (int row = 0; row < bits->num_rows; ++row) {
+        if (bits->bits_per_row[row] > max_bits) {
+            max_bits = bits->bits_per_row[row];
+        }
+    }
+
+    if (!device->decode_fn
+            || (device->verbose && ret > 0)
+            || (device->verbose > 1 && max_bits > 16)
+            || (device->verbose > 2)) {
+        decoder_log_bitbuffer(
+                device,
+                ret > 0 ? 1 : 2,
+                "PSK",
+                bits,
+                device->name);
+    }
+
+    bitbuffer_clear(bits);
+
+    return ret;
+}
+
+static int candidate_is_duplicate(
+        struct dm_state const *demod,
+        uint64_t candidate_pos)
+{
+    uint64_t duplicate_samples;
+    uint64_t delta;
+
+    if (!demod->psk_have_last_event) {
+        return 0;
+    }
+
+    duplicate_samples =
+            ((uint64_t)demod->samp_rate * PSK_DUPLICATE_MS) /
+            1000;
+
+    if (candidate_pos >= demod->psk_last_event_pos) {
+        delta = candidate_pos - demod->psk_last_event_pos;
+    }
+    else {
+        delta = demod->psk_last_event_pos - candidate_pos;
+    }
+
+    return delta <= duplicate_samples;
+}
+
+static void set_candidate_position(
+        struct dm_state *demod,
+        uint64_t candidate_pos,
+        uint64_t current_end_pos)
+{
+    uint64_t ago;
+
+    if (candidate_pos >= current_end_pos) {
+        demod->pulse_data.start_ago = 0;
+        demod->pulse_data.end_ago   = 0;
+        return;
+    }
+
+    ago = current_end_pos - candidate_pos;
+
+    if (ago > UINT_MAX) {
+        ago = UINT_MAX;
+    }
+
+    /*
+     * The candidate detector reports the center of its strongest 4 ms
+     * signature window rather than exact packet edges. For PSK this position
+     * is sufficient for rtl_433 timestamp bookkeeping.
+     */
+    demod->pulse_data.start_ago = (unsigned)ago;
+    demod->pulse_data.end_ago   = (unsigned)ago;
+}
+
+static int run_psk_window(
+        r_cfg_t *cfg,
+        uint8_t const *iq_buf,
+        size_t sample_count,
+        uint64_t window_start_pos,
+        uint64_t current_end_pos)
+{
+    struct dm_state *demod = cfg->demod;
+    psk_candidate_t candidate;
+    uint64_t candidate_pos;
+    unsigned next_priority;
+    int events = 0;
+
+    if (!iq_buf || sample_count == 0) {
+        return 0;
+    }
+
+    if (!psk_find_candidate(
+                iq_buf,
+                sample_count,
+                demod->sample_size,
+                demod->samp_rate,
+                &candidate)) {
+        return 0;
+    }
+
+    candidate_pos =
+            window_start_pos +
+            (uint64_t)llround(
+                    candidate.offset_s *
+                    demod->samp_rate);
+
+    if (candidate_is_duplicate(demod, candidate_pos)) {
+        return 0;
+    }
+
+    /*
+     * A PSK candidate corresponds to the same concept as an OOK/FSK detected
+     * package. Count it as a PSK frame whether or not a protocol validates it.
+     */
+    demod->total_frames_psk += 1;
+    demod->frames_psk += 1;
+
+    set_candidate_position(
+            demod,
+            candidate_pos,
+            current_end_pos);
+
+    /*
+     * Follow the normal rtl_433 priority behavior: try the lowest configured
+     * PSK decoder priority first and stop advancing to later priorities after
+     * an event has been produced.
+     */
+    next_priority = 0;
+
+    for (unsigned priority = 0;
+            !events && priority < UINT_MAX;
+            priority = next_priority) {
+        next_priority = UINT_MAX;
+
+        for (void **iter = demod->r_devs.elems;
+                iter && *iter;
+                ++iter) {
+            r_device *r_dev = *iter;
+            bitbuffer_t bits = {0};
+
+            if (r_dev->modulation != PSK_PULSE_DBPSK) {
+                continue;
+            }
+
+            if (r_dev->priority > priority
+                    && r_dev->priority < next_priority) {
+                next_priority = r_dev->priority;
+            }
+
+            if (r_dev->priority != priority) {
+                continue;
+            }
+
+            if (!r_dev->validate_fn || !r_dev->decode_fn) {
+                continue;
+            }
+
+            if (!psk_demod_candidate(
+                        iq_buf,
+                        sample_count,
+                        demod->sample_size,
+                        demod->samp_rate,
+                        &candidate,
+                        r_dev->validate_fn,
+                        r_dev->decode_ctx,
+                        &bits)) {
+                continue;
+            }
+
+            events += account_psk_event(
+                    r_dev,
+                    &bits);
+        }
+    }
+
+    if (events > 0) {
+        demod->psk_last_event_pos  = candidate_pos;
+        demod->psk_have_last_event = 1;
+
+        demod->total_frames_events += 1;
+        demod->frames_events += 1;
+    }
+
+    return events;
+}
+
+void psk_stream_reset(r_cfg_t *cfg)
+{
+    struct dm_state *demod;
+
+    if (!cfg || !cfg->demod) {
+        return;
+    }
+
+    demod = cfg->demod;
+
+    demod->psk_iq_len          = 0;
+    demod->psk_iq_start_pos    = demod->input_pos;
+    demod->psk_last_event_pos  = 0;
+    demod->psk_have_last_event = 0;
+}
+
+int psk_stream_push(
+        r_cfg_t *cfg,
+        uint8_t const *iq_buf,
+        size_t sample_count)
+{
+    struct dm_state *demod;
+    size_t window_samples;
+    size_t overlap_samples;
+    size_t hop_samples;
+    size_t window_bytes;
+    size_t hop_bytes;
+    size_t consumed = 0;
+    uint64_t current_end_pos;
+    int events = 0;
+
+    if (!cfg || !cfg->demod) {
+        return 0;
+    }
+
+    demod = cfg->demod;
+
+    if (!demod->enable_PSK_demod) {
+        return 0;
+    }
+
+    /*
+     * CU8 is the only raw-IQ representation currently validated by the PSK
+     * detector. Do not reinterpret CS16 samples as CU8.
+     */
+    if (demod->sample_size != 2) {
+        return 0;
+    }
+
+    if (demod->samp_rate == 0) {
+        return 0;
+    }
+
+    window_samples =
+            ((size_t)demod->samp_rate *
+                    PSK_STREAM_WINDOW_MS) /
+            1000;
+
+    overlap_samples =
+            ((size_t)demod->samp_rate *
+                    PSK_STREAM_OVERLAP_MS) /
+            1000;
+
+    if (window_samples == 0
+            || overlap_samples >= window_samples) {
+        return 0;
+    }
+
+    window_bytes =
+            window_samples *
+            (size_t)demod->sample_size;
+
+    if (window_bytes > sizeof(demod->psk_iq_buf)) {
+        print_logf(
+                LOG_WARNING,
+                "PSK",
+                "Sample rate %u is too high for the PSK streaming buffer",
+                demod->samp_rate);
+        return 0;
+    }
+
+    hop_samples =
+            window_samples -
+            overlap_samples;
+
+    hop_bytes =
+            hop_samples *
+            (size_t)demod->sample_size;
+
+    /*
+     * At normal input calls input_pos points to the first sample in iq_buf.
+     * At EOF input_pos already points immediately after the final input block.
+     */
+    current_end_pos =
+            demod->input_pos +
+            sample_count;
+
+    /*
+     * EOF flush: process the remaining overlap/partial window once.
+     */
+    if (!iq_buf || sample_count == 0) {
+        size_t buffered_samples =
+                demod->psk_iq_len /
+                (size_t)demod->sample_size;
+
+        size_t flush_min_samples =
+                ((size_t)demod->samp_rate *
+                        PSK_FLUSH_MIN_MS) /
+                1000;
+
+        if (buffered_samples >= flush_min_samples) {
+            events += run_psk_window(
+                    cfg,
+                    demod->psk_iq_buf,
+                    buffered_samples,
+                    demod->psk_iq_start_pos,
+                    current_end_pos);
+        }
+
+        demod->psk_iq_len = 0;
+
+        return events;
+    }
+
+    while (consumed < sample_count) {
+        size_t buffered_samples =
+                demod->psk_iq_len /
+                (size_t)demod->sample_size;
+
+        size_t needed_samples =
+                window_samples -
+                buffered_samples;
+
+        size_t remaining_samples =
+                sample_count -
+                consumed;
+
+        size_t copy_samples =
+                remaining_samples < needed_samples
+                        ? remaining_samples
+                        : needed_samples;
+
+        size_t copy_bytes =
+                copy_samples *
+                (size_t)demod->sample_size;
+
+        if (demod->psk_iq_len == 0) {
+            demod->psk_iq_start_pos =
+                    demod->input_pos +
+                    consumed;
+        }
+
+        memcpy(
+                demod->psk_iq_buf +
+                        demod->psk_iq_len,
+                iq_buf +
+                        consumed *
+                                (size_t)demod->sample_size,
+                copy_bytes);
+
+        demod->psk_iq_len += copy_bytes;
+        consumed += copy_samples;
+
+        if (demod->psk_iq_len < window_bytes) {
+            continue;
+        }
+
+        events += run_psk_window(
+                cfg,
+                demod->psk_iq_buf,
+                window_samples,
+                demod->psk_iq_start_pos,
+                current_end_pos);
+
+        memmove(
+                demod->psk_iq_buf,
+                demod->psk_iq_buf + hop_bytes,
+                demod->psk_iq_len - hop_bytes);
+
+        demod->psk_iq_len -= hop_bytes;
+        demod->psk_iq_start_pos += hop_samples;
+    }
+
+    return events;
+}

--- a/src/r_api.c
+++ b/src/r_api.c
@@ -489,6 +489,7 @@ int run_ook_demods(list_t *r_devs, pulse_data_t *pulse_data)
             case FSK_PULSE_PCM:
             case FSK_PULSE_PWM:
             case FSK_PULSE_MANCHESTER_ZEROBIT:
+            case PSK_PULSE_DBPSK:
                 break;
             default:
                 fprintf(stderr, "Unknown modulation %u in protocol!\n", r_dev->modulation);
@@ -539,6 +540,8 @@ int run_fsk_demods(list_t *r_devs, pulse_data_t *fsk_pulse_data)
                 break;
             case FSK_PULSE_MANCHESTER_ZEROBIT:
                 p_events += pulse_slicer_manchester_zerobit(fsk_pulse_data, r_dev);
+                break;
+            case PSK_PULSE_DBPSK:
                 break;
             default:
                 fprintf(stderr, "Unknown modulation %u in protocol!\n", r_dev->modulation);

--- a/src/r_flow.c
+++ b/src/r_flow.c
@@ -31,6 +31,7 @@
 #include "am_analyze.h"
 #include "logger.h"
 #include "fatal.h"
+#include "psk_stream.h"
 
 static void calc_rssi_snr(struct dm_state const *demod, pulse_data_t *pulse_data)
 {
@@ -93,8 +94,9 @@ void reset_sdr_flow(r_cfg_t *cfg)
     baseband_low_pass_filter_reset(&demod->lowpass_filter_state);
     baseband_demod_FM_reset(&demod->demod_FM_state);
 
-    pulse_detect_reset(demod->pulse_detect);
-}
+    psk_stream_reset(cfg);
+
+    pulse_detect_reset(demod->pulse_detect);}
 
 /**
 Push an IQ data frame to the SDR IQ data frame processing.
@@ -118,6 +120,7 @@ int push_sdr_flow(r_cfg_t *cfg, unsigned char *iq_buf, uint32_t len)
     }
 
     int process_frame = 1;
+    int d_events = 0;
 
     // Process new frame data if available
     if (len) {
@@ -145,6 +148,15 @@ int push_sdr_flow(r_cfg_t *cfg, unsigned char *iq_buf, uint32_t len)
     if (demod->samp_grab) {
         samp_grab_push(demod->samp_grab, iq_buf, len);
     }
+
+    /*
+     * PSK demodulation operates directly on raw IQ. It runs before AM/FSK
+     * processing and independently of the AM squelch decision.
+     */
+    d_events += psk_stream_push(
+            cfg,
+            iq_buf,
+            n_samples);
 
     // AM demodulation
     float avg_db;
@@ -226,7 +238,7 @@ int push_sdr_flow(r_cfg_t *cfg, unsigned char *iq_buf, uint32_t len)
     }
 
     // Run a pulse discriminator and pass packages to all configured slicers
-    int d_events = 0; // Sensor events successfully detected
+
     if (demod->r_devs.len || demod->analyze_pulses || demod->dumper.len || demod->samp_grab) {
         // Detect a package and loop through demodulators with pulse data
         int package_type = PULSE_DATA_OOK;  // Just to get us started
@@ -374,9 +386,13 @@ int push_sdr_flow(r_cfg_t *cfg, unsigned char *iq_buf, uint32_t len)
 
     // End processing if no new frame data
     if (!len) {
+        d_events += psk_stream_push(
+                cfg,
+                NULL,
+                0);
+
         return d_events;
     }
-
     // Run the AM analyzer (deprecated)
     if (demod->am_analyze) {
         am_analyze(demod->am_analyze, demod->am_buf, n_samples, demod->verbosity >= LOG_INFO, NULL);

--- a/src/rtl_433.c
+++ b/src/rtl_433.c
@@ -1512,12 +1512,17 @@ int main(int argc, char **argv) {
         register_all_protocols(cfg, 0); // register all defaults
     }
 
-    // check if we need FM demod
+    // check if we need FM or PSK demod
     for (void **iter = demod->r_devs.elems; iter && *iter; ++iter) {
         r_device *r_dev = *iter;
-        if (r_dev->modulation >= FSK_DEMOD_MIN_VAL) {
+
+        if (r_dev->modulation >= FSK_DEMOD_MIN_VAL
+                && r_dev->modulation <= FSK_DEMOD_MAX_VAL) {
             demod->enable_FM_demod = 1;
-            break;
+        }
+
+        if (r_dev->modulation == PSK_PULSE_DBPSK) {
+            demod->enable_PSK_demod = 1;
         }
     }
     // if any dumpers are requested the FM demod might be needed

--- a/tools/tx63/psk_candidate_test.c
+++ b/tools/tx63/psk_candidate_test.c
@@ -1,0 +1,102 @@
+#include "psk_demod.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int infer_sample_rate(char const *filename)
+{
+    if (strstr(filename, "_1000k")) {
+        return 1000000;
+    }
+
+    if (strstr(filename, "_250k")) {
+        return 250000;
+    }
+
+    return 250000;
+}
+
+int main(int argc, char **argv)
+{
+    char const *filename;
+    FILE *fp;
+    long file_size;
+    uint8_t *iq_buf;
+    size_t bytes_read;
+    size_t sample_count;
+    unsigned sample_rate;
+    psk_candidate_t candidate;
+
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s <capture.cu8>\n", argv[0]);
+        return 2;
+    }
+
+    filename = argv[1];
+    sample_rate = (unsigned)infer_sample_rate(filename);
+
+    fp = fopen(filename, "rb");
+    if (!fp) {
+        fprintf(stderr, "ERROR: cannot open %s\n", filename);
+        return 2;
+    }
+
+    if (fseek(fp, 0, SEEK_END) != 0) {
+        fclose(fp);
+        return 2;
+    }
+
+    file_size = ftell(fp);
+    if (file_size <= 0) {
+        fclose(fp);
+        return 2;
+    }
+
+    if (fseek(fp, 0, SEEK_SET) != 0) {
+        fclose(fp);
+        return 2;
+    }
+
+    iq_buf = malloc((size_t)file_size);
+    if (!iq_buf) {
+        fclose(fp);
+        return 2;
+    }
+
+    bytes_read = fread(iq_buf, 1, (size_t)file_size, fp);
+    fclose(fp);
+
+    if (bytes_read != (size_t)file_size || (bytes_read & 1)) {
+        fprintf(stderr, "ERROR: invalid CU8 capture\n");
+        free(iq_buf);
+        return 2;
+    }
+
+    sample_count = bytes_read / 2;
+
+    printf("Testing %s at %u samples/s\n", filename, sample_rate);
+
+    if (!psk_find_candidate(
+                iq_buf,
+                sample_count,
+                2,
+                sample_rate,
+                &candidate)) {
+        fprintf(stderr, "No PSK candidate found.\n");
+        free(iq_buf);
+        return 1;
+    }
+
+    printf(
+            "candidate t=%.6f s  signature=%.1f dB  "
+            "carrier_offset=%.1f Hz  symbol_hint=%.1f\n",
+            candidate.offset_s,
+            candidate.signature_db,
+            candidate.carrier_offset_hz,
+            candidate.symbol_rate_hint);
+
+    free(iq_buf);
+    return 0;
+}

--- a/tools/tx63/psk_demod_test.c
+++ b/tools/tx63/psk_demod_test.c
@@ -1,0 +1,410 @@
+#include "psk_demod.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    uint8_t frame[9];
+} tx63_validate_context_t;
+
+static uint16_t crc16_x25(uint8_t const *data, size_t len)
+{
+    uint16_t crc = 0xffff;
+    size_t i;
+
+    for (i = 0; i < len; ++i) {
+        int bit;
+
+        crc ^= data[i];
+
+        for (bit = 0; bit < 8; ++bit) {
+            if (crc & 1) {
+                crc = (uint16_t)((crc >> 1) ^ 0x8408);
+            }
+            else {
+                crc >>= 1;
+            }
+        }
+    }
+
+    return (uint16_t)(crc ^ 0xffff);
+}
+
+static int flag_at(
+        uint8_t const *row,
+        size_t bit_count,
+        size_t pos)
+{
+    static uint8_t const flag[8] = {
+            0, 1, 1, 1, 1, 1, 1, 0};
+    size_t i;
+
+    if (pos + 8 > bit_count) {
+        return 0;
+    }
+
+    for (i = 0; i < 8; ++i) {
+        if (bitrow_get_bit(row, (unsigned)(pos + i)) != flag[i]) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+static int destuff_frame(
+        uint8_t const *row,
+        size_t start,
+        size_t end,
+        uint8_t frame[9])
+{
+    uint8_t bits[72];
+    size_t bit_count = 0;
+    unsigned ones = 0;
+    size_t i;
+
+    memset(frame, 0, 9);
+
+    for (i = start; i < end; ++i) {
+        uint8_t bit = bitrow_get_bit(row, (unsigned)i);
+
+        /*
+         * HDLC inserts a zero after five consecutive one bits.
+         * That stuffed zero is not part of the payload.
+         */
+        if (ones == 5) {
+            if (bit != 0) {
+                return 0;
+            }
+
+            ones = 0;
+            continue;
+        }
+
+        if (bit_count >= 72) {
+            return 0;
+        }
+
+        bits[bit_count++] = bit;
+
+        if (bit) {
+            ++ones;
+        }
+        else {
+            ones = 0;
+        }
+    }
+
+    if (bit_count != 72) {
+        return 0;
+    }
+
+    /*
+     * TX63 HDLC payload bytes are transmitted LSB first.
+     */
+    for (i = 0; i < 72; ++i) {
+        if (bits[i]) {
+            frame[i / 8] |=
+                    (uint8_t)(1U << (i % 8));
+        }
+    }
+
+    return 1;
+}
+
+static int find_valid_frame(
+        bitbuffer_t const *bitbuffer,
+        uint8_t frame[9])
+{
+    uint8_t const *row;
+    size_t bit_count;
+    size_t start_flag;
+
+    if (!bitbuffer || bitbuffer->num_rows < 1) {
+        return 0;
+    }
+
+    row = bitbuffer->bb[0];
+    bit_count = bitbuffer->bits_per_row[0];
+
+    for (start_flag = 0;
+            start_flag + 8 <= bit_count;
+            ++start_flag) {
+        size_t end_flag;
+
+        if (!flag_at(row, bit_count, start_flag)) {
+            continue;
+        }
+
+        /*
+         * This is the validated TX63 search range from the standalone
+         * decoder. The separation is measured between flag starts.
+         */
+        for (end_flag = start_flag + 75;
+                end_flag <= start_flag + 110 &&
+                end_flag + 8 <= bit_count;
+                ++end_flag) {
+            uint16_t received_crc;
+            uint16_t calculated_crc;
+
+            if (!flag_at(row, bit_count, end_flag)) {
+                continue;
+            }
+
+            if (!destuff_frame(
+                        row,
+                        start_flag + 8,
+                        end_flag,
+                        frame)) {
+                continue;
+            }
+
+            /*
+             * Known TX63 family prefix from all validated captures.
+             * This is intentionally in the protocol validator, not
+             * in the generic PSK demodulator.
+             */
+            if (frame[0] != 0x3c || frame[1] != 0xc0) {
+                continue;
+            }
+
+            received_crc =
+                    (uint16_t)frame[7] |
+                    ((uint16_t)frame[8] << 8);
+
+            calculated_crc = crc16_x25(frame, 7);
+
+            if (received_crc != calculated_crc) {
+                continue;
+            }
+
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static int tx63_validate(
+        bitbuffer_t *bitbuffer,
+        void *context)
+{
+    tx63_validate_context_t *tx63_context = context;
+
+    if (!tx63_context) {
+        return 0;
+    }
+
+    return find_valid_frame(
+            bitbuffer,
+            tx63_context->frame);
+}
+
+static unsigned infer_sample_rate(char const *filename)
+{
+    if (strstr(filename, "_1000k")) {
+        return 1000000;
+    }
+
+    if (strstr(filename, "_250k")) {
+        return 250000;
+    }
+
+    return 0;
+}
+
+static int load_cu8(
+        char const *filename,
+        uint8_t **data,
+        size_t *byte_count)
+{
+    FILE *fp;
+    long length;
+    uint8_t *buffer;
+    size_t read_count;
+
+    if (!filename || !data || !byte_count) {
+        return 0;
+    }
+
+    fp = fopen(filename, "rb");
+    if (!fp) {
+        fprintf(stderr, "Unable to open: %s\n", filename);
+        return 0;
+    }
+
+    if (fseek(fp, 0, SEEK_END) != 0) {
+        fclose(fp);
+        return 0;
+    }
+
+    length = ftell(fp);
+    if (length <= 0) {
+        fclose(fp);
+        return 0;
+    }
+
+    if (fseek(fp, 0, SEEK_SET) != 0) {
+        fclose(fp);
+        return 0;
+    }
+
+    buffer = malloc((size_t)length);
+    if (!buffer) {
+        fclose(fp);
+        return 0;
+    }
+
+    read_count =
+            fread(buffer, 1, (size_t)length, fp);
+
+    fclose(fp);
+
+    if (read_count != (size_t)length) {
+        free(buffer);
+        return 0;
+    }
+
+    /*
+     * CU8 contains one unsigned I byte followed by one unsigned Q byte.
+     */
+    if (read_count & 1) {
+        --read_count;
+    }
+
+    *data = buffer;
+    *byte_count = read_count;
+
+    return 1;
+}
+
+static char const *direction_name(unsigned code)
+{
+    static char const *const names[16] = {
+            "N", "NNE", "NE", "ENE",
+            "E", "ESE", "SE", "SSE",
+            "S", "SSW", "SW", "WSW",
+            "W", "WNW", "NW", "NNW"};
+
+    return names[code & 0x0f];
+}
+
+int main(int argc, char **argv)
+{
+    char const *filename;
+    unsigned sample_rate;
+    uint8_t *iq_buf = NULL;
+    size_t byte_count = 0;
+    size_t sample_count;
+    psk_candidate_t candidate;
+    bitbuffer_t bitbuffer;
+    tx63_validate_context_t validate_context = {{0}};
+    uint8_t const *frame;
+    unsigned direction_code;
+    unsigned speed_raw;
+    unsigned gust_direction_code;
+    unsigned gust_raw;
+    int i;
+
+    if (argc != 2) {
+        fprintf(
+                stderr,
+                "Usage: %s capture.cu8\n",
+                argv[0]);
+        return 2;
+    }
+
+    filename = argv[1];
+
+    sample_rate = infer_sample_rate(filename);
+    if (!sample_rate) {
+        fprintf(
+                stderr,
+                "Cannot infer sample rate from filename: %s\n",
+                filename);
+        return 2;
+    }
+
+    if (!load_cu8(
+                filename,
+                &iq_buf,
+                &byte_count)) {
+        return 1;
+    }
+
+    sample_count = byte_count / 2;
+
+    if (!psk_find_candidate(
+                iq_buf,
+                sample_count,
+                2,
+                sample_rate,
+                &candidate)) {
+        fprintf(stderr, "No PSK candidate found\n");
+        free(iq_buf);
+        return 1;
+    }
+
+    printf(
+            "candidate t=%.6f s  signature=%.1f dB  "
+            "carrier_offset=%.1f Hz  symbol_hint=%.1f\n",
+            candidate.offset_s,
+            candidate.signature_db,
+            candidate.carrier_offset_hz,
+            candidate.symbol_rate_hint);
+
+    bitbuffer_clear(&bitbuffer);
+
+    if (!psk_demod_candidate(
+                iq_buf,
+                sample_count,
+                2,
+                sample_rate,
+                &candidate,
+                tx63_validate,
+                &validate_context,
+                &bitbuffer)) {
+        fprintf(stderr, "PSK candidate did not validate\n");
+        free(iq_buf);
+        return 1;
+    }
+
+    frame = validate_context.frame;
+
+    printf("frame=");
+
+    for (i = 0; i < 9; ++i) {
+        printf(
+                "%s%02X",
+                i ? " " : "",
+                frame[i]);
+    }
+
+    printf("\n");
+
+    direction_code =
+            (frame[2] >> 4) & 0x0f;
+
+    speed_raw =
+            ((unsigned)(frame[2] & 0x0f) << 8) |
+            frame[3];
+
+    gust_direction_code =
+            (frame[4] >> 4) & 0x0f;
+
+    gust_raw =
+            ((unsigned)(frame[4] & 0x0f) << 8) |
+            frame[5];
+
+    printf(
+            "wind=%.1f m/s %s  gust=%.1f m/s %s\n",
+            speed_raw / 10.0,
+            direction_name(direction_code),
+            gust_raw / 10.0,
+            direction_name(gust_direction_code));
+
+    free(iq_buf);
+
+    return 0;
+}

--- a/tools/tx63/tx63_psk_test.c
+++ b/tools/tx63/tx63_psk_test.c
@@ -1,0 +1,845 @@
+/*
+ * TX63U-IT standalone PSK demodulation proof-of-concept
+ *
+ * Port of the working Python decoder used for La Crosse TX63U-IT / FCC OMO-M-12.
+ * This file is intentionally isolated from rtl_433 core. It reads CU8 I/Q files,
+ * detects the ~36 kHz phase-signature sidebands, differentially demodulates the
+ * ~36 ksymbol/s BPSK-like signal, finds HDLC flags, removes bit stuffing, and
+ * validates CRC-16/X-25.
+ *
+ * This is development/test code, not yet an rtl_433 device implementation.
+ */
+
+#define _CRT_SECURE_NO_WARNINGS
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+typedef struct {
+    double re;
+    double im;
+} cpx_t;
+
+typedef struct {
+    double offset_s;
+    double signature_db;
+    double carrier_offset_hz;
+    double symbol_rate_hint;
+} detection_t;
+
+static const char *directions[16] = {
+        "N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE",
+        "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW"};
+
+static cpx_t c_add(cpx_t a, cpx_t b)
+{
+    cpx_t r = {a.re + b.re, a.im + b.im};
+    return r;
+}
+
+static cpx_t c_sub(cpx_t a, cpx_t b)
+{
+    cpx_t r = {a.re - b.re, a.im - b.im};
+    return r;
+}
+
+static cpx_t c_mul(cpx_t a, cpx_t b)
+{
+    cpx_t r = {a.re * b.re - a.im * b.im, a.re * b.im + a.im * b.re};
+    return r;
+}
+
+static cpx_t c_conj(cpx_t a)
+{
+    cpx_t r = {a.re, -a.im};
+    return r;
+}
+
+static cpx_t c_scale(cpx_t a, double s)
+{
+    cpx_t r = {a.re * s, a.im * s};
+    return r;
+}
+
+static double c_abs2(cpx_t a)
+{
+    return a.re * a.re + a.im * a.im;
+}
+
+static double c_abs(cpx_t a)
+{
+    return sqrt(c_abs2(a));
+}
+
+static cpx_t c_expj(double phase)
+{
+    cpx_t r = {cos(phase), sin(phase)};
+    return r;
+}
+
+static void fft_inplace(cpx_t *a, size_t n)
+{
+    size_t i, j, len;
+
+    for (i = 1, j = 0; i < n; i++) {
+        size_t bit = n >> 1;
+        for (; j & bit; bit >>= 1) {
+            j ^= bit;
+        }
+        j ^= bit;
+        if (i < j) {
+            cpx_t t = a[i];
+            a[i] = a[j];
+            a[j] = t;
+        }
+    }
+
+    for (len = 2; len <= n; len <<= 1) {
+        double ang = -2.0 * M_PI / (double)len;
+        cpx_t wlen = c_expj(ang);
+        for (i = 0; i < n; i += len) {
+            cpx_t w = {1.0, 0.0};
+            size_t half = len >> 1;
+            for (j = 0; j < half; j++) {
+                cpx_t u = a[i + j];
+                cpx_t v = c_mul(a[i + j + half], w);
+                a[i + j] = c_add(u, v);
+                a[i + j + half] = c_sub(u, v);
+                w = c_mul(w, wlen);
+            }
+        }
+    }
+}
+
+static int cmp_double(const void *pa, const void *pb)
+{
+    double a = *(const double *)pa;
+    double b = *(const double *)pb;
+    return (a > b) - (a < b);
+}
+
+static double median_copy(const double *v, size_t n)
+{
+    double *tmp;
+    double result;
+
+    if (!n) {
+        return 0.0;
+    }
+
+    tmp = (double *)malloc(n * sizeof(*tmp));
+    if (!tmp) {
+        return 0.0;
+    }
+    memcpy(tmp, v, n * sizeof(*tmp));
+    qsort(tmp, n, sizeof(*tmp), cmp_double);
+
+    if (n & 1) {
+        result = tmp[n / 2];
+    }
+    else {
+        result = 0.5 * (tmp[n / 2 - 1] + tmp[n / 2]);
+    }
+
+    free(tmp);
+    return result;
+}
+
+static uint16_t crc16_x25(const uint8_t *data, size_t len)
+{
+    uint16_t crc = 0xffff;
+    size_t i;
+    int bit;
+
+    for (i = 0; i < len; i++) {
+        crc ^= data[i];
+        for (bit = 0; bit < 8; bit++) {
+            crc = (crc & 1) ? (uint16_t)((crc >> 1) ^ 0x8408) : (uint16_t)(crc >> 1);
+        }
+    }
+
+    return (uint16_t)(crc ^ 0xffff);
+}
+
+static int flag_at(const uint8_t *bits, size_t nbits, size_t pos)
+{
+    static const uint8_t flag_bits[8] = {0, 1, 1, 1, 1, 1, 1, 0};
+    size_t k;
+
+    if (pos + 8 > nbits) {
+        return 0;
+    }
+    for (k = 0; k < 8; k++) {
+        if (bits[pos + k] != flag_bits[k]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int destuff_72(const uint8_t *in, size_t nin, uint8_t out[72])
+{
+    size_t i = 0;
+    size_t o = 0;
+    int ones = 0;
+
+    while (i < nin) {
+        uint8_t b = in[i++];
+
+        if (o >= 72) {
+            return 0;
+        }
+        out[o++] = b;
+
+        if (b) {
+            ones++;
+            if (ones == 5) {
+                if (i >= nin || in[i] != 0) {
+                    return 0;
+                }
+                i++;
+                ones = 0;
+            }
+        }
+        else {
+            ones = 0;
+        }
+    }
+
+    return o == 72;
+}
+
+static void bits_to_bytes_lsb(const uint8_t bits[72], uint8_t bytes[9])
+{
+    size_t i, k;
+
+    memset(bytes, 0, 9);
+    for (i = 0; i < 9; i++) {
+        for (k = 0; k < 8; k++) {
+            bytes[i] |= (uint8_t)((bits[i * 8 + k] & 1) << k);
+        }
+    }
+}
+
+static int find_valid_frame(const uint8_t *bits, size_t nbits, uint8_t frame[9])
+{
+    size_t start, end;
+
+    for (start = 0; start + 8 <= nbits; start++) {
+        uint8_t destuffed[72];
+        uint8_t body[9];
+        uint16_t received;
+        uint16_t calculated;
+        size_t separation;
+
+        if (!flag_at(bits, nbits, start)) {
+            continue;
+        }
+
+        for (end = start + 8; end + 8 <= nbits; end++) {
+            if (!flag_at(bits, nbits, end)) {
+                continue;
+            }
+
+            separation = end - start;
+            if (separation > 110) {
+                break;
+            }
+            if (separation < 75) {
+                continue;
+            }
+
+            if (!destuff_72(bits + start + 8, end - (start + 8), destuffed)) {
+                continue;
+            }
+
+            bits_to_bytes_lsb(destuffed, body);
+
+            if (body[0] != 0x3c || body[1] != 0xc0) {
+                continue;
+            }
+
+            received = (uint16_t)(body[7] | ((uint16_t)body[8] << 8));
+            calculated = crc16_x25(body, 7);
+
+            if (received == calculated) {
+                memcpy(frame, body, 9);
+                return 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+static int load_cu8(const char *filename, cpx_t **out_iq, size_t *out_count)
+{
+    FILE *fp;
+    long bytes;
+    uint8_t *raw;
+    cpx_t *iq;
+    size_t samples;
+    size_t i;
+
+    fp = fopen(filename, "rb");
+    if (!fp) {
+        fprintf(stderr, "ERROR: cannot open %s\n", filename);
+        return 0;
+    }
+
+    if (fseek(fp, 0, SEEK_END) != 0) {
+        fclose(fp);
+        return 0;
+    }
+    bytes = ftell(fp);
+    if (bytes < 2) {
+        fclose(fp);
+        fprintf(stderr, "ERROR: input file is empty\n");
+        return 0;
+    }
+    rewind(fp);
+
+    if (bytes & 1) {
+        bytes--;
+    }
+
+    raw = (uint8_t *)malloc((size_t)bytes);
+    if (!raw) {
+        fclose(fp);
+        return 0;
+    }
+
+    if (fread(raw, 1, (size_t)bytes, fp) != (size_t)bytes) {
+        free(raw);
+        fclose(fp);
+        fprintf(stderr, "ERROR: short read from %s\n", filename);
+        return 0;
+    }
+    fclose(fp);
+
+    samples = (size_t)bytes / 2;
+    iq = (cpx_t *)malloc(samples * sizeof(*iq));
+    if (!iq) {
+        free(raw);
+        return 0;
+    }
+
+    for (i = 0; i < samples; i++) {
+        iq[i].re = (double)raw[i * 2] - 127.5;
+        iq[i].im = (double)raw[i * 2 + 1] - 127.5;
+    }
+
+    free(raw);
+    *out_iq = iq;
+    *out_count = samples;
+    return 1;
+}
+
+static double fft_bin_freq(size_t bin, size_t nfft, double sample_rate)
+{
+    if (bin <= nfft / 2) {
+        return (double)bin * sample_rate / (double)nfft;
+    }
+    return ((double)bin - (double)nfft) * sample_rate / (double)nfft;
+}
+
+static int detect_best_candidate(
+        const cpx_t *iq,
+        size_t count,
+        int sample_rate,
+        detection_t *best_out)
+{
+    size_t window_samples = (size_t)(sample_rate * 0.004);
+    size_t rows;
+    size_t nfft = 1;
+    size_t row;
+    int found = 0;
+    detection_t global_best = {0};
+
+    if (window_samples < 256) {
+        window_samples = 256;
+    }
+    rows = count / window_samples;
+    if (!rows) {
+        return 0;
+    }
+    while (nfft < window_samples) {
+        nfft <<= 1;
+    }
+
+    for (row = 0; row < rows; row++) {
+        cpx_t *buf;
+        double *bg;
+        size_t bg_count = 0;
+        size_t k;
+        size_t top_bins[16] = {0};
+        double top_power[16] = {0};
+        cpx_t mean = {0, 0};
+        double bg_hi;
+        double background;
+        double row_best_score = 0.0;
+        double row_best_midpoint = 0.0;
+        double row_best_sep = 0.0;
+
+        buf = (cpx_t *)calloc(nfft, sizeof(*buf));
+        bg = (double *)malloc(nfft * sizeof(*bg));
+        if (!buf || !bg) {
+            free(buf);
+            free(bg);
+            return 0;
+        }
+
+        for (k = 0; k < window_samples; k++) {
+            mean = c_add(mean, iq[row * window_samples + k]);
+        }
+        mean = c_scale(mean, 1.0 / (double)window_samples);
+
+        for (k = 0; k < window_samples; k++) {
+            double w = 0.5 - 0.5 * cos(2.0 * M_PI * (double)k / (double)(window_samples - 1));
+            buf[k] = c_scale(c_sub(iq[row * window_samples + k], mean), w);
+        }
+
+        fft_inplace(buf, nfft);
+
+        bg_hi = sample_rate / 2.0 * 0.90;
+        if (bg_hi > 110000.0) {
+            bg_hi = 110000.0;
+        }
+
+        for (k = 0; k < nfft; k++) {
+            double f = fft_bin_freq(k, nfft, (double)sample_rate);
+            double af = fabs(f);
+            double p = c_abs2(buf[k]);
+
+            if (af > 2000.0 && af < 60000.0) {
+                int slot;
+                for (slot = 0; slot < 16; slot++) {
+                    if (p > top_power[slot]) {
+                        int s;
+                        for (s = 15; s > slot; s--) {
+                            top_power[s] = top_power[s - 1];
+                            top_bins[s] = top_bins[s - 1];
+                        }
+                        top_power[slot] = p;
+                        top_bins[slot] = k;
+                        break;
+                    }
+                }
+            }
+
+            if (af > 60000.0 && af < bg_hi) {
+                bg[bg_count++] = p;
+            }
+        }
+
+        if (bg_count < 5) {
+            bg_count = 0;
+            for (k = 0; k < nfft; k++) {
+                double f = fft_bin_freq(k, nfft, (double)sample_rate);
+                double af = fabs(f);
+                if (af > 40000.0 && af < sample_rate / 2.0 * 0.90) {
+                    bg[bg_count++] = c_abs2(buf[k]);
+                }
+            }
+        }
+
+        if (bg_count >= 5) {
+            int a, b;
+            background = median_copy(bg, bg_count) + 1e-12;
+
+            for (a = 0; a < 16; a++) {
+                if (top_power[a] <= 0.0) {
+                    continue;
+                }
+                for (b = a + 1; b < 16; b++) {
+                    double fi, fj, sep, midpoint, score;
+                    if (top_power[b] <= 0.0) {
+                        continue;
+                    }
+
+                    fi = fft_bin_freq(top_bins[a], nfft, (double)sample_rate);
+                    fj = fft_bin_freq(top_bins[b], nfft, (double)sample_rate);
+                    if (fj < fi) {
+                        double t = fi;
+                        fi = fj;
+                        fj = t;
+                    }
+
+                    sep = fj - fi;
+                    midpoint = (fi + fj) / 2.0;
+                    if (sep >= 34500.0 && sep <= 37500.0 && fabs(midpoint) <= 22000.0) {
+                        double weaker = top_power[a] < top_power[b] ? top_power[a] : top_power[b];
+                        score = weaker / background;
+                        if (score > row_best_score) {
+                            row_best_score = score;
+                            row_best_midpoint = midpoint;
+                            row_best_sep = sep;
+                        }
+                    }
+                }
+            }
+
+            if (row_best_score > 20.0) {
+                detection_t d;
+                d.offset_s = (double)(row * window_samples) / (double)sample_rate;
+                d.signature_db = 10.0 * log10(row_best_score);
+                d.carrier_offset_hz = row_best_midpoint;
+                d.symbol_rate_hint = row_best_sep;
+
+                if (!found || d.signature_db > global_best.signature_db) {
+                    global_best = d;
+                    found = 1;
+                }
+            }
+        }
+
+        free(buf);
+        free(bg);
+    }
+
+    if (found) {
+        *best_out = global_best;
+    }
+    return found;
+}
+
+static int demod_bits(
+        const cpx_t *iq,
+        size_t count,
+        int sample_rate,
+        double symbol_rate,
+        double carrier_offset_hz,
+        double phase_samples,
+        uint8_t **bits_out,
+        size_t *nbits_out)
+{
+    cpx_t *mixed;
+    cpx_t *cumulative;
+    cpx_t *symbols;
+    cpx_t *diff;
+    double *magnitudes;
+    double samples_per_symbol;
+    size_t symbol_count;
+    size_t i;
+    double threshold;
+    cpx_t sq_sum = {0, 0};
+    double residual_phase;
+    cpx_t correction;
+    uint8_t *bits;
+
+    samples_per_symbol = (double)sample_rate / symbol_rate;
+    if ((double)count <= phase_samples + samples_per_symbol * 102.0) {
+        return 0;
+    }
+
+    symbol_count = (size_t)(((double)count - phase_samples) / samples_per_symbol) - 1;
+    if (symbol_count < 100) {
+        return 0;
+    }
+
+    mixed = (cpx_t *)malloc(count * sizeof(*mixed));
+    cumulative = (cpx_t *)malloc((count + 1) * sizeof(*cumulative));
+    symbols = (cpx_t *)malloc(symbol_count * sizeof(*symbols));
+    diff = (cpx_t *)malloc((symbol_count - 1) * sizeof(*diff));
+    magnitudes = (double *)malloc((symbol_count - 1) * sizeof(*magnitudes));
+    bits = (uint8_t *)malloc((symbol_count - 1) * sizeof(*bits));
+
+    if (!mixed || !cumulative || !symbols || !diff || !magnitudes || !bits) {
+        free(mixed);
+        free(cumulative);
+        free(symbols);
+        free(diff);
+        free(magnitudes);
+        free(bits);
+        return 0;
+    }
+
+    for (i = 0; i < count; i++) {
+        double phase = -2.0 * M_PI * carrier_offset_hz * (double)i / (double)sample_rate;
+        mixed[i] = c_mul(iq[i], c_expj(phase));
+    }
+
+    cumulative[0].re = 0.0;
+    cumulative[0].im = 0.0;
+    for (i = 0; i < count; i++) {
+        cumulative[i + 1] = c_add(cumulative[i], mixed[i]);
+    }
+
+    for (i = 0; i < symbol_count; i++) {
+        long start = lround(phase_samples + (double)i * samples_per_symbol);
+        long end = lround(phase_samples + (double)(i + 1) * samples_per_symbol);
+        int width;
+
+        if (start < 0) {
+            start = 0;
+        }
+        if (end > (long)count) {
+            end = (long)count;
+        }
+        width = (int)(end - start);
+        if (width <= 0) {
+            free(mixed);
+            free(cumulative);
+            free(symbols);
+            free(diff);
+            free(magnitudes);
+            free(bits);
+            return 0;
+        }
+
+        symbols[i] = c_scale(c_sub(cumulative[end], cumulative[start]), 1.0 / (double)width);
+    }
+
+    for (i = 0; i + 1 < symbol_count; i++) {
+        diff[i] = c_mul(symbols[i + 1], c_conj(symbols[i]));
+        magnitudes[i] = c_abs(diff[i]);
+    }
+
+    {
+        double *sorted = (double *)malloc((symbol_count - 1) * sizeof(*sorted));
+        size_t idx;
+        if (!sorted) {
+            free(mixed);
+            free(cumulative);
+            free(symbols);
+            free(diff);
+            free(magnitudes);
+            free(bits);
+            return 0;
+        }
+        memcpy(sorted, magnitudes, (symbol_count - 1) * sizeof(*sorted));
+        qsort(sorted, symbol_count - 1, sizeof(*sorted), cmp_double);
+        idx = (size_t)(0.20 * (double)(symbol_count - 1));
+        if (idx >= symbol_count - 1) {
+            idx = symbol_count - 2;
+        }
+        threshold = sorted[idx];
+        free(sorted);
+    }
+
+    for (i = 0; i + 1 < symbol_count; i++) {
+        if (magnitudes[i] > threshold) {
+            cpx_t normalized;
+            cpx_t squared;
+            double denom = magnitudes[i] + 1e-12;
+
+            normalized = c_scale(diff[i], 1.0 / denom);
+            squared = c_mul(normalized, normalized);
+            sq_sum = c_add(sq_sum, squared);
+        }
+    }
+
+    residual_phase = 0.5 * atan2(sq_sum.im, sq_sum.re);
+    correction = c_expj(-residual_phase);
+
+    for (i = 0; i + 1 < symbol_count; i++) {
+        cpx_t corrected = c_mul(diff[i], correction);
+        bits[i] = corrected.re >= 0.0 ? 1 : 0;
+    }
+
+    free(mixed);
+    free(cumulative);
+    free(symbols);
+    free(diff);
+    free(magnitudes);
+
+    *bits_out = bits;
+    *nbits_out = symbol_count - 1;
+    return 1;
+}
+
+static int try_frame_for_bits(const uint8_t *bits, size_t nbits, uint8_t frame[9])
+{
+    uint8_t *inv;
+    size_t i;
+
+    if (find_valid_frame(bits, nbits, frame)) {
+        return 1;
+    }
+
+    inv = (uint8_t *)malloc(nbits);
+    if (!inv) {
+        return 0;
+    }
+    for (i = 0; i < nbits; i++) {
+        inv[i] = bits[i] ^ 1;
+    }
+
+    i = find_valid_frame(inv, nbits, frame);
+    free(inv);
+    return (int)i;
+}
+
+static int decode_candidate(
+        const cpx_t *iq,
+        size_t count,
+        int sample_rate,
+        double carrier_offset_hint,
+        double symbol_rate_hint,
+        uint8_t frame[9],
+        double *used_rate)
+{
+    int delta;
+    int rate_index = 0;
+    double rates[41];
+
+    rates[rate_index++] = symbol_rate_hint;
+    for (delta = 50; delta <= 1000; delta += 50) {
+        rates[rate_index++] = symbol_rate_hint - delta;
+        rates[rate_index++] = symbol_rate_hint + delta;
+    }
+
+    for (int r = 0; r < rate_index; r++) {
+        double symbol_rate = rates[r];
+        double samples_per_symbol;
+
+        if (symbol_rate < 35000.0 || symbol_rate > 37000.0) {
+            continue;
+        }
+
+        samples_per_symbol = (double)sample_rate / symbol_rate;
+
+        for (int p = 0; p < 16; p++) {
+            double phase = samples_per_symbol * (double)p / 16.0;
+            uint8_t *bits = NULL;
+            size_t nbits = 0;
+
+            if (!demod_bits(
+                        iq, count, sample_rate, symbol_rate,
+                        carrier_offset_hint, phase, &bits, &nbits)) {
+                continue;
+            }
+
+            if (try_frame_for_bits(bits, nbits, frame)) {
+                free(bits);
+                *used_rate = symbol_rate;
+                return 1;
+            }
+
+            free(bits);
+        }
+    }
+
+    return 0;
+}
+
+static void print_frame(const uint8_t frame[9], const detection_t *d, double used_rate)
+{
+    int direction_code = (frame[2] >> 4) & 0x0f;
+    int speed_raw = ((frame[2] & 0x0f) << 8) | frame[3];
+    int gust_direction_code = (frame[4] >> 4) & 0x0f;
+    int gust_raw = ((frame[4] & 0x0f) << 8) | frame[5];
+    int i;
+
+    printf("frame=");
+    for (i = 0; i < 9; i++) {
+        printf("%02X%s", frame[i], i == 8 ? "" : " ");
+    }
+    printf("\n");
+
+    printf("wind=%.1f m/s %s  gust=%.1f m/s %s\n",
+            speed_raw / 10.0,
+            directions[direction_code],
+            gust_raw / 10.0,
+            directions[gust_direction_code]);
+
+    printf("status=0x%02X  CRC=OK  signature=%.1f dB  carrier_offset=%.1f Hz  symbol_rate=%.1f\n",
+            frame[6],
+            d->signature_db,
+            d->carrier_offset_hz,
+            used_rate);
+}
+
+static int infer_sample_rate(const char *filename)
+{
+    const char *p;
+
+    p = strstr(filename, "_1000k");
+    if (p) {
+        return 1000000;
+    }
+
+    p = strstr(filename, "_250k");
+    if (p) {
+        return 250000;
+    }
+
+    return 250000;
+}
+
+int main(int argc, char **argv)
+{
+    const char *filename;
+    int sample_rate;
+    cpx_t *iq = NULL;
+    size_t count = 0;
+    detection_t d;
+    size_t center;
+    size_t half;
+    size_t start;
+    size_t end;
+    uint8_t frame[9];
+    double used_rate = 0.0;
+
+    if (argc < 2 || argc > 3) {
+        fprintf(stderr, "Usage: %s <capture.cu8> [sample_rate]\n", argv[0]);
+        return 2;
+    }
+
+    filename = argv[1];
+    sample_rate = argc == 3 ? atoi(argv[2]) : infer_sample_rate(filename);
+    if (sample_rate <= 0) {
+        fprintf(stderr, "ERROR: invalid sample rate\n");
+        return 2;
+    }
+
+    printf("Decoding %s at %d samples/s\n", filename, sample_rate);
+
+    if (!load_cu8(filename, &iq, &count)) {
+        return 2;
+    }
+
+    if (!detect_best_candidate(iq, count, sample_rate, &d)) {
+        fprintf(stderr, "No TX63 phase-signature candidate found.\n");
+        free(iq);
+        return 1;
+    }
+
+    printf("candidate t=%.6f s  signature=%.1f dB  carrier_offset=%.1f Hz  symbol_hint=%.1f\n",
+            d.offset_s, d.signature_db, d.carrier_offset_hz, d.symbol_rate_hint);
+
+    center = (size_t)(d.offset_s * sample_rate);
+    half = (size_t)(0.012 * sample_rate);
+    start = center > half ? center - half : 0;
+    end = center + half < count ? center + half : count;
+
+    if (end <= start || end - start < (size_t)(0.015 * sample_rate)) {
+        fprintf(stderr, "Candidate window too short.\n");
+        free(iq);
+        return 1;
+    }
+
+    if (!decode_candidate(
+                iq + start,
+                end - start,
+                sample_rate,
+                d.carrier_offset_hz,
+                d.symbol_rate_hint,
+                frame,
+                &used_rate)) {
+        fprintf(stderr, "Candidate found, but no CRC-valid TX63 frame decoded.\n");
+        free(iq);
+        return 1;
+    }
+
+    print_frame(frame, &d, used_rate);
+    free(iq);
+    return 0;
+}


### PR DESCRIPTION
Adds support for the La Crosse TX63U-IT solar wind sensor (FCC ID OMO-M-12) and introduces a reusable DBPSK demodulation path for raw IQ input.

### Highlights

* Adds TX63U-IT protocol decoder with CRC-16/X-25 validation.
* Decodes average wind speed, gust speed, wind direction, and gust direction.
* Adds reusable PSK candidate detection and differential-BPSK symbol recovery.
* Integrates PSK demodulation into the streaming IQ path with duplicate suppression.
* Does not invent a sensor ID; currently observed fixed bytes are treated only as protocol constants.

### Protocol details validated from captures

* Approximately 36 ksymbol/s differential phase-coded signal.
* HDLC-style `0x7E` framing with zero-bit stuffing.
* Bytes transmitted LSB-first.
* CRC-16/X-25:

  * polynomial `0x1021`
  * init `0xFFFF`
  * reflected input/output
  * xorout `0xFFFF`

### Validation performed

* All 5 available TX63U-IT captures decode correctly.
* Verified at both 1 Msps and 250 ksps.
* 17/17 shifted stream-boundary tests passed.
* Multiple distinct packets in one continuous stream decode correctly.
* 6/6 short-gap tests passed, including a synthetic 0 ms gap.
* Existing CTest suite passes.

Related test-data PR: `merbanan/rtl_433_tests#524`
