### PR TITLE
Improve Vivint Security to reliably decode cipher seed and add additi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ See [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
     [339]  Florabest FB-TH-1 BBQ Thermometer
     [340]  Holman Industries iWeather WS5029 weather station (older PWM, OOK), BIOWIN 270208
     [341]  Esun EN2053 two-channel BBQ thermometer
-    [342]  Vivint Door/Window Sensor, V-DW21R-345/V-DW11-345
+    [342]  Vivint 345MHz Sensors, V-DW11-345/V-DW21R-345, V-GB2-345/V-GB3-345, V-PIR2-345/V-PIR3-345
     [343]  SmarTire TPMS sensor, Aston Martin/Vantage DB9 protocol
     [344]* Dickert MAHS433-01 garage door remote control
     [345]  FSL Cricket Scoreboard Controller

--- a/conf/rtl_433.example.conf
+++ b/conf/rtl_433.example.conf
@@ -581,7 +581,7 @@ convert si
   protocol 339 # Florabest FB-TH-1 BBQ Thermometer
   protocol 340 # Holman Industries iWeather WS5029 weather station (older PWM, OOK), BIOWIN 270208
   protocol 341 # Esun EN2053 two-channel BBQ thermometer
-  protocol 342 # Vivint Door/Window Sensor, V-DW21R-345/V-DW11-345
+  protocol 342 # Vivint 345MHz Sensors, V-DW11-345/V-DW21R-345, V-GB2-345/V-GB3-345, V-PIR2-345/V-PIR3-345
   protocol 343 # SmarTire TPMS sensor, Aston Martin/Vantage DB9 protocol
 # protocol 344 # Dickert MAHS433-01 garage door remote control
   protocol 345 # FSL Cricket Scoreboard Controller

--- a/src/devices/vivint.c
+++ b/src/devices/vivint.c
@@ -1,5 +1,5 @@
 /** @file
-    Vivint Door/Window Sensors (345 MHz).
+    Vivint security sensors (345 MHz).
 
     Copyright (C) 2026 Benjamin Larsson <banan@ludd.ltu.se>
 
@@ -9,35 +9,140 @@
     (at your option) any later version.
 */
 
+#include "bit_util.h"
+#include "data.h"
 #include "decoder.h"
+#include "r_device.h"
 
+#include <openssl/crypto.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 
 #define VIVINT_MSG_BIT_LEN 80
-#define VIVINT_MAX_SEEDS 8
-#define VIVINT_ENTRY_COUNTER 0x17
+#ifndef VIVINT_MAX_SENSORS
+#define VIVINT_MAX_SENSORS 32
+#endif
+#ifndef VIVINT_CACHED_COUNTERS
+#define VIVINT_CACHED_COUNTERS 8
+#endif
+#ifndef VIVINT_SEED_DATA_REQUIRED
+#define VIVINT_SEED_DATA_REQUIRED 6
+#endif
+#if VIVINT_SEED_DATA_REQUIRED < 1 || VIVINT_SEED_DATA_REQUIRED > VIVINT_CACHED_COUNTERS
+#error "VIVINT_SEED_DATA_REQUIRED must be between 1 and VIVINT_CACHED_COUNTERS"
+#endif
+
+#define VIVINT_ENTRY_COUNTER      0x17
+#define VIVINT_RABBIT_CIPHER_SIZE 48
+
+#define CHANNEL_VIVINT            0x70
+#define CHANNEL_POWERON           0xd0
+#define CHANNEL_SKEY              0xe0
+#define CHANNEL_LEGACY            0xf0
+
+/* Some devices will send a packet without encrypted status data
+ This could be a change in device configuration or some devices
+ may just not use the encryted options */
+/* The following values only apply to vivint devices */
+#define VIVINT_EVENT_UNENCRYPTED 0x01
+#define VIVINT_PACKET_BATTERY    0x02
+#define VIVINT_PACKET_SEED       0x03
+// For some reason the flood sensor will send out a 0x74 packet when the WPS/Pair button is pressed
+// It looks like b[1] is the temperature in C when the flood sensor sends a 0x74. Additionally, the
+// bit that is cleared when the packet is encrypted is set, signifying a change in format where the
+// counter should be.
+#define VIVINT_EVENT_PIR       0x04
+#define VIVINT_PACKET_MFG_BOOT 0x06
+#define VIVINT_EVENT_FLOOD     0x07
+#define VIVINT_EVENT_GB        0x09
+#define VIVINT_EVENT_DW        0x0a
+
+/* This bit in b[3] can change the meaning of a packet to include values */
+#define VIVINT_UNENCRYPTED_FLAG_BIT 0x02
+
+/* Sent with the 0xd0 packet */
+#define VIVINT_DEVICE_TYPE_V_PIR2_345    0x0a
+#define VIVINT_DEVICE_TYPE_VS_SKEY2_345  0x0b
+#define VIVINT_DEVICE_TYPE_VS_FLD001_345 0x0c
+#define VIVINT_DEVICE_TYPE_V_DW21R_345   0x0f
+#define VIVINT_DEVICE_TYPE_V_GB2_345     0x14
+#define VIVINT_DEVICE_TYPE_V_DW11_345    0x18
+
+// Include seed and seed-discovery diagnostics in decoder output by default.
+// Define OUTPUT_VIVINT_DECODE=0 to omit these fields from emitted data.
+#ifndef OUTPUT_VIVINT_DECODE
+#define OUTPUT_VIVINT_DECODE 1
+#endif
 
 /**
-Vivint Door/Window Sensors (345.0 MHz).
+Vivint security sensors (345.0 MHz).
 
-Tested with the Vivint V-DW21R-345 door/window sensor and Vivint V-DW11-345 Door Sensor.
+@attention stateful
+This decoder stores data from a number of packets in order to collect enough
+data to determine a 16 bit unique seed value that each sensor uses as a base
+to encode certain packets
+
+Tested with the Vivint V-DW21R-345 and V-DW11-345 door/window sensors,
+as well as with the V-PIR2-345 and V-GB2-345 devices.
+
+Tested with the VS-FLD001-345, but need more data to confirm packet
+formats. The tested version does not use packet encryption
+
+This can capture the 0xd0 message from the VS-SKEY2-345 but can not
+decode the button presses.
 
 OOK Manchester (zerobit), 0xFFFE preamble, 96 bit (12 byte) packet. Decoded
 payload (80 data bits, 10 bytes) after the preamble:
 
+    For the 0xd0 messages:
+
+    TT BB NN BB II II II II RR RR
+
+    For the 0x74, 0x79, and 0x7a messages:
+
     TT CC CC FF II II II II RR RR
 
-- T: 8 bit frame subtype: 0x7a = DW11 door/window, 0x79 = GB2 glass-break,
-     0x74 = PIR2 motion, 0x72/0x73/0x76 = other sensor families,
+    For the 0x72 messages the format is device dependent
+
+    For the 0x73 messages:
+
+    TT SS SS 02 II II II II RR RR
+
+
+
+
+- T: 8 bit frame subtype:
+     0x71 = Unencrypted event
+     0x72 = Battery voltage and threshold
+     0x73 = Raw seed value
+     0x74 = PIR motion
+     0x76 = Used during manufacturing bringup
+     0x79 = GB glass-break
+     0x7a = DW door/window
      0xd0 = power-on/startup beacon
+
+- N: 8 bit constant used to identify the type of device
+     0x0a: V-PIR2-345
+     0x0b: VS-SKEY2-345
+     0x0c: VS-FLD001-345
+     0x0f: V-DW21R-345
+     0x14: V-GB2-345
+     0x18: V-DW11-345
+     Other unknown device values are the V-PIR3-345, V-GB3-345, keyfobs, flood, and some other sensors
+
+- B: 16 bit value that gives a device specific battery level
+
 - C: 16 bit counter, increments every transmission
-- F: 8 bit status byte. The low 2 bits are always zero; the rest (including
+- F: 8 bit status byte. The low 2 bits are always zero for a standard encrypted message; the rest (including
      bit 7, open/closed for 0x7a) are XORed with a per-device keystream,
      see below
 - I: 32 bit device identifier
 - R: 16 bit CRC
+
+- S: 16 bit raw seed value
 
 I is the sensor's printed TXID: split into a 12 bit and a 20 bit decimal
 number, e.g. 0x0137beda -> 19, 507610 -> "0019-0507610" (label
@@ -51,82 +156,107 @@ Non-0xd0 subtypes use a packed 12-bit CRC:
 
 0xd0 frames use standard CRC-16 poly 0x8050 over b[0..7].
 
-Per-device keystream (F field, 0x7a frames only):
+A 0xd0 frame is sent with a packet counter of 24 which happens every 65kish
+packets or upon powerup because the packet counter is reset to 24 on every boot
 
-Each sensor has a 16 bit per-device seed, not transmitted over the air,
-that keys a Rabbit stream cipher core (RFC 4503) advancing every
-transmission (keyed off the 16 bit counter) to produce a keystream byte
-XORed into F; bit 7 of the decrypted byte is the door contact (1 = open).
-The auth nibble in byte 10 of the on-air frame is `(c3 ^ 0x10) & 0xf0`.
+Per-device keystream (F field, 0x7a, 0x74, 0x79 frames only):
 
-The seed cannot be derived from a single frame or from this decoder alone;
-it must be obtained externally from several frames at known low counters
-(ideally right after a power-cycle). Once known, supply it at registration
-time to decrypt F:
+Each sensor has a 16 bit per-device seed, that under unknown circumstances,
+can be transmitted over the air, that keys a Rabbit stream cipher core
+(RFC 4503) advancing every transmission (keyed off the 16 bit counter) to
+produce a keystream byte XORed into F; bit 7 of the decrypted byte is the
+Loop 1, which for a DW21R is the door state (1 = open). The high nibble of
+the first CRC byte carries an authentication value of `(c3 ^ 0x10) & 0xf0`.
+
+The decoder can discover the 16 bit seed by collecting frames with distinct
+packet counters. Once VIVINT_SEED_DATA_REQUIRED samples are available (six by
+default), it searches the seed space using their authentication nibbles. If the
+result is not unique, later frames replace older samples and the search is
+retried. Seed discovery state is reported in `decode_status`,
+`seed_data_count`, `seed_data_required`, and `seed_candidate_count`.
+
+A known seed can be supplied to decrypt F immediately. rtl_433 accepts a
+comma-separated TXID-to-seed list as a runtime decoder argument:
 
     rtl_433 -R 342:0019-0507610=05c9,0019-0507743=dda9
 
-Without a matching seed, `state`/`contact_open` are omitted and the raw
-payload is reported in `data` instead.
+rtl_433_ESP accepts the same list through the compile-time VIVINT_SEEDS
+definition and can omit seed diagnostics with OUTPUT_VIVINT_DECODE=0:
+
+    '-DVIVINT_SEEDS="0019-0507610=05c9,0019-0507743=dda9"'
+    '-DOUTPUT_VIVINT_DECODE=0'
+
+The runtime argument takes precedence when both are present. Without either,
+automatic seed discovery remains enabled.
+
+When OUTPUT_VIVINT_DECODE is enabled (the default), a configured or discovered
+seed is reported in `seed` as a four-character hexadecimal string along with
+the seed-discovery status fields; set it to 0 to omit them. Valid seeds and
+authentication nibbles emit the decrypted `state`, `loop1`, `tamper`, `loop2`,
+`loop3`, `battery_low`, and `heartbeat` fields. Otherwise, `data` contains the
+raw payload.
+
+For example, create `vivint-defines.cmake` in the source directory to supply a
+seed and disable its diagnostic fields:
+
+    set(CMAKE_C_FLAGS
+        "${CMAKE_C_FLAGS} -DOUTPUT_VIVINT_DECODE=0 -DVIVINT_SEED_DATA_REQUIRED=6 -DVIVINT_SEEDS=\\\"0016-0357170=c283\\\""
+        CACHE STRING "Custom Vivint compiler definitions" FORCE)
+
+Then configure and build normally:
+
+    cmake -S . -B build -G Ninja -C vivint-defines.cmake
+    cmake --build build -j4
 
 See https://github.com/merbanan/rtl_433/issues/1504
 */
 
 /* Rabbit stream cipher core (RFC 4503). Inner state: eight 32-bit state
-   words X0..X7 at 0x232.. and eight 32-bit counter words C0..C7 at 0x252..,
+   words X0..X7, eight 32-bit counter words C0..C7,
    modeled as a flat byte window. Custom to this protocol (not part of
    RFC 4503): a 16-bit seed in place of Rabbit's 128-bit key/IV, and a
    per-packet schedule keyed off the transmission counter. */
 typedef struct {
-    uint8_t m[0x300];
+    uint32_t C[8];
+    uint32_t X[8];
+    uint16_t S[8];
+    uint16_t K[8];
+    uint32_t b;
 } vivint_rabbit_t;
 
-static uint16_t vivint_rabbit_r16(vivint_rabbit_t *g, unsigned a)
+/* Rabbit concat two 16 bit values */
+static uint32_t vivint_rabbit_concat(uint16_t a, uint16_t b)
 {
-    return g->m[a] | ((uint16_t)g->m[a + 1] << 8);
+    return (((uint32_t)a) << 16) | (uint32_t)b;
 }
 
-static void vivint_rabbit_w16(vivint_rabbit_t *g, unsigned a, uint16_t v)
-{
-    g->m[a]     = (uint8_t)v;
-    g->m[a + 1] = (uint8_t)(v >> 8);
-}
-
-static uint32_t vivint_rabbit_r32(vivint_rabbit_t *g, unsigned a)
-{
-    return (uint32_t)vivint_rabbit_r16(g, a) | ((uint32_t)vivint_rabbit_r16(g, a + 2) << 16);
-}
-
-static void vivint_rabbit_w32(vivint_rabbit_t *g, unsigned a, uint32_t v)
-{
-    vivint_rabbit_w16(g, a, (uint16_t)(v & 0xffff));
-    vivint_rabbit_w16(g, a + 2, (uint16_t)(v >> 16));
-}
-
+/* Rabbit rotate a 32bit value to the left */
 static uint32_t vivint_rotl32(uint32_t x, unsigned n)
 {
     return (x << n) | (x >> (32 - n));
 }
 
-/* RFC 4503 SS2.5 counter-update constants A0..A7. */
-static uint32_t const VIVINT_RABBIT_A[8] = {
-        0x4D34D34D, 0xD34D34D3, 0x34D34D34, 0x4D34D34D,
-        0xD34D34D3, 0x34D34D34, 0x4D34D34D, 0xD34D34D3,
-};
+/* Base of the rabbit cipher function 'g' */
+static uint32_t vivint_rabbit_g(uint32_t u, uint32_t v)
+{
+    uint64_t sq = u + v;
+    sq          = sq * sq;
+    return ((sq >> 32) & 0x00000000ffffffff) ^ (sq & 0x00000000ffffffff);
+}
 
 /* Expands the 16-bit seed into the 8 words vivint_rabbit_key_setup()
-   interleaves into X and C. */
-static void vivint_expand(uint16_t seed, uint16_t out[8])
+   The magic values are pulled from sensor firmwares. */
+static void vivint_expand_key(vivint_rabbit_t *g, uint16_t seed)
 {
     uint16_t base = seed ^ 0x0008;
-    out[0]        = base;
-    out[1]        = (uint16_t)(base + 0x25);
-    out[2]        = (uint16_t)(base - 0x04);
-    out[3]        = (uint16_t)(base + 0x2c);
-    out[4]        = (uint16_t)(base - 0x09);
-    out[5]        = (uint16_t)(base - 0x1d);
-    out[6]        = base ^ 0x00f9;
-    out[7]        = base ^ 0x0022;
+    g->K[0]       = base;
+    g->K[1]       = (uint16_t)(base + 0x25);
+    g->K[2]       = (uint16_t)(base - 0x04);
+    g->K[3]       = (uint16_t)(base + 0x2c);
+    g->K[4]       = (uint16_t)(base - 0x09);
+    g->K[5]       = (uint16_t)(base - 0x1d);
+    g->K[6]       = base ^ 0x00f9;
+    g->K[7]       = base ^ 0x0022;
 }
 
 /* Derives X0..X7 and C0..C7 (RFC 4503 SS2.2) from the 8 seed-expanded words,
@@ -134,34 +264,68 @@ static void vivint_expand(uint16_t seed, uint16_t out[8])
    permutation, re-derived from the counter each call. */
 static void vivint_rabbit_key_setup(vivint_rabbit_t *g)
 {
-    uint16_t counter = vivint_rabbit_r16(g, 0x206);
-    unsigned m       = counter % 7;
-    vivint_rabbit_w16(g, 0x27a + m * 2, (uint16_t)(vivint_rabbit_r16(g, 0x27a + m * 2) + counter + m));
-    vivint_rabbit_w16(g, 0x288, vivint_rabbit_r16(g, 0x288) ^ (uint16_t)m);
+    /* 2.3.  Key Setup Scheme
 
-    uint16_t e[8];
-    for (int i = 0; i < 8; ++i)
-        e[i] = vivint_rabbit_r16(g, 0x27a + 2 * i);
+     The counter carry bit b is initialized to zero.  The state and
+     counter words are derived from the key K[127..0].
 
-    uint16_t x_words[16];
-    uint16_t c_words[16];
-    for (int r = 0; r < 8; ++r) {
-        if (r % 2 == 0) {
-            x_words[2 * r]     = e[r];
-            x_words[2 * r + 1] = e[(r + 1) % 8];
-            c_words[2 * r]     = e[(r + 5) % 8];
-            c_words[2 * r + 1] = e[(r + 4) % 8];
+     The key is divided into subkeys K0 = K[15..0], K1 = K[31..16], ... K7
+     = K[127..112].  The initial state is initialized as follows:
+
+       for j=0 to 7:
+         if j is even:
+           Xj = K(j+1 mod 8) || Kj
+           Cj = K(j+4 mod 8) || K(j+5 mod 8)
+         else:
+           Xj = K(j+5 mod 8) || K(j+4 mod 8)
+           Cj = Kj || K(j+1 mod 8)
+    */
+
+    g->b = 0;
+    for (int j = 0u; j < 8; j++) {
+        if (j % 2 == 0) {
+            /* EVEN */
+            g->X[j] = vivint_rabbit_concat(g->K[(j + 1) % 8], g->K[j]);
+            g->C[j] = vivint_rabbit_concat(g->K[(j + 4) % 8], g->K[(j + 5) % 8]);
         }
         else {
-            x_words[2 * r]     = e[(r + 4) % 8];
-            x_words[2 * r + 1] = e[(r + 5) % 8];
-            c_words[2 * r]     = e[(r + 1) % 8];
-            c_words[2 * r + 1] = e[r];
+            /* ODD */
+            g->X[j] = vivint_rabbit_concat(g->K[(j + 5) % 8], g->K[(j + 4) % 8]);
+            g->C[j] = vivint_rabbit_concat(g->K[j], g->K[(j + 1) % 8]);
         }
     }
-    for (int i = 0; i < 16; ++i) {
-        vivint_rabbit_w16(g, 0x232 + 2 * i, x_words[i]);
-        vivint_rabbit_w16(g, 0x252 + 2 * i, c_words[i]);
+}
+
+static void vivint_rabbit_update_counters(vivint_rabbit_t *g)
+{
+    /* 2.5.  Counter System
+
+     Before each execution of the next-state function (Section 2.6), the
+     counter system has to be updated.  This system uses constants
+     A1,...,A7, as follows:
+
+     A0 = 0x4D34D34D         A1 = 0xD34D34D3
+     A2 = 0x34D34D34         A3 = 0x4D34D34D
+     A4 = 0xD34D34D3         A5 = 0x34D34D34
+     A6 = 0x4D34D34D         A7 = 0xD34D34D3
+
+     It also uses the counter carry bit b to update the counter system, as
+     follows:
+
+     for j=0 to 7:
+      temp = Cj + Aj + b
+      b    = temp div WORDSIZE
+      Cj   = temp mod WORDSIZE
+
+     Note that on exiting this loop, the variable b has to be preserved
+     for the next iteration of the system.  */
+
+    const uint32_t A[8] = {0x4D34D34D, 0xD34D34D3, 0x34D34D34, 0x4D34D34D, 0xD34D34D3, 0x34D34D34, 0x4D34D34D, 0xD34D34D3};
+
+    for (int j = 0u; j < 8; j++) {
+        uint64_t temp = (uint64_t)(g->C[j]) + (uint64_t)(A[j]) + (uint64_t)(g->b);
+        g->b          = temp / 0x100000000;
+        g->C[j]       = temp & 0xffffffff;
     }
 }
 
@@ -170,148 +334,136 @@ static void vivint_rabbit_key_setup(vivint_rabbit_t *g)
    products. */
 static void vivint_rabbit_next_state(vivint_rabbit_t *g)
 {
-    unsigned const scratch = 0x294;
+    /* 2.6.  Next-State Function
 
-    for (int r8 = 0; r8 < 8; ++r8) {
-        uint16_t lo = vivint_rabbit_r16(g, 0x252 + r8 * 4);
-        uint16_t hi = vivint_rabbit_r16(g, 0x254 + r8 * 4);
-        vivint_rabbit_w16(g, scratch + r8 * 4, lo);
-        vivint_rabbit_w16(g, scratch + 2 + r8 * 4, hi);
+      The core of the Rabbit algorithm is the next-state function.  It is
+      based on the function g, which transforms two 32-bit inputs into one
+      32-bit output, as follows:
+
+        g(u,v) = LSW(square(u+v)) ^ MSW(square(u+v))
+
+      where square(u+v) = ((u+v mod WORDSIZE) * (u+v mod WORDSIZE)).
+
+      Using this function, the algorithm updates the inner state as
+      follows:
+
+        for j=0 to 7:
+          Gj = g(Xj,Cj)
+
+    */
+
+    uint32_t G[8];
+    for (int j = 0u; j < 8; j++) {
+        G[j] = vivint_rabbit_g(g->X[j], g->C[j]);
     }
 
-    uint32_t lcg = vivint_rabbit_r32(g, 0x272) + VIVINT_RABBIT_A[0];
-    vivint_rabbit_w32(g, 0x252, vivint_rabbit_r32(g, 0x252) + lcg);
-    for (int r8 = 1; r8 < 8; ++r8) {
-        uint32_t a      = vivint_rabbit_r32(g, 0x252 + r8 * 4);
-        uint32_t b      = vivint_rabbit_r32(g, 0x24e + r8 * 4);
-        uint32_t sub    = vivint_rabbit_r32(g, scratch - 4 + r8 * 4);
-        uint32_t borrow = (b < sub) ? 1 : 0;
-        vivint_rabbit_w32(g, 0x252 + r8 * 4, a + VIVINT_RABBIT_A[r8] + borrow);
-    }
-
-    uint32_t borrow = (vivint_rabbit_r32(g, 0x26e) < vivint_rabbit_r32(g, 0x2b0)) ? 1 : 0;
-    vivint_rabbit_w16(g, 0x272, (uint16_t)borrow);
-    vivint_rabbit_w16(g, 0x274, 0);
-
-    for (int r8 = 0; r8 < 8; ++r8) {
-        uint32_t x   = vivint_rabbit_r32(g, 0x232 + r8 * 4) + vivint_rabbit_r32(g, 0x252 + r8 * 4);
-        uint32_t lo  = x & 0xffff;
-        uint32_t hi  = x >> 16;
-        uint32_t xsq = x * x;
-        uint32_t acc = (lo * lo >> 16) >> 1;
-        acc          = acc + lo * hi;
-        acc >>= 15;
-        acc = acc + hi * hi;
-        acc ^= xsq;
-        vivint_rabbit_w32(g, scratch + r8 * 4, acc);
-    }
-
-    int r11        = 7;
-    int r10        = 6;
-    int r8s[4]     = {0, 2, 4, 6};
-    for (int i = 0; i < 4; ++i) {
-        int r8      = r8s[i];
-        uint32_t t1 = vivint_rotl32(vivint_rabbit_r32(g, scratch + r11 * 4), 16);
-        uint32_t t2 = vivint_rotl32(vivint_rabbit_r32(g, scratch + r10 * 4), 16);
-        vivint_rabbit_w32(g, 0x232 + r8 * 4, t1 + vivint_rabbit_r32(g, scratch + r8 * 4) + t2);
-        r11 = (r11 + 1) % 8;
-        r10 = (r10 + 1) % 8;
-        uint32_t t3 = vivint_rotl32(vivint_rabbit_r32(g, scratch + r11 * 4), 8);
-        vivint_rabbit_w32(g, 0x236 + r8 * 4, t3 + vivint_rabbit_r32(g, scratch + 4 + r8 * 4) + vivint_rabbit_r32(g, scratch + r10 * 4));
-        r11 = (r11 + 1) % 8;
-        r10 = (r10 + 1) % 8;
-    }
+    // X0 = G0 + (G7 <<< 16) + (G6 <<< 16) mod WORDSIZE
+    g->X[0] = G[0] + vivint_rotl32(G[7], 16) + vivint_rotl32(G[6], 16);
+    // X1 = G1 + (G0 <<<  8) +  G7         mod WORDSIZE
+    g->X[1] = G[1] + vivint_rotl32(G[0], 8) + G[7];
+    // X2 = G2 + (G1 <<< 16) + (G0 <<< 16) mod WORDSIZE
+    g->X[2] = G[2] + vivint_rotl32(G[1], 16) + vivint_rotl32(G[0], 16);
+    // X3 = G3 + (G2 <<<  8) +  G1         mod WORDSIZE
+    g->X[3] = G[3] + vivint_rotl32(G[2], 8) + G[1];
+    // X4 = G4 + (G3 <<< 16) + (G2 <<< 16) mod WORDSIZE
+    g->X[4] = G[4] + vivint_rotl32(G[3], 16) + vivint_rotl32(G[2], 16);
+    // X5 = G5 + (G4 <<<  8) +  G3         mod WORDSIZE
+    g->X[5] = G[5] + vivint_rotl32(G[4], 8) + G[3];
+    // X6 = G6 + (G5 <<< 16) + (G4 <<< 16) mod WORDSIZE
+    g->X[6] = G[6] + vivint_rotl32(G[5], 16) + vivint_rotl32(G[4], 16);
+    // X7 = G7 + (G6 <<<  8) +  G5         mod WORDSIZE
+    g->X[7] = G[7] + vivint_rotl32(G[6], 8) + G[5];
 }
 
-/* RFC 4503 SS2.3 post-key-setup counter reinitialization: Cj ^= X(j+4 mod 8). */
-static void vivint_rabbit_counter_remix(vivint_rabbit_t *g)
+/* Function used during Rabbit stream generation after setup */
+static void vivint_rabbit_reinitialize_counters(vivint_rabbit_t *g)
 {
-    for (int r10 = 0; r10 < 8; ++r10) {
-        int r11 = r10 * 4;
-        int r14 = ((r10 + 4) % 8) * 4;
-        vivint_rabbit_w16(g, 0x252 + r11, vivint_rabbit_r16(g, 0x252 + r11) ^ vivint_rabbit_r16(g, 0x232 + r14));
-        vivint_rabbit_w16(g, 0x254 + r11, vivint_rabbit_r16(g, 0x254 + r11) ^ vivint_rabbit_r16(g, 0x234 + r14));
+    for (int j = 0u; j < 8; j++) {
+        g->C[j] ^= g->X[(j + 4) % 8];
     }
 }
 
-/* Reduced extraction: RFC 4503 SS2.7 derives a full 128 bit block; this
-   protocol only needs the status keystream byte (c1) and the auth byte
-   (c3), selecting a different X-word combination per counter mod 4. */
+/* The MSP430s and MCUs on the vivint sensors do not have enough
+ * RAM and rather than extracting the full 16 byte secret every
+ * cycle, grabs a byte based off of the packet counter and
+ * caculates them on demand. In this application, we can extract
+ * the full 48 byte cipher stream. */
 static void vivint_rabbit_extract(vivint_rabbit_t *g)
 {
-    unsigned k = vivint_rabbit_r16(g, 0x206) & 3;
-    uint16_t r14;
-    uint16_t r12;
-    uint16_t r13;
-    switch (k) {
-    case 0:
-        r14 = vivint_rabbit_r16(g, 0x23e);
-        r12 = vivint_rabbit_r16(g, 0x248) ^ vivint_rabbit_r16(g, 0x232);
-        r13 = vivint_rabbit_r16(g, 0x234);
-        break;
-    case 1:
-        r14 = vivint_rabbit_r16(g, 0x246);
-        r12 = vivint_rabbit_r16(g, 0x250) ^ vivint_rabbit_r16(g, 0x23a);
-        r13 = vivint_rabbit_r16(g, 0x23c);
-        break;
-    case 2:
-        r14 = vivint_rabbit_r16(g, 0x24e);
-        r12 = vivint_rabbit_r16(g, 0x238) ^ vivint_rabbit_r16(g, 0x242);
-        r13 = vivint_rabbit_r16(g, 0x244);
-        break;
-    default:
-        r14 = vivint_rabbit_r16(g, 0x236);
-        r12 = vivint_rabbit_r16(g, 0x240) ^ vivint_rabbit_r16(g, 0x24a);
-        r13 = vivint_rabbit_r16(g, 0x24c);
-        break;
-    }
-    r13 ^= r14;
-    g->m[0x2c1] = (uint8_t)r12;
-    g->m[0x2c2] = (uint8_t)(r12 >> 8);
-    g->m[0x2c3] = (uint8_t)r13;
-    g->m[0x2c4] = (uint8_t)(r13 >> 8);
+    //  2.7.  Extraction Scheme
+
+    //  After the key and IV setup are concluded, the algorithm is iterated
+    //  in order to produce one 128-bit output block, S, per round.  Each
+    //  round consists of executing steps 2.5 and 2.6 and then extracting an
+    //  output S[127..0] as follows:
+
+    //    S[15..0]    = X0[15..0]  ^ X5[31..16]
+    g->S[0] = (g->X[0] & 0xffff) ^ ((g->X[5] >> 16) & 0xffff);
+    //    S[31..16]   = X0[31..16] ^ X3[15..0]
+    g->S[1] = ((g->X[0] >> 16) & 0xffff) ^ (g->X[3] & 0xffff);
+    //    S[47..32]   = X2[15..0]  ^ X7[31..16]
+    g->S[2] = (g->X[2] & 0xffff) ^ ((g->X[7] >> 16) & 0xffff);
+    //    S[63..48]   = X2[31..16] ^ X5[15..0]
+    g->S[3] = ((g->X[2] >> 16) & 0xffff) ^ (g->X[5] & 0xffff);
+    //    S[79..64]   = X4[15..0]  ^ X1[31..16]
+    g->S[4] = (g->X[4] & 0xffff) ^ ((g->X[1] >> 16) & 0xffff);
+    //    S[95..80]   = X4[31..16] ^ X7[15..0]
+    g->S[5] = ((g->X[4] >> 16) & 0xffff) ^ (g->X[7] & 0xffff);
+    //    S[111..96]  = X6[15..0]  ^ X3[31..16]
+    g->S[6] = (g->X[6] & 0xffff) ^ ((g->X[3] >> 16) & 0xffff);
+    //    S[127..112] = X6[31..16] ^ X1[15..0]
+    g->S[7] = ((g->X[6] >> 16) & 0xffff) ^ (g->X[1] & 0xffff);
 }
 
-/* Full reseed: key setup, 4 rounds of next-state, counter remix, one more
-   next-state, then extract. Run every 12th counter tick. */
-static void vivint_rabbit_reseed(vivint_rabbit_t *g)
+/* Generate the 48 bytes of cipher given a specific key
+   out should be a uint8_t[48] */
+static void vivint_rabbit_gen_cipher(vivint_rabbit_t *g, uint8_t *out)
 {
-    vivint_rabbit_w16(g, 0x272, 0);
-    vivint_rabbit_w16(g, 0x274, 0);
+
     vivint_rabbit_key_setup(g);
-    for (int i = 0; i < 4; ++i)
+
+    // Iterate 4 times before extracting secrets
+    for (int i = 0; i < 4; i++) {
+        vivint_rabbit_update_counters(g);
         vivint_rabbit_next_state(g);
-    vivint_rabbit_counter_remix(g);
-    vivint_rabbit_next_state(g);
-    vivint_rabbit_extract(g);
-}
-
-static void vivint_rabbit_begin(vivint_rabbit_t *g, uint16_t seed)
-{
-    uint16_t init[8];
-    memset(g->m, 0, sizeof(g->m));
-    vivint_expand(seed, init);
-    for (int i = 0; i < 8; ++i)
-        vivint_rabbit_w16(g, 0x27a + 2 * i, init[i]);
-}
-
-/* Advances one transmit; returns the new counter and status-key (c1) byte. */
-static uint16_t vivint_rabbit_tick(vivint_rabbit_t *g, uint16_t counter, uint8_t *c1_out)
-{
-    counter = (counter == 0xfff7) ? 0 : (uint16_t)(counter + 1);
-    vivint_rabbit_w16(g, 0x206, counter);
-    if (counter % 12 == 0) {
-        vivint_rabbit_reseed(g);
     }
-    else if (counter % 4 == 0) {
+    // Necessary step before extracting the secrets
+    vivint_rabbit_reinitialize_counters(g);
+
+    // Now we pull out all 48 bytes of data for the cipher
+    // auto out = ret.begin();
+    for (int i = 0; i < 3; i++) {
+
+        vivint_rabbit_update_counters(g);
         vivint_rabbit_next_state(g);
         vivint_rabbit_extract(g);
+
+        for (int j = 0; j < 8; j++) {
+            *out = g->S[j] & 0x00ff;
+            out++;
+            *out = (g->S[j] >> 8) & 0x00ff;
+            out++;
+        }
     }
-    else {
-        vivint_rabbit_extract(g);
-    }
-    *c1_out = g->m[0x2c1];
-    return counter;
+}
+
+/* Customization to the rabbit cipher that modifies the 128bit key based on the packet counter
+ * This makes the key seem like it is more than 16 bits */
+static void vivint_gen_rabbit_key(vivint_rabbit_t *g, uint16_t seed, uint16_t counter)
+{
+    uint16_t i = 24;
+    do {
+        if (i > 0xfff7) {
+            i = 0;
+        }
+        if (i == 24) {
+            vivint_expand_key(g, seed);
+        }
+        int mod   = i % 7;
+        g->K[mod] = i + mod + g->K[mod];
+        g->K[7]   = g->K[7] ^ mod;
+        i += 12;
+    } while (i <= counter);
 }
 
 /* Per-device decode state: advanced incrementally as packets with
@@ -320,59 +472,27 @@ static uint16_t vivint_rabbit_tick(vivint_rabbit_t *g, uint16_t counter, uint8_t
 typedef struct {
     uint32_t id;
     uint16_t seed;
-    vivint_rabbit_t gen;
-    uint16_t counter;
-    uint8_t last_c1;
-    int has_last_c1;
-} vivint_seed_t;
+    uint16_t last_counter;
+    uint8_t cipher[VIVINT_RABBIT_CIPHER_SIZE];
+    int counter_idx;
+    int seed_matches;
+    uint16_t counters[VIVINT_CACHED_COUNTERS];
+    uint8_t cipher_cache[VIVINT_CACHED_COUNTERS];
+} vivint_sensor_t;
 
 typedef struct {
     unsigned count;
-    vivint_seed_t seeds[VIVINT_MAX_SEEDS];
+    vivint_sensor_t sensors[VIVINT_MAX_SENSORS];
 } vivint_ctx_t;
 
-static void vivint_seed_reset(vivint_seed_t *s)
-{
-    vivint_rabbit_begin(&s->gen, s->seed);
-    s->counter     = VIVINT_ENTRY_COUNTER;
-    s->has_last_c1 = 0;
-}
-
-/* Returns the status-key byte at counter `target`, or -1 if unreachable
-   (more than one counter cycle away, or target is the entry counter
-   itself, which is never an observed on-air value). */
-static int vivint_seed_c1_at(vivint_seed_t *s, uint16_t target)
-{
-    if (s->has_last_c1 && target == s->counter) {
-        return s->last_c1;
-    }
-    if (target < s->counter) {
-        vivint_seed_reset(s);
-    }
-    unsigned steps = 0;
-    while (s->counter != target) {
-        uint8_t c1;
-        s->counter     = vivint_rabbit_tick(&s->gen, s->counter, &c1);
-        s->last_c1     = c1;
-        s->has_last_c1 = 1;
-        if (s->counter == target) {
-            return c1;
-        }
-        if (++steps > 0x10000) {
-            return -1;
-        }
-    }
-    return -1;
-}
-
-static vivint_seed_t *vivint_ctx_find(vivint_ctx_t *ctx, uint32_t id)
+static vivint_sensor_t *vivint_ctx_find(vivint_ctx_t *ctx, uint32_t id)
 {
     if (!ctx) {
         return NULL;
     }
     for (unsigned i = 0; i < ctx->count; ++i) {
-        if (ctx->seeds[i].id == id) {
-            return &ctx->seeds[i];
+        if (ctx->sensors[i].id == id) {
+            return &ctx->sensors[i];
         }
     }
     return NULL;
@@ -389,8 +509,9 @@ static char *vivint_strtok(char *str, char const *delim, char **saveptr)
 #endif
 }
 
-/* Parses a comma separated "NNNN-NNNNNNN=hexseed" list (the same TXID
-   format this decoder prints), e.g. -R N:0019-0507610=05c9,0019-0507743=dda9 */
+/* Parses a comma-separated "NNNN-NNNNNNN=hexseed" list (the same TXID
+   format this decoder prints). The list can come from rtl_433's standard
+   runtime decoder argument or rtl_433_ESP's VIVINT_SEEDS definition. */
 static r_device *vivint_create(char const *args)
 {
     r_device *dev = decoder_create(&vivint, sizeof(vivint_ctx_t));
@@ -400,6 +521,15 @@ static r_device *vivint_create(char const *args)
 
     vivint_ctx_t *ctx = (vivint_ctx_t *)decoder_user_data(dev);
     ctx->count        = 0;
+
+#ifdef VIVINT_SEEDS
+    // Preserve rtl_433's runtime decoder argument as the preferred method.
+    // ESP32 has no command-line registration, so fall back to the compile-time
+    // seed list only when the caller supplied no runtime argument.
+    if (!args || !*args) {
+        args = VIVINT_SEEDS;
+    }
+#endif
 
     if (!args || !*args) {
         return dev;
@@ -416,12 +546,10 @@ static r_device *vivint_create(char const *args)
         unsigned p1;
         unsigned p2;
         unsigned seed;
-        if (ctx->count < VIVINT_MAX_SEEDS
-                && sscanf(tok, "%u-%u=%x", &p1, &p2, &seed) == 3) {
-            vivint_seed_t *s = &ctx->seeds[ctx->count++];
-            s->id            = ((p1 & 0xfff) << 20) | (p2 & 0xfffff);
-            s->seed          = (uint16_t)seed;
-            vivint_seed_reset(s);
+        if (ctx->count < VIVINT_MAX_SENSORS && sscanf(tok, "%u-%u=%x", &p1, &p2, &seed) == 3) {
+            vivint_sensor_t *s = &ctx->sensors[ctx->count++];
+            s->id              = ((p1 & 0xfff) << 20) | (p2 & 0xfffff);
+            s->seed            = (uint16_t)seed;
         }
         tok = vivint_strtok(NULL, ",", &saveptr);
     }
@@ -430,6 +558,454 @@ static r_device *vivint_create(char const *args)
     return dev;
 }
 
+// Generates the cipher values given a specific seed and counter
+static void vivint_rabbit_advance_cipher(vivint_sensor_t *s, uint16_t counter)
+{
+    // Need to check to see if we need to regenerate our cipher output
+    int diff = counter - s->last_counter;
+    if ((s->last_counter == 0xffff) ||
+            (counter % 12 == 0) || (diff > 12) || (diff < -12) ||
+            (counter % 12 < s->last_counter % 12)) {
+        // We need to regenerate
+        // Could make static to take it off of the stack
+        vivint_rabbit_t rabbit;
+        vivint_gen_rabbit_key(&rabbit, s->seed, counter);
+        vivint_rabbit_gen_cipher(&rabbit, s->cipher);
+    }
+    s->last_counter = counter;
+}
+
+/* The other 4 bits of bytes 8 and 9 in the data contain 4 bits of the raw cipher data xor'd with 0x10 */
+static int vivint_validate_rabbit_nibble(vivint_sensor_t *s, uint8_t check, uint16_t counter)
+{
+    int mod          = counter % 12;
+    uint8_t mac_byte = s->cipher[mod * 4 + 2] & 0xf0;
+
+    return mac_byte == (check ^ 0x10);
+}
+
+/* Returns the decrypted message data */
+static int vivint_decrypt_flags(vivint_sensor_t *s, int flags, uint16_t counter)
+{
+    int mod = counter % 12;
+
+    int decrypt_byte = s->cipher[mod * 4];
+
+    // The last 2 bits are always 0 in encrypted messages
+    return (flags ^ decrypt_byte) & 0xfc;
+}
+
+/* Iterates through cached data from a sensor to determine the seed */
+static int vivint_determine_seed(r_device *decoder, vivint_sensor_t *s)
+{
+    int num_matches       = 0;
+    uint16_t matched_seed = 0xffff;
+    for (uint16_t seed = 1; seed < 0xffff; seed++) {
+        s->last_counter = 0xffff;
+        for (int i = 0; i < VIVINT_SEED_DATA_REQUIRED; i++) {
+            int idx = (s->counter_idx - VIVINT_SEED_DATA_REQUIRED + i) % VIVINT_CACHED_COUNTERS;
+            s->seed = seed;
+            vivint_rabbit_advance_cipher(s, s->counters[idx]);
+            if (!vivint_validate_rabbit_nibble(s, s->cipher_cache[idx], s->counters[idx])) {
+                break;
+            }
+            if (i == VIVINT_SEED_DATA_REQUIRED - 1) {
+                matched_seed = seed;
+                num_matches++;
+            }
+        }
+    }
+
+    s->seed_matches = num_matches;
+
+    if (num_matches == 1) {
+        decoder_logf(decoder, 1, __func__, "Determined seed: %x", (unsigned)matched_seed);
+        s->seed = matched_seed;
+        // Reset the last counter so it regenerates the cipher with the new key
+        s->last_counter = 0xffff;
+        vivint_rabbit_advance_cipher(s, s->counters[(s->counter_idx - 1) % VIVINT_CACHED_COUNTERS]);
+        return 1;
+    }
+    else {
+        s->seed = 0xffff;
+        return 0;
+    }
+}
+
+static int vivint_decode_poweron(r_device *decoder, uint8_t *b)
+{
+    int crc           = (b[8] << 8) | b[9];
+    int model_type    = b[2];
+    int battery_level = ((b[3] << 4) | b[1]) & 0x0fff;
+    // Contains the full 32bit TXID
+    int id = ((unsigned)b[4] << 24) | ((unsigned)b[5] << 16) | ((unsigned)b[6] << 8) | b[7];
+    char id_str[13];
+    snprintf(id_str, sizeof(id_str), "%04u-%07u", (id >> 20) & 0xfff, id & 0xfffff);
+
+    const char *model;
+    switch (model_type) {
+    case VIVINT_DEVICE_TYPE_VS_FLD001_345:
+        model = "Vivint Security VS-FLD001-345";
+        break;
+    case VIVINT_DEVICE_TYPE_VS_SKEY2_345:
+        model = "Vivint Security VS-SKEY2-345";
+        break;
+    case VIVINT_DEVICE_TYPE_V_DW11_345:
+        model = "Vivint Security V-DW11-345";
+        break;
+    case VIVINT_DEVICE_TYPE_V_DW21R_345:
+        model = "Vivint Security V-DW21R-345";
+        break;
+    case VIVINT_DEVICE_TYPE_V_GB2_345:
+        model = "Vivint Security V-GB2-345";
+        break;
+    case VIVINT_DEVICE_TYPE_V_PIR2_345:
+        model = "Vivint Security V-PIR2-345";
+        break;
+    default:
+        model = "Vivint Security";
+        break;
+    }
+
+    if (crc != crc16(b, 8, 0x8050, 0)) {
+        decoder_logf(decoder, 2, __func__, "CRC check failed");
+        return DECODE_FAIL_MIC;
+    }
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "id",              "TXID",          DATA_STRING, id_str,
+            "event",           "Event",         DATA_STRING, "power_on",
+            "model",           "",              DATA_STRING, model,
+            "battery_level",   "",              DATA_INT, battery_level,
+            "mic",             "Integrity",     DATA_STRING, "CRC",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+
+    return 1;
+}
+
+/* This packet is device specific, and contains stuff like counter for RC circuits and register settings for voltage monitors on MSP430s */
+static int vivint_decode_battery(r_device *decoder, uint8_t *b, const char *id_str)
+{
+    /* This might not be true for all device types */
+    int bat_level     = ((b[1] << 4) & 0x0ff0) | b[2] >> 4;
+    int bat_threshold = ((b[2] & 0x0f) << 4) | (b[3] >> 2);
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",             "",              DATA_STRING, "Vivint Security",
+            "id",                "TXID",          DATA_STRING, id_str,
+            "event",             "Event",         DATA_STRING, "battery",
+            "battery_level",     "",              DATA_INT, bat_level,
+            "battery_threshold", "",              DATA_INT, bat_threshold,
+            "mic",               "Integrity",     DATA_STRING, "CRC",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+
+    return 1;
+}
+
+/* For devices that are not yet included in this decoder.
+ * If you have a device that generates this type of message,
+ * consider creating an issue with some captured data */
+static int vivint_decode_unknown(r_device *decoder, uint8_t *b)
+{
+    char payload[21];
+
+    for (int i = 0; i < 10; ++i) {
+        snprintf(&payload[i * 2], 3, "%02x", b[i]);
+    }
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",             "",              DATA_STRING, "Vivint Security",
+            "id",                "",              DATA_STRING, "0000-000-0000",
+            "event",             "Event",         DATA_STRING, "unknown",
+            "data",              "",              DATA_STRING,  payload,
+            "mic",               "Integrity",     DATA_STRING, "CRC",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+
+    return 1;
+}
+
+/* Sent while upgrading to encrypted communication
+ * Unknown exactly what the counter means, but once it
+ * reaches 25, it upgrades the device to encrypted communication.
+ * Probably set within 60 seconds of powering on the device with
+ * tamper or another input. */
+static int vivint_decode_mfg_boot(r_device *decoder, uint8_t *b, const char *id_str)
+{
+    int counter  = ((b[3] >> 2) & 0x0ff) | (b[1] & 0x0001);
+    int val_0xca = b[2];        // Should be 0xca
+    int val_0x34 = b[1] & 0xfe; // Should be 0x34
+
+    if (!(b[3] & 0x02) && val_0x34 != 0x34 && val_0xca != 0xca) {
+        decoder_logf(decoder, 2, __func__, "Non-conforming mfg boot packet format");
+        return DECODE_FAIL_SANITY;
+    }
+
+    char payload[21];
+    for (int i = 0; i < 10; ++i) {
+        snprintf(&payload[i * 2], 3, "%02x", b[i]);
+    }
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",             "",              DATA_STRING, "Vivint Security",
+            "id",                "TXID",          DATA_STRING, id_str,
+            "counter",           "",              DATA_INT,    counter,
+            "event",             "Event",         DATA_STRING, "battery",
+            "data",              "",              DATA_STRING,  payload,
+            "mic",               "Integrity",     DATA_STRING, "CRC",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+
+    return 1;
+}
+
+/* Untested, difficult to get devices to trigger this output */
+static int vivint_decode_seed(r_device *decoder, uint8_t *b, int id, const char *id_str)
+{
+    uint8_t two   = b[3];
+    uint16_t seed = (b[1] << 8) | b[2]; // Useful data included in packet
+
+    if (two != 0x02) {
+        decoder_logf(decoder, 2, __func__, "Non-conforming seed packet format");
+        return DECODE_FAIL_SANITY;
+    }
+    //
+    vivint_sensor_t *s = vivint_ctx_find((vivint_ctx_t *)decoder_user_data(decoder), id);
+    if (!s) {
+        vivint_ctx_t *ctx = (vivint_ctx_t *)decoder_user_data(decoder);
+        if (ctx->count < VIVINT_MAX_SENSORS) {
+            s               = &ctx->sensors[ctx->count++];
+            s->id           = id;
+            s->seed         = seed;
+            s->last_counter = 0xffff;
+            s->counter_idx  = 0;
+            s->seed_matches = 1;
+        }
+    }
+    else {
+        if (s->seed == 0xffff || s->seed == 0) {
+            s->seed = seed;
+        }
+        else if (s->seed != seed) {
+            s->seed = seed;
+        }
+    }
+
+    char seed_str[5];
+    snprintf(seed_str, sizeof(seed_str), "%04x", seed);
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",           "",              DATA_STRING, "Vivint Security",
+            "id",              "TXID",          DATA_STRING, id_str,
+            "event",           "Event",         DATA_STRING, "seed",
+            "seed",            "",              DATA_INT, seed_str,
+            "mic",             "Integrity",     DATA_STRING, "CRC",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+
+    return 1;
+}
+
+static int vivint_decode_event(r_device *decoder, uint8_t *b, int id, const char *id_str, int event, int has_encrypted_flags)
+{
+    int flags         = b[3];        // Useful data included in packet
+    int cipher_nibble = b[8] & 0xf0; // For encrypted messages, contains 4 bits of the cipher
+
+    int loop1_bit       = 0; // Loop 1, PIR motion, external contact for DW11, and reed for DW21R
+    int tamper_bit      = 0; // Case open tamper
+    int loop2_bit       = 0; // Loop 2, or reed for DW11
+    int loop3_bit       = 0; // Loop 3, or freeze for FLD001
+    int battery_low_bit = 0; // Does the sensor have a low battery voltage?
+    int heartbeat_bit   = 0; // Bit that toggles at a timed interval based on sum of 797
+    int counter         = 0; // For encrypted packets, we need to track this counter because it tells us where in the cipher the packet is
+    int has_valid_flags = 0; // Were the flags appropriately decoded?
+
+    uint16_t seed       = 0xffff;
+    int seed_data_count = 0;
+    int seed_matches    = -1;
+
+    const char *decode_status = "unknown";
+    const char *event_str;
+
+    char payload[21];
+
+    if (has_encrypted_flags) {
+        /* The bit[1] of the flags tells if the event data is encrypted or not
+         * and is always low when encrypted and contains a counter */
+        if (!(flags & VIVINT_UNENCRYPTED_FLAG_BIT)) {
+            counter = (b[1] << 8) | b[2];
+            // This means that we have the counter and need to work on decrypting
+            vivint_sensor_t *s = vivint_ctx_find((vivint_ctx_t *)decoder_user_data(decoder), id);
+            if (!s) {
+                vivint_ctx_t *ctx = (vivint_ctx_t *)decoder_user_data(decoder);
+                if (ctx->count < VIVINT_MAX_SENSORS) {
+                    s               = &ctx->sensors[ctx->count++];
+                    s->id           = id;
+                    s->seed         = 0xffff;
+                    s->last_counter = 0xffff;
+                    s->counter_idx  = 0;
+                    s->seed_matches = -1;
+                }
+            }
+            if (s) {
+                decode_status = "collecting_seed";
+                // Let's see if we can determine the seed
+                if (s->seed == 0xffff || s->seed == 0x0000) {
+                    // Store the data we need to determine the seed
+                    // Prevent duplicates
+                    if (counter != s->last_counter) {
+                        int idx              = s->counter_idx % VIVINT_CACHED_COUNTERS;
+                        s->cipher_cache[idx] = cipher_nibble;
+                        s->counters[idx]     = counter;
+                        s->counter_idx++;
+                        // Check if we have enough data to determine the seed
+                        if (s->counter_idx >= VIVINT_SEED_DATA_REQUIRED) {
+                            decoder_logf(decoder, 1, __func__, "Attempting to crack seed");
+                            vivint_determine_seed(decoder, s);
+                        }
+                    }
+                    s->last_counter = counter;
+                }
+
+                if (s->seed != 0xffff && s->seed != 0x0000) {
+                    // This is where we try to decode the message
+                    // We also need to check the high nibble of byte 8 to check if
+                    // the cipher is correct
+                    vivint_rabbit_advance_cipher(s, counter);
+                    if (vivint_validate_rabbit_nibble(s, cipher_nibble, counter)) {
+                        has_valid_flags = 1;
+                        flags           = vivint_decrypt_flags(s, flags, counter);
+                    }
+                    else {
+                        decode_status = "cipher_check_failed";
+                        decoder_logf(decoder, 2, __func__, "Invalid Rabbit cipher check nibble");
+                    }
+                }
+                seed            = s->seed;
+                seed_data_count = s->counter_idx < VIVINT_CACHED_COUNTERS ? s->counter_idx : VIVINT_CACHED_COUNTERS;
+                seed_matches    = s->seed_matches;
+                if (has_valid_flags) {
+                    decode_status = "decoded";
+                }
+                else if (seed == 0xffff || seed == 0x0000) {
+                    if (seed_matches == 0)
+                        decode_status = "seed_not_found";
+                    else if (seed_matches > 1)
+                        decode_status = "seed_ambiguous";
+                }
+            }
+            else {
+                decode_status = "sensor_cache_full";
+            }
+        }
+        else {
+            /* Some devices include values here for different messages,
+             * for example the VS-FLD001-345 sends a 0x74 message with the current temperature in C. */
+
+            decode_status   = "unencrypted";
+            has_valid_flags = 0;
+        }
+    }
+    else {
+        decode_status   = "unencrypted";
+        has_valid_flags = 1;
+    }
+
+#if OUTPUT_VIVINT_DECODE
+    char seed_str[5];
+    snprintf(seed_str, sizeof(seed_str), "%04x", seed);
+#else
+    // These values still drive decoder state above, but are not emitted.
+    (void)seed_data_count;
+    (void)decode_status;
+#endif
+
+    switch (event) {
+    case VIVINT_EVENT_DW:
+        event_str = "door_window_open_close";
+        break;
+    case VIVINT_EVENT_FLOOD:
+        event_str = "flood_heat_freeze";
+        break;
+    case VIVINT_EVENT_GB:
+        event_str = "glass_break";
+        break;
+    case VIVINT_EVENT_PIR:
+        event_str = "motion";
+        break;
+    default:
+        event_str = "unknown";
+        break;
+    }
+
+    if (has_valid_flags) {
+        /* Extract DW11 event bits (1T23BHEZ layout):
+                   1=loop1(7), T=tamper(6), 2=loop2(5), 3=loop3(4),
+                   B=battery_low(3), H=heartbeat(2), E=Encrypted(1),
+                   Z=zero(0) */
+        loop1_bit       = flags & 0x80 ? 1 : 0;
+        tamper_bit      = flags & 0x40 ? 1 : 0;
+        loop2_bit       = flags & 0x20 ? 1 : 0;
+        loop3_bit       = flags & 0x10 ? 1 : 0;
+        battery_low_bit = flags & 0x08 ? 1 : 0;
+        heartbeat_bit   = flags & 0x04 ? 1 : 0;
+    }
+    else {
+        for (int i = 0; i < 10; ++i) {
+            snprintf(&payload[i * 2], 3, "%02x", b[i]);
+        }
+    }
+
+    /* clang-format off */
+    data_t *data = data_make(
+            "model",        "",              DATA_STRING, "Vivint Security",
+            "id",           "TXID",          DATA_STRING, id_str,
+            "counter",      "",              DATA_COND, has_valid_flags, DATA_FORMAT, "%04x", DATA_INT, counter,
+#if OUTPUT_VIVINT_DECODE
+            "seed",         "",              DATA_COND, has_encrypted_flags && seed != 0xffff && seed != 0x0000, DATA_STRING, seed_str,
+            "decode_status", "Decode status", DATA_COND, has_encrypted_flags, DATA_STRING, decode_status,
+            "seed_data_count", "Seed samples collected", DATA_COND, has_encrypted_flags && (seed == 0xffff || seed == 0x0000), DATA_INT, seed_data_count,
+            "seed_data_required", "Seed samples required", DATA_COND, has_encrypted_flags && (seed == 0xffff || seed == 0x0000), DATA_INT, VIVINT_SEED_DATA_REQUIRED,
+            "seed_candidate_count", "Seed candidates", DATA_COND, has_encrypted_flags && (seed == 0xffff || seed == 0x0000) && seed_matches >= 0, DATA_INT, seed_matches,
+#endif
+            "flags",        "",              DATA_COND, has_valid_flags, DATA_FORMAT, "%02x", DATA_INT, flags,
+            "event_type",   "",              DATA_FORMAT, "%02x", DATA_INT, event,
+            "event",        "Event",         DATA_STRING, event_str,
+            "state",        "",              DATA_COND, has_valid_flags,  DATA_STRING,  loop1_bit ? "open" : "closed",
+            "loop1",        "",              DATA_COND, has_valid_flags,  DATA_INT,     loop1_bit,
+            "tamper",       "",              DATA_COND, has_valid_flags,  DATA_INT,     tamper_bit,
+            "loop2",        "",              DATA_COND, has_valid_flags,  DATA_INT,     loop2_bit,
+            "loop3",        "",              DATA_COND, has_valid_flags,  DATA_INT,     loop3_bit,
+            "battery_low",  "Battery",       DATA_COND, has_valid_flags,  DATA_INT,     battery_low_bit,
+            "heartbeat",    "",              DATA_COND, has_valid_flags,  DATA_INT,     heartbeat_bit,
+            "data",         "",              DATA_COND, !has_valid_flags, DATA_STRING,  payload,
+            "mic",          "Integrity",     DATA_STRING, "CRC",
+            NULL);
+    /* clang-format on */
+
+    decoder_output_data(decoder, data);
+
+    return 1;
+}
+
+/* Base function used by rtl_433 to decode the bit stream */
 static int vivint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     uint8_t const preamble_pattern[2] = {0xff, 0xe0}; /* 12 bits of 0xFFFE */
@@ -443,6 +1019,7 @@ static int vivint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     bitbuffer_invert(bitbuffer);
 
+    /* This still misses a lot of packets when it catches a high bit at the start of the packet, leading to 0x80000 being seen instead of 0xfffe */
     int pos = bitbuffer_search(bitbuffer, row, 0, preamble_pattern, 12) + 12;
     int len = bitbuffer->bits_per_row[row] - pos;
     if (len < VIVINT_MSG_BIT_LEN) {
@@ -454,120 +1031,119 @@ static int vivint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     bitbuffer_extract_bytes(bitbuffer, row, pos, b, VIVINT_MSG_BIT_LEN);
     decoder_log_bitrow(decoder, 2, __func__, b, VIVINT_MSG_BIT_LEN, "MSG (inverted, aligned)");
 
-    int event_type  = b[0];
-    int counter     = (b[1] << 8) | b[2];
-    int flags       = b[3];
-    unsigned id     = ((unsigned)b[4] << 24) | ((unsigned)b[5] << 16) | ((unsigned)b[6] << 8) | b[7];
-    int crc         = (b[8] << 8) | b[9];
-
-    if (id == 0 || id == 0xffffffff) {
-        decoder_logf(decoder, 2, __func__, "Id sanity check failed (%08x)", id);
-        return DECODE_FAIL_SANITY;
-    }
-
-    int crc_valid = 0;
-    if (event_type == 0xd0) {
-        if (crc == crc16(b, 8, 0x8050, 0)) crc_valid = 1;
-    }
-    else {
-        uint8_t b8_full = b[8];
-        b[8] &= 0xF0;
-        int crc_full = crc16(b, 9, 0x8050, 0);
-        b[8]         = b8_full;
-        int check12  = crc_full >> 4;
-        int stored12 = ((b8_full & 0x0F) << 8) | b[9];
-        if (check12 == stored12) crc_valid = 1;
-    }
-
-    if (!crc_valid) {
-        decoder_logf(decoder, 2, __func__, "CRC check failed");
-        return DECODE_FAIL_MIC;
-    }
-
+    int channel = b[0] & 0xf0;
+    int event   = b[0] & 0x0f;
+    unsigned id = 0;
     char id_str[13];
-    snprintf(id_str, sizeof(id_str), "%04u-%07u", (id >> 20) & 0xfff, id & 0xfffff);
 
-    int has_contact  = 0;
+    if (channel == CHANNEL_POWERON) {
+        return vivint_decode_poweron(decoder, b);
+    }
+    else if ((channel & 0xf0) == CHANNEL_VIVINT) {
+        int has_encrypted_flags = 0;
 
-    int contact_bit     = 0;    // External contact open/closed state
-    int tamper_bit      = 0;    // Case open tamper
-    int reed_bit        = 0;    // Primary use case for DW11
-    int alarm_bit       = 0;    // Unknown meaning for DW11, copied from honeywell.c
-    int battery_low_bit = 0;    // Tested
-    int heartbeat_bit   = 0;    // Unknown meaning for DW11, copied from honeywell.c
+        /* Contains the full 32bit TXID */
+        id = ((unsigned)b[4] << 24) | ((unsigned)b[5] << 16) | ((unsigned)b[6] << 8) | b[7];
+        snprintf(id_str, sizeof(id_str), "%04u-%07u", (id >> 20) & 0xfff, id & 0xfffff);
 
-    if (event_type == 0x7a) {
-        vivint_seed_t *s = vivint_ctx_find((vivint_ctx_t *)decoder_user_data(decoder), id);
-        if (s) {
-            int c1 = vivint_seed_c1_at(s, (uint16_t)counter);
-            if (c1 >= 0) {
-                has_contact  = 1;
-                /* Extract DW11 event bits (CTRABHUU layout):
-                   C=contact(7), T=tamper(6), R=reed(5), A=alarm(4),
-                   B=battery_low(3), H=heartbeat(2), U,U=unused(1,0) */
-                contact_bit     = (flags ^ c1) & 0x80 ? 1 : 0;
-                tamper_bit      = (flags ^ c1) & 0x40 ? 1 : 0;
-                reed_bit        = (flags ^ c1) & 0x20 ? 1 : 0;
-                alarm_bit       = (flags ^ c1) & 0x10 ? 1 : 0;
-                battery_low_bit = (flags ^ c1) & 0x08 ? 1 : 0;
-                heartbeat_bit   = (flags ^ c1) & 0x04 ? 1 : 0;
-            }
+        /* Check the CRC. Encrypted messages leak 4 bits of the raw cipher and unencrypted messages
+           contain a multiple of 797 in those 4 bits. */
+        int crc     = ((b[8] << 8) | b[9]) & 0x0fff;
+        int b8_full = b[8];
+
+        b[8] &= 0xf0;
+        if (crc != (crc16(b, 9, 0x8050, 0) >> 4)) {
+            decoder_logf(decoder, 2, __func__, "CRC check failed");
+            return DECODE_FAIL_MIC;
+        }
+        b[8] = b8_full;
+
+        /* Check if we just have an unencrypted event. The high nibble of b[1] will be the actual event code */
+        if (event == VIVINT_EVENT_UNENCRYPTED) {
+            /* Check to see if the bit is set in the flags to signify not encrypted */
+            event = (b[1] & 0xf0) >> 4;
+        }
+        else {
+            has_encrypted_flags = 1;
+        }
+
+        if (event == VIVINT_PACKET_BATTERY) {
+            return vivint_decode_battery(decoder, b, id_str);
+        }
+        else if (event == VIVINT_PACKET_SEED) {
+            return vivint_decode_seed(decoder, b, id, id_str);
+        }
+        else if (event == VIVINT_PACKET_MFG_BOOT) {
+            return vivint_decode_mfg_boot(decoder, b, id_str);
+        }
+        else if (event == VIVINT_EVENT_DW || event == VIVINT_EVENT_GB || event == VIVINT_EVENT_PIR || event == VIVINT_EVENT_FLOOD) {
+            return vivint_decode_event(decoder, b, id, id_str, event, has_encrypted_flags);
+        }
+        else {
+            decoder_logf(decoder, 2, __func__, "Unknown event type");
+            return DECODE_FAIL_OTHER;
         }
     }
+    else if (channel == CHANNEL_SKEY) {
+        /* SKEY codes start with 0xe0 and then have the 24bit TXID */
+        decoder_logf(decoder, 2, __func__, "Unhandled device messages");
+        return DECODE_FAIL_OTHER;
+    }
+    else {
+        /* Check the possible known CRC configurations
+           Could change decoding behavior based on which crc is correct */
+        int crc = (b[8] << 8) | b[9];
 
-    char payload[21];
-    if (!has_contact) {
-        for (int i = 0; i < 10; ++i)
-            snprintf(&payload[i * 2], 3, "%02x", b[i]);
+        if (crc != crc16(b, 8, 0x8005, 0) && crc != crc16(b, 8, 0x8050, 0)) {
+            crc         = ((b[8] << 8) | b[9]) & 0x0fff;
+            int b8_full = b[8];
+
+            b[8] &= 0xf0;
+            if (crc != (crc16(b, 9, 0x8050, 0) >> 4) && crc != (crc16(b, 9, 0x8005, 0) >> 4)) {
+                decoder_logf(decoder, 2, __func__, "CRC check failed");
+                return DECODE_FAIL_MIC;
+            }
+            b[8] = b8_full;
+        }
+        return vivint_decode_unknown(decoder, b);
     }
 
-    /* clang-format off */
-    data_t *data = data_make(
-            "model",        "",              DATA_STRING, "Vivint-Security",
-            "id",           "",              DATA_STRING, id_str,
-            "counter",      "",              DATA_FORMAT, "%04x", DATA_INT, counter,
-            "flags",        "",              DATA_FORMAT, "%02x", DATA_INT, flags,
-            "event_type",   "",              DATA_FORMAT, "%02x", DATA_INT, event_type,
-            "state",        "",              DATA_COND, has_contact,  DATA_STRING, contact_bit ? "open" : "closed",
-            "contact_open", "",              DATA_COND, has_contact,  DATA_INT,     contact_bit,
-            "tamper",       "",              DATA_COND, has_contact,  DATA_INT,     tamper_bit,
-            "reed",         "",              DATA_COND, has_contact,  DATA_INT,     reed_bit,
-            "alarm",        "",              DATA_COND, has_contact,  DATA_INT,     alarm_bit,
-            "battery_low",  "Battery",       DATA_COND, has_contact,  DATA_INT,     battery_low_bit,
-            "heartbeat",    "",              DATA_COND, has_contact,  DATA_INT,     heartbeat_bit,
-            "data",         "",              DATA_COND, !has_contact, DATA_STRING, payload,
-            "mic",          "Integrity",     DATA_STRING, "CRC",
-            NULL);
-    /* clang-format on */
-
-    decoder_output_data(decoder, data);
-    return 1;
+    return DECODE_FAIL_OTHER;
 }
 
 static char const *const output_fields[] = {
         "model",
         "id",
         "counter",
+#if OUTPUT_VIVINT_DECODE
+        "seed",
+        "decode_status",
+        "seed_data_count",
+        "seed_data_required",
+        "seed_candidate_count",
+#endif
         "flags",
         "event_type",
         "state",
-        "contact_open",
+        "loop1",
         "tamper",
-        "reed",
-        "alarm",
+        "loop2",
+        "loop3",
         "battery_low",
         "heartbeat",
         "data",
+        "battery_level",
+        "battery_threshold",
         "mic",
         NULL,
 };
 
 r_device const vivint = {
-        .name        = "Vivint Door/Window Sensor, V-DW21R-345/V-DW11-345",
+        .name        = "Vivint 345MHz Sensors, V-DW11-345/V-DW21R-345, V-GB2-345/V-GB3-345, V-PIR2-345/V-PIR3-345",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
-        .short_width = 150,
-        .long_width  = 0,
-        .reset_limit = 300,
+        .short_width = 139,
+        .long_width  = 0,   /* Not used for manchester encoding */
+        .reset_limit = 300, /* Single sensors typically wait 10ms between sending packets */
         .decode_fn   = &vivint_decode,
         .create_fn   = &vivint_create,
         .fields      = output_fields,


### PR DESCRIPTION
Improves the current Vivint decoder to reliably determine the seed used to encrypt event data

Tested added support for VS-FLD001-345, V-PIR2-345, V-GB2-345. Should support newer models of these sensors, as well.

Decoding requires 6 encrypted packets in order to determine the 16 bit seed used to encrypt the event data.