### PR TITLE
Fix vevor bytewise offset

### DIFF
--- a/src/devices/vevor_7in1.c
+++ b/src/devices/vevor_7in1.c
@@ -13,7 +13,7 @@
 
 #include "decoder.h"
 
-/**
+/** @fn static int vevor_7in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 Vevor Wireless Weather Station 7-in-1.
 
 Manufacturer : Fujian Youtong Industries Co., Ltd. rebrand under Vevor name.
@@ -62,14 +62,6 @@ Data Layout:
 
 #define VEVOR_MESSAGE_BITLEN     264
 
-// Multi-byte values are transmitted with an offset of one applied to each
-// byte independently. Decode the bytes before combining them so a low-byte
-// wrap from 0xff to 0x00 does not borrow from the high byte.
-static int vevor_decode_offset_1(uint8_t high, uint8_t low)
-{
-    return ((uint8_t)(high - 1) << 8) | (uint8_t)(low - 1);
-}
-
 static int vevor_7in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     // preamble is ....aaaaaaaaaacaca54
@@ -116,6 +108,17 @@ static int vevor_7in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             continue;
         }
 
+        // Multi-byte values are transmitted with an offset of one applied to
+        // each byte independently. uint8_t conversion wraps 0x00 to 0xff.
+        b[8]  = b[8] - 1;
+        b[9]  = b[9] - 1;
+        b[11] = b[11] - 1;
+        b[12] = b[12] - 1;
+        b[13] = b[13] - 1;
+        b[14] = b[14] - 1;
+        b[16] = b[16] - 1;
+        b[17] = b[17] - 1;
+
         //int kind        = ((b[1] & 0xf0) >> 4);
         int channel     = (b[1] & 0x0f);
         int id          = (b[2] << 8) | b[3];
@@ -126,15 +129,15 @@ static int vevor_7in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             int temp_raw      = (b[5] << 8) | b[6];
             float temp_c      = (temp_raw - 500) * 0.1f;
             int humidity      = b[7];
-            int wind_raw      = vevor_decode_offset_1(b[8], b[9]);
+            int wind_raw      = (b[8] << 8) | b[9];
             float speed_kmh   = wind_raw / 8.333f; // wind_raw / 30.0f for m/s
             int gust_raw      = b[10];
             float gust_kmh    = gust_raw / 1.25f; // gust_raw / 4.5f for m/s
-            int direction_deg = vevor_decode_offset_1(b[11] & 0x0f, b[12]) & 0x0fff;
-            int rain_raw      = vevor_decode_offset_1(b[13], b[14]);
+            int direction_deg = ((b[11] & 0x0f) << 8) | b[12];
+            int rain_raw      = (b[13] << 8) | b[14];
             float rain_mm     = rain_raw * 0.233f;
             int uv_index      = (b[15] & 0x1f) - 1;
-            int light_lux     = vevor_decode_offset_1(b[16], b[17]);
+            int light_lux     = (b[16] << 8) | b[17];
             int lux_multi     = (light_lux & 0x8000) >> 15;
 
             if (lux_multi == 1) {

--- a/src/devices/vevor_7in1.c
+++ b/src/devices/vevor_7in1.c
@@ -45,12 +45,12 @@ Data Layout:
 - BF: {8} Battery Flag 0x9d = battery low, 0x1d = normal battery, may be pairing button to be confirmed ?
 - T: {12} temperature in C, offset 500, scale 10
 - H:  {8} humidity %
-- W: {16} Wind speed, scale 8.333 (km/h), offset 257 (0x0101)
+- W: {16} Wind speed, scale 8.333 (km/h), offset 1 per byte
 - G:  {8} Wind Gust, scale 1.25 (km/h)
-- D: {12} Wind Direction, offset 257
-- R: {16} Total Rain mm/m2, 0.4 mm/m²/tips , offset 257
+- D: {12} Wind Direction, offset 1 per encoded byte
+- R: {16} Total Rain mm/m2, 0.233 mm/m²/tip, offset 1 per byte
 - U:  {5} UV index from 0 to 16, offset 1
-- L: {1 + 15 bit} Lux value, if first bit = 1 , then x 10 the 15 bit (offset 257).
+- L: {1 + 15 bit} Lux value, if first bit = 1, then x 10 the 15 bit, offset 1 per byte.
 - ?: unknown, fixed values
 - A:  {4} fixed values of 0xA
 - 0:  {4} fixed values of 0x0
@@ -61,6 +61,14 @@ Data Layout:
 */
 
 #define VEVOR_MESSAGE_BITLEN     264
+
+// Multi-byte values are transmitted with an offset of one applied to each
+// byte independently. Decode the bytes before combining them so a low-byte
+// wrap from 0xff to 0x00 does not borrow from the high byte.
+static int vevor_decode_offset_1(uint8_t high, uint8_t low)
+{
+    return ((uint8_t)(high - 1) << 8) | (uint8_t)(low - 1);
+}
 
 static int vevor_7in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
@@ -100,6 +108,14 @@ static int vevor_7in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             continue;
         }
 
+        // Verify the second TX counter, including the uint8_t wrap from
+        // 0xff to 0x00.
+        if (b[20] != (uint8_t)(b[18] + 1)) {
+            decoder_logf(decoder, 2, __func__, "TX counter mismatch: %02x -> %02x", b[18], b[20]);
+            ret = DECODE_FAIL_MIC;
+            continue;
+        }
+
         //int kind        = ((b[1] & 0xf0) >> 4);
         int channel     = (b[1] & 0x0f);
         int id          = (b[2] << 8) | b[3];
@@ -110,15 +126,15 @@ static int vevor_7in1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             int temp_raw      = (b[5] << 8) | b[6];
             float temp_c      = (temp_raw - 500) * 0.1f;
             int humidity      = b[7];
-            int wind_raw      = ((b[8] << 8) | b[9]) - 257; // need to remove 0x0101.
+            int wind_raw      = vevor_decode_offset_1(b[8], b[9]);
             float speed_kmh   = wind_raw / 8.333f; // wind_raw / 30.0f for m/s
             int gust_raw      = b[10];
             float gust_kmh    = gust_raw / 1.25f; // gust_raw / 4.5f for m/s
-            int direction_deg = (((b[11] & 0x0f) << 8) | b[12]) - 257; // need to remove 0x101.
-            int rain_raw      = ((b[13] << 8) | b[14]) - 257; // need to remove 0x101.
-            float rain_mm     = rain_raw * 0.233f; // calculation is 0.43f but display is 0.5f
+            int direction_deg = vevor_decode_offset_1(b[11] & 0x0f, b[12]) & 0x0fff;
+            int rain_raw      = vevor_decode_offset_1(b[13], b[14]);
+            float rain_mm     = rain_raw * 0.233f;
             int uv_index      = (b[15] & 0x1f) - 1;
-            int light_lux     = ((b[16] << 8) | b[17]) - 257; // need to remove 0x0101.
+            int light_lux     = vevor_decode_offset_1(b[16], b[17]);
             int lux_multi     = (light_lux & 0x8000) >> 15;
 
             if (lux_multi == 1) {


### PR DESCRIPTION
## Summary

Fix decoding of multi-byte values in the Vevor 7-in-1 weather station protocol.

The protocol applies an offset of one to each encoded byte independently. Subtracting `0x0101` after combining the bytes causes an unintended borrow when the low byte wraps from `0xff` to `0x00`. This produced large discontinuities, most visibly in the cumulative rainfall value.

This change:

- decodes wind speed, wind direction, rainfall, and illuminance by removing the offset from each byte before combining them;
- documents the observed rainfall scale of 0.233 mm per tip;
- validates that the trailing TX counter is one greater than the first TX counter, including the `0xff` to `0x00` wrap.

## Verification

Tested with a Vevor YT60231-compatible 868 MHz weather station through `rtl_433_ESP` and OpenMQTTGateway.

Nine observed checksum-valid frames satisfied the TX counter relationship.

Synthetic checksum-valid boundary vectors decode as:

- encoded rain `0x1000`: 954.135 mm
- encoded rain `0x1101`: 954.368 mm

The transition is therefore one rain-gauge tip of 0.233 mm instead of the previous large discontinuity.

An otherwise checksum-valid frame with an invalid trailing TX counter is rejected.

## Tests

- Full CMake build
- Complete CTest suite: 16/16 passed
- Project style check
- Existing documented Vevor test vector
- Synthetic low-byte wrap boundary vectors